### PR TITLE
Bug-fix and tweaks.

### DIFF
--- a/samples/make/remote_attestation/common/attestation.cpp
+++ b/samples/make/remote_attestation/common/attestation.cpp
@@ -102,10 +102,9 @@ bool Attestation::attest_remote_report(
         goto exit;
     }
 
-    // 2) validate the enclave's identify
-    // signed_id is the hash of the public signing key that was used to sign an
-    // enclave.
-    // Check that the enclave was signed by an trusted entity.
+    // 2) validate the enclave identity's signed_id is the hash of the public
+    // signing key that was used to sign an enclave. Check that the enclave was
+    // signed by an trusted entity.
     if (memcmp(parsed_report.identity.signer_id, m_enclave_mrsigner, 32) != 0)
     {
         ENC_DEBUG_PRINTF("identity.signer_id checking failed.");

--- a/samples/make/remote_attestation/common/attestation.h
+++ b/samples/make/remote_attestation/common/attestation.h
@@ -18,8 +18,7 @@ class Attestation
     Attestation(Crypto* crypto, uint8_t* enclave_mrsigner);
 
     // Generate a remote report for the given data. The SHA256 digest of the
-    // data is stored
-    // in the report_data field of the generated remote report.
+    // data is stored in the report_data field of the generated remote report.
     bool generate_remote_report(
         const uint8_t* data,
         size_t data_size,

--- a/samples/make/remote_attestation/common/dispatcher.cpp
+++ b/samples/make/remote_attestation/common/dispatcher.cpp
@@ -71,11 +71,7 @@ int ecall_dispatcher::get_remote_report_with_pubkey(
     m_crypto->retrieve_public_key(pem_public_key);
 
     // Generate a remote report for the public key so that the enclave that
-    // receives the
-    // key can attest this enclave. It is safer to use enclave memory for all
-    // operations within the enclave. A malicious host could tamper with host
-    // memory while enclave is processing it.
-    // report = new uint8_t[OE_MAX_REPORT_SIZE];
+    // receives the key can attest this enclave.
     report = (uint8_t*)oe_host_malloc(OE_MAX_REPORT_SIZE);
     if (report == NULL)
     {
@@ -111,9 +107,9 @@ exit:
     if (ret != 0)
     {
         if (report)
-            free(report);
+            oe_host_free(report);
         if (key_buf)
-            free(key_buf);
+            oe_host_free(key_buf);
     }
     return ret;
 }
@@ -207,7 +203,7 @@ int ecall_dispatcher::process_encrypted_msg(
     {
         // This is where the business logic for verifying the data should be.
         // In this sample, both enclaves start with identical data in
-        // m_enclave_config->enclave_secret_data
+        // m_enclave_config->enclave_secret_data.
         // The following checking is to make sure the decrypted values are what
         // we have expected.
         ENC_DEBUG_PRINTF("Decrypted data: ");

--- a/samples/make/remote_attestation/enc1/ecalls.cpp
+++ b/samples/make/remote_attestation/enc1/ecalls.cpp
@@ -6,18 +6,16 @@
 
 // For this purpose of this example: demonstrating how to do remote attestation
 // g_enclave_secret_data is hardcoded as part of the enclave. In this sample,
-// the
-// secret data is hard coded as part of the enclave binary. In a real world
+// the secret data is hard coded as part of the enclave binary. In a real world
 // enclave implementation, secrets are never hard coded in the enclave binary
 // since the enclave binary itself is not encrypted. Instead, secrets are
 // acquired via provisioning from a service (such as a cloud server) after
 // successful attestation.
-// This g_enclave_secret_data holds the secret data specific to the holding
+// The g_enclave_secret_data holds the secret data specific to the holding
 // enclave, it's only visible inside this secured enclave. Arbitrary enclave
-// specific seccret data exchanged by the enclaves. In this sample, the first
+// specific secret data exchanged by the enclaves. In this sample, the first
 // enclave sends its g_enclave_secret_data (encrypted) to the second enclave.
-// The
-// this enclave decrypts the received data and adds it to its own
+// The second enclave decrypts the received data and adds it to its own
 // g_enclave_secret_data, and sends it back to the other enclave.
 uint8_t g_enclave_secret_data[ENCLAVE_SECRET_DATA_SIZE] =
     {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};

--- a/samples/make/remote_attestation/enc2/ecalls.cpp
+++ b/samples/make/remote_attestation/enc2/ecalls.cpp
@@ -6,8 +6,7 @@
 
 // For this purpose of this example: demonstrating how to do remote attestation
 // g_enclave_secret_data is hardcoded as part of the enclave. In this sample,
-// the
-// secret data is hard coded as part of the enclave binary. In a real world
+// the secret data is hard coded as part of the enclave binary. In a real world
 // enclave implementation, secrets are never hard coded in the enclave binary
 // since the enclave binary itself is not encrypted. Instead, secrets are
 // acquired via provisioning from a service (such as a cloud server) after
@@ -16,8 +15,7 @@
 // enclave, it's only visible inside this secured enclave. Arbitrary enclave
 // specific secret data exchanged by the enclaves. In this sample, the first
 // enclave sends its g_enclave_secret_data (encrypted) to the second enclave.
-// The
-// this enclave decrypts the received data and adds it to its own
+// The second enclave decrypts the received data and adds it to its own
 // g_enclave_secret_data, and sends it back to the other enclave.
 uint8_t g_enclave_secret_data[ENCLAVE_SECRET_DATA_SIZE] =
     {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};


### PR DESCRIPTION
1. Use oe_host_free for memory allocated in host.
2. Cleanup comment formatting and other comment tweaks.