### PR TITLE
Fixed cppException and stdcxx test aborts with optimized builds

### DIFF
--- a/3rdparty/libunwind/libunwind/src/unwind/RaiseException.c
+++ b/3rdparty/libunwind/libunwind/src/unwind/RaiseException.c
@@ -23,10 +23,10 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#include <stdbool.h>
 #include "unwind-internal.h"
 
 #ifdef OPEN_ENCLAVE
+#include <stdbool.h>
 extern bool OE_IsWithinEnclave(const void* ptr, size_t size);
 
 //


### PR DESCRIPTION
Modified OE_IsWithinEnclave() to work with the optimizer. This fixes the cppException and stdcxx test aborts with optimized builds (Release, Relwithdbginfo, Debug) -- Referenced in #144 and #143  
Verified on SGX HW and also in simulator modes.