### PR TITLE
Use clang++ for C++ when auto-detecting clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if (NOT CMAKE_C_COMPILER AND "$ENV{CC}" STREQUAL "")
     message(STATUS "Trying to find a supported version of Clang")
     find_program(CMAKE_C_COMPILER NAMES clang-7.0 clang-7)
     if (CMAKE_C_COMPILER)
-        set(CMAKE_CXX_COMPILER ${CMAKE_C_COMPILER})
+        string(REPLACE "/clang-" "/clang++-" CMAKE_CXX_COMPILER ${CMAKE_C_COMPILER})
     else()
         message(WARNING "Clang not found, will use default compiler. "
             "Override the compiler by setting CC and CXX environment variables.")


### PR DESCRIPTION
Even though `clang++` is a symlink to `clang`, they behave differently which caused issues in the auto-detection code as it used `clang` for both the C and C++ compiler. This PR fixes that.

CI didn't detect this in #656 as the CI scripts set `CC` and `CXX` explicitly, meaning that the auto-detection logic didn't kick in which would have triggered the bug.