### PR TITLE
Temporary clang fix for test using unsupported fputs

### DIFF
--- a/tests/libcxxrt/enc/CMakeLists.txt
+++ b/tests/libcxxrt/enc/CMakeLists.txt
@@ -31,6 +31,14 @@ function(add_libcxxrt_test_enc NAME CXXFILE)
     target_link_libraries(libcxxrttest-${NAME}_enc libcxxrttest-support oelibcxx oelibc cxxrt-static)
     if("${NAME}" STREQUAL "test_foreign_exceptions")
         target_link_libraries(libcxxrttest-${NAME}_enc -Wl,--wrap,_Unwind_RaiseException)
+
+        # Temporary work-around until https://github.com/Microsoft/openenclave/issues/494
+        # is solved. This forces clang to optimize out fputs (unsupported currently) and
+        # instead use fwrite.
+        # TODO remove once fputs is supported
+        if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+            target_compile_options(libcxxrttest-${NAME}_enc PRIVATE -O)
+        endif()
     endif()
 endfunction(add_libcxxrt_test_enc)
 


### PR DESCRIPTION
This is for #494 to be able to compile with clang. The code should be removed again once support for fputs is in place.