### PR TITLE
Set CPACK_PACKAGE_NAME to open-enclave.

### DIFF
--- a/cmake/package_settings.cmake
+++ b/cmake/package_settings.cmake
@@ -40,6 +40,7 @@ install(
 
 # CPack package handling
 include(InstallRequiredSystemLibraries)
+set(CPACK_PACKAGE_NAME "open-enclave")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Open Enclave SDK")
 set(CPACK_PACKAGE_CONTACT "openenclave@microsoft.com")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/README.md")


### PR DESCRIPTION
Recently, a change was made to the main project's name in the root CMakeLists.txt file which inadvertently changed the name of the package (the project name was changed from "open-enclave" to "Open Enclave SDK", thereby accidentally changing the name of the package to that value as well).

This patch will keep the project's new name ("Open Enclave SDK") but will make sure that the package name will be what we expect it to be ("open-enclave").