### PR TITLE
Bug@libcxxrt#316

### DIFF
--- a/tests/libcxxrt/CMakeLists.txt
+++ b/tests/libcxxrt/CMakeLists.txt
@@ -1,23 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-if(NOT EXISTS ${PROJECT_BINARY_DIR}/3rdparty/libcxxrt-test/build)
-    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/3rdparty/libcxxrt-test/build)
-endif()
-
-include (ExternalProject)
-ExternalProject_Add(libcxxrt-test
-    DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/3rdparty/libcxxrt/libcxxrt ${PROJECT_BINARY_DIR}/3rdparty/libcxxrt-test
-    CONFIGURE_COMMAND cd ${PROJECT_BINARY_DIR}/3rdparty/libcxxrt-test/build && cmake ..
-    BUILD_COMMAND $(MAKE) -C ${PROJECT_BINARY_DIR}/3rdparty/libcxxrt-test/build
-    # copy libs & test scripts
-    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy
-        ${PROJECT_BINARY_DIR}/3rdparty/libcxxrt-test/build/lib/libcxxrt.a ${PROJECT_BINARY_DIR}/tests/libcxxrt/libcxxrt-test.a
-        COMMAND ${CMAKE_COMMAND} -E copy
-        ${PROJECT_SOURCE_DIR}/3rdparty/libcxxrt/libcxxrt/test/run_test.sh ${PROJECT_BINARY_DIR}/tests/libcxxrt/
-)
-
+file(COPY ${PROJECT_SOURCE_DIR}/3rdparty/libcxxrt/libcxxrt/test/run_test.sh DESTINATION ${PROJECT_BINARY_DIR}/tests/libcxxrt/)
 # add a test-case for each file listed in tests.supported
 include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/get_testcase_name.cmake)
 
@@ -32,15 +16,10 @@ foreach(testcase ${alltests})
         add_executable(${name}
             enc/${name}.cpp
         )
-        add_dependencies(${name} libcxxrt-test)
         target_compile_options(${name} PRIVATE
             -Wno-error
         )
-        target_include_directories(${name} PRIVATE
-            ${PROJECT_SOURCE_DIR}/3rdparty/libcxxrt/libcxxrt/src
-            ${PROJECT_SOURCE_DIR}/3rdparty/libcxx/libcxx/include/
-        )
-        target_link_libraries(${name} ${PROJECT_BINARY_DIR}/tests/libcxxrt/libcxxrt-test.a gcc_s dl c)
+        target_link_libraries(${name} gcc_s pthread dl c)
 # Generating expected output with system-test
         add_custom_target(test-expected-${name}-output ALL
                 COMMAND ${name} > ${PROJECT_BINARY_DIR}/tests/libcxxrt/exp_${name}_output.log 2>&1

--- a/tests/libcxxrt/README.md
+++ b/tests/libcxxrt/README.md
@@ -60,9 +60,8 @@ the enclave version compares the log of the test built against **libcxxrt
 using OE dependencies** (e.g. OE version of libunwind) with the log of the
 one built against **libcxxrt and standard library dependencies**.
 
-Note that test_exception.cc requires std::uncaught_exceptions(), which is not
-supported by gcc version 5 that Open Enclave targets as the standard compiler
-version. With compilers that support this, such as Clang 3.8, or gcc version 6
-and above, the comparison version of the test can be compiled directly against
-system dependent libraries instead of **libcxxrt and standard library
-dependencies**.
+Note that test_exception.cc requires std::uncaught_exceptions(), which requires
+cpp standard **stdc++17** (or above) with compiler version **GCC version 6 or
+Clang 3.8** (or above). But Open Enclave currently support only **GCC version
+5 with cpp standard stdc++14** (at the most). Hence, test_exception.cc is not
+currently supported in Open Enclave.

--- a/tests/libcxxrt/tests.supported
+++ b/tests/libcxxrt/tests.supported
@@ -1,4 +1,3 @@
 test_foreign_exceptions.cpp
 test_guard.cpp
 test_typeinfo.cpp
-test_exception.cpp

--- a/tests/libcxxrt/tests.unsupported
+++ b/tests/libcxxrt/tests.unsupported
@@ -1,0 +1,1 @@
+test_exception.cpp


### PR DESCRIPTION
This bug arises due to mix up of third party libc headers with system libc headers when tried to support a test named "test_exception.cc" under libcxxrt. test_exception.cc requires std::uncaught_exceptions(), which requires stdc++17 (or above) with compiler version GCC version 6 or Clang 3.8 (or above). But Open Enclave currently support only GCC version 5 with cpp standard stdc++14 (at the most). Hence, test_exception.cc is not currently supported in Open Enclave.

Fixes #316 #325 