### PR TITLE
A few CI script changes

### DIFF
--- a/scripts/test-build-config
+++ b/scripts/test-build-config
@@ -130,14 +130,16 @@ fi
 
 #Finally run the tests in Simulator mode or on Hardware
 if [ ${DISABLE_SIM} != 1 ]; then
+   SIMULATION_MODE_TEXT="simulation"
    OE_SIMULATION=1 ctest --output-on-failure
 else
+   SIMULATION_MODE_TEXT="hardware"
    ctest --output-on-failure
 fi
 
 if [ "$?" != "0" ]; then
     echo ""
-    echo "Test failed for ${PLATFORM_MODE} ${BUILD_TYPE} in simulation mode"
+    echo "Test failed for ${PLATFORM_MODE} ${BUILD_TYPE} in ${SIMULATION_MODE_TEXT} mode"
     echo ""
     exit 1
 fi


### PR DESCRIPTION
This fixes 2 bugs:

- The tests will now report accurately when they are being run in hardware mode 
- ctest will now be run with the -V option.  Should this be -VV, or is that too much?