### PR TITLE
Fix build break (releated to backtrace in release mode)

### DIFF
--- a/tests/backtrace/host/host.cpp
+++ b/tests/backtrace/host/host.cpp
@@ -21,7 +21,7 @@ static void _print_backtrace(
     int num_expected_symbols,
     const char* expected_symbols[])
 {
-    /* Backtrace does not work in release mode */
+/* Backtrace does not work in release mode */
 #ifndef NDEBUG
 
     char** symbols = oe_backtrace_symbols(enclave, buffer, size);


### PR DESCRIPTION
The test backtrace failed in RelWithDebInfo and Release mode in SGX1 mode. Here is the info from the CI run:

The following tests FAILED:
             41 - tests/backtrace (Child aborted)
Errors while running CTest
 Test failed for SGX1 RELEASE in simulation mode