### PR TITLE
Fix install-prereqs script regression

### DIFF
--- a/scripts/install-prereqs
+++ b/scripts/install-prereqs
@@ -11,36 +11,36 @@
 #
 
 # Needed for Open Enclave build and scripts
-PACKAGES="clang-format-3.8 cmake make"
+PACKAGES=('clang-format-3.8' 'cmake' 'make')
 
 # Needed for using oedbg
-PACKAGES+=" gdb"
+PACKAGES+=('gdb')
 
 # Needed for 3rdparty/libunwind
-PACKAGES+=" autoconf libtool"
+PACKAGES+=('autoconf' 'libtool')
 
 # Needed to generate documentation during make
-PACKAGES+=" doxygen graphviz"
+PACKAGES+=('doxygen' 'graphviz')
 
 # Needed for cmake/get_c_compiler_dir.sh
-PACKAGES+=" gawk"
+PACKAGES+=('gawk')
 
 # Needed for dox2md document generation
-PACKAGES+=" libexpat1-dev"
+PACKAGES+=('libexpat1-dev')
 
 # Needed for oesign
-PACKAGES+=" openssl"
+PACKAGES+=('openssl')
 
 # Needed for oehost
-PACKAGES+=" libssl-dev"
+PACKAGES+=('libssl-dev')
 
 # Needed for 3rdparty/libcxx/update.make
-PACKAGES+=" subversion"
+PACKAGES+=('subversion')
 
 # Needed for oeedger8r
-PACKAGES+=" ocaml-native-compilers"
+PACKAGES+=('ocaml-native-compilers')
 
-apt-get -y install "$PACKAGES"
+apt-get -y install "${PACKAGES[@]}"
 
 # Now install clang from LLVM private repo, this has the spectre mitigations
 # (unlike anything in Ubuntu 16.04).


### PR DESCRIPTION
Fix for regression in scripts/install-prereqs introduced in #712. Alternative to #732 which preserves @andschwa's fix for [ShellCheck 2086 warning](https://github.com/koalaman/shellcheck/wiki/SC2086)