### PR TITLE
Separate arguments to apt install in install-prereqs

### DIFF
--- a/scripts/install-prereqs
+++ b/scripts/install-prereqs
@@ -40,7 +40,7 @@ PACKAGES+=" subversion"
 # Needed for oeedger8r
 PACKAGES+=" ocaml-native-compilers"
 
-apt-get -y install "$PACKAGES"
+apt-get -y install $PACKAGES
 
 # Now install clang from LLVM private repo, this has the spectre mitigations
 # (unlike anything in Ubuntu 16.04).


### PR DESCRIPTION
At the moment, all the packages are passed in as one argument, since they are quoted, which fails of course:

```
$ sudo ./scripts/install-prereqs
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package clang-format-3.8 cmake make gdb autoconf libtool doxygen graphviz gawk libexpat1-dev openssl libssl-dev subversion ocaml-native-compilers
E: Couldn't find any package by glob 'clang-format-3.8 cmake make gdb autoconf libtool doxygen graphviz gawk libexpat1-dev openssl libssl-dev subversion ocaml-native-compilers'
E: Couldn't find any package by regex 'clang-format-3.8 cmake make gdb autoconf libtool doxygen graphviz gawk libexpat1-dev openssl libssl-dev subversion ocaml-native-compilers'
...
```