### PR TITLE
Removed internal headers from SDK package.

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -9,5 +9,7 @@ target_include_directories(oe_includes INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
-install(DIRECTORY openenclave DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY openenclave/bits DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
+install(FILES openenclave/enclave.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
+install(FILES openenclave/host.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(TARGETS oe_includes EXPORT openenclave-targets)


### PR DESCRIPTION
I tested installing a kit built based upon these changes and the samples will build and run successfully.