### PR TITLE
Added graphviz package 

### DIFF
--- a/prereqs/packages/Makefile
+++ b/prereqs/packages/Makefile
@@ -26,8 +26,7 @@ PACKAGES=build-essential \
 	cloc \
 	libexpat1 \
 	libexpat1-dev \
-	ccache \
-	graphviz
+	ccache
 
 all: .packages
 

--- a/scripts/install-prereqs
+++ b/scripts/install-prereqs
@@ -10,7 +10,7 @@
 # and add it to the list.
 #
 
-# Needed for Open Enclve build and scripts
+# Needed for Open Enclave build and scripts
 PACKAGES="clang-format cmake gcc g++ make"
 
 # Needed for using oedbg
@@ -20,7 +20,7 @@ PACKAGES="$PACKAGES gdb"
 PACKAGES="$PACKAGES autoconf libtool"
 
 # Needed to generate documentation during make
-PACKAGES="$PACKAGES doxygen"
+PACKAGES="$PACKAGES doxygen graphviz"
 
 # Needed for cmake/get_c_compiler_dir.sh
 PACKAGES="$PACKAGES gawk"


### PR DESCRIPTION
Fix for #332 

I was seeing tons of dot error messages (benign) with the make command (the following was reported by John) which went away after installing graphviz package on my Ubuntu VM. So, added this to the list of prereqs/packages.

error: Problems running dot: exit code=127, command='dot', arguments='"/home/johnliu/dev/openenclave/build/doc/refman/html/result_8h__dep__incl.dot" -Tpng -o "/home/johnliu/dev/openenclave/build/doc/refman/html/result_8h__dep__incl.png"'
dot: not found
