### PR TITLE
Move libc/libcxx headers install location

### DIFF
--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -15,7 +15,7 @@ ExternalProject_Add(oelibcxx_cxx_includes
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/__config ${OE_INCDIR}/openenclave/libcxx/__config
     INSTALL_COMMAND ""
     )
-install (DIRECTORY ${OE_INCDIR}/openenclave/libcxx DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install (DIRECTORY ${OE_INCDIR}/openenclave/libcxx DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave)
 
 # build sources
 
@@ -67,7 +67,7 @@ add_dependencies(oelibcxx_cxx oelibcxx_cxx_includes)
 # this project and its dependents require include/libcxx in the include path
 target_include_directories(oelibcxx_cxx PUBLIC
     $<BUILD_INTERFACE:${OE_INCDIR}/openenclave/libcxx>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libcxx>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/libcxx>
     )
 
 # this project (and is dependents) require the LIBC includes

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -10,9 +10,9 @@ set(MUSL_DIR ${CMAKE_CURRENT_BINARY_DIR}/musl)
 
 include (ExternalProject)
 ExternalProject_Add(oelibc_includes
-    DOWNLOAD_COMMAND 
+    DOWNLOAD_COMMAND
         ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_LIST_DIR}/musl 
+        ${CMAKE_CURRENT_LIST_DIR}/musl
         ${CMAKE_CURRENT_BINARY_DIR}/musl
     PATCH_COMMAND
         COMMAND ${CMAKE_COMMAND} -E copy
@@ -21,23 +21,23 @@ ExternalProject_Add(oelibc_includes
         COMMAND ${CMAKE_COMMAND} -E copy
             ${PATCHES_DIR}/syscall_arch.h
             ${MUSL_DIR}/arch/x86_64/syscall_arch.h
-        COMMAND ${CMAKE_COMMAND} -E copy 
-            ${PATCHES_DIR}/pthread_arch.h 
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${PATCHES_DIR}/pthread_arch.h
             ${MUSL_DIR}/arch/x86_64/pthread_arch.h
-    CONFIGURE_COMMAND 
+    CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/musl
-        ./configure 
-            --includedir=${OE_INCDIR}/openenclave/libc 
+        ./configure
+            --includedir=${OE_INCDIR}/openenclave/libc
             CFLAGS=${CFLAGS}
-            CC=${CMAKE_C_COMPILER} 
+            CC=${CMAKE_C_COMPILER}
             CXX=${CMAKE_CXX_COMPILER}
-    BUILD_COMMAND 
+    BUILD_COMMAND
         ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/musl
         make install-headers
-        COMMAND ${CMAKE_COMMAND} -E copy 
+        COMMAND ${CMAKE_COMMAND} -E copy
             ${OE_INCDIR}/openenclave/libc/endian.h
             ${OE_INCDIR}/openenclave/libc/__endian.h
-        COMMAND ${CMAKE_COMMAND} -E copy 
+        COMMAND ${CMAKE_COMMAND} -E copy
             ${PATCHES_DIR}/endian.h
             ${OE_INCDIR}/openenclave/libc/endian.h
 
@@ -50,13 +50,13 @@ ExternalProject_Add(oelibc_includes
             ${CMAKE_CURRENT_LIST_DIR}/deprecations.h
             ${OE_INCDIR}/openenclave/libc/bits/deprecations.h
 
-    BUILD_BYPRODUCTS 
+    BUILD_BYPRODUCTS
         ${OE_INCDIR}/openenclave/libc ${CMAKE_CURRENT_BINARY_DIR}/musl
     INSTALL_COMMAND "")
 
-# install-rule can be generated here, usage requirements defined in 
+# install-rule can be generated here, usage requirements defined in
 # <ROOT>/libc/.
-install(DIRECTORY 
-    ${OE_INCDIR}/openenclave/libc 
-    DESTINATION 
-    ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY
+    ${OE_INCDIR}/openenclave/libc
+    DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/openenclave)

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -698,16 +698,14 @@ target_link_libraries(oelibc oecore)
 # as a pre-build step, place the musl LIBC headers
 add_dependencies(oelibc oelibc_includes)
 
-target_include_directories(oelibc PRIVATE 
+target_include_directories(oelibc PRIVATE
     ${PROJECT_BINARY_DIR}/3rdparty/musl/musl/src/internal
     ${PROJECT_BINARY_DIR}/3rdparty/musl/musl/arch/x86_64)
 
-# this project and its dependents require include/libc in the include path.
-# Note the difference between build time (absolute in build tree) and install
-# time (relative to install prefix)
+# pick up Open Enclave's version of the headers when using oelibc
 target_include_directories(oelibc PUBLIC
     $<BUILD_INTERFACE:${OE_INCDIR}/openenclave/libc>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libc>)
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/libc>)
 
 # when building this project, we also need a number of internal includes
 target_include_directories(oelibc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/internal)

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -23,16 +23,16 @@ set(PREFIX "${CMAKE_INSTALL_PREFIX}")
 ##
 ##==============================================================================
 
-set(ENCLAVE_CINCLUDES 
-    "-I\${includedir}/libc -I\${includedir}")
+set(ENCLAVE_CINCLUDES
+    "-I\${includedir}/openenclave/libc -I\${includedir}")
 
-set(ENCLAVE_CXXINCLUDES 
-    "-I\${includedir}/libcxx ${ENCLAVE_CINCLUDES}")
+set(ENCLAVE_CXXINCLUDES
+    "-I\${includedir}/openenclave/libcxx ${ENCLAVE_CINCLUDES}")
 
-set(ENCLAVE_CFLAGS_CLANG 
+set(ENCLAVE_CFLAGS_CLANG
     "-nostdinc -m64 -fPIC -mllvm -x86-speculative-load-hardening")
 
-set(ENCLAVE_CFLAGS_GCC 
+set(ENCLAVE_CFLAGS_GCC
     "-nostdinc -m64 -fPIC")
 
 ##==============================================================================
@@ -104,7 +104,7 @@ configure_file(
 
 install(FILES
     ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oeenclave-gcc.pc
-    DESTINATION 
+    DESTINATION
     "${CMAKE_INSTALL_DATADIR}/pkgconfig")
 
 ##==============================================================================
@@ -120,7 +120,7 @@ configure_file(
 
 install(FILES
     ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oeenclave-g++.pc
-    DESTINATION 
+    DESTINATION
     "${CMAKE_INSTALL_DATADIR}/pkgconfig")
 
 ##==============================================================================
@@ -136,7 +136,7 @@ configure_file(
 
 install(FILES
     ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-gcc.pc
-    DESTINATION 
+    DESTINATION
     "${CMAKE_INSTALL_DATADIR}/pkgconfig")
 
 ##==============================================================================
@@ -152,7 +152,7 @@ configure_file(
 
 install(FILES
     ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-g++.pc
-    DESTINATION 
+    DESTINATION
     "${CMAKE_INSTALL_DATADIR}/pkgconfig")
 
 ##==============================================================================
@@ -168,7 +168,7 @@ configure_file(
 
 install(FILES
     ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oeenclave-clang.pc
-    DESTINATION 
+    DESTINATION
     "${CMAKE_INSTALL_DATADIR}/pkgconfig")
 
 ##==============================================================================
@@ -184,7 +184,7 @@ configure_file(
 
 install(FILES
     ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oeenclave-clang++.pc
-    DESTINATION 
+    DESTINATION
     "${CMAKE_INSTALL_DATADIR}/pkgconfig")
 
 ##==============================================================================
@@ -200,7 +200,7 @@ configure_file(
 
 install(FILES
     ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang.pc
-    DESTINATION 
+    DESTINATION
     "${CMAKE_INSTALL_DATADIR}/pkgconfig")
 
 ##==============================================================================
@@ -216,7 +216,7 @@ configure_file(
 
 install(FILES
     ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang++.pc
-    DESTINATION 
+    DESTINATION
     "${CMAKE_INSTALL_DATADIR}/pkgconfig")
 
 ##==============================================================================
@@ -227,10 +227,10 @@ install(FILES
 
 set(PREFIX "${CMAKE_BINARY_DIR}/output")
 
-set(ENCLAVE_CINCLUDES 
+set(ENCLAVE_CINCLUDES
     "-I\${includedir}/openenclave/libc -I\${includedir} -I${PROJECT_SOURCE_DIR}/include")
 
-set(ENCLAVE_CXXINCLUDES 
+set(ENCLAVE_CXXINCLUDES
     "-I\${includedir}/openenclave/libcxx ${ENCLAVE_CINCLUDES}")
 
 set(HOST_INCLUDES "-I${PROJECT_SOURCE_DIR}/include")


### PR DESCRIPTION
- Move libc/libcxx headers under openenclave folder to prevent collisions if installing to usr/include
- Update pkgconfig to include updated install paths

This has a dependency on updating the samples to use pkgconfig instead of hardcoded includes in Makefiles