### PR TITLE
Fix for #365 - make error with cmake .. due to missing libssl-dev

### DIFF
--- a/scripts/install-prereqs
+++ b/scripts/install-prereqs
@@ -31,6 +31,9 @@ PACKAGES="$PACKAGES libexpat1-dev"
 # Needed for oesign
 PACKAGES="$PACKAGES openssl"
 
+# Needed for oehost
+PACKAGES="$PACKAGES libssl-dev"
+
 # Needed for 3rdparty/libcxx/update.make
 PACKAGES="$PACKAGES subversion"
 


### PR DESCRIPTION
This is PR request for #365 
Error infor:
Make Error: The following varible are used in this project, but they are set to NOTFOUND.
Linked by target: "oehost" in directory /home/johnlui/openenclave/host
------------------
Steps to repro this:  (You need a fresh Ubuntu VM to see this).

Create a fresh Ubuntu VM with 16.04 LTS

- Install git
- do a git clone of the OE repository
- cd
- sudo ./scripts/install-prereqs
- mkdir build
- cd build
- cmake ..

Please note that you will not see this if you are running on SGX h/w as sudo make -C prereqs will install libssl-dev. This step is not needed for simulation or builds on non-SGX h/w
