### PR TITLE
Adds the USE_PKGS_IN variable for prereq fetching.

### DIFF
--- a/prereqs/ngsa/Makefile
+++ b/prereqs/ngsa/Makefile
@@ -61,9 +61,15 @@ PACKAGES_INSTALLED=\
 # packages for apt-get
 get-package:
 	apt-get -y install wget dpkg-dev
+ifdef USE_PKGS_IN
+	@ for PKG in $(PACKAGES); do \
+		cp $(USE_PKGS_IN)/$$PKG .; \
+	done
+else
 	@ for PKG in $(PACKAGES); do \
 		wget http://10.224.140.70:8888/$$PKG; \
 	done
+endif
 
 check-installed:
 	@ for PKG in $(PACKAGES_INSTALLED); do \

--- a/prereqs/sgx-driver/Makefile
+++ b/prereqs/sgx-driver/Makefile
@@ -35,7 +35,11 @@ RUNNING=$(shell lsmod | grep intel_sgx)
 # Workaround until sgx_linux_x64_driver.bin is available from public endpoint
 get-driver:
 	apt-get -y install wget
+ifdef USE_PKGS_IN
+	cp $(USE_PKGS_IN)/sgx_linux_x64_driver.bin .
+else
 	@ wget http://10.224.140.70:8888/sgx_linux_x64_driver.bin
+endif
 	chmod 744 sgx_linux_x64_driver.bin
 
 check-running:


### PR DESCRIPTION
This change allows for a user to specify the USE_PKGS_IN environment variable as a path to a local directory where the private packages can be found. This simplifies the experience for people that use Azure VMs that do not have access to the firewalled web server but have the ability to put those packages manually on the Azure VM.

To use this, specify USE_PKGS_IN on the command line when running "make -C prereqs" and "make -C prereqs install". Similar to this:

sudo make -C prereqs USE_LIBSGX=1 USE_PKGS_IN=/home/johnkord
sudo make -C prereqs install USE_LIBSGX=1 USE_PKGS_IN=/home/johnkord

