### PR TITLE
Update Azure quote provider install script

### DIFF
--- a/docs/GettingStartedDocs/SGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/SGX1FLCGettingStarted.md
@@ -29,7 +29,7 @@ sudo ./scripts/install-prereqs
 There are two Intel packages needed for SGX1-FLC:
 
 - Intel(R) SGX driver with FLC support
-- Intel(R) NGSA SDK
+- Intel(R) SGX DCAP SDK
 
 To install these prerequisites type the following commands from the root of
 the source distribution.
@@ -54,6 +54,15 @@ Then run `cmake` to configure the build and generate the make files and build:
 cmake .. -DUSE_LIBSGX=1
 make
 ```
+
+If you are running in an Azure Confidential Compute VM and would like to use the attestation features, you should also run the following command from the root of the source tree:
+
+```bash
+sudo make -C prereqs/az-dcap-client
+sudo make -C prereqs/az-dcap-client install
+```
+
+Open Enclave will support attestation workflows outside of Azure using DCAP in an upcoming release.
 
 Refer to the [Advanced Build Information](advancedBuildInfo.md) documentation for further information.
 
@@ -97,4 +106,4 @@ For more information refer to the [Advanced Test Info](AdvancedTestInfo.md) docu
 
 ## Install
 
- Follow the instructions in the [Install Info](InstallInfo.md) document to install the Open Enclave SDK built above.
+Follow the instructions in the [Install Info](InstallInfo.md) document to install the Open Enclave SDK built above.

--- a/docs/GettingStartedDocs/sampledocs/buildandsign.md
+++ b/docs/GettingStartedDocs/sampledocs/buildandsign.md
@@ -90,6 +90,6 @@ There are relatively fewer restrictions on building a host app compared to build
 - Include path: /opt/openenclave/include 
 - Link library path: /opt/openenclave/lib/openenclave/host
 - Linker option: -rdynamic
-- Link libraries: -loehost -lcrypto -lpthread -ldl -lsgx_enclave_common -lsgxoeql -lsgx_urts_ng
+- Link libraries: -loehost -lcrypto -lpthread -ldl -lsgx_enclave_common -lsgx_dcap_ql -lsgx_urts
 
 As with building an enclave, the /opt/openenclave/share/openenclave/config.mak provides an example of default path constants to use when working with Open Enclave projects.

--- a/prereqs/az-dcap-client/Makefile
+++ b/prereqs/az-dcap-client/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-AZQUOTPROV=azquotprov_0.3-1_amd64.deb
+AZ_DCAP_PKG=az-dcap-client_1.0_amd64.deb
 
 all: getdist
 
@@ -10,7 +10,7 @@ getdist:
 	$(MAKE) get-quote-provider
 
 distclean:
-	- rm -f $(AZQUOTPROV)
+	- rm -f $(AZ_DCAP_PKG)
 
 build:
 
@@ -18,10 +18,10 @@ clean:
 
 install:
 	$(MAKE) -s uninstall
-	dpkg -i $(AZQUOTPROV)
+	dpkg -i $(AZ_DCAP_PKG)
 
 uninstall:
-	- dpkg -P azquotprov
+	- dpkg -P az-dcap-client
 
 ##==============================================================================
 ##
@@ -31,8 +31,8 @@ uninstall:
 
 get-quote-provider:
 ifdef USE_PKGS_IN
-	cp $(USE_PKGS_IN)/$(AZQUOTPROV) .
+	cp $(USE_PKGS_IN)/$(AZ_DCAP_PKG) .
 else
 	@ apt-get -y install wget
-	@ wget http://10.31.100.105/$(AZQUOTPROV)
+	@ wget https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod/pool/main/a/az-dcap-client/$(AZ_DCAP_PKG)
 endif

--- a/prereqs/az-dcap-client/README.md
+++ b/prereqs/az-dcap-client/README.md
@@ -1,8 +1,8 @@
-azquotprov
-==========
+az-dcap-client
+==============
 
-This directory contains an optional Makefile to install the Azure quote provider
-package. The quote provider is necessary for performing remote attestation in
+This directory contains an optional Makefile to install the Azure DCAP client
+package. The DCAP client is necessary for performing remote attestation in
 Open Enclave apps running in the Azure environment.
 
 You can download and install the package with:

--- a/samples/helloworld/README.md
+++ b/samples/helloworld/README.md
@@ -465,8 +465,8 @@ define optlib
 $(patsubst /usr/lib/x86_64-linux-gnu/lib%.so,-l%,$(wildcard /usr/lib/x86_64-linux-gnu/lib$(1).so))
 endef
 LIBRARIES += $(call optlib,sgx_enclave_common)
-LIBRARIES += $(call optlib,sgx_ngsa_ql)
-LIBRARIES += $(call optlib,sgx_urts_ng)
+LIBRARIES += $(call optlib,sgx_dcap_ql)
+LIBRARIES += $(call optlib,sgx_urts)
 
 build:
     $(OE_BINDIR)/oeedger8r ../helloworld.edl --untrusted


### PR DESCRIPTION
* Move prereqs/azquotprov to prereqs/az-dcap-client folder to match package name

* Update Makefile to point to public published az-dcap-client_1.0_amd64.deb package

* Update documents with outdated library references