### PR TITLE
Fix string buffer length

### DIFF
--- a/tools/dox2md/element.cpp
+++ b/tools/dox2md/element.cpp
@@ -79,7 +79,7 @@ static void _PrintString(ostream& os, const char* s)
                     break;
                 default:
                 {
-                    char buf[4];
+                    char buf[5];
                     snprintf(buf, sizeof(buf), "\\%03o", c);
                     os << c;
                     break;


### PR DESCRIPTION
The current code uses snprintf to print a 4 byte string into a 4 byte buffer. snprintf always NULL-terminates, so the string gets truncated.