### PR TITLE
Update test to use OE_TEST. Add necessary dependencies to get the enclave version of the macro

### DIFF
--- a/tests/report/enc/CMakeLists.txt
+++ b/tests/report/enc/CMakeLists.txt
@@ -5,5 +5,3 @@ include(add_enclave_executable)
 add_enclave_executable(reportenc sign.conf private.pem
     enc.cpp
     )
-
-target_link_libraries(reportenc oelibc)

--- a/tests/report/enc/enc.cpp
+++ b/tests/report/enc/enc.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// Define this for OE_TEST to work without stdio.h being available.
+#define OE_BUILD_ENCLAVE
+
 #include <openenclave/bits/enclavelibc.h>
 #include <openenclave/bits/tests.h>
 #include <openenclave/enclave.h>


### PR DESCRIPTION
…wise compilation fails saying it can't find stdio.h.