### PR TITLE
Enabled 34 libcxx thread tests using std::create or std::join

### DIFF
--- a/tests/libcxxthrd/tests.broken
+++ b/tests/libcxxthrd/tests.broken
@@ -24,3 +24,7 @@ after pthread_create_hook
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.condition/thread.condition.condvar/notify_one.pass.cpp
 #no info - Test failed with timeout (possible hang)
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.search/awk.pass.cpp
+#intermittent CI failure with SGX1FLC
+../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_try_to_lock.pass.cpp
+../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_shared.pass.cpp
+

--- a/tests/libcxxthrd/tests.supported
+++ b/tests/libcxxthrd/tests.supported
@@ -9,7 +9,6 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock.algorithm/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.guard/adopt_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.guard/mutex.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_try_to_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_try_to_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.class/default.pass.cpp
@@ -20,7 +19,6 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.recursive/try_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_shared.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/try_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/lock.pass.cpp

--- a/tests/libcxxthrd/tests.supported.default
+++ b/tests/libcxxthrd/tests.supported.default
@@ -6,12 +6,10 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock.algorithm/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.guard/adopt_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.guard/mutex.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_try_to_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_try_to_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.class/try_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.recursive/lock.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_shared.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.algorithm/swap.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.constr/move.pass.cpp

--- a/tests/libcxxthrd/tests.unsupported
+++ b/tests/libcxxthrd/tests.unsupported
@@ -9,7 +9,7 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.promise/set_exception_at_thread_exit.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.promise/set_lvalue_at_thread_exit.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.promise/set_rvalue_at_thread_exit.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.promise/set_vdf87d4fca7d9abd19e102ec24801b7a8b154f0eaalue_at_thread_exit_const.pass.cpp
+../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.promise/set_value_at_thread_exit_const.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.promise/set_value_at_thread_exit_void.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.shared_future/get.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.shared_future/wait_for.pass.cpp
@@ -18,7 +18,7 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.task/futures.task.members/dtor.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.task/futures.task.members/make_ready_at_thread_exit.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.task/futures.task.members/operator.pass.cpp
-../../3rdparty/libcxx/lidf87d4fca7d9abd19e102ec24801b7a8b154f0eabcxx/test/std/thread/futures/futures.unique_future/get.pass.cpp
+../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.unique_future/get.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.unique_future/wait_for.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.unique_future/wait.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.unique_future/wait_until.pass.cpp


### PR DESCRIPTION
Since PR #676 provides pthread_create and pthread_join hooks for use by the enclave with the new test libcxxthrd, enabled 34 of the previously unsupported libcxx unit tests that used std::create or std::join. Enabled 17 of these tests to run by default.

Here is info on running all the 94 tests that used pthread create/join/detach:

- 43% tests passed, 54 tests failed out of 94; ==> 40 tests PASS (34 tests are stable)
			§ 26 failed due to clock_gettime() panic which is unsupported
			§ 19 failed due to pthread_detach(): panic (soon to be supported)
			§ 9-10 tests are issues with pthread_join 
			§ 1 was assert in hardware_concurrency -possible unsupport. 
