### PR TITLE
Updated Docker image 1.6 with minor fix to git user name/email

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -5,7 +5,7 @@
 # IMPORTANT- Please update the version number in the next sentence
 # when you create a new docker image.
 #
-# This Dockerfile script builds an image for tag oetools:1.5
+# This Dockerfile script builds an image for tag oetools:1.6
 
 # To use this Dockerfile, you will need to install docker-ce.
 # Instructions for installing it on Ubuntu 16.04 LTS are at:
@@ -69,7 +69,7 @@ RUN dpkg -i libsgx-ngsa-ql_1.0.101.45575-1.0_amd64.deb
 RUN dpkg -i libsgx-ngsa-ql-dev_1.0.101.45575-1.0_amd64.deb
 
 RUN git config --global user.email "oeciteam@microsoft.com"
-RUN git config --global user.email "OE CI Team"
+RUN git config --global user.name "OE CI Team"
 
 # Cleanup after we are done
 RUN rm -f cmake-3.11.4-Linux-x86_64.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   # check-precommit-reqs test - check license and formatting info
   check-precommit-reqs-test:
     docker:
-      - image: oeciteam/oetools:1.5
+      - image: oeciteam/oetools:1.6
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
@@ -28,7 +28,7 @@ jobs:
   # SGX1 | Debug 
   ci-sgx1-debug:
     docker:
-      - image: oeciteam/oetools:1.5
+      - image: oeciteam/oetools:1.6
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
@@ -48,7 +48,7 @@ jobs:
   # SGX1 | RelWithDebInfo
   ci-sgx1-relwithdebinfo:
     docker:
-      - image: oeciteam/oetools:1.5
+      - image: oeciteam/oetools:1.6
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
@@ -68,7 +68,7 @@ jobs:
   # SGX1 | Release
   ci-sgx1-release:
     docker:
-      - image: oeciteam/oetools:1.5
+      - image: oeciteam/oetools:1.6
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
@@ -88,7 +88,7 @@ jobs:
   # SGX1-FLC | Debug 
   ci-sgx1-flc-debug:
     docker:
-      - image: oeciteam/oetools:1.5
+      - image: oeciteam/oetools:1.6
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
@@ -108,7 +108,7 @@ jobs:
   # SGX1-FLC | RelWithDebInfo
   ci-sgx1-flc-relwithdebinfo:
     docker:
-      - image: oeciteam/oetools:1.5
+      - image: oeciteam/oetools:1.6
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
@@ -128,7 +128,7 @@ jobs:
   # SGX1-FLC | Release 
   ci-sgx1-flc-release:
     docker:
-      - image: oeciteam/oetools:1.5
+      - image: oeciteam/oetools:1.6
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
Minor fixes to git user name and email in Dockerfile. Created new image 1.6 and modified config.yml to use this.