### PR TITLE
CI - Merge branch to master before build and test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - checkout
       # Merge master to your branch; check if not master
-      - run : 
+      - run: 
           name: Check-Precommit-Reqs Test
           command: | 
             if [ ${CIRCLE_BRANCH} != "master" ]; then


### PR DESCRIPTION
Since conflicts or build failures can potentially arise after the PR branch has been approved and merge to master happens, doing the merge of branch to master before the CI run. 