### PR TITLE
Fix typo in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Specify the install-prefix to the cmake call. As of now, there is no real need t
 system-wide, so you might use a tree in your home directory:
 
 ```
-build$ cmake -DCMAKE_INSTALL_PREFIX:PATH=$~/openenclave ..
+build$ cmake -DCMAKE_INSTALL_PREFIX:PATH=~/openenclave ..
 build$ make install
 ```
 


### PR DESCRIPTION
Remove errant '$' in a cmake sample.