### PR TITLE
Set the default install prefix

### DIFF
--- a/cmake/package_settings.cmake
+++ b/cmake/package_settings.cmake
@@ -8,7 +8,7 @@
 # Set the default install prefix for Open Enclave. One may override this value
 # with the cmake command. For example:
 #
-#     $ cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/my_openenclave ..
+#     $ cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/myplace ..
 #
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX


### PR DESCRIPTION
This PR sets the default install prefix used by the **make install** command (per issue #799). The previous default value was **/usr/local**. Developers may still override this as before:
```
$ cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/myplace
```