### PR TITLE
Implementation of CRL chains.

### DIFF
--- a/enclave/crl.c
+++ b/enclave/crl.c
@@ -42,28 +42,33 @@ oe_result_t oe_crl_read_der(
     crl_t* impl = (crl_t*)crl;
     mbedtls_x509_crl* x509_crl = NULL;
 
-    /* Clear the implementation */
-    if (impl)
-        oe_memset(impl, 0, sizeof(crl_t));
-
     /* Check for invalid parameters */
     if (!der_data || !der_size || !crl)
         OE_RAISE(OE_UNEXPECTED);
 
-    /* Allocate memory for the CRL */
-    if (!(x509_crl = mbedtls_calloc(1, sizeof(mbedtls_x509_crl))))
-        OE_RAISE(OE_OUT_OF_MEMORY);
+    if (crl_is_valid(impl))
+    {
+        /* Append to crl chain */
+        if (mbedtls_x509_crl_parse_der(impl->crl, der_data, der_size) != 0)
+            OE_RAISE(OE_FAILURE);
+    }
+    else
+    {
+        /* Allocate memory for the CRL */
+        if (!(x509_crl = mbedtls_calloc(1, sizeof(mbedtls_x509_crl))))
+            OE_RAISE(OE_OUT_OF_MEMORY);
 
-    /* Initialize the CRL structure */
-    mbedtls_x509_crl_init(x509_crl);
+        /* Initialize the CRL structure */
+        mbedtls_x509_crl_init(x509_crl);
 
-    /* Parse the DER data to populate the mbedtls_x509_crl struct */
-    if (mbedtls_x509_crl_parse_der(x509_crl, der_data, der_size) != 0)
-        OE_RAISE(OE_FAILURE);
+        /* Parse the DER data to populate the mbedtls_x509_crl struct */
+        if (mbedtls_x509_crl_parse_der(x509_crl, der_data, der_size) != 0)
+            OE_RAISE(OE_FAILURE);
 
-    /* Initialize the implementation */
-    _crl_init(impl, x509_crl);
-    x509_crl = NULL;
+        /* Initialize the implementation */
+        _crl_init(impl, x509_crl);
+        x509_crl = NULL;
+    }
 
     result = OE_OK;
 

--- a/host/crypto/cert.c
+++ b/host/crypto/cert.c
@@ -638,11 +638,14 @@ oe_result_t oe_cert_verify(
         if (!(crls = sk_X509_CRL_new_null()))
             OE_RAISE(OE_OUT_OF_MEMORY);
 
-        if (!_X509_CRL_up_ref(crl_impl->crl))
-            OE_RAISE(OE_FAILURE);
+        for (uint64_t i = 0; i < crl_impl->num_crls; ++i)
+        {
+            if (!_X509_CRL_up_ref(crl_impl->crls[i]))
+                OE_RAISE(OE_FAILURE);
 
-        if (!sk_X509_CRL_push(crls, crl_impl->crl))
-            OE_RAISE(OE_FAILURE);
+            if (!sk_X509_CRL_push(crls, crl_impl->crls[i]))
+                OE_RAISE(OE_FAILURE);
+        }
 
         X509_STORE_CTX_set0_crls(ctx, crls);
     }

--- a/host/crypto/crl.h
+++ b/host/crypto/crl.h
@@ -10,7 +10,8 @@
 typedef struct _crl
 {
     uint64_t magic;
-    X509_CRL* crl;
+    X509_CRL** crls;
+    uint64_t num_crls;
 } crl_t;
 
 bool crl_is_valid(const crl_t* impl);

--- a/include/openenclave/internal/crl.h
+++ b/include/openenclave/internal/crl.h
@@ -19,7 +19,8 @@ typedef struct _oe_crl
 typedef struct _oe_crl oe_crl_t;
 
 /**
- * Read a certificate revocation list (CRL) from DER format.
+ * Read a certificate revocation list (CRL) from DER format
+ * and append it to the given oe_crl_t object.
  *
  * The caller is responsible for releasing the certificate by passing it to
  * oe_crl_free().
@@ -51,6 +52,8 @@ oe_result_t oe_crl_free(oe_crl_t* crl);
  * given CRL. The **last** date specifies when this CRL was last updated. The
  * **next** date specifies when a newer version of the CRL will be available
  * (after which this CRL should be considered invalid).
+ * If the CRL object contains a chain of CRLs then the **last** and **next**
+ * updates of the first CRL is returned.
  *
  * @param crl the handle of a CRL.
  * @param last the date when the CRL was last updated (may be null).


### PR DESCRIPTION
Prototype implementation of CRL chains. 

1. The CRLs for the leaf and intermediate certs passed together to the cert verification API.
2. The certificate chain in the quote is used for cert verification instead of the crl issuer chains.
It is just an intel artifact that these two chains are the same for the leaf cert.

Challenges:
1. mbedtls has the notion of a "crl chain" (linked list of crls). Each crl is a crl-chain. mbedtls has api to read a single crl and append it to a crl-chain.
2. mbedtls cert verify function just take in a pointer to the root of the crl chain (ie crl*)

3. openssl treats each crl as a separate entity. Each crl is not itself a chain (node in a linked list).
4. openssl verification requires all the crls to be pushed to the verification ctx via sk_X509_CRL_push

5. We need last/next update dates for each crl.

Not sure if we need to formalize the notion of "crl-chain".

