### PR TITLE
Fixed usage of program and section header variables in host/elf.c

### DIFF
--- a/host/elf.c
+++ b/host/elf.c
@@ -69,7 +69,7 @@ void* Elf64_GetSegment(const Elf64* elf, size_t index)
 
 Elf64_Shdr* Elf64_GetSectionHeader(const Elf64* elf, size_t index)
 {
-    if (!_Ok(elf) || index >= _GetHeader(elf)->e_phnum)
+    if (!_Ok(elf) || index >= _GetHeader(elf)->e_shnum)
         return NULL;
 
     return _GetShdr(elf, index);
@@ -77,7 +77,7 @@ Elf64_Shdr* Elf64_GetSectionHeader(const Elf64* elf, size_t index)
 
 Elf64_Phdr* Elf64_GetProgramHeader(const Elf64* elf, size_t index)
 {
-    if (!_Ok(elf) || index >= _GetHeader(elf)->e_shnum)
+    if (!_Ok(elf) || index >= _GetHeader(elf)->e_phnum)
         return NULL;
 
     return _GetPhdr(elf, index);


### PR DESCRIPTION
Program header and section header variables were accidentally swapped in function **Elf64_GetSectionHeader** and **Elf64_GetProgramHeader**. Fixed it by swapping them.