### PR TITLE
Enable intrinsics in clang & enable xsave globally

### DIFF
--- a/cmake/compilersettings.cmake
+++ b/cmake/compilersettings.cmake
@@ -35,16 +35,17 @@ if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MAT
     # to fix warnings as they arise, so they don't accumulate "to be fixed later".
     add_compile_options(-Wall -Werror $<$<COMPILE_LANGUAGE:C>:-Wjump-misses-init> --no-strict-aliasing)
 
-    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-        # Obtain default gcc include dir to gain access to intrinsics
-        execute_process(
-            COMMAND /bin/bash ${PROJECT_SOURCE_DIR}/cmake/get_c_compiler_dir.sh ${CMAKE_C_COMPILER}
-            OUTPUT_VARIABLE OE_C_COMPILER_INCDIR
-            ERROR_VARIABLE OE_ERR
-        )
-        if(NOT "${OE_ERR}" STREQUAL "")
-            message(FATAL_ERROR ${OE_ERR})
-        endif()
+    # Enables XSAVE intrinsics.
+    add_compile_options(-mxsave)
+
+    # Obtain default compiler include dir to gain access to intrinsics
+    execute_process(
+        COMMAND /bin/bash ${PROJECT_SOURCE_DIR}/cmake/get_c_compiler_dir.sh ${CMAKE_C_COMPILER}
+        OUTPUT_VARIABLE OE_C_COMPILER_INCDIR
+        ERROR_VARIABLE OE_ERR
+    )
+    if(NOT "${OE_ERR}" STREQUAL "")
+        message(FATAL_ERROR ${OE_ERR})
     endif()
 
 elseif(MSVC)

--- a/enclave/core/exception.c
+++ b/enclave/core/exception.c
@@ -381,9 +381,6 @@ void _oe_virtual_exception_dispatcher(TD* td, uint64_t argIn, uint64_t* argOut)
     return;
 }
 
-#pragma GCC push_options
-#pragma GCC target("xsave")
-
 /*
 **==============================================================================
 **
@@ -413,4 +410,3 @@ void _oe_cleanup_xstates(void)
 
     return;
 }
-#pragma GCC pop_options


### PR DESCRIPTION
This PR does two things:
1. Enable intrinsics header discovery for clang, not just gcc. This is related to https://github.com/Microsoft/openenclave/issues/276 and all tests pass.
2. Replace gcc-specific macro for enabling xsave by a compiler flag compatible with both gcc and clang. This is related to https://github.com/Microsoft/openenclave/issues/277#issuecomment-409237418. Since OE cannot work without the code that uses the xsave intrinsics (`_oe_cleanup_xstates`), it makes sense to enable it globally.