### PR TITLE
Avoid unused function warning in Clang for _DumpRelocations

### DIFF
--- a/host/create.c
+++ b/host/create.c
@@ -782,6 +782,7 @@ done:
     return result;
 }
 
+#if (OE_TRACE_LEVEL >= OE_TRACE_LEVEL_INFO)
 OE_INLINE void _DumpRelocations(const void* data, size_t size)
 {
     const Elf64_Rela* p = (const Elf64_Rela*)data;
@@ -800,6 +801,7 @@ OE_INLINE void _DumpRelocations(const void* data, size_t size)
             OE_LLD(p->r_addend));
     }
 }
+#endif
 
 /*
 **==============================================================================


### PR DESCRIPTION
The function is used like that:
```c
#if (OE_TRACE_LEVEL >= OE_TRACE_LEVEL_INFO)
    _DumpRelocations(relocData, relocSize);
#endif
```
Hence, the definition of the function in the same file should be guarded by the same check, otherwise there will be an unused function warning emitted by Clang.