### PR TITLE
Added multi-thread hardware exception test to abortStatus.

### DIFF
--- a/tests/abortStatus/README.md
+++ b/tests/abortStatus/README.md
@@ -11,3 +11,5 @@ enclave.
 * Enclave is aborted in one thread, other active enclave threads can return to 
 host with correct abort status, and both enclave thread and host thread can exit
 gracefully.
+* Same case as scenario 3, but the enclave is aborted due to an un-handled
+hardware exception.


### PR DESCRIPTION
For #23, there were some tests for abort / exceptions and threading, but it looks like abortStatus already covered most of them. Just added another test for checking an hardware exception in a multi threaded scenario. 