### PR TITLE
Remove redundant check that generates warning in clang

### DIFF
--- a/host/calls.c
+++ b/host/calls.c
@@ -281,12 +281,6 @@ static void _HandleCallHost(uint64_t arg)
     if (!args)
         return;
 
-    if (!args->func)
-    {
-        args->result = OE_INVALID_PARAMETER;
-        return;
-    }
-
     args->result = OE_UNEXPECTED;
 
     /* Find the host function with this name */


### PR DESCRIPTION
`args->func` is declared as zero sized array `char func[]` which will always evaluate to true in the check that this PR removes. Clang generates an appropriate warning as well for this case. Apart from that, the function name is already checked within the `oe_call_host` function.