### PR TITLE
Turn on debug_malloc by default only on debug builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,14 @@ if (USE_LIBSGX AND WIN32)
 message(FATAL_ERROR "USE_LIBSGX is not supported on Windows. Disable this when calling cmake with -DUSE_LIBSGX=OFF")
 endif()
 
-option(USE_DEBUG_MALLOC "Build oehost using SGX library requiring FLC" OFF)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT WIN32)
+# In non-win32 debug build, debug_malloc is on by default.
+option(USE_DEBUG_MALLOC "Build oeenclave with memory leak detection capability." ON)
+else()
+# In win32 or non-debug builds, debug_malloc is off by default.
+option(USE_DEBUG_MALLOC "Build oeenclave with memory leak detection capability." OFF)
+endif()
+
 if (USE_DEBUG_MALLOC AND WIN32)
 message(FATAL_ERROR "USE_DEBUG_MALLOC is not supported on Windows. Disable this when calling cmake with -DUSE_DEBUG_MALLOC=OFF")
 endif()

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -65,6 +65,7 @@ endif()
 
 if(USE_DEBUG_MALLOC)
     add_target_compile_defs(oecore PRIVATE "C;CXX" OE_USE_DEBUG_MALLOC)
+    message("USE_DEBUG_MALLOC is set, building oecore with memory leak detection.")
 endif()
 
 add_target_compile_defs(oecore PUBLIC "C;CXX" OE_BUILD_ENCLAVE)

--- a/include/openenclave/bits/defs.h
+++ b/include/openenclave/bits/defs.h
@@ -129,16 +129,6 @@
 /* OE_OCALL */
 #define OE_OCALL OE_EXTERNC OE_EXPORT
 
-// Enable debug-malloc for debug builds, where CMAKE_BUILD_TYPE="Debug". For
-// the following build types, NDEBUG is defined.
-//
-//     CMAKE_BUILD_TYPE="Release"
-//     CMAKE_BUILD_TYPE="RelWithDebugInfo"
-//
-#if !defined(NDEBUG) && !defined(OE_USE_DEBUG_MALLOC)
-#define OE_USE_DEBUG_MALLOC
-#endif
-
 /* The maxiumum value for a four-byte enum tag */
 #define OE_ENUM_MAX 0xffffffff
 


### PR DESCRIPTION
Previously debug_malloc on the enclave side looked at NDEBUG, causing it to be turned on in RelWithDebInfo builds as well. This was not the original intention when this was introduced (#499 )