### PR TITLE
Apply -nostdinc++ only for C++ compilation

### DIFF
--- a/3rdparty/libcxx/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/libcxx/CMakeLists.txt
@@ -460,7 +460,7 @@ endif()
 # MSVC only has -X, which disables all default includes; including the crt.
 # Thus, we do nothing and hope we don't accidentally include any of the C++
 # headers
-add_compile_flags_if_supported(-nostdinc++)
+add_cxx_compile_flags_if_supported(-nostdinc++)
 
 # Hide all inline function definitions which have not explicitly been marked
 # visible. This prevents new definitions for inline functions from appearing in

--- a/3rdparty/libcxx/libcxx/cmake/Modules/HandleLibcxxFlags.cmake
+++ b/3rdparty/libcxx/libcxx/cmake/Modules/HandleLibcxxFlags.cmake
@@ -152,6 +152,16 @@ macro(add_compile_flags_if_supported)
   endforeach()
 endmacro()
 
+# For each specified flag, add that flag for C++ compilation
+# to 'LIBCXX_COMPILE_FLAGS' if the flag is supported by the C++ compiler.
+macro(add_cxx_compile_flags_if_supported)
+  foreach(flag ${ARGN})
+      mangle_name("${flag}" flagname)
+      check_cxx_compiler_flag("${flag}" "LIBCXX_SUPPORTS_${flagname}_FLAG")
+      add_compile_flags_if(LIBCXX_SUPPORTS_${flagname}_FLAG $<$<COMPILE_LANGUAGE:CXX>:${flag}>)
+  endforeach()
+endmacro()
+
 # Add a list of flags to 'LIBCXX_LINK_FLAGS'.
 macro(add_link_flags)
   foreach(f ${ARGN})

--- a/3rdparty/libcxxrt/CMakeLists.txt
+++ b/3rdparty/libcxxrt/CMakeLists.txt
@@ -11,7 +11,7 @@ target_compile_options(cxxrt-static PRIVATE
     -include ${CMAKE_CURRENT_SOURCE_DIR}/stubs.h
     -fPIC
     # cannot use add_link_libraries on out-of-dir target
-    -nostdinc -nostdinc++
+    -nostdinc $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>
     -I${OE_INCDIR}/openenclave/libc
     )
 add_dependencies(cxxrt-static oelibc_includes)


### PR DESCRIPTION
Clang complains if `-nostdinc++` is used for compiling C files. This PR applies the flag for C++ only.