### PR TITLE
changing str_rtrim second argument to solve  Windows line endings issue

### DIFF
--- a/tools/oesign/main.c
+++ b/tools/oesign/main.c
@@ -234,7 +234,7 @@ static int _LoadConfigFile(const char* path, ConfigFileOptions* options)
     {
         /* Remove leading and trailing whitespace */
         str_ltrim(&str, " \t");
-        str_rtrim(&str, " \t\n");
+        str_rtrim(&str, " \t\n\r");
 
         /* Skip comments and empty lines */
         if (str_ptr(&str)[0] == '#' || str_len(&str) == 0)


### PR DESCRIPTION
In order to solve windows line ending issue , changed str_rtrim delimiter argument from " \t\n" to "  \t\n\r" .