### PR TITLE
Remove redundant argument in test function call leading to warning in clang

### DIFF
--- a/tests/VectorException/enc/sigill_handling.c
+++ b/tests/VectorException/enc/sigill_handling.c
@@ -154,7 +154,7 @@ OE_ECALL void TestSigillHandling(void* args_)
     }
 
     // Test illegal SGX instruction that is not emulated (GETSEC)
-    if (!TestGetsecInstruction(args))
+    if (!TestGetsecInstruction())
     {
         return;
     }


### PR DESCRIPTION
The `TestGetsecInstruction` function in `tests/VectorException/enc/sigill_handling.c` doesn't take any arguments and this PR fixes the relevant call of this function within the test. This lead to a warning in Clang.