### PR TITLE
tools/oesgx: correctly detect SGX2

### DIFF
--- a/tools/oesgx/oesgx.c
+++ b/tools/oesgx/oesgx.c
@@ -53,14 +53,14 @@ int main(int argc, const char* argv[])
 
         _CPUID(&regs);
 
-        if (HAVE_SGX1(regs))
-        {
-            printf("1\n");
-            return 0;
-        }
         if (HAVE_SGX2(regs))
         {
             printf("2\n");
+            return 0;
+        }
+        if (HAVE_SGX1(regs))
+        {
+            printf("1\n");
             return 0;
         }
     }


### PR DESCRIPTION
SGX2 also sets the SGX1 bit in CPUID, so we'd better test the SGX2 bit first.