### PR TITLE
#215 Deprecation of unsafe crt functions

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -10,8 +10,6 @@
 // When compiling for enclave, it routes the C library calls to enclavelibc
 // functions.
 
-#include <openenclave/bits/safecrt.h>
-
 #ifdef OE_BUILD_ENCLAVE
 
 #include <openenclave/enclave.h>

--- a/common/revocation.c
+++ b/common/revocation.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "revocation.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/bits/safemath.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/cert.h>
@@ -133,7 +134,7 @@ static oe_result_t _get_crl_distribution_point(oe_cert_t* cert, char** url)
         if (*url == NULL)
             OE_RAISE(OE_OUT_OF_MEMORY);
 
-        memcpy(*url, urls[0], url_length);
+        OE_CHECK(oe_memcpy_s(*url, url_length, urls[0], url_length));
         result = OE_OK;
     }
 
@@ -181,10 +182,12 @@ oe_result_t oe_enforce_revocation(
 
     // Gather fmspc.
     OE_CHECK(_parse_sgx_extensions(leaf_cert, &parsed_extension_info));
-    memcpy(
-        revocation_args.fmspc,
-        parsed_extension_info.fmspc,
-        sizeof(parsed_extension_info.fmspc));
+    OE_CHECK(
+        oe_memcpy_s(
+            revocation_args.fmspc,
+            sizeof(revocation_args.fmspc),
+            parsed_extension_info.fmspc,
+            sizeof(parsed_extension_info.fmspc)));
 
     // Gather CRL distribution point URLs from certs.
     OE_CHECK(

--- a/common/safecrt.c
+++ b/common/safecrt.c
@@ -96,7 +96,6 @@ OE_INLINE oe_result_t _oe_validate_string(char* str, size_t size)
 }
 
 OE_INLINE void _oe_fill_string(char* str, size_t size)
-
 {
 #ifndef NDEBUG
     // Fill memory with pattern.

--- a/common/sgxcertextensions.c
+++ b/common/sgxcertextensions.c
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/cert.h>
 #include <openenclave/internal/ec.h>
 #include <openenclave/internal/hexdump.h>
+#include <openenclave/internal/raise.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/sgxcertextensions.h>
 #include <openenclave/internal/trace.h>
@@ -227,7 +229,7 @@ static oe_result_t _read_octet_extension(
     if (data_length != length)
         OE_RAISE(OE_FAILURE);
 
-    memcpy(buffer, data, data_length);
+    OE_CHECK(oe_memcpy_s(buffer, length, data, data_length));
     _trace_hex_dump(tag, buffer, data_length);
     result = OE_OK;
 done:

--- a/common/tcbinfo.c
+++ b/common/tcbinfo.c
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "tcbinfo.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/hexdump.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/trace.h>
+#include <openenclave/internal/utils.h>
 #include "common.h"
 
 #ifdef OE_USE_LIBSGX
@@ -197,14 +199,18 @@ static bool _json_str_equal(
            (memcmp(str1, str2, str2_length) == 0);
 }
 
-static void _trace_json_string(const uint8_t* str, size_t str_length)
+static oe_result_t _trace_json_string(const uint8_t* str, size_t str_length)
 {
+    oe_result_t result = OE_OK;
 #if (OE_TRACE_LEVEL >= OE_TRACE_LEVEL_INFO)
     char buffer[str_length + 1];
-    memcpy(buffer, str, str_length);
+    OE_CHECK(oe_memcpy_s(buffer, sizeof(buffer), str, str_length));
     buffer[str_length] = 0;
     OE_TRACE_INFO("value = %s\n", buffer);
+
+done:
 #endif
+    return result;
 }
 
 /**
@@ -337,7 +343,7 @@ static oe_result_t _read_tcb_level(
     OE_TRACE_INFO("Reading status\n");
     OE_CHECK(_read_property_name_and_colon("status", itr, end));
     OE_CHECK(_read_string(itr, end, &status, &status_length));
-    _trace_json_string(status, status_length);
+    OE_CHECK(_trace_json_string(status, status_length));
 
     OE_CHECK(_read('}', itr, end));
 

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -8,7 +8,6 @@ add_library(oeenclave STATIC
     ../common/quote.c
     ../common/report.c
     ../common/revocation.c
-    ../common/safecrt.c    
     ../common/sgxcertextensions.c
     ../common/tcbinfo.c
     asn1.c

--- a/enclave/asn1.c
+++ b/enclave/asn1.c
@@ -4,10 +4,12 @@
 #include "../common/asn1.h"
 #include <mbedtls/asn1.h>
 #include <mbedtls/oid.h>
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/asn1.h>
 #include <openenclave/internal/enclavelibc.h>
 #include <openenclave/internal/print.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
 
 OE_STATIC_ASSERT(MBEDTLS_ASN1_CONSTRUCTED == OE_ASN1_TAG_CONSTRUCTED);
 OE_STATIC_ASSERT(MBEDTLS_ASN1_SEQUENCE == OE_ASN1_TAG_SEQUENCE);

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -5,6 +5,7 @@ include(add_compile_flags_if_supported)
 include(add_compile_defs)
 
 add_library(oecore STATIC
+    ../../common/safecrt.c
     assert.c
     atexit.c
     backtrace.c

--- a/enclave/core/backtrace.c
+++ b/enclave/core/backtrace.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/backtrace.h>
 #include <openenclave/internal/calls.h>
@@ -94,7 +95,12 @@ char** oe_backtrace_symbols(void* const* buffer, int size)
     if (!(args = oe_host_malloc(sizeof(oe_backtrace_symbols_args_t))))
         goto done;
 
-    oe_memcpy(args->buffer, buffer, sizeof(void*) * size);
+    if (oe_memcpy_s(
+            args->buffer,
+            sizeof(void*) * OE_BACKTRACE_MAX,
+            buffer,
+            sizeof(void*) * size) != OE_OK)
+        goto done;
     args->size = size;
     args->ret = NULL;
 

--- a/enclave/core/cpuid.h
+++ b/enclave/core/cpuid.h
@@ -4,9 +4,10 @@
 #ifndef _OE_CPUID_ENCLAVE_H
 #define _OE_CPUID_ENCLAVE_H
 
+#include <openenclave/bits/result.h>
 #include <openenclave/bits/types.h>
 
-void oe_initialize_cpuid(uint64_t arg_in);
+oe_result_t oe_initialize_cpuid(uint64_t arg_in);
 
 int oe_emulate_cpuid(
     uint64_t* rax,

--- a/enclave/core/debugmalloc.c
+++ b/enclave/core/debugmalloc.c
@@ -3,6 +3,7 @@
 
 #define USE_DL_PREFIX
 #include "debugmalloc.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/backtrace.h>
 #include <openenclave/internal/backtrace.h>
@@ -315,7 +316,7 @@ void* oe_debug_malloc(size_t size)
         return NULL;
 
     /* Fill block with 0xAA (Allocated) bytes */
-    oe_memset(block, 0xAA, block_size);
+    oe_memset_s(block, block_size, 0xAA, block_size);
 
     header_t* header = (header_t*)block;
     INIT_BLOCK(header, 0, size);
@@ -336,7 +337,7 @@ void oe_debug_free(void* ptr)
         /* Fill the whole block with 0xDD (Deallocated) bytes */
         void* block = _get_block_address(ptr);
         size_t block_size = _get_block_size(ptr);
-        oe_memset(block, 0xDD, block_size);
+        oe_memset_s(block, block_size, 0xDD, block_size);
 
         dlfree(block);
     }
@@ -354,7 +355,7 @@ void* oe_debug_calloc(size_t nmemb, size_t size)
     if (!(ptr = oe_debug_malloc(total_size)))
         return NULL;
 
-    oe_memset(ptr, 0, total_size);
+    oe_memset_s(ptr, total_size, 0, total_size);
 
     return ptr;
 }
@@ -376,9 +377,15 @@ void* oe_debug_realloc(void* ptr, size_t size)
             return NULL;
 
         if (size > header->size)
-            oe_memcpy(new_ptr, ptr, header->size);
+        {
+            if (oe_memcpy_s(new_ptr, size, ptr, header->size) != OE_OK)
+                return NULL;
+        }
         else
-            oe_memcpy(new_ptr, ptr, size);
+        {
+            if (oe_memcpy_s(new_ptr, size, ptr, size) != OE_OK)
+                return NULL;
+        }
 
         oe_debug_free(ptr);
 

--- a/enclave/core/entropy.c
+++ b/enclave/core/entropy.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/enclavelibc.h>
 
@@ -40,7 +41,9 @@ int mbedtls_hardware_poll(
         {
             uint64_t x = _rdrand();
 
-            oe_memcpy(p, &x, sizeof(uint64_t));
+            if (oe_memcpy_s(p, sizeof(uint64_t), &x, sizeof(uint64_t)) != OE_OK)
+                goto done;
+
             p += sizeof(uint64_t);
         }
     }

--- a/enclave/core/exception.c
+++ b/enclave/core/exception.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/atexit.h>
 #include <openenclave/internal/calls.h>
@@ -253,8 +254,7 @@ void _oe_exception_dispatcher(oe_context_t* oe_context)
     // Compose the oe_exception_record_t.
     // N.B. In second pass exception handling, the XSTATE is recovered by SGX
     // hardware correctly on ERESUME, so we don't touch the XSTATE.
-    oe_exception_record_t oe_exception_record;
-    oe_memset(&oe_exception_record, 0, sizeof(oe_exception_record_t));
+    oe_exception_record_t oe_exception_record = {0};
     oe_exception_record.code = td->base.exception_code;
     oe_exception_record.flags = td->base.exception_flags;
     oe_exception_record.address = td->base.exception_address;
@@ -317,8 +317,7 @@ void _oe_virtual_exception_dispatcher(
     uint64_t arg_in,
     uint64_t* arg_out)
 {
-    SSA_Info ssa_info;
-    oe_memset(&ssa_info, 0, sizeof(SSA_Info));
+    SSA_Info ssa_info = {0};
 
     // Verify if the first SSA has valid exception info.
     if (_get_enclave_thread_first_ssa_info(td, &ssa_info) != 0)

--- a/enclave/core/keys.c
+++ b/enclave/core/keys.c
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/enclavelibc.h>
+#include <openenclave/internal/raise.h>
 #include <openenclave/internal/sgxtypes.h>
+#include <openenclave/internal/utils.h>
 #include "asmdefs.h"
 #include "report.h"
 
@@ -22,13 +25,11 @@ static oe_result_t _get_key_imp(
     const sgx_key_request_t* sgx_key_request,
     sgx_key_t* sgx_key)
 {
-    oe_result_t ret;
+    oe_result_t result;
     uint64_t egetkey_result;
-    OE_ALIGNED(SGX_KEY_REQUEST_ALIGNMENT) sgx_key_request_t tmp_key_request;
+    OE_ALIGNED(SGX_KEY_REQUEST_ALIGNMENT)
+    sgx_key_request_t tmp_key_request = *sgx_key_request;
     OE_ALIGNED(SGX_KEY_ALIGNMENT) sgx_key_t tmp_sgx_key;
-
-    // Copy input parameter into local aligned buffers.
-    oe_memcpy(&tmp_key_request, sgx_key_request, sizeof(sgx_key_request_t));
 
     // Execute EGETKEY instruction.
     egetkey_result = oe_egetkey(&tmp_key_request, &tmp_sgx_key);
@@ -37,40 +38,41 @@ static oe_result_t _get_key_imp(
     switch (egetkey_result)
     {
         case SGX_EGETKEY_SUCCESS:
-            ret = OE_OK;
+            result = OE_OK;
             break;
 
         case SGX_EGETKEY_INVALID_ATTRIBUTE:
-            ret = OE_INVALID_PARAMETER;
+            result = OE_INVALID_PARAMETER;
             break;
 
         case SGX_EGETKEY_INVALID_CPUSVN:
-            ret = OE_INVALID_CPUSVN;
+            result = OE_INVALID_CPUSVN;
             break;
 
         case SGX_EGETKEY_INVALID_ISVSVN:
-            ret = OE_INVALID_ISVSVN;
+            result = OE_INVALID_ISVSVN;
             break;
 
         case SGX_EGETKEY_INVALID_KEYNAME:
-            ret = OE_INVALID_KEYNAME;
+            result = OE_INVALID_KEYNAME;
             break;
 
         default:
-            ret = OE_UNEXPECTED;
+            result = OE_UNEXPECTED;
             break;
     }
 
     // Copy the request key to output buffer, and clear it from stack.
-    if (ret == OE_OK)
+    if (result == OE_OK)
     {
         // The sgx key is the secret, it should not be left on stack. Clean it
         // up to avoid leak by incident.
-        oe_memcpy(sgx_key, &tmp_sgx_key, sizeof(sgx_key_t));
-        oe_memset(&tmp_sgx_key, 0, sizeof(sgx_key_t));
+
+        *sgx_key = tmp_sgx_key;
+        oe_secure_zero_fill(&tmp_sgx_key, sizeof(tmp_sgx_key));
     }
 
-    return ret;
+    return result;
 }
 
 oe_result_t oe_get_key(
@@ -168,26 +170,30 @@ static oe_result_t _get_default_key_request_attributes(
 {
     sgx_report_t sgx_report = {{{0}}};
 
-    oe_result_t ret;
+    oe_result_t result;
 
     // Get a local report of current enclave.
-    ret = sgx_create_report(NULL, 0, NULL, 0, &sgx_report);
+    result = sgx_create_report(NULL, 0, NULL, 0, &sgx_report);
 
-    if (ret != OE_OK)
+    if (result != OE_OK)
     {
-        return ret;
+        return result;
     }
 
     // Set key request attributes(isv svn, cpu svn, and attribute masks)
     sgx_key_request->isv_svn = sgx_report.body.isvsvn;
-    oe_memcpy(
-        &sgx_key_request->cpu_svn,
-        sgx_report.body.cpusvn,
-        OE_FIELD_SIZE(sgx_key_request_t, cpu_svn));
+    OE_CHECK(
+        oe_memcpy_s(
+            &sgx_key_request->cpu_svn,
+            sizeof(sgx_key_request->cpu_svn),
+            sgx_report.body.cpusvn,
+            sizeof(sgx_report.body.cpusvn)));
     sgx_key_request->attribute_mask.flags = OE_SEALKEY_DEFAULT_FLAGSMASK;
     sgx_key_request->attribute_mask.xfrm = OE_SEALKEY_DEFAULT_XFRMMASK;
     sgx_key_request->misc_attribute_mask = OE_SEALKEY_DEFAULT_MISCMASK;
-    return OE_OK;
+
+done:
+    return result;
 }
 
 oe_result_t oe_get_seal_key_by_policy(
@@ -197,7 +203,7 @@ oe_result_t oe_get_seal_key_by_policy(
     uint8_t* key_info,
     size_t* key_info_size)
 {
-    oe_result_t ret;
+    oe_result_t result;
     sgx_key_request_t sgx_key_request = {0};
 
     // Check parameters.
@@ -221,8 +227,8 @@ oe_result_t oe_get_seal_key_by_policy(
     }
 
     // Get default key request attributes.
-    ret = _get_default_key_request_attributes(&sgx_key_request);
-    if (ret != OE_OK)
+    result = _get_default_key_request_attributes(&sgx_key_request);
+    if (result != OE_OK)
     {
         return OE_UNEXPECTED;
     }
@@ -244,22 +250,28 @@ oe_result_t oe_get_seal_key_by_policy(
     }
 
     // Get the seal key.
-    ret = oe_get_key(&sgx_key_request, (sgx_key_t*)key_buffer);
-    if (ret == OE_OK)
+    result = oe_get_key(&sgx_key_request, (sgx_key_t*)key_buffer);
+    if (result == OE_OK)
     {
         *key_buffer_size = sizeof(sgx_key_t);
 
         if (key_info != NULL)
         {
-            oe_memcpy(key_info, &sgx_key_request, sizeof(sgx_key_request_t));
+            OE_CHECK(
+                oe_memcpy_s(
+                    key_info,
+                    *key_info_size,
+                    &sgx_key_request,
+                    sizeof(sgx_key_request_t)));
             *key_info_size = sizeof(sgx_key_request_t);
         }
     }
     else
     {
         // oe_get_key should not fail unless we set the key request wrong.
-        ret = OE_UNEXPECTED;
+        result = OE_UNEXPECTED;
     }
 
-    return ret;
+done:
+    return result;
 }

--- a/enclave/core/malloc.c
+++ b/enclave/core/malloc.c
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/enclavelibc.h>
 #include <openenclave/internal/fault.h>
 #include <openenclave/internal/globals.h>
 #include <openenclave/internal/malloc.h>
+#include <openenclave/internal/raise.h>
 #include <openenclave/internal/thread.h>
 #include "debugmalloc.h"
 
@@ -208,7 +210,7 @@ oe_result_t oe_get_malloc_stats(oe_malloc_stats_t* stats)
     static oe_mutex_t _mutex = OE_MUTEX_INITIALIZER;
 
     if (stats)
-        memset(stats, 0, sizeof(oe_malloc_stats_t));
+        oe_memset(stats, 0, sizeof(oe_malloc_stats_t));
 
     oe_mutex_lock(&_mutex);
 

--- a/enclave/core/report.c
+++ b/enclave/core/report.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "report.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/bits/safemath.h>
 #include <openenclave/bits/types.h>
 #include <openenclave/enclave.h>
@@ -44,12 +45,14 @@ oe_result_t sgx_create_report(
         OE_RAISE(OE_INVALID_PARAMETER);
 
     if (target_info != NULL)
-        oe_memcpy(&ti, target_info, target_info_size);
+        OE_CHECK(
+            oe_memcpy_s(
+                &ti, sizeof(sgx_target_info_t), target_info, target_info_size));
 
     if (report_data != NULL)
-        oe_memcpy(&rd, report_data, report_data_size);
-
-    oe_memset(&r, 0, sizeof(sgx_report_t));
+        OE_CHECK(
+            oe_memcpy_s(
+                &rd, sizeof(sgx_report_data_t), report_data, report_data_size));
 
     /* Invoke EREPORT instruction */
     asm volatile(
@@ -59,7 +62,8 @@ oe_result_t sgx_create_report(
         : "memory");
 
     /* Copy REPORT to caller's buffer */
-    oe_memcpy(report, &r, sizeof(sgx_report_t));
+    OE_CHECK(
+        oe_memcpy_s(report, sizeof(sgx_report_t), &r, sizeof(sgx_report_t)));
 
     result = OE_OK;
 
@@ -175,7 +179,7 @@ static oe_result_t _oe_get_quote(
         *quote_size = args->quote_size;
 
     if (result == OE_OK)
-        oe_memcpy(quote, args->quote, *quote_size);
+        OE_CHECK(oe_memcpy_s(quote, *quote_size, args->quote, *quote_size));
 
 done:
     if (args)

--- a/enclave/core/td.c
+++ b/enclave/core/td.c
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 #include "td.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/enclavelibc.h>
 #include <openenclave/internal/fault.h>
 #include <openenclave/internal/globals.h>
 #include <openenclave/internal/sgxtypes.h>
+#include <openenclave/internal/utils.h>
 #include "asmdefs.h"
 
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, magic) == td_magic);

--- a/enclave/core/thread.c
+++ b/enclave/core/thread.c
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 #include "thread.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/enclavelibc.h>
 #include <openenclave/internal/hostalloc.h>
+#include <openenclave/internal/raise.h>
 #include <openenclave/internal/sgxtypes.h>
 #include <openenclave/internal/thread.h>
 #include "td.h"
@@ -166,6 +168,7 @@ OE_STATIC_ASSERT(sizeof(oe_mutex_impl_t) <= sizeof(oe_mutex_t));
 oe_result_t oe_mutex_init(oe_mutex_t* mutex)
 {
     oe_mutex_impl_t* m = (oe_mutex_impl_t*)mutex;
+    oe_result_t result = OE_UNEXPECTED;
 
     if (!m)
         return OE_INVALID_PARAMETER;
@@ -173,7 +176,9 @@ oe_result_t oe_mutex_init(oe_mutex_t* mutex)
     oe_memset(m, 0, sizeof(oe_mutex_t));
     m->lock = OE_SPINLOCK_INITIALIZER;
 
-    return OE_OK;
+    result = OE_OK;
+
+    return result;
 }
 
 /* Caller manages the spinlock */
@@ -370,6 +375,7 @@ OE_STATIC_ASSERT(sizeof(oe_cond_impl_t) <= sizeof(oe_cond_t));
 oe_result_t oe_cond_init(oe_cond_t* condition)
 {
     oe_cond_impl_t* cond = (oe_cond_impl_t*)condition;
+    oe_result_t result = OE_UNEXPECTED;
 
     if (!cond)
         return OE_INVALID_PARAMETER;
@@ -377,7 +383,9 @@ oe_result_t oe_cond_init(oe_cond_t* condition)
     oe_memset(cond, 0, sizeof(oe_cond_t));
     cond->lock = OE_SPINLOCK_INITIALIZER;
 
-    return OE_OK;
+    result = OE_OK;
+
+    return result;
 }
 
 oe_result_t oe_cond_destroy(oe_cond_t* condition)
@@ -529,6 +537,7 @@ OE_STATIC_ASSERT(sizeof(oe_rwlock_impl_t) <= sizeof(oe_rwlock_t));
 oe_result_t oe_rwlock_init(oe_rwlock_t* read_write_lock)
 {
     oe_rwlock_impl_t* rw_lock = (oe_rwlock_impl_t*)read_write_lock;
+    oe_result_t result = OE_UNEXPECTED;
 
     if (!rw_lock)
         return OE_INVALID_PARAMETER;
@@ -536,7 +545,9 @@ oe_result_t oe_rwlock_init(oe_rwlock_t* read_write_lock)
     oe_memset(rw_lock, 0, sizeof(oe_rwlock_t));
     rw_lock->lock = OE_SPINLOCK_INITIALIZER;
 
-    return OE_OK;
+    result = OE_OK;
+
+    return result;
 }
 
 oe_result_t oe_rwlock_rdlock(oe_rwlock_t* read_write_lock)

--- a/enclave/crl.c
+++ b/enclave/crl.c
@@ -4,10 +4,12 @@
 #include "crl.h"
 #include <mbedtls/platform.h>
 #include <mbedtls/x509_crl.h>
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/crl.h>
 #include <openenclave/internal/enclavelibc.h>
 #include <openenclave/internal/print.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
 
 /* Randomly generated magic number */
 #define OE_CRL_MAGIC 0xf8cf8e04f4ed40f3

--- a/enclave/ec.c
+++ b/enclave/ec.c
@@ -5,9 +5,11 @@
 #include <mbedtls/asn1.h>
 #include <mbedtls/asn1write.h>
 #include <mbedtls/ecp.h>
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/enclavelibc.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
 #include "key.h"
 #include "pem.h"
 #include "random.h"
@@ -97,10 +99,10 @@ static oe_result_t _generate_key_pair(
     mbedtls_pk_init(&pk);
 
     if (private_key)
-        oe_memset(private_key, 0, sizeof(*private_key));
+        oe_secure_zero_fill(private_key, sizeof(*private_key));
 
     if (public_key)
-        oe_memset(public_key, 0, sizeof(*public_key));
+        oe_secure_zero_fill(public_key, sizeof(*public_key));
 
     /* Check for invalid parameters */
     if (!private_key || !public_key)
@@ -329,7 +331,7 @@ oe_result_t oe_ec_public_key_from_coordinates(
     const mbedtls_pk_info_t* info;
 
     if (public_key)
-        oe_memset(public_key, 0, sizeof(oe_ec_public_key_t));
+        oe_secure_zero_fill(public_key, sizeof(oe_ec_public_key_t));
 
     if (impl)
         mbedtls_pk_init(&impl->pk);
@@ -460,7 +462,7 @@ oe_result_t oe_ecdsa_signature_write_der(
         OE_RAISE(OE_BUFFER_TOO_SMALL);
     }
 
-    oe_memcpy(signature, p, len);
+    OE_CHECK(oe_memcpy_s(signature, *signature_size, p, len));
     *signature_size = len;
 
     result = OE_OK;

--- a/enclave/key.c
+++ b/enclave/key.c
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 #include "key.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/enclavelibc.h>
 #include <openenclave/internal/hash.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
 #include "pem.h"
 
 typedef oe_result_t (*oe_copy_key)(
@@ -50,7 +52,7 @@ void oe_private_key_release(oe_private_key_t* private_key, uint64_t magic)
     if (oe_private_key_is_valid(private_key, magic))
     {
         mbedtls_pk_free(&private_key->pk);
-        oe_memset(private_key, 0, sizeof(oe_private_key_t));
+        oe_secure_zero_fill(private_key, sizeof(oe_private_key_t));
     }
 }
 
@@ -90,7 +92,7 @@ void oe_public_key_release(oe_public_key_t* public_key, uint64_t magic)
     if (oe_public_key_is_valid(public_key, magic))
     {
         mbedtls_pk_free(&public_key->pk);
-        oe_memset(public_key, 0, sizeof(oe_public_key_t));
+        oe_secure_zero_fill(public_key, sizeof(oe_public_key_t));
     }
 }
 
@@ -200,7 +202,7 @@ oe_result_t oe_private_key_write_pem(
             OE_RAISE(OE_BUFFER_TOO_SMALL);
         }
 
-        oe_memcpy(pem_data, buf, size);
+        OE_CHECK(oe_memcpy_s(pem_data, *pem_size, buf, size));
         *pem_size = size;
     }
 
@@ -283,7 +285,7 @@ oe_result_t oe_public_key_write_pem(
             OE_RAISE(OE_BUFFER_TOO_SMALL);
         }
 
-        oe_memcpy(pem_data, buf, size);
+        OE_CHECK(oe_memcpy_s(pem_data, *pem_size, buf, size));
         *pem_size = size;
     }
 
@@ -378,7 +380,7 @@ oe_result_t oe_private_key_sign(
     }
 
     /* Copy result to output buffer */
-    oe_memcpy(signature, buffer, buffer_size);
+    OE_CHECK(oe_memcpy_s(signature, *signature_size, buffer, buffer_size));
     *signature_size = buffer_size;
 
     result = OE_OK;

--- a/enclave/report.c
+++ b/enclave/report.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "report.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/bits/types.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/calls.h>
@@ -24,8 +25,12 @@ static oe_result_t _oe_get_report_key(
     sgx_key_request_t sgx_key_request = {0};
 
     sgx_key_request.key_name = SGX_KEYSELECT_REPORT;
-    oe_memcpy(
-        sgx_key_request.key_id, sgx_report->keyid, sizeof(sgx_report->keyid));
+    OE_CHECK(
+        oe_memcpy_s(
+            sgx_key_request.key_id,
+            sizeof(sgx_key_request.key_id),
+            sgx_report->keyid,
+            sizeof(sgx_report->keyid)));
 
     OE_CHECK(oe_get_key(&sgx_key_request, sgx_key));
     result = OE_OK;

--- a/enclave/revocationinfo.c
+++ b/enclave/revocationinfo.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "../common/revocation.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/bits/safemath.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/calls.h>
@@ -26,7 +27,7 @@ static oe_result_t _copy_buffer_to_enclave(
     if (*dst == NULL)
         OE_RAISE(OE_OUT_OF_MEMORY);
 
-    oe_memcpy(*dst, src, src_size);
+    OE_CHECK(oe_memcpy_s(*dst, src_size, src, src_size));
     *dst_size = src_size;
     result = OE_OK;
 
@@ -81,7 +82,9 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
     for (uint32_t i = 0; i < args->num_crl_urls; ++i)
     {
         host_args->crl_urls[i] = (const char*)p;
-        oe_memcpy(p, args->crl_urls[i], crl_url_sizes[i]);
+        OE_CHECK(
+            oe_memcpy_s(
+                p, crl_url_sizes[i], args->crl_urls[i], crl_url_sizes[i]));
         p += crl_url_sizes[i];
     }
 

--- a/enclave/rsa.c
+++ b/enclave/rsa.c
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 #include "rsa.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/enclavelibc.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
 #include "key.h"
 #include "pem.h"
 #include "random.h"
@@ -140,10 +142,10 @@ static oe_result_t _generate_key_pair(
     mbedtls_pk_init(&pk);
 
     if (private_key)
-        oe_memset(private_key, 0, sizeof(*private_key));
+        oe_secure_zero_fill(private_key, sizeof(*private_key));
 
     if (public_key)
-        oe_memset(public_key, 0, sizeof(*public_key));
+        oe_secure_zero_fill(public_key, sizeof(*public_key));
 
     /* Check for invalid parameters */
     if (!private_key || !public_key)

--- a/host/calls.c
+++ b/host/calls.c
@@ -18,6 +18,7 @@
 #error "unsupported platform"
 #endif
 
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/registers.h>

--- a/host/crypto/asn1.c
+++ b/host/crypto/asn1.c
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 #include "../common/asn1.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/asn1.h>
 #include <openenclave/internal/defs.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
 #include <openssl/asn1.h>
 #include <openssl/pem.h>
 #include <string.h>

--- a/host/crypto/cert.c
+++ b/host/crypto/cert.c
@@ -3,6 +3,7 @@
 
 #include <ctype.h>
 #include <openenclave/bits/result.h>
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/asn1.h>
 #include <openenclave/internal/cert.h>
 #include <openenclave/internal/hexdump.h>
@@ -39,7 +40,8 @@ static void _set_err(oe_verify_cert_error_t* error, const char* str)
     if (error)
     {
         error->buf[0] = '\0';
-        strncat(error->buf, str, sizeof(error->buf) - 1);
+        oe_strncat_s(
+            error->buf, sizeof(error->buf), str, sizeof(error->buf) - 1);
     }
 }
 
@@ -682,7 +684,7 @@ oe_result_t oe_cert_get_rsa_public_key(
 
     /* Clear public key for all error pathways */
     if (public_key)
-        memset(public_key, 0, sizeof(oe_rsa_public_key_t));
+        oe_secure_zero_fill(public_key, sizeof(oe_rsa_public_key_t));
 
     /* Reject invalid parameters */
     if (!_cert_is_valid(impl) || !public_key)
@@ -723,7 +725,7 @@ oe_result_t oe_cert_get_ec_public_key(
 
     /* Clear public key for all error pathways */
     if (public_key)
-        memset(public_key, 0, sizeof(oe_ec_public_key_t));
+        oe_secure_zero_fill(public_key, sizeof(oe_ec_public_key_t));
 
     /* Reject invalid parameters */
     if (!_cert_is_valid(impl) || !public_key)
@@ -927,7 +929,7 @@ oe_result_t oe_cert_find_extension(
 
             if (data)
             {
-                memcpy(data, str->data, str->length);
+                OE_CHECK(oe_memcpy_s(data, *size, str->data, str->length));
                 *size = str->length;
                 result = OE_OK;
                 goto done;

--- a/host/crypto/crl.c
+++ b/host/crypto/crl.c
@@ -3,9 +3,11 @@
 
 #include "crl.h"
 #include <limits.h>
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/crl.h>
 #include <openenclave/internal/defs.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
 #include <openssl/asn1.h>
 #include <openssl/x509.h>
 #include <string.h>

--- a/host/crypto/ec.c
+++ b/host/crypto/ec.c
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 #include "ec.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/defs.h>
 #include <openenclave/internal/hexdump.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
 #include <openssl/obj_mac.h>
 #include <openssl/pem.h>
 #include <string.h>
@@ -64,10 +66,10 @@ static oe_result_t _generate_key_pair(
     EC_POINT* point = NULL;
 
     if (private_key)
-        memset(private_key, 0, sizeof(*private_key));
+        oe_secure_zero_fill(private_key, sizeof(*private_key));
 
     if (public_key)
-        memset(public_key, 0, sizeof(*public_key));
+        oe_secure_zero_fill(public_key, sizeof(oe_public_key_t));
 
     /* Check parameters */
     if (!private_key || !public_key)
@@ -373,7 +375,7 @@ oe_result_t oe_ec_public_key_from_coordinates(
     BIGNUM* y = NULL;
 
     if (public_key)
-        memset(public_key, 0, sizeof(oe_ec_public_key_t));
+        oe_secure_zero_fill(public_key, sizeof(oe_ec_public_key_t));
 
     /* Initialize OpenSSL */
     oe_initialize_openssl();

--- a/host/crypto/key.c
+++ b/host/crypto/key.c
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 #include "key.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
@@ -53,7 +55,7 @@ oe_result_t oe_private_key_read_pem(
 
     /* Initialize the key output parameter */
     if (impl)
-        memset(impl, 0, sizeof(*impl));
+        oe_secure_zero_fill(impl, sizeof(oe_private_key_t));
 
     /* Check parameters */
     if (!pem_data || pem_size == 0 || !impl)
@@ -110,7 +112,7 @@ oe_result_t oe_public_key_read_pem(
 
     /* Zero-initialize the key */
     if (impl)
-        memset(impl, 0, sizeof(*impl));
+        oe_secure_zero_fill(impl, sizeof(oe_public_key_t));
 
     /* Check parameters */
     if (!pem_data || pem_size == 0 || !impl)
@@ -199,7 +201,7 @@ oe_result_t oe_private_key_write_pem(
         }
 
         /* Copy result to output buffer */
-        memcpy(data, mem->data, mem->length);
+        OE_CHECK(oe_memcpy_s(data, *size, mem->data, mem->length));
         *size = mem->length;
     }
 
@@ -259,7 +261,7 @@ oe_result_t oe_public_key_write_pem(
         }
 
         /* Copy result to output buffer */
-        memcpy(data, mem->data, mem->length);
+        OE_CHECK(oe_memcpy_s(data, *size, mem->data, mem->length));
         *size = mem->length;
     }
 
@@ -290,7 +292,7 @@ oe_result_t oe_private_key_free(oe_private_key_t* key, uint64_t magic)
 
         /* Clear the fields of the implementation */
         if (impl)
-            memset(impl, 0, sizeof(*impl));
+            oe_secure_zero_fill(impl, sizeof(oe_private_key_t));
     }
 
     result = OE_OK;
@@ -316,7 +318,7 @@ oe_result_t oe_public_key_free(oe_public_key_t* key, uint64_t magic)
 
         /* Clear the fields of the implementation */
         if (impl)
-            memset(impl, 0, sizeof(*impl));
+            oe_secure_zero_fill(impl, sizeof(oe_public_key_t));
     }
 
     result = OE_OK;

--- a/host/crypto/rsa.c
+++ b/host/crypto/rsa.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "rsa.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/defs.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/rsa.h>
@@ -53,10 +54,10 @@ static oe_result_t _generate_key_pair(
     EVP_PKEY* pkey_public = NULL;
 
     if (private_key)
-        memset(private_key, 0, sizeof(*private_key));
+        oe_secure_zero_fill(private_key, sizeof(*private_key));
 
     if (public_key)
-        memset(public_key, 0, sizeof(*public_key));
+        oe_secure_zero_fill(public_key, sizeof(*public_key));
 
     /* Check parameters */
     if (!private_key || !public_key)

--- a/host/linux/exception.c
+++ b/host/linux/exception.c
@@ -3,6 +3,7 @@
 
 #include <assert.h>
 #include <dlfcn.h>
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/registers.h>

--- a/host/linux/sgxioctl.c
+++ b/host/linux/sgxioctl.c
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 #include "sgxioctl.h"
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/sgxtypes.h>
+#include <openenclave/internal/utils.h>
 #include <string.h>
 #include <sys/ioctl.h>
 

--- a/host/ocalls.c
+++ b/host/ocalls.c
@@ -15,9 +15,9 @@
 #include <Windows.h>
 #endif
 
-#include <openenclave/host.h>
-
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/bits/safemath.h>
+#include <openenclave/host.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/elf.h>
 #include <openenclave/internal/report.h>
@@ -243,7 +243,7 @@ static char** _backtrace_symbols(
             name = unknown;
 
         size_t name_size = strlen(name) + sizeof(char);
-        memcpy(ptr, name, name_size);
+        oe_memcpy_s(ptr, name_size, name, name_size);
         ret[i] = ptr;
         ptr += name_size;
     }

--- a/host/quote.c
+++ b/host/quote.c
@@ -4,6 +4,7 @@
 #include "quote.h"
 #include <assert.h>
 #include <limits.h>
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/sgxtypes.h>
@@ -144,7 +145,7 @@ done:
 oe_result_t sgx_get_qetarget_info(sgx_target_info_t* target_info)
 {
     oe_result_t result = OE_UNEXPECTED;
-    memset(target_info, 0, sizeof(*target_info));
+    memset(target_info, 0, sizeof(sgx_target_info_t));
 
 #if defined(OE_USE_LIBSGX)
     // Quote workflow always begins with obtaining the target info. Therefore

--- a/host/report.c
+++ b/host/report.c
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/bits/safemath.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/calls.h>
@@ -50,13 +51,20 @@ static oe_result_t _oe_get_local_report(
         OE_RAISE(OE_OUT_OF_MEMORY);
 
     if (opt_params != NULL)
-        memcpy(arg->opt_params, opt_params, opt_params_size);
+        OE_CHECK(
+            oe_memcpy_s(
+                arg->opt_params, opt_params_size, opt_params, opt_params_size));
 
     arg->opt_params_size = opt_params_size;
 
     OE_CHECK(oe_ecall(enclave, OE_ECALL_GET_SGX_REPORT, (uint64_t)arg, NULL));
 
-    memcpy(report_buffer, &arg->sgx_report, sizeof(sgx_report_t));
+    OE_CHECK(
+        oe_memcpy_s(
+            report_buffer,
+            *report_buffer_size,
+            &arg->sgx_report,
+            sizeof(sgx_report_t)));
     *report_buffer_size = sizeof(sgx_report_t);
     result = OE_OK;
 

--- a/host/sgxquoteprovider.c
+++ b/host/sgxquoteprovider.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <dlfcn.h>
+#include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/hexdump.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/report.h>
@@ -200,7 +201,12 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
     {
         args->tcb_info = p;
         args->tcb_info_size = revocation_info->tcb_info_size;
-        memcpy(args->tcb_info, revocation_info->tcb_info, args->tcb_info_size);
+        OE_CHECK(
+            oe_memcpy_s(
+                args->tcb_info,
+                args->tcb_info_size,
+                revocation_info->tcb_info,
+                revocation_info->tcb_info_size));
         // Add null terminator
         args->tcb_info[args->tcb_info_size++] = 0;
         p += args->tcb_info_size;
@@ -212,10 +218,12 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
     {
         args->tcb_issuer_chain = p;
         args->tcb_issuer_chain_size = revocation_info->tcb_issuer_chain_size;
-        memcpy(
-            args->tcb_issuer_chain,
-            revocation_info->tcb_issuer_chain,
-            args->tcb_issuer_chain_size);
+        OE_CHECK(
+            oe_memcpy_s(
+                args->tcb_issuer_chain,
+                args->tcb_issuer_chain_size,
+                revocation_info->tcb_issuer_chain,
+                revocation_info->tcb_issuer_chain_size));
         // Add null terminator
         args->tcb_issuer_chain[args->tcb_issuer_chain_size++] = 0;
         p += args->tcb_issuer_chain_size;
@@ -230,10 +238,12 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
         {
             args->crl[i] = p;
             args->crl_size[i] = revocation_info->crls[i].crl_data_size;
-            memcpy(
-                args->crl[i],
-                revocation_info->crls[i].crl_data,
-                args->crl_size[i]);
+            OE_CHECK(
+                oe_memcpy_s(
+                    args->crl[i],
+                    args->crl_size[i],
+                    revocation_info->crls[i].crl_data,
+                    revocation_info->crls[i].crl_data_size));
             // CRL is in DER format. Null not added.
             p += args->crl_size[i];
             OE_TRACE_INFO(
@@ -246,10 +256,12 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
             args->crl_issuer_chain[i] = p;
             args->crl_issuer_chain_size[i] =
                 revocation_info->crls[i].crl_issuer_chain_size;
-            memcpy(
-                args->crl_issuer_chain[i],
-                revocation_info->crls[i].crl_issuer_chain,
-                args->crl_issuer_chain_size[i]);
+            OE_CHECK(
+                oe_memcpy_s(
+                    args->crl_issuer_chain[i],
+                    args->crl_issuer_chain_size[i],
+                    revocation_info->crls[i].crl_issuer_chain,
+                    revocation_info->crls[i].crl_issuer_chain_size));
             // Add null terminator
             args->crl_issuer_chain[i][args->crl_issuer_chain_size[i]++] = 0;
             p += args->crl_issuer_chain_size[i];

--- a/include/openenclave/internal/elf.h
+++ b/include/openenclave/internal/elf.h
@@ -4,6 +4,7 @@
 #ifndef _OE_ELF_H
 #define _OE_ELF_H
 
+#include <openenclave/bits/result.h>
 #include <openenclave/bits/types.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -302,7 +303,7 @@ int elf64_add_section(
     const void* secdata,
     size_t secsize);
 
-int elf64_remove_section(elf64_t* elf, const char* name);
+oe_result_t elf64_remove_section(elf64_t* elf, const char* name);
 
 void elf64_dump_section_names(const elf64_t* elf);
 
@@ -319,7 +320,10 @@ int elf64_visit_symbols(
     void* data);
 
 /* Load relocations (size will be a multiple of the page size) */
-int elf64_load_relocations(const elf64_t* elf, void** data, size_t* size);
+oe_result_t elf64_load_relocations(
+    const elf64_t* elf,
+    void** data,
+    size_t* size);
 
 /* Get the segment with the given index; return NULL on error */
 void* elf64_get_segment(const elf64_t* elf, size_t index);


### PR DESCRIPTION
Occurances of memcpy, memmove, strncat, memset and strncopy has been replaced with their safer implementations.