### PR TITLE
Feature.corelibc.status@exit

### DIFF
--- a/enclave/core/calls.c
+++ b/enclave/core/calls.c
@@ -9,12 +9,12 @@
 #include <openenclave/internal/fault.h>
 #include <openenclave/internal/globals.h>
 #include <openenclave/internal/hostalloc.h>
+#include <openenclave/internal/malloc.h>
+#include <openenclave/internal/print.h>
 #include <openenclave/internal/reloc.h>
 #include <openenclave/internal/sgxtypes.h>
 #include <openenclave/internal/trace.h>
-#include <openenclave/internal/malloc.h>
 #include <openenclave/internal/utils.h>
-#include <openenclave/internal/print.h>
 
 #include "asmdefs.h"
 #include "cpuid.h"
@@ -287,7 +287,7 @@ static void _HandleECall(
     /* Insert ECALL context onto front of TD.ecalls list */
     Callsite callsite;
     uint64_t argOut = 0;
-    uint64_t LeakBytes=0;
+    uint64_t LeakBytes = 0;
 
     oe_memset(&callsite, 0, sizeof(callsite));
     TD_PushCallsite(td, &callsite);
@@ -333,10 +333,10 @@ static void _HandleECall(
         }
         case OE_FUNC_DESTRUCTOR:
         {
-	    LeakBytes=oe_print_malloc_stats();
+            LeakBytes = oe_print_malloc_stats();
 #if (OE_TRACE_LEVEL >= OE_TRACE_LEVEL_INFO)
-	    if(LeakBytes)
-		oe_host_printf("\nLeak of %ld bytes detected \n",LeakBytes);
+            if (LeakBytes)
+                oe_host_printf("\nLeak of %ld bytes detected \n", LeakBytes);
 #endif
             /* Call functions installed by __cxa_atexit() and oe_atexit() */
             oe_call_at_exit_functions();

--- a/enclave/core/enclavelibc/malloc.c
+++ b/enclave/core/enclavelibc/malloc.c
@@ -167,7 +167,7 @@ done:
     return ret;
 }
 
-uint64_t oe_print_malloc_stats ( )
+uint64_t oe_print_malloc_stats()
 {
     oe_malloc_stats_t Stats;
     oe_get_malloc_stats(&Stats);

--- a/include/openenclave/internal/malloc.h
+++ b/include/openenclave/internal/malloc.h
@@ -43,7 +43,7 @@ typedef struct _oe_malloc_stats
  * @return -1 failure
  */
 oe_result_t oe_get_malloc_stats(oe_malloc_stats_t* stats);
-uint64_t oe_print_malloc_stats (void);
+uint64_t oe_print_malloc_stats(void);
 OE_EXTERNC_END
 
 #endif /* _OE_MALLOC_H */


### PR DESCRIPTION
Adding the feature for leak detection for corelibc branch under oe_enclave_terminate functionality.

All tests are tested under this fix and it should be developed as a part of feature.corelibc branch functionality

leaks founded so far is,

                   tests                                                     |       leak (in bytes)
             ----------------------------------------------------------------------------------
               tests/cppException                                             8288
                tests/libc/api_main                                             32
                tests/libc/functional_clock_gettime                    32
                tests/libc/functional_qsort                                  32
                tests/libc/functional_wcsstr                               32
                tests/libc/math_acos                                         32
                tests/libc/math_fenv                                         32
                tests/libc/math_nearbyint                                 32
                tests/libc/regression_fpclassify-invalid-ld80     32
                tests/libc/regression_malloc-0                         32
                tests/libc/regression_wcsncpy-read-overflow  32
                tests/ocall-alloc                                                40
                tests/stdcxx                                                      8320
                tests/libcxxrt/test_foreign_exceptions              8288
                tests/libcxxrt/test_exception                             8288
                tests/tester                                                       32
