### PR TITLE
format-code-check - script to check whether format-code would make changes

### DIFF
--- a/scripts/format-code-check
+++ b/scripts/format-code-check
@@ -104,22 +104,9 @@ ${format_code}
 
 ##==============================================================================
 ##
-## Compile list of new and old source files
+## Diff the formattted and unformatted directories
 ##
 ##==============================================================================
-
-cd ${dir1}
-src1=`find . -name '*.[ch]'`
-src1+=" `find . -name '*.cpp'`"
-
-cd ${dir2}
-src2=`find . -name '*.[ch]'`
-src2+=" `find . -name '*.cpp'`"
-
-if [ "${src1}" != "${src2}" ]; then
-    echo "$0: unexpected : new and old source list are different"
-    Exit 1
-fi
 
 diff -r ${dir1} ${dir2}
 if [ "$?" != "0" ]; then


### PR DESCRIPTION
This script checks whether format-code would change anything. If so, it exits with a status of 1. This script can be safely run to block pushing of changes if the developer forgot to run format-code.