### PR TITLE
Update download location of SGX driver

### DIFF
--- a/prereqs/sgx-driver/Makefile
+++ b/prereqs/sgx-driver/Makefile
@@ -32,13 +32,12 @@ DEV=$(wildcard /dev/sgx)
 
 RUNNING=$(shell lsmod | grep intel_sgx)
 
-# Workaround until sgx_linux_x64_driver.bin is available from public endpoint
 get-driver:
 	apt-get -y install wget
 ifdef USE_PKGS_IN
 	cp $(USE_PKGS_IN)/sgx_linux_x64_driver.bin .
 else
-	@ wget http://10.31.100.105/sgx_linux_x64_driver.bin
+	@ wget https://download.01.org/intel-sgx/dcap-1.0/sgx_linux_x64_driver_dcap_36594a7.bin -O sgx_linux_x64_driver.bin
 endif
 	chmod 744 sgx_linux_x64_driver.bin
 


### PR DESCRIPTION
The driver is now available to the public under the Intel SGX DCAP
Linux 1.0 Release at
https://01.org/intel-software-guard-extensions/downloads

So we can download it from there install of an internal share.