### PR TITLE
Fix build issue with USE_LIBSGX=1

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -46,13 +46,13 @@ add_library(oehost STATIC
     load.c
     memalign.c
     ocalls.c
-    oe_sgx_ql.c
     quote.c
     registers.c
     report.c
     result.c
     sgxload.c
     sgxmeasure.c
+    sgxquote.c
     sgxtypes.c
     signkey.c
     strings.c

--- a/host/quote.c
+++ b/host/quote.c
@@ -10,7 +10,7 @@
 #include <openenclave/internal/utils.h>
 
 #if defined(OE_USE_LIBSGX)
-#include "oe_sgx_ql.h"
+#include "sgxquote.h"
 #include "sgxquoteprovider.h"
 #else
 #include <openenclave/internal/aesm.h>
@@ -159,7 +159,7 @@ oe_result_t sgx_get_qetarget_info(sgx_target_info_t* targetInfo)
     // called many times.
 
     oe_initialize_quote_provider();
-    result = oe_sgx_qe_get_target_info( (uint8_t*) targetInfo);
+    result = oe_sgx_qe_get_target_info((uint8_t*)targetInfo);
 
 #else
 
@@ -229,7 +229,7 @@ oe_result_t sgx_get_quote(
 
 #if defined(OE_USE_LIBSGX)
 
-    result = oe_sgx_qe_get_quote( (uint8_t*)report, *quoteSize, quote);
+    result = oe_sgx_qe_get_quote((uint8_t*)report, *quoteSize, quote);
 
 #else
 

--- a/host/sgxquote.c
+++ b/host/sgxquote.c
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 #if defined(OE_USE_LIBSGX)
 
-#include "oe_sgx_ql.h"
+#include "sgxquote.h"
 #include <sgx_ql_oe_wrapper.h>
+
+// Check consistency with OE definition.
+OE_STATIC_ASSERT(sizeof(sgx_target_info_t) == 512);
+OE_STATIC_ASSERT(sizeof(sgx_report_t) == 432);
 
 oe_result_t oe_sgx_qe_get_target_info(uint8_t* targetInfo)
 {
-    // Check consistency with OE definition.
-    OE_STATIC_ASSERT(sizeof(sgx_target_info_t) == 512);
-
     quote3_error_t err = sgx_qe_get_target_info((sgx_target_info_t*)targetInfo);
     return (err == SGX_QL_SUCCESS) ? OE_OK : OE_PLATFORM_ERROR;
 }
@@ -25,7 +26,6 @@ oe_result_t oe_sgx_qe_get_quote(
     uint32_t quoteSize,
     uint8_t* quote)
 {
-    OE_STATIC_ASSERT(sizeof(sgx_report_t) == sizeof(sgx_report_t));
     quote3_error_t err =
         sgx_qe_get_quote((sgx_report_t*)report, quoteSize, quote);
     return (err == SGX_QL_SUCCESS) ? OE_OK : OE_PLATFORM_ERROR;

--- a/host/sgxquote.h
+++ b/host/sgxquote.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#ifndef _OE_SGX_QL_H
-#define _OE_SGX_QL_H
+#ifndef _OE_SGXQUOTE_H
+#define _OE_SGXQUOTE_H
 
 #include <openenclave/bits/result.h>
 #include <openenclave/bits/types.h>
@@ -14,4 +14,4 @@ oe_result_t oe_sgx_qe_get_quote(
     uint32_t quoteSize,
     uint8_t* quote);
 
-#endif
+#endif // _OE_SGXQUOTE_H


### PR DESCRIPTION
With USE_LIBSGX=1 host/quote.c include /usr/include/sgx_ql_oe_wrapper.h.
This causes conflicting definitions for sgx_attributes_t, sgx_report_t etc..a lot of types.
There is no easy way to allow redefinitions in C.

For now, create a oe_sgx_ql.c that includes sgx_ql_oe_wrapper.h, and have quote.c include only sgxtypes.h.