### PR TITLE
Skip unsupported VectorException test in simulation mode

### DIFF
--- a/tests/VectorException/CMakeLists.txt
+++ b/tests/VectorException/CMakeLists.txt
@@ -2,3 +2,4 @@ add_subdirectory(enc)
 add_subdirectory(host)
 
 add_test(tests/VectorException host/VectorExceptionHost ./enc/VectorExceptionEnc.signed.so)
+set_tests_properties(tests/VectorException PROPERTIES SKIP_RETURN_CODE 2)

--- a/tests/VectorException/host/host.c
+++ b/tests/VectorException/host/host.c
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include "../args.h"
 
+#define SKIP_RETURN_CODE    2
+
 int main(int argc, const char* argv[])
 {
     OE_Result result;
@@ -22,6 +24,11 @@ int main(int argc, const char* argv[])
     printf("=== This program is used to test basic vector exception functionalities.\n");
 
     const uint32_t flags = OE_GetCreateFlags();
+    if ((flags & OE_FLAG_SIMULATE) != 0)
+    {
+        printf("=== Skipped unsupported test in simulation mode (VectorException)\n");
+        return SKIP_RETURN_CODE;
+    }
 
     if ((result = OE_CreateEnclave(argv[1], flags, &enclave)) != OE_OK)
         OE_PutErr("OE_CreateEnclave(): result=%u", result);


### PR DESCRIPTION
Illustration of test handling for unsupported functions in simulation mode.