### PR TITLE
tests/VectorException : Windows compilation fixed

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_subdirectory(SampleApp)
 add_subdirectory(SampleAppCRT)
 add_subdirectory(sealKey)
 add_subdirectory(stdcxx)
+add_subdirectory(VectorException)
 endif()
 
 if (UNIX)
@@ -52,7 +53,6 @@ add_subdirectory(NestedCall)
 add_subdirectory(ricochet)
 add_subdirectory(stdc)
 add_subdirectory(thread)
-add_subdirectory(VectorException)
 
 # Following five tests are UNIX only because they depend on the oegen tool
 # that is not supported on Windows.

--- a/tests/VectorException/host/host.c
+++ b/tests/VectorException/host/host.c
@@ -47,6 +47,7 @@ void TestSigillHandling(oe_enclave_t* enclave)
     {
         uint32_t cpuidInfo[OE_CPUID_REG_COUNT];
         memset(cpuidInfo, 0, sizeof(cpuidInfo));
+#if defined(__linux__)
         int supported = __get_cpuid_count(
             i,
             0,
@@ -60,6 +61,9 @@ void TestSigillHandling(oe_enclave_t* enclave)
                 "Test machine does not support CPUID leaf %x expected by "
                 "TestSigillHandling.\n",
                 i);
+#elif defined(_WIN32)
+        __cpuid(cpuidInfo[i], i);
+#endif
 
         for (int j = 0; j < OE_CPUID_REG_COUNT; j++)
         {


### PR DESCRIPTION
tests/VectorException : Windows compilation fixed but test for windows throws illegal instruction exception.