### PR TITLE
Fix crypto test failures in release mode.

### DIFF
--- a/host/crypto/ec.c
+++ b/host/crypto/ec.c
@@ -362,7 +362,7 @@ OE_Result OE_ECPublicKeyFromCoordinates(
     EC_KEY* ec = NULL;
     EVP_PKEY* pkey = NULL;
     EC_GROUP* group = NULL;
-    EC_POINT* point;
+    EC_POINT* point = NULL;
     BIGNUM* x = NULL;
     BIGNUM* y = NULL;
 

--- a/tests/crypto/ec_tests.c
+++ b/tests/crypto/ec_tests.c
@@ -89,7 +89,7 @@ static void _TestSignAndVerify()
     OE_Result r;
 
     {
-        OE_ECPrivateKey key;
+        OE_ECPrivateKey key = {0};
 
         r = OE_ECPrivateKeyReadPEM(
             (const uint8_t*)_PRIVATE_KEY, sizeof(_PRIVATE_KEY), &key);
@@ -122,7 +122,7 @@ static void _TestSignAndVerify()
     }
 
     {
-        OE_ECPublicKey key;
+        OE_ECPublicKey key = {0};
 
         r = OE_ECPublicKeyReadPEM(
             (const uint8_t*)_PUBLIC_KEY, sizeof(_PUBLIC_KEY), &key);
@@ -224,8 +224,8 @@ static void _TestGenerate()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_ECPrivateKey privateKey;
-    OE_ECPublicKey publicKey;
+    OE_ECPrivateKey privateKey = {0};
+    OE_ECPublicKey publicKey = {0};
     uint8_t* signature = NULL;
     size_t signatureSize = 0;
 
@@ -273,9 +273,9 @@ static void _TestWritePrivate()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_ECPublicKey publicKey;
-    OE_ECPrivateKey key1;
-    OE_ECPrivateKey key2;
+    OE_ECPublicKey publicKey = {0};
+    OE_ECPrivateKey key1 = {0};
+    OE_ECPrivateKey key2 = {0};
     uint8_t* pemData1 = NULL;
     size_t pemSize1 = 0;
     uint8_t* pemData2 = NULL;
@@ -328,7 +328,7 @@ static void _TestWritePublic()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_ECPublicKey key;
+    OE_ECPublicKey key = {0};
     void* pemData = NULL;
     size_t pemSize = 0;
 
@@ -363,8 +363,8 @@ static void _TestCertMethods()
 
     /* Test OE_CertGetECPublicKey() */
     {
-        OE_Cert cert;
-        OE_ECPublicKey key;
+        OE_Cert cert = {0};
+        OE_ECPublicKey key = {0};
 
         r = OE_CertReadPEM(_CERT, sizeof(_CERT), &cert);
         OE_TEST(r == OE_OK);
@@ -423,8 +423,8 @@ static void _TestKeyFromBytes()
 
     /* Create a public EC key and get its bytes */
     {
-        OE_ECPrivateKey privateKey;
-        OE_ECPublicKey publicKey;
+        OE_ECPrivateKey privateKey = {0};
+        OE_ECPublicKey publicKey = {0};
         r = OE_ECGenerateKeyPair(ecType, &privateKey, &publicKey);
         OE_TEST(r == OE_OK);
 
@@ -437,7 +437,7 @@ static void _TestKeyFromBytes()
             &publicKey, xData, &xSize, yData, &ySize);
         OE_TEST(r == OE_OK);
 
-        OE_ECPublicKey key;
+        OE_ECPublicKey key = {0};
         r = OE_ECPublicKeyFromCoordinates(
             &key, ecType, xData, xSize, yData, ySize);
         OE_TEST(r == OE_OK);
@@ -449,7 +449,7 @@ static void _TestKeyFromBytes()
 
     /* Test creating an EC key from bytes */
     {
-        OE_ECPublicKey key;
+        OE_ECPublicKey key = {0};
         const uint8_t xBytes[32] = {
             0xB5, 0x5D, 0x06, 0xD6, 0xE5, 0xA2, 0xC7, 0x2D, 0x5D, 0xA0, 0xAE,
             0xD5, 0x83, 0x61, 0x4C, 0x51, 0x60, 0xD6, 0xFE, 0x90, 0x8A, 0xC2,
@@ -481,9 +481,9 @@ static void _TestKeyFromBytes()
 
     /* Test generating a key and then re-creating it from its bytes */
     {
-        OE_ECPrivateKey privateKey;
-        OE_ECPublicKey publicKey;
-        OE_ECPublicKey publicKey2;
+        OE_ECPrivateKey privateKey = {0};
+        OE_ECPublicKey publicKey = {0};
+        OE_ECPublicKey publicKey2 = {0};
         uint8_t signature[1024];
         size_t signatureSize = sizeof(signature);
 

--- a/tests/crypto/hash.c
+++ b/tests/crypto/hash.c
@@ -3,7 +3,7 @@
 
 #include "hash.h"
 
-const char ALPHABET[26] = "abcdefghijklmnopqrstuvwxyz";
+const char* ALPHABET = "abcdefghijklmnopqrstuvwxyz";
 
 /* Hash of ALPHABET string above */
 OE_SHA256 ALPHABET_HASH = {{

--- a/tests/crypto/hash.h
+++ b/tests/crypto/hash.h
@@ -7,7 +7,7 @@
 #include <openenclave/bits/sha.h>
 
 /* Upper case alphabet */
-extern const char ALPHABET[26];
+extern const char* ALPHABET;
 
 /* Hash of ALPHABET string above */
 extern OE_SHA256 ALPHABET_HASH;

--- a/tests/crypto/rsa_tests.c
+++ b/tests/crypto/rsa_tests.c
@@ -114,7 +114,7 @@ static void _TestSign()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_RSAPrivateKey key;
+    OE_RSAPrivateKey key = {0};
     uint8_t* signature = NULL;
     size_t signatureSize = 0;
 
@@ -157,7 +157,7 @@ static void _TestVerify()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_RSAPublicKey key;
+    OE_RSAPublicKey key = {0};
 
     r = OE_RSAPublicKeyReadPEM(
         (const uint8_t*)_PUBLIC_KEY, sizeof(_PUBLIC_KEY), &key);
@@ -321,9 +321,9 @@ static void _TestCertVerifyGood()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_VerifyCertError error;
-    OE_Cert cert;
-    OE_CertChain chain;
+    OE_VerifyCertError error = {0};
+    OE_Cert cert = {0};
+    OE_CertChain chain = {0};
     OE_CRL* crl = NULL;
 
     r = OE_CertReadPEM(_CERT1, sizeof(_CERT1), &cert);
@@ -346,9 +346,9 @@ static void _TestCertVerifyBad()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_VerifyCertError error;
-    OE_Cert cert;
-    OE_CertChain chain;
+    OE_VerifyCertError error = {0};
+    OE_Cert cert = {0};
+    OE_CertChain chain = {0};
     OE_CRL* crl = NULL;
 
     r = OE_CertReadPEM(_CERT1, sizeof(_CERT1), &cert);
@@ -372,8 +372,8 @@ static void _TestMixedChain()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_Cert cert;
-    OE_CertChain chain;
+    OE_Cert cert = {0};
+    OE_CertChain chain = {0};
 
     r = OE_CertReadPEM(_CERT1, sizeof(_CERT1), &cert);
     OE_TEST(r == OE_OK);
@@ -393,8 +393,8 @@ static void _TestGenerate()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_RSAPrivateKey privateKey;
-    OE_RSAPublicKey publicKey;
+    OE_RSAPrivateKey privateKey = {0};
+    OE_RSAPublicKey publicKey = {0};
     uint8_t* signature = NULL;
     size_t signatureSize = 0;
 
@@ -442,7 +442,7 @@ static void _TestWritePrivate()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_RSAPrivateKey key;
+    OE_RSAPrivateKey key = {0};
     void* pemData = NULL;
     size_t pemSize = 0;
 
@@ -472,7 +472,7 @@ static void _TestWritePublic()
     printf("=== begin %s()\n", __FUNCTION__);
 
     OE_Result r;
-    OE_RSAPublicKey key;
+    OE_RSAPublicKey key = {0};
     void* pemData = NULL;
     size_t pemSize = 0;
 
@@ -505,12 +505,12 @@ static void _TestCertMethods()
 
     /* Test OE_CertGetRSAPublicKey() */
     {
-        OE_Cert cert;
+        OE_Cert cert = {0};
 
         r = OE_CertReadPEM(_CERT1, sizeof(_CERT1), &cert);
         OE_TEST(r == OE_OK);
 
-        OE_RSAPublicKey key;
+        OE_RSAPublicKey key = {0};
         r = OE_CertGetRSAPublicKey(&cert, &key);
         OE_TEST(r == OE_OK);
 
@@ -569,7 +569,7 @@ static void _TestCertMethods()
 
     /* Test OE_CertChainGetCert() */
     {
-        OE_CertChain chain;
+        OE_CertChain chain = {0};
 
         /* Load the chain from PEM format */
         r = OE_CertChainReadPEM(CHAIN1, sizeof(CHAIN1), &chain);
@@ -584,7 +584,7 @@ static void _TestCertMethods()
         /* Get each certificate in the chain */
         for (size_t i = 0; i < length; i++)
         {
-            OE_Cert cert;
+            OE_Cert cert = {0};
             r = OE_CertChainGetCert(&chain, i, &cert);
             OE_TEST(r == OE_OK);
             OE_CertFree(&cert);
@@ -592,7 +592,7 @@ static void _TestCertMethods()
 
         /* Test out of bounds */
         {
-            OE_Cert cert;
+            OE_Cert cert = {0};
             r = OE_CertChainGetCert(&chain, length + 1, &cert);
             OE_TEST(r == OE_OUT_OF_BOUNDS);
             OE_CertFree(&cert);
@@ -603,10 +603,10 @@ static void _TestCertMethods()
 
     /* Test OE_CertChainGetRootCert() and OE_CertChainGetLeafCert() */
     {
-        OE_CertChain chain;
-        OE_Cert root;
-        OE_Cert cert0;
-        OE_Cert leaf;
+        OE_CertChain chain = {0};
+        OE_Cert root = {0};
+        OE_Cert cert0 = {0};
+        OE_Cert leaf = {0};
 
         /* Load the chain from PEM format */
         r = OE_CertChainReadPEM(CHAIN1, sizeof(CHAIN1), &chain);
@@ -626,8 +626,8 @@ static void _TestCertMethods()
 
         /* Check that the keys are identical for top and root certificate */
         {
-            OE_RSAPublicKey rootKey;
-            OE_RSAPublicKey certKey;
+            OE_RSAPublicKey rootKey = {0};
+            OE_RSAPublicKey certKey = {0};
             bool equal;
 
             OE_TEST(OE_CertGetRSAPublicKey(&root, &rootKey) == OE_OK);
@@ -642,8 +642,8 @@ static void _TestCertMethods()
 
         /* Check that the keys are not identical for leaf and root */
         {
-            OE_RSAPublicKey rootKey;
-            OE_RSAPublicKey leafKey;
+            OE_RSAPublicKey rootKey = {0};
+            OE_RSAPublicKey leafKey = {0};
             bool equal;
 
             OE_TEST(OE_CertGetRSAPublicKey(&root, &rootKey) == OE_OK);

--- a/tests/crypto/sha_tests.c
+++ b/tests/crypto/sha_tests.c
@@ -17,8 +17,8 @@ void TestSHA()
 {
     printf("=== begin %s()\n", __FUNCTION__);
 
-    OE_SHA256 hash;
-    OE_SHA256Context ctx;
+    OE_SHA256 hash = {0};
+    OE_SHA256Context ctx = {0};
     OE_SHA256Init(&ctx);
     OE_SHA256Update(&ctx, ALPHABET, strlen(ALPHABET));
     OE_SHA256Final(&ctx, &hash);


### PR DESCRIPTION
Mostly due to uninitialized locals.
Also use of strlen on non-nullterminated string.