### PR TITLE
Added args.divisor to trick optimizer for abortStatus test to PASS with optimized builds

### DIFF
--- a/common/result.c
+++ b/common/result.c
@@ -3,7 +3,7 @@
 
 #include <openenclave/result.h>
 
-// OE abort status depends on the order of these enums to transfer status 
+// OE abort status depends on the order of these enums to transfer status
 // correctly.
 OE_STATIC_ASSERT(OE_ENCLAVE_ABORTING > OE_OK);
 OE_STATIC_ASSERT(OE_ENCLAVE_ABORTED > OE_ENCLAVE_ABORTING);

--- a/enclave/calls.c
+++ b/enclave/calls.c
@@ -394,7 +394,7 @@ OE_Result OE_OCall(
     Callsite* callsite = td->callsites;
     uint32_t old_ocall_flags = td->ocall_flags;
 
-    /* If the enclave is in crashing/crashed status, new OCALL should fail 
+    /* If the enclave is in crashing/crashed status, new OCALL should fail
     immediately. */
     if (__oe_enclave_status != OE_OK)
         OE_THROW((OE_Result)__oe_enclave_status);
@@ -583,35 +583,35 @@ void __OE_HandleMain(
     // Block enclave enter based on current enclave status.
     switch (__oe_enclave_status)
     {
-    case OE_OK:
-        break;
+        case OE_OK:
+            break;
 
-    case OE_ENCLAVE_ABORTING:
-        // Block any ECALL except first time OE_FUNC_DESTRUCTOR call.
-        // Don't block ORET here.
-        if (code == OE_CODE_ECALL)
-        {
-            if (func == OE_FUNC_DESTRUCTOR)
+        case OE_ENCLAVE_ABORTING:
+            // Block any ECALL except first time OE_FUNC_DESTRUCTOR call.
+            // Don't block ORET here.
+            if (code == OE_CODE_ECALL)
             {
-                // Termination function should be only called once.
-                __oe_enclave_status = OE_ENCLAVE_ABORTED;
+                if (func == OE_FUNC_DESTRUCTOR)
+                {
+                    // Termination function should be only called once.
+                    __oe_enclave_status = OE_ENCLAVE_ABORTED;
+                }
+                else
+                {
+                    // Return crashing status.
+                    *outputArg1 = OE_MakeCallArg1(OE_CODE_ERET, func, 0);
+                    *outputArg2 = __oe_enclave_status;
+                    return;
+                }
             }
-            else
-            {
-                // Return crashing status.
-                *outputArg1 = OE_MakeCallArg1(OE_CODE_ERET, func, 0);
-                *outputArg2 = __oe_enclave_status;
-                return;
-            }
-        }
 
-        break;
+            break;
 
-    default:
-        // Return crashed status.
-        *outputArg1 = OE_MakeCallArg1(OE_CODE_ERET, func, 0);
-        *outputArg2 = OE_ENCLAVE_ABORTED;
-        return;
+        default:
+            // Return crashed status.
+            *outputArg1 = OE_MakeCallArg1(OE_CODE_ERET, func, 0);
+            *outputArg2 = OE_ENCLAVE_ABORTED;
+            return;
     }
 
     /* Initialize the enclave the first time it is ever entered */
@@ -697,7 +697,8 @@ void _OE_NotifyNestedExitStart(uint64_t arg1, OE_OCallContext* ocallContext)
 
 void OE_Abort(void)
 {
-    // Once it starts to crash, the state can only transit forward, not backward.
+    // Once it starts to crash, the state can only transit forward, not
+    // backward.
     if (__oe_enclave_status < OE_ENCLAVE_ABORTING)
     {
         __oe_enclave_status = OE_ENCLAVE_ABORTING;

--- a/tests/abortStatus/args.h
+++ b/tests/abortStatus/args.h
@@ -10,6 +10,7 @@ typedef struct _AbortStatusArgs
 {
     volatile uint32_t* thread_ready_count;
     volatile uint32_t* is_enclave_crashed;
+    int divisor;
 
     int ret;
 } AbortStatusArgs;

--- a/tests/abortStatus/enc/enc.cpp
+++ b/tests/abortStatus/enc/enc.cpp
@@ -29,7 +29,6 @@ OE_ECALL void GenerateUnhandledHardwareException(void* args_)
 {
     AbortStatusArgs* args = (AbortStatusArgs*)args_;
     int t = 1;
-    int s = 0;
 
     if (!OE_IsOutsideEnclave(args, sizeof(AbortStatusArgs)))
     {
@@ -38,11 +37,13 @@ OE_ECALL void GenerateUnhandledHardwareException(void* args_)
 
     args->ret = 0;
 
-    // Generate a divided by zero hardware exception. Since there is no
-    // handlers to handle it, the enclave should abort itself.
-    t = t / s;
-
-    OE_HostPrintf("Error: unreachable code is reached.\n");
+    // Generate a divide by zero hardware exception. Since there is no
+    // handler to handle it, the enclave should abort itself.
+    t = t / args->divisor;
+    // We should never get here but this is to trick optimizer
+    args->divisor = t;
+    OE_HostPrintf(
+        "Error: unreachable code is reached. Divisor=%d\n", args->divisor);
     args->ret = -1;
     return;
 }

--- a/tests/abortStatus/host/host.cpp
+++ b/tests/abortStatus/host/host.cpp
@@ -25,6 +25,7 @@ void TestAbortStatus(OE_Enclave* enclave, const char* functionName)
 {
     OE_Result result;
     AbortStatusArgs args;
+    args.divisor = 0;
     args.ret = -1;
 
     printf("=== %s(%s)  \n", __FUNCTION__, functionName);


### PR DESCRIPTION
The new test abortStatus fails with optimized builds and I root-caused this to the following line of interest (where we divide by 0) to be optimized out.
   // Generate a divide by zero hardware exception. Since there is no
    // handlers to handle it, the enclave should abort itself.
    t = t / s;

Modified GenerateUnhandledHardwareException() so that the result of the operation is plugged into args.divisor, a new argument that is set to 0 in the host. 3 files were modified.

common/result.c and enclave/calls.c are formatting changes automatically done by the script. 