### PR TITLE
Build: Add default gcc include dir to gain access to intrinsics

### DIFF
--- a/cmake/compilersettings.cmake
+++ b/cmake/compilersettings.cmake
@@ -32,6 +32,18 @@ if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MAT
     # to fix warnings as they arise, so they don't accumulate "to be fixed later".
     add_compile_options(-Wall -Werror)
 
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+        # Obtain default gcc include dir to gain access to intrinsics
+        execute_process(
+            COMMAND /bin/bash ${PROJECT_SOURCE_DIR}/cmake/get_c_compiler_dir.sh ${CMAKE_C_COMPILER}
+            OUTPUT_VARIABLE OE_C_COMPILER_INCDIR
+            ERROR_VARIABLE OE_ERR
+        )
+        if(NOT "${OE_ERR}" STREQUAL "")
+            message(FATAL_ERROR ${OE_ERR})
+        endif()
+    endif()
+
 elseif(MSVC)
     # MSVC options go here
 endif()

--- a/cmake/get_c_compiler_dir.sh
+++ b/cmake/get_c_compiler_dir.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# obtain default compiler include holding the intrinsics
+#
+# Args: <CC> - The C-compiler to use
+#
+function exit_handler()
+{
+    test "$?" == 0 && return
+    echo "An error occured" >&2
+    exit 1
+}
+trap exit_handler EXIT
+trap exit ERR
+
+CC=$1
+
+file=$(echo "#include <x86intrin.h>" | $CC -E - -M | gawk '/x86intrin\.h/{$0=gensub("-.o: ","","g"); print $1; exit}')
+echo $file | grep -q 'x86intrin\.h' && test -f $file
+dir=$(dirname $file)
+test -d $dir
+echo -n $dir

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -25,6 +25,10 @@ add_library(oeenclave STATIC
 
 target_link_libraries(oeenclave PUBLIC oe_includes)
 
+# we strip the default include containing the compiler-provided intrinsics
+# add it back in
+target_include_directories(oeenclave SYSTEM PUBLIC ${OE_C_COMPILER_INCDIR})
+
 target_compile_options(oeenclave PUBLIC
     -m64 -fPIC
     -nostdinc


### PR DESCRIPTION
This is to allow the compiler's intrinsics (which are independent of the libc) to be used.