### PR TITLE
Fix libcxxrt build with GCC 7.3

### DIFF
--- a/3rdparty/libcxxrt/CMakeLists.txt
+++ b/3rdparty/libcxxrt/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 # Compile CXXRT
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-tautological-compare")
+
 # build cxxrt sources passing additional options
 add_subdirectory(libcxxrt/src)
 target_compile_options(cxxrt-static PRIVATE


### PR DESCRIPTION
Building the current master with gcc version 7.3.0 (Ubuntu 7.3.0-21ubuntu1~16.04) yields the following errors:

$HOME/openenclave/3rdparty/libcxxrt/libcxxrt/src/guard.cc: In function ‘int __cxa_guard_acquire(volatile guard_t*)’:
$HOME/openenclave/3rdparty/libcxxrt/libcxxrt/src/guard.cc:138:23: error: self-comparison always evaluates to true [-Werror=tautological-compare]
    if (INIT_PART(guard_object) == LOCK_PART(guard_object))
        ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
$HOME/openenclave/3rdparty/libcxxrt/libcxxrt/src/guard.cc:150:22: error: self-comparison always evaluates to true [-Werror=tautological-compare]
   if (INIT_PART(guard_object) == LOCK_PART(guard_object) &&
       ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
$HOME/openenclave/3rdparty/libcxxrt/libcxxrt/src/guard.cc:158:22: error: self-comparison always evaluates to false [-Werror=tautological-compare]
   if (INIT_PART(guard_object) != LOCK_PART(guard_object) &&
       ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
$HOME/openenclave/3rdparty/libcxxrt/libcxxrt/src/guard.cc: In function ‘void __cxa_guard_release(volatile guard_t*)’:
$HOME/openenclave/3rdparty/libcxxrt/libcxxrt/src/guard.cc:183:21: error: self-comparison always evaluates to true [-Werror=tautological-compare]
  if (INIT_PART(guard_object) == LOCK_PART(guard_object))
      ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
$HOME/openenclave/3rdparty/libcxxrt/libcxxrt/src/guard.cc:191:21: error: self-comparison always evaluates to false [-Werror=tautological-compare]
  if (INIT_PART(guard_object) != LOCK_PART(guard_object))
      ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors

Turning off this particular warning fixes the problem without complicating the next sync-up(s) with upstream, so it seemed like a reasonable thing to do. There are other options of course.