### PR TITLE
Changes to access private Docker hub image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
   pre-commit-test:
     docker:
       - image: oeciteam/oetools:1.1
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
     working_directory: ~/Microsoft-OE
     steps:
       - checkout


### PR DESCRIPTION
As the Docker image oetools was made private after adding libsgx packages, the authentication information is now needed to access the Docker image. Created 2 new environment variables DOCKERHUB_PASSWORD and DOCKER_HUB_USER in the CircleCI Project Settings page (https://circleci.com/gh/Microsoft/openenclave/edit#env-vars) which does not expose the username/password. These environment variables are referenced in the YAML file.