### PR TITLE
Disable oe_backtrace collection during debug malloc.

### DIFF
--- a/enclave/core/debugmalloc.c
+++ b/enclave/core/debugmalloc.c
@@ -110,17 +110,17 @@ OE_INLINE footer_t* _get_footer(void* ptr)
 }
 
 /* Use a macro so the function name will not appear in the backtrace */
-#define INIT_BLOCK(HEADER, ALIGNMENT, SIZE)                                \
-    do                                                                     \
-    {                                                                      \
-        HEADER->magic1 = HEADER_MAGIC1;                                    \
-        HEADER->next = NULL;                                               \
-        HEADER->prev = NULL;                                               \
-        HEADER->alignment = ALIGNMENT;                                     \
-        HEADER->size = SIZE;                                               \
-        HEADER->num_addrs = oe_backtrace(HEADER->addrs, OE_BACKTRACE_MAX); \
-        HEADER->magic2 = HEADER_MAGIC2;                                    \
-        _get_footer(HEADER->data)->magic = FOOTER_MAGIC;                   \
+#define INIT_BLOCK(HEADER, ALIGNMENT, SIZE)              \
+    do                                                   \
+    {                                                    \
+        HEADER->magic1 = HEADER_MAGIC1;                  \
+        HEADER->next = NULL;                             \
+        HEADER->prev = NULL;                             \
+        HEADER->alignment = ALIGNMENT;                   \
+        HEADER->size = SIZE;                             \
+        HEADER->num_addrs = 0;                           \
+        HEADER->magic2 = HEADER_MAGIC2;                  \
+        _get_footer(HEADER->data)->magic = FOOTER_MAGIC; \
     } while (0)
 
 /* Assert and abort if magic numbers are wrong */


### PR DESCRIPTION
oe_backtrace uses __builtin_return_address which can crash.