### PR TITLE
Fixed static OE_Mutex initializer

### DIFF
--- a/include/openenclave/thread.h
+++ b/include/openenclave/thread.h
@@ -143,7 +143,8 @@ int OE_SpinUnlock(
  */
 int OE_SpinDestroy(OE_Spinlock* spinlock);
 
-#define OE_MUTEX_INITIALIZER {OE_SPINLOCK_INITIALIZER,0,{NULL,NULL},{0}}
+#define OE_MUTEX_INITIALIZER \
+    {OE_SPINLOCK_INITIALIZER,0,{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},{NULL,NULL}}
 
 /* Definition of a mutex */
 typedef struct _OE_Mutex

--- a/tests/thread/enc/enc.cpp
+++ b/tests/thread/enc/enc.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <pthread.h>
 #include "../args.h"
 
 static OE_Mutex mutex = OE_MUTEX_INITIALIZER;
@@ -24,9 +25,20 @@ static void _TestParallelMallocs()
     }
 }
 
+/* Check consistency of OE/pthread mutex static-initializer layout */
+void TestMutexLayoutConsistency()
+{
+    assert(sizeof(OE_Mutex) == sizeof(pthread_mutex_t));
+    static pthread_mutex_t m1 = PTHREAD_MUTEX_INITIALIZER;
+    static OE_Mutex m2 = OE_MUTEX_INITIALIZER;
+    assert(memcmp(&m1, &m2, sizeof(pthread_mutex_t)) == 0);
+}
+
 OE_ECALL void TestMutex(void* args_)
 {
     TestMutexArgs* args = (TestMutexArgs*)args_;
+
+    TestMutexLayoutConsistency();
 
     OE_MutexLock(&mutex);
     args->count++;

--- a/tests/thread/host/host.cpp
+++ b/tests/thread/host/host.cpp
@@ -8,6 +8,7 @@
 #include <openenclave/host.h>
 #include <openenclave/bits/tests.h>
 #include <openenclave/bits/error.h>
+#include <openenclave/bits/utils.h>
 #include "../args.h"
 
 static TestMutexArgs _args;
@@ -63,6 +64,15 @@ void TestCond(OE_Enclave* enclave)
         pthread_join(threads[i], NULL);
 }
 
+/* Check consistency of OE/pthread mutex static-initializer layout */
+void TestMutexLayoutConsistency()
+{
+    assert(sizeof(OE_Mutex) == sizeof(pthread_mutex_t));
+    static pthread_mutex_t m1 = PTHREAD_MUTEX_INITIALIZER;
+    static OE_Mutex m2 = OE_MUTEX_INITIALIZER;
+    assert(memcmp(&m1, &m2, sizeof(pthread_mutex_t)) == 0);
+}
+
 int main(int argc, const char* argv[])
 {
     OE_Result result;
@@ -73,6 +83,8 @@ int main(int argc, const char* argv[])
         fprintf(stderr, "Usage: %s ENCLAVE\n", argv[0]);
         exit(1);
     }
+
+    TestMutexLayoutConsistency();
 
     const uint32_t flags = OE_GetCreateFlags();
 


### PR DESCRIPTION
This patch:

(1) Fixes the static initializer (OE_MUTEX_INITIALIZER) for the OE_Mutex type. 
(2) Adds a test to check that statically initialized pthread_mutex_t and OE_Mutex have the same layout for both GLIBC (host) and MUSL (enclave).
