### PR TITLE
Fixes for #123 and #124

### DIFF
--- a/debugger/ptraceLib/enclave_context.c
+++ b/debugger/ptraceLib/enclave_context.c
@@ -204,7 +204,7 @@ static int _GetEnclaveThreadCurrentSsaInfo(
 {
     int ret;
     size_t read_byte_length;
-    long ssa_frame_size;
+    long ssa_frame_size = 0;
     SGX_TCS tcs;
 
     // Read TCS header.

--- a/host/quote.c
+++ b/host/quote.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <assert.h>
 #include <limits.h>
 #include <openenclave/bits/aesm.h>
 #include <openenclave/bits/sgxtypes.h>
@@ -54,7 +55,9 @@ OE_Result SGX_GetQuoteSize(
             goto done;
         }
 
-        n = OE_ByteSwap32(*(uint32_t*)&sigrl->sigrl.n2);
+	assert(sizeof(sigrl->sigrl.n2) == sizeof(uint32_t));
+	const void* tmp = &sigrl->sigrl.n2;
+        n = OE_ByteSwap32(*(uint32_t*)tmp);
     }
 
     /* Calculate variable size of EPID_Signature with N entries */


### PR DESCRIPTION
Mike: Here are the changes for #123 and #124. Please review. - Anita

--- a/debugger/ptraceLib/enclave_context.c
+++ b/debugger/ptraceLib/enclave_context.c
@@ -204,7 +204,7 @@ static int _GetEnclaveThreadCurrentSsaInfo(
 {
     int ret;
     size_t read_byte_length;
-    long ssa_frame_size = 0;
+    long ssa_frame_size;
     SGX_TCS tcs;
 
     // Read TCS header.
diff --git a/host/quote.c b/host/quote.c
index 5cc8db6..e044e03 100644
--- a/host/quote.c
+++ b/host/quote.c
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <assert.h>
 #include <limits.h>
 #include <openenclave/bits/aesm.h>
 #include <openenclave/bits/sgxtypes.h>
@@ -55,9 +54,7 @@ OE_Result SGX_GetQuoteSize(
             goto done;
         }
 
-       assert(sizeof(sigrl->sigrl.n2) == sizeof(uint32_t));
-       const void* tmp = &sigrl->sigrl.n2;
-        n = OE_ByteSwap32(*(uint32_t*)tmp);
+        n = OE_ByteSwap32(*(uint32_t*)&sigrl->sigrl.n2);
     }
