### PR TITLE
Avoid oe_segmentation_violation from being optimized out

### DIFF
--- a/include/openenclave/internal/fault.h
+++ b/include/openenclave/internal/fault.h
@@ -15,7 +15,7 @@ OE_INLINE void oe_illegal_instruction(void)
 
 OE_INLINE void oe_segmentation_violation(void)
 {
-    *((int*)0) = 0;
+    *((volatile int*)0) = 0;
 }
 
 OE_INLINE void oe_pause(void)


### PR DESCRIPTION
The changed line produced a warning in clang as below:
```
openenclave/include/openenclave/internal/fault.h:18:5: error: indirection of non-volatile null pointer will be deleted, not trap [-Werror,-Wnull-dereference]
    *((int*)0) = 0;
    ^~~~~~~~~~
openenclave/include/openenclave/internal/fault.h:18:5: note: consider using __builtin_trap() or qualifying pointer with 'volatile'
```

This PR adds the `volatile` keyword to avoid being optimized away.

I note that none of the functions in the `fault.h` file are used anywhere in the code base. So the other option is to remove the file if it's not needed anymore.