### PR TITLE
Fix problem with Visual C compile

### DIFF
--- a/common/safecrt.c
+++ b/common/safecrt.c
@@ -23,8 +23,8 @@ oe_result_t oe_memcpy_s(
     }
 
     /* Reject overlapping buffers. */
-    if ((dst >= src && (dst < src + num_bytes)) ||
-        (dst < src && (dst + dst_size > src)))
+    if ((dst >= src && ((uint8_t*)dst < (uint8_t*)src + num_bytes)) ||
+        (dst < src && ((uint8_t*)dst + dst_size > (uint8_t*)src)))
     {
         memset(dst, 0, dst_size);
         OE_RAISE(OE_OVERLAPPED_COPY);


### PR DESCRIPTION
safecrt.c is doing address calculations based on a void*. 