### PR TITLE
Avoid clang warnings in stdcxx test

### DIFF
--- a/tests/stdcxx/enc/enc.cpp
+++ b/tests/stdcxx/enc/enc.cpp
@@ -24,7 +24,7 @@ static string _str;
 class X
 {
   public:
-    X() : _x(0)
+    X()
     {
     }
 
@@ -35,9 +35,6 @@ class X
     virtual void foo()
     {
     }
-
-  private:
-    int _x;
 };
 
 class Y : public X
@@ -172,6 +169,7 @@ OE_ECALL void Test(void* args_)
     {
         struct E
         {
+            int x;
         };
 
         try


### PR DESCRIPTION
X::_x was unused which generated a warning in Clang. struct E had no fields which Clang on the other hand warned about as this has different sizes on C vs C++ (0 and 1). Adding a dummy field removes the warning.