### PR TITLE
Fix format-code file handling in subfolder with source files.

### DIFF
--- a/scripts/format-code
+++ b/scripts/format-code
@@ -84,9 +84,9 @@ Formats all C/C++ source files based on the .clang-format rules
 
 OPTIONS:
     -h, --help              Print this help message.
-    -v, --verbose           Display verbose output. When used with --whatif,
-                            will also display XML output of expected changes.
-    -w, --whatif            Run the script without actually modifying the files.
+    -v, --verbose           Display verbose output.
+    -w, --whatif            Run the script without actually modifying the files
+                            and display the diff of expected changes, if any.
     --exclude-dirs          Subdirectories to exclude. If unspecified, then
                             ./3rdparty, ./build and ./prereqs are excluded.
                             All subdirectories are relative to the current path.
@@ -98,7 +98,7 @@ EXAMPLES:
 To determine what lines of each file in the default configuration would be
 modified by format-code, you can run from the root folder:
 
-    $ ./scripts/format-code -v -w
+    $ ./scripts/format-code -w
 
 To update only all .c and .cpp files in tests/ except for tests/echo/host, you
 can run from the tests folder:
@@ -209,10 +209,10 @@ log_verbose ""
 ##==============================================================================
 
 filecount=0
-failcount=0
+changecount=0
 
 if [ "${whatif}" = "1" ]; then
-    cfargs='-style=file -output-replacements-xml '
+    cfargs='-style=file '
 else
     cfargs='-style=file -i '
 fi
@@ -223,17 +223,24 @@ do
 
     log_whatif "Formatting $file ..."
 
-    if [ "${verbose}" = "1" ]; then
-        ${cf} ${cfargs} $file
+    if [ "${whatif}" = "1" ]; then
+        ${cf} ${cfargs} $file | diff -u "$file" -
     else
-        ${cf} ${cfargs} $file > /dev/null
+        if [ "${verbose}" = "1" ]; then
+            ${cf} ${cfargs} $file
+        else
+            ${cf} ${cfargs} $file > /dev/null
+        fi
     fi
 
     if [ "$?" != "0" ]; then
-        echo "clang-format failed on file: $file."
-        ((failcount+=1))
+        if [ "${whatif}" = "1" ]; then
+            ((changecount+=1))
+        else
+            echo "clang-format failed on file: $file."
+        fi
     fi
 done
 
-log_whatif "${filecount} files processed, ${failcount} failures."
+log_whatif "${filecount} files processed, ${changecount} changed."
 exit 0


### PR DESCRIPTION
Format-code was not correctly quoting wildcards for find command, which
leads to path expansion that breaks it when run in a folder containing
source files.

Fixes #125