### PR TITLE
Fix to check whether the ArgIn taken by _HandleInitEnclave is outside enclave

### DIFF
--- a/enclave/core/calls.c
+++ b/enclave/core/calls.c
@@ -136,7 +136,6 @@ static oe_result_t _HandleInitEnclave(uint64_t argIn)
     {
         if (!oe_is_outside_enclave(
                 (void*)argIn, sizeof(oe_init_enclave_args_t)))
-
         {
             OE_THROW(OE_INVALID_PARAMETER);
         }


### PR DESCRIPTION

  As part of #8 a fix for _HandleInitEnclave interface function for the host enclave interface.