### PR TITLE
Edger8r: Minor bugfix and extensive tests for wchar_t, long long, and…

### DIFF
--- a/tests/oeedger8r/edl/array.edl
+++ b/tests/oeedger8r/edl/array.edl
@@ -13,6 +13,13 @@ enclave  {
             [user_check] char a4[4][4]
         );
 
+        public void ecall_array_wchar_t(
+            [in] wchar_t a1[2],
+            [in,out] wchar_t a2[2][2],
+            [out] wchar_t a3[3][3],
+            [user_check] wchar_t a4[4][4]
+        );
+
         public void ecall_array_short(
             [in] short a1[2],
             [in,out] short a2[2][2],
@@ -118,6 +125,20 @@ enclave  {
             [user_check] uint64_t a4[4][4]
         );       
 
+        public void ecall_array_long_long(
+            [in] long long a1[2],
+            [in,out] long long a2[2][2],
+            [out] long long a3[3][3],
+            [user_check] long long a4[4][4]
+        );
+
+        public void ecall_array_long_double(
+            [in] long double a1[2],
+            [in,out] long double a2[2][2],
+            [out] long double a3[3][3],
+            [user_check] long double a4[4][4]
+        );
+
         public void test_array_edl_ocalls();
         public void ecall_array_assert_all_called();
     };
@@ -132,6 +153,13 @@ enclave  {
             [user_check] char a4[4][4]
         );
     
+        void ocall_array_wchar_t(
+            [in] wchar_t a1[2],
+            [in,out] wchar_t a2[2][2],
+            [out] wchar_t a3[3][3],
+            [user_check] wchar_t a4[4][4]
+        );
+
         void ocall_array_short(
             [in] short a1[2],
             [in,out] short a2[2][2],
@@ -237,6 +265,20 @@ enclave  {
             [user_check] uint64_t a4[4][4]
         );         
     
+        void ocall_array_long_long(
+            [in] long long a1[2],
+            [in,out] long long a2[2][2],
+            [out] long long a3[3][3],
+            [user_check] long long a4[4][4]
+        );  
+
+        void ocall_array_long_double(
+            [in] long double a1[2],
+            [in,out] long double a2[2][2],
+            [out] long double a3[3][3],
+            [user_check] long double a4[4][4]
+        );  
+
         void ocall_array_assert_all_called();
     };
 };

--- a/tests/oeedger8r/edl/basic.edl
+++ b/tests/oeedger8r/edl/basic.edl
@@ -7,9 +7,7 @@ enclave  {
         /* Test all basic type parameters */
         public void ecall_basic_types(
             char arg1, 
-            // wchar_t is not supported since
-            // wchar_t has different sizes on linux and windows.
-            //wchar_t arg2, 
+            wchar_t arg2, 
             short arg3, 
             int arg4, 
             float arg5, 
@@ -24,12 +22,14 @@ enclave  {
             uint8_t arg14, 
             uint16_t arg15, 
             uint32_t arg16, 
-            uint64_t arg17
+            uint64_t arg17,
+            long long arg18,
+            long double arg19
         );
 
         /* Test all basic types are return type */
         public char ecall_ret_char();
-        //public wchar_t ecall_ret_wchar_t();
+        public wchar_t ecall_ret_wchar_t();
         public short ecall_ret_short();
         public int ecall_ret_int();
         public float ecall_ret_float();
@@ -45,6 +45,8 @@ enclave  {
         public uint16_t ecall_ret_uint16_t();
         public uint32_t ecall_ret_uint32_t();
         public uint64_t ecall_ret_uint64_t();   
+        public long long ecall_ret_long_long();
+        public long double ecall_ret_long_double();
 
         public void test_basic_edl_ocalls();             
     };
@@ -53,9 +55,7 @@ enclave  {
         /* Test all basic type parameters */
         void ocall_basic_types(
             char arg1, 
-            // wchar_t is not supported since
-            // wchar_t has different sizes on linux and windows.
-            //wchar_t arg2, 
+            wchar_t arg2, 
             short arg3, 
             int arg4, 
             float arg5, 
@@ -70,12 +70,14 @@ enclave  {
             uint8_t arg14, 
             uint16_t arg15, 
             uint32_t arg16, 
-            uint64_t arg17
+            uint64_t arg17,
+            long long arg18,
+            long double arg19
         );
 
         /* Test all basic types are return type */
         char ocall_ret_char();
-        //public wchar_t ocall_ret_wchar_t();
+        wchar_t ocall_ret_wchar_t();
         short ocall_ret_short();
         int ocall_ret_int();
         float ocall_ret_float();
@@ -90,6 +92,8 @@ enclave  {
         uint8_t ocall_ret_uint8_t();
         uint16_t ocall_ret_uint16_t();
         uint32_t ocall_ret_uint32_t();
-        uint64_t ocall_ret_uint64_t();          
+        uint64_t ocall_ret_uint64_t();     
+        long long ocall_ret_long_long();
+        long double ocall_ret_long_double();             
     }; 
 };

--- a/tests/oeedger8r/edl/pointer.edl
+++ b/tests/oeedger8r/edl/pointer.edl
@@ -37,6 +37,39 @@ enclave {
             int psize
         );
 
+        public wchar_t* ecall_pointer_wchar_t(
+            // No count or size, defaults to 1.
+            [in] wchar_t* p1,
+            [in,out] wchar_t* p2,
+            [out] wchar_t* p3,            
+
+            // count specifies number of elements.
+            [in, count=16] wchar_t* p4,
+            [in,out, count=16] wchar_t* p5,
+            [out, count=16] wchar_t* p6,
+
+            // size specifies size in bytes.
+            [in, size=80] wchar_t* p7,
+            [in, out, size=80] wchar_t* p8,
+            [in, size=80] wchar_t* p9,
+
+            // user handled.
+            [user_check] wchar_t* p10,
+
+            // count as parameter
+            [in, count=pcount] wchar_t* p11,
+            [in,out, count=pcount] wchar_t* p12,
+            [out, count=pcount] wchar_t* p13,
+
+            // size as parameter
+            [in, size=psize] wchar_t* p14,
+            [in,out, size=psize] wchar_t* p15,
+            [out, size=psize] wchar_t* p16,
+
+            int pcount,
+            int psize
+        );
+
         public short* ecall_pointer_short(
             // No count or size, defaults to 1.
             [in] short* p1,
@@ -532,6 +565,72 @@ enclave {
             int psize             
         ); 
 
+        public long long* ecall_pointer_long_long(
+            // No count or size, defaults to 1.
+            [in] long long* p1,
+            [in,out] long long* p2,
+            [out] long long* p3,            
+
+            // count specifies number of elements.
+            [in, count=16] long long* p4,
+            [in,out, count=16] long long* p5,
+            [out, count=16] long long* p6,
+
+            // size specifies size in bytes.
+            [in, size=80] long long* p7,
+            [in, out, size=80] long long* p8,
+            [in, size=80] long long* p9,
+
+            // user handled.
+            [user_check] long long* p10,
+
+            // count as parameter
+            [in, count=pcount] long long* p11,
+            [in,out, count=pcount] long long* p12,
+            [out, count=pcount] long long* p13,
+
+            // size as parameter
+            [in, size=psize] long long* p14,
+            [in,out, size=psize] long long* p15,
+            [out, size=psize] long long* p16,
+
+            int pcount,
+            int psize             
+        ); 
+
+        public long double* ecall_pointer_long_double(
+            // No count or size, defaults to 1.
+            [in] long double* p1,
+            [in,out] long double* p2,
+            [out] long double* p3,            
+
+            // count specifies number of elements.
+            [in, count=16] long double* p4,
+            [in,out, count=16] long double* p5,
+            [out, count=16] long double* p6,
+
+            // size specifies size in bytes.
+            [in, size=80] long double* p7,
+            [in, out, size=80] long double* p8,
+            [in, size=80] long double* p9,
+
+            // user handled.
+            [user_check] long double* p10,
+
+            // count as parameter
+            [in, count=pcount] long double* p11,
+            [in,out, count=pcount] long double* p12,
+            [out, count=pcount] long double* p13,
+
+            // size as parameter
+            [in, size=psize] long double* p14,
+            [in,out, size=psize] long double* p15,
+            [out, size=psize] long double* p16,
+
+            int pcount,
+            int psize             
+        ); 
+
         // Test that various types can be used as size, count attributes.
         // Checked to make sure no compile errors are encountered.
         public void ecall_count_attribute_all_types(
@@ -551,6 +650,9 @@ enclave {
             [in, count=uint16_t_count] int* b14,
             [in, count=uint32_t_count] int* b15,
             [in, count=uint64_t_count] int* b16,            
+            [in, count=wchar_t_count] int* b17,            
+            [in, count=long_long_count] int* b18,            
+            [in, count=long_double_count] int* b19,   
             char char_count,
             short short_count,
             int int_count,
@@ -566,7 +668,10 @@ enclave {
             uint8_t uint8_t_count,
             uint16_t uint16_t_count,
             uint32_t uint32_t_count,
-            uint64_t uint64_t_count
+            uint64_t uint64_t_count,
+            wchar_t wchar_t_count,
+            long long long_long_count,
+            long double long_double_count
         );
 
         public void ecall_size_attribute_all_types(
@@ -585,7 +690,10 @@ enclave {
             [in, size=uint8_t_size] int* b13,
             [in, size=uint16_t_size] int* b14,
             [in, size=uint32_t_size] int* b15,
-            [in, size=uint64_t_size] int* b16,            
+            [in, size=uint64_t_size] int* b16,        
+            [in, size=wchar_t_size] int* b17,            
+            [in, size=long_long_size] int* b18,            
+            [in, size=long_double_size] int* b19,                   
             char char_size,
             short short_size,
             int int_size,
@@ -601,7 +709,10 @@ enclave {
             uint8_t uint8_t_size,
             uint16_t uint16_t_size,
             uint32_t uint32_t_size,
-            uint64_t uint64_t_size
+            uint64_t uint64_t_size,
+            wchar_t wchar_t_size,
+            long long long_long_size,
+            long double long_double_size            
         );  
 
         public void test_pointer_edl_ocalls();
@@ -638,6 +749,39 @@ enclave {
             [in, size=psize] char* p14,
             [in,out, size=psize] char* p15,
             [out, size=psize] char* p16,
+
+            int pcount,
+            int psize            
+        );
+
+        wchar_t* ocall_pointer_wchar_t(
+            // No count or size, defaults to 1.
+            [in] wchar_t* p1,
+            [in,out] wchar_t* p2,
+            [out] wchar_t* p3,            
+
+            // count specifies number of elements.
+            [in, count=16] wchar_t* p4,
+            [in,out, count=16] wchar_t* p5,
+            [out, count=16] wchar_t* p6,
+
+            // size specifies size in bytes.
+            [in, size=80] wchar_t* p7,
+            [in, out, size=80] wchar_t* p8,
+            [in, size=80] wchar_t* p9,
+
+            // user handled.
+            [user_check] wchar_t* p10,
+
+            // count as parameter
+            [in, count=pcount] wchar_t* p11,
+            [in,out, count=pcount] wchar_t* p12,
+            [out, count=pcount] wchar_t* p13,
+
+            // size as parameter
+            [in, size=psize] wchar_t* p14,
+            [in,out, size=psize] wchar_t* p15,
+            [out, size=psize] wchar_t* p16,
 
             int pcount,
             int psize            
@@ -1138,6 +1282,72 @@ enclave {
             int psize
         ); 
 
+        long long* ocall_pointer_long_long(
+            // No count or size, defaults to 1.
+            [in] long long* p1,
+            [in,out] long long* p2,
+            [out] long long* p3,            
+
+            // count specifies number of elements.
+            [in, count=16] long long* p4,
+            [in,out, count=16] long long* p5,
+            [out, count=16] long long* p6,
+
+            // size specifies size in bytes.
+            [in, size=80] long long* p7,
+            [in, out, size=80] long long* p8,
+            [in, size=80] long long* p9,
+
+            // user handled.
+            [user_check] long long* p10,
+
+            // count as parameter
+            [in, count=pcount] long long* p11,
+            [in,out, count=pcount] long long* p12,
+            [out, count=pcount] long long* p13,
+
+            // size as parameter
+            [in, size=psize] long long* p14,
+            [in,out, size=psize] long long* p15,
+            [out, size=psize] long long* p16,
+
+            int pcount,
+            int psize
+        ); 
+
+        long double* ocall_pointer_long_double(
+            // No count or size, defaults to 1.
+            [in] long double* p1,
+            [in,out] long double* p2,
+            [out] long double* p3,            
+
+            // count specifies number of elements.
+            [in, count=16] long double* p4,
+            [in,out, count=16] long double* p5,
+            [out, count=16] long double* p6,
+
+            // size specifies size in bytes.
+            [in, size=80] long double* p7,
+            [in, out, size=80] long double* p8,
+            [in, size=80] long double* p9,
+
+            // user handled.
+            [user_check] long double* p10,
+
+            // count as parameter
+            [in, count=pcount] long double* p11,
+            [in,out, count=pcount] long double* p12,
+            [out, count=pcount] long double* p13,
+
+            // size as parameter
+            [in, size=psize] long double* p14,
+            [in,out, size=psize] long double* p15,
+            [out, size=psize] long double* p16,
+
+            int pcount,
+            int psize
+        ); 
+
         // Test that various types can be used as size, count attributes.
         // Checked to make sure no compile errors are encountered.
         void ocall_count_attribute_all_types(
@@ -1156,7 +1366,10 @@ enclave {
             [in, count=uint8_t_count] int* b13,
             [in, count=uint16_t_count] int* b14,
             [in, count=uint32_t_count] int* b15,
-            [in, count=uint64_t_count] int* b16,            
+            [in, count=uint64_t_count] int* b16,    
+            [in, count=wchar_t_count] int* b17,            
+            [in, count=long_long_count] int* b18,            
+            [in, count=long_double_count] int* b19,                     
             char char_count,
             short short_count,
             int int_count,
@@ -1172,7 +1385,10 @@ enclave {
             uint8_t uint8_t_count,
             uint16_t uint16_t_count,
             uint32_t uint32_t_count,
-            uint64_t uint64_t_count
+            uint64_t uint64_t_count,
+            wchar_t wchar_t_count,
+            long long long_long_count,
+            long double long_double_count            
         );
 
         void ocall_size_attribute_all_types(
@@ -1191,7 +1407,10 @@ enclave {
             [in, size=uint8_t_size] int* b13,
             [in, size=uint16_t_size] int* b14,
             [in, size=uint32_t_size] int* b15,
-            [in, size=uint64_t_size] int* b16,            
+            [in, size=uint64_t_size] int* b16,           
+            [in, size=wchar_t_size] int* b17,            
+            [in, size=long_long_size] int* b18,            
+            [in, size=long_double_size] int* b19,               
             char char_size,
             short short_size,
             int int_size,
@@ -1207,7 +1426,10 @@ enclave {
             uint8_t uint8_t_size,
             uint16_t uint16_t_size,
             uint32_t uint32_t_size,
-            uint64_t uint64_t_size
+            uint64_t uint64_t_size,
+            wchar_t wchar_t_size,
+            long long long_long_size,
+            long double long_double_size
         );      
 
         void ocall_pointer_assert_all_called();                                                                                                                           

--- a/tests/oeedger8r/edl/string.edl
+++ b/tests/oeedger8r/edl/string.edl
@@ -4,40 +4,76 @@
 enclave {
     trusted {
         // string attribute must be used only with in or in-out attributes.
-        public void  ecall_string_fun1([string, in] char* s);
-        public void  ecall_string_fun2([string, in] const char* s);
+        public void ecall_string_fun1([string, in] char* s);
+        public void ecall_string_fun2([string, in] const char* s);
        
-        public void  ecall_string_fun3([string, in, out] char* s);
+        public void ecall_string_fun3([string, in, out] char* s);
 
         // Edger8r allows this even though const cannot be modified.
-        // public void  ecall_string_fun4([string, in, out] const char* s);
+        // public void ecall_string_fun4([string, in, out] const char* s);
 
-        public void  ecall_string_fun5([user_check] char* s);
-        public void  ecall_string_fun6([user_check] const char* s);
+        // user_check attribute is supported.
+        public void ecall_string_fun5([user_check] char* s);
+        public void ecall_string_fun6([user_check] const char* s);
 
         // Multiple string parameters
         public void ecall_string_fun7([string, in] char* s1, [string, in] char* s2);
 
         public void test_string_edl_ocalls();
+
+        // wstring attribute must be used only with in or in-out attributes.
+        public void ecall_wstring_fun1([wstring, in] wchar_t* s);
+        public void ecall_wstring_fun2([wstring, in] const wchar_t* s);
+       
+        public void ecall_wstring_fun3([wstring, in, out] wchar_t* s);
+
+        // Edger8r allows this even though const cannot be modified.
+        // public void ecall_wstring_fun4([string, in, out] const wchar_t* s);
+
+        // user_check attribute is supported.
+        public void ecall_wstring_fun5([user_check] wchar_t* s);
+        public void ecall_wstring_fun6([user_check] const wchar_t* s);
+
+        // Multiple string parameters
+        public void ecall_wstring_fun7([wstring, in] wchar_t* s1, [wstring, in] wchar_t* s2);
+
+        public void test_wstring_edl_ocalls();
     };
 
     untrusted {
         // string attribute must be used only with in or in-out attributes.
-        void  ocall_string_fun1([string, in] char* s);
-        void  ocall_string_fun2([string, in] const char* s);
+        void ocall_string_fun1([string, in] char* s);
+        void ocall_string_fun2([string, in] const char* s);
        
-        void  ocall_string_fun3([string, in, out] char* s);
+        void ocall_string_fun3([string, in, out] char* s);
 
         // Edger8r allows this even though const cannot be modified.
         // public void  ocall_string_fun4([string, in, out] const char* s);
 
         // user_check for ocalls does not add much value since
         // the pointer cannot be de-referenced on the host side.
-        void  ocall_string_fun5([user_check] char* s);
-        void  ocall_string_fun6([user_check] const char* s);
+        void ocall_string_fun5([user_check] char* s);
+        void ocall_string_fun6([user_check] const char* s);
 
         // Multiple string parameters
         void ocall_string_fun7([string, in] char* s1, [string, in] char* s2);
+
+        // wstring attribute must be used only with in or in-out attributes.
+        void ocall_wstring_fun1([wstring, in] wchar_t* s);
+        void ocall_wstring_fun2([wstring, in] const wchar_t* s);
+       
+        void ocall_wstring_fun3([wstring, in, out] wchar_t* s);
+
+        // Edger8r allows this even though const cannot be modified.
+        // public void  ocall_string_fun4([string, in, out] const char* s);
+
+        // user_check for ocalls does not add much value since
+        // the pointer cannot be de-referenced on the host side.
+        void ocall_wstring_fun5([user_check] wchar_t* s);
+        void ocall_wstring_fun6([user_check] const wchar_t* s);
+
+        // Multiple string parameters
+        void ocall_wstring_fun7([wstring, in] wchar_t* s1, [wstring, in] wchar_t* s2);        
     };
 };
 

--- a/tests/oeedger8r/edltestutils.h
+++ b/tests/oeedger8r/edltestutils.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <wchar.h>
+
 // Assert that given arguments are of specified types.
 // Results in compile error on type mismatch.
 template <typename... Args>
@@ -42,3 +44,19 @@ struct unused
     }
 
 DEFINE_ASSERT_NO_FIELD(s_len)
+
+template <typename T, int N, typename U>
+inline int array_compare(const T (&a1)[N], U u)
+{
+    const T* a2 = (const T*)u;
+    for (int i = 0; i < N; ++i)
+    {
+        if (a1[i] < a2[i])
+            return -1;
+        else if (a1[i] > a2[i])
+            return 1;
+    }
+    return 0;
+}
+
+const wchar_t ohm = L'\u2126';

--- a/tests/oeedger8r/enc/testarray.cpp
+++ b/tests/oeedger8r/enc/testarray.cpp
@@ -37,18 +37,18 @@ static void test_ocall_array_fun(F ocall_array_fun)
     OE_TEST(ocall_array_fun(a1, a2, a3, a4) == OE_OK);
     {
         T exp[] = {4, 3, 2, 1};
-        OE_TEST(memcmp(exp, a2, sizeof(a2)) == 0);
+        OE_TEST(array_compare(exp, (T*)a2) == 0);
     }
 
     {
         T exp[] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
-        OE_TEST(memcmp(exp, a3, sizeof(a3)) == 0);
+        OE_TEST(array_compare(exp, (T*)a3) == 0);
     }
     {
         // a4 cannot be modified by host.
         // expected value is original value.
         T exp[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-        OE_TEST(memcmp(exp, a4, sizeof(a4)) == 0);
+        OE_TEST(array_compare(exp, (T*)a4) == 0);
     }
 
     // Call with nulls.
@@ -58,6 +58,7 @@ static void test_ocall_array_fun(F ocall_array_fun)
 void test_array_edl_ocalls()
 {
     test_ocall_array_fun<char>(ocall_array_char);
+    test_ocall_array_fun<wchar_t>(ocall_array_wchar_t);
     test_ocall_array_fun<short>(ocall_array_short);
     test_ocall_array_fun<int>(ocall_array_int);
     test_ocall_array_fun<float>(ocall_array_float);
@@ -73,6 +74,8 @@ void test_array_edl_ocalls()
     test_ocall_array_fun<uint16_t>(ocall_array_uint16_t);
     test_ocall_array_fun<uint32_t>(ocall_array_uint32_t);
     test_ocall_array_fun<uint64_t>(ocall_array_uint64_t);
+    test_ocall_array_fun<long long>(ocall_array_long_long);
+    test_ocall_array_fun<long double>(ocall_array_long_double);
 
     OE_TEST(ocall_array_assert_all_called() == OE_OK);
     printf("=== test_array_edl_ocalls passed\n");
@@ -104,7 +107,7 @@ static void ecall_array_fun_impl(T a1[2], T a2[2][2], T a3[3][3], T a4[4][4])
     {
         OE_TEST(oe_is_within_enclave(a2, sizeof(T) * 2 * 2));
         T exp[] = {1, 2, 3, 4};
-        OE_TEST(memcmp(exp, a2, sizeof(T) * 2 * 2) == 0);
+        OE_TEST(array_compare(exp, (T*)a2) == 0);
         reverse((T*)a2, 4);
     }
 
@@ -127,6 +130,15 @@ static void ecall_array_fun_impl(T a1[2], T a2[2][2], T a3[3][3], T a4[4][4])
 }
 
 void ecall_array_char(char a1[2], char a2[2][2], char a3[3][3], char a4[4][4])
+{
+    ecall_array_fun_impl(a1, a2, a3, a4);
+}
+
+void ecall_array_wchar_t(
+    wchar_t a1[2],
+    wchar_t a2[2][2],
+    wchar_t a3[3][3],
+    wchar_t a4[4][4])
 {
     ecall_array_fun_impl(a1, a2, a3, a4);
 }
@@ -258,9 +270,27 @@ void ecall_array_uint64_t(
     ecall_array_fun_impl(a1, a2, a3, a4);
 }
 
+void ecall_array_long_long(
+    long long a1[2],
+    long long a2[2][2],
+    long long a3[3][3],
+    long long a4[4][4])
+{
+    ecall_array_fun_impl(a1, a2, a3, a4);
+}
+
+void ecall_array_long_double(
+    long double a1[2],
+    long double a2[2][2],
+    long double a3[3][3],
+    long double a4[4][4])
+{
+    ecall_array_fun_impl(a1, a2, a3, a4);
+}
+
 void ecall_array_assert_all_called()
 {
-    // Each of the 16 functions above is called twice.
+    // Each of the 19 functions above is called twice.
     // Once with arrays and then with nulls.
-    OE_TEST(num_ecalls == 32);
+    OE_TEST(num_ecalls == 38);
 }

--- a/tests/oeedger8r/enc/testbasic.cpp
+++ b/tests/oeedger8r/enc/testbasic.cpp
@@ -13,7 +13,7 @@ void test_basic_edl_ocalls()
     OE_TEST(
         ocall_basic_types(
             '?',
-            // '\x3b1',
+            ohm,
             3,
             4,
             3.1415f,
@@ -28,12 +28,20 @@ void test_basic_edl_ocalls()
             14,
             15,
             16,
-            17) == OE_OK);
+            17,
+            18,
+            19) == OE_OK);
 
     {
         char ret = 0;
         OE_TEST(ocall_ret_char(&ret) == OE_OK);
         OE_TEST(ret == '?');
+    }
+
+    {
+        wchar_t ret = 0;
+        OE_TEST(ocall_ret_wchar_t(&ret) == OE_OK);
+        OE_TEST(ret == ohm);
     }
 
     {
@@ -125,12 +133,24 @@ void test_basic_edl_ocalls()
         OE_TEST(ocall_ret_uint64_t(&ret) == OE_OK);
         OE_TEST(ret == 171717);
     }
+
+    {
+        long long ret = 0;
+        OE_TEST(ocall_ret_long_long(&ret) == OE_OK);
+        OE_TEST(ret == 181818);
+    }
+
+    {
+        long double ret = 0;
+        OE_TEST(ocall_ret_long_double(&ret) == OE_OK);
+        OE_TEST(ret == 0.191919);
+    }
     printf("=== test_basic_edl_ocalls passed\n");
 }
 
 void ecall_basic_types(
     char arg1,
-    // wchar_t arg2,
+    wchar_t arg2,
     short arg3,
     int arg4,
     float arg5,
@@ -145,13 +165,15 @@ void ecall_basic_types(
     uint8_t arg14,
     uint16_t arg15,
     uint32_t arg16,
-    uint64_t arg17)
+    uint64_t arg17,
+    long long arg18,
+    long double arg19)
 {
     ecall_basic_types_args_t args;
 
     // Assert types of fields of the marshaling struct.
     check_type<char>(args.arg1);
-    // check_type<wchar_t>(args.arg2);
+    check_type<wchar_t>(args.arg2);
     check_type<short>(args.arg3);
     check_type<int>(args.arg4);
     check_type<int>(args.arg4);
@@ -170,7 +192,7 @@ void ecall_basic_types(
     check_type<uint64_t>(args.arg17);
 
     OE_TEST(arg1 == '?');
-    // OE_TEST(arg2 == '\x3b1');
+    OE_TEST(arg2 == ohm);
     OE_TEST(arg3 = 3);
     OE_TEST(arg4 = 4);
     OE_TEST(arg5 = 3.1415f);
@@ -186,12 +208,20 @@ void ecall_basic_types(
     OE_TEST(arg15 = 15);
     OE_TEST(arg16 = 16);
     OE_TEST(arg17 = 17);
+    OE_TEST(arg18 = 18);
+    OE_TEST(arg19 = 19);
 }
 
 char ecall_ret_char()
 {
     check_return_type<ecall_ret_char_args_t, char>();
     return '?';
+}
+
+wchar_t ecall_ret_wchar_t()
+{
+    check_return_type<ecall_ret_wchar_t_args_t, wchar_t>();
+    return ohm;
 }
 
 short ecall_ret_short()
@@ -282,4 +312,16 @@ uint64_t ecall_ret_uint64_t()
 {
     check_return_type<ecall_ret_uint64_t_args_t, uint64_t>();
     return 171717;
+}
+
+long long ecall_ret_long_long()
+{
+    check_return_type<ecall_ret_long_long_args_t, long long>();
+    return 181818;
+}
+
+long double ecall_ret_long_double()
+{
+    check_return_type<ecall_ret_long_double_args_t, long double>();
+    return 0.191919;
 }

--- a/tests/oeedger8r/enc/testpointer.cpp
+++ b/tests/oeedger8r/enc/testpointer.cpp
@@ -81,7 +81,7 @@ static void test_ocall_pointer_fun(F ocall_pointer_fun)
 
         // p5 is reversed.
         T exp[] = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
-        OE_TEST(memcmp(exp, p5, sizeof(exp)) == 0);
+        OE_TEST(array_compare(exp, p5) == 0);
 
         // p6 is initialized
         for (size_t i = 0; i < 16; ++i)
@@ -164,6 +164,7 @@ static void test_ocall_pointer_fun(F ocall_pointer_fun)
 void test_pointer_edl_ocalls()
 {
     test_ocall_pointer_fun<char>(ocall_pointer_char);
+    test_ocall_pointer_fun<wchar_t>(ocall_pointer_wchar_t);
     test_ocall_pointer_fun<short>(ocall_pointer_short);
     test_ocall_pointer_fun<int>(ocall_pointer_int);
     test_ocall_pointer_fun<float>(ocall_pointer_float);
@@ -179,6 +180,8 @@ void test_pointer_edl_ocalls()
     test_ocall_pointer_fun<uint16_t>(ocall_pointer_uint16_t);
     test_ocall_pointer_fun<uint32_t>(ocall_pointer_uint32_t);
     test_ocall_pointer_fun<uint64_t>(ocall_pointer_uint64_t);
+    test_ocall_pointer_fun<long long>(ocall_pointer_long_long);
+    test_ocall_pointer_fun<long double>(ocall_pointer_long_double);
 
     OE_TEST(ocall_pointer_assert_all_called() == OE_OK);
     printf("=== test_pointer_edl_ocalls passed\n");
@@ -277,7 +280,7 @@ static T* ecall_pointer_fun_impl(
 
     // size specified as 80 (lcm of sizeof(double), sizeof(long))
     {
-        size_t count = 80 / sizeof(T);
+        const size_t count = 80 / sizeof(T);
         T exp[count];
         for (size_t i = 0; i < count; ++i)
             exp[i] = i + 1;
@@ -286,7 +289,7 @@ static T* ecall_pointer_fun_impl(
         if (p7)
         {
             OE_TEST(oe_is_within_enclave(p7, 80));
-            OE_TEST(memcmp(p7, exp, 80) == 0);
+            OE_TEST(array_compare(exp, p7) == 0);
 
             // change p7. Should not have any effect on host.
             memset(p7, 0, 80);
@@ -296,7 +299,7 @@ static T* ecall_pointer_fun_impl(
         if (p8)
         {
             OE_TEST(oe_is_within_enclave(p8, 80));
-            OE_TEST(memcmp(p8, exp, 80) == 0);
+            OE_TEST(array_compare(exp, p8) == 0);
             reverse(p8, count);
         }
 
@@ -397,6 +400,47 @@ char* ecall_pointer_char(
     char* p14,
     char* p15,
     char* p16,
+    int pcount,
+    int psize)
+{
+    return ecall_pointer_fun_impl(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+        p16,
+        pcount,
+        psize);
+}
+
+wchar_t* ecall_pointer_wchar_t(
+    wchar_t* p1,
+    wchar_t* p2,
+    wchar_t* p3,
+    wchar_t* p4,
+    wchar_t* p5,
+    wchar_t* p6,
+    wchar_t* p7,
+    wchar_t* p8,
+    wchar_t* p9,
+    wchar_t* p10,
+    wchar_t* p11,
+    wchar_t* p12,
+    wchar_t* p13,
+    wchar_t* p14,
+    wchar_t* p15,
+    wchar_t* p16,
     int pcount,
     int psize)
 {
@@ -1036,12 +1080,94 @@ uint64_t* ecall_pointer_uint64_t(
         psize);
 }
 
+long long* ecall_pointer_long_long(
+    long long* p1,
+    long long* p2,
+    long long* p3,
+    long long* p4,
+    long long* p5,
+    long long* p6,
+    long long* p7,
+    long long* p8,
+    long long* p9,
+    long long* p10,
+    long long* p11,
+    long long* p12,
+    long long* p13,
+    long long* p14,
+    long long* p15,
+    long long* p16,
+    int pcount,
+    int psize)
+{
+    return ecall_pointer_fun_impl(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+        p16,
+        pcount,
+        psize);
+}
+
+long double* ecall_pointer_long_double(
+    long double* p1,
+    long double* p2,
+    long double* p3,
+    long double* p4,
+    long double* p5,
+    long double* p6,
+    long double* p7,
+    long double* p8,
+    long double* p9,
+    long double* p10,
+    long double* p11,
+    long double* p12,
+    long double* p13,
+    long double* p14,
+    long double* p15,
+    long double* p16,
+    int pcount,
+    int psize)
+{
+    return ecall_pointer_fun_impl(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+        p16,
+        pcount,
+        psize);
+}
+
 void ecall_pointer_assert_all_called()
 {
-    // Each of the 16 functions above is called twice.
+    // Each of the 19 functions above is called twice.
     // Once with arrays and then with nulls.
-    OE_TEST(num_ecalls == 32);
-    OE_TEST(num_null_ecalls == 16);
+    OE_TEST(num_ecalls == 38);
+    OE_TEST(num_null_ecalls == 19);
 }
 
 // The following functions exists to make sure there are no
@@ -1064,6 +1190,9 @@ void ecall_count_attribute_all_types(
     int* b14,
     int* b15,
     int* b16,
+    int* b17,
+    int* b18,
+    int* b19,
     char char_count,
     short short_count,
     int int_count,
@@ -1079,7 +1208,10 @@ void ecall_count_attribute_all_types(
     uint8_t uint8_t_count,
     uint16_t uint16_t_count,
     uint32_t uint32_t_count,
-    uint64_t uint64_t_count)
+    uint64_t uint64_t_count,
+    wchar_t wchar_t_count,
+    long long long_long_count,
+    long double long_double_count)
 {
 }
 
@@ -1100,6 +1232,9 @@ void ecall_size_attribute_all_types(
     int* b14,
     int* b15,
     int* b16,
+    int* b17,
+    int* b18,
+    int* b19,
     char char_size,
     short short_size,
     int int_size,
@@ -1115,6 +1250,9 @@ void ecall_size_attribute_all_types(
     uint8_t uint8_t_size,
     uint16_t uint16_t_size,
     uint32_t uint32_t_size,
-    uint64_t uint64_t_size)
+    uint64_t uint64_t_size,
+    wchar_t wchar_t_size,
+    long long long_long_size,
+    long double long_double_size)
 {
 }

--- a/tests/oeedger8r/enc/teststring.cpp
+++ b/tests/oeedger8r/enc/teststring.cpp
@@ -127,3 +127,123 @@ void ecall_string_fun7(char* s1, char* s2)
     OE_TEST(s1 != NULL);
     OE_TEST(s2 == NULL);
 }
+
+void test_wstring_edl_ocalls()
+{
+    const wchar_t* str_value = L"Hello, World\n";
+
+    wchar_t str[50];
+    swprintf(str, 50, L"%S", str_value);
+
+    // char*
+    OE_TEST(ocall_wstring_fun1(str) == OE_OK);
+    OE_TEST(wcscmp(str, str_value) == 0);
+
+    // const char*. (char* is passed in)
+    OE_TEST(ocall_wstring_fun2(str) == OE_OK);
+    OE_TEST(wcscmp(str, str_value) == 0);
+
+    // char* in/out
+    OE_TEST(ocall_wstring_fun3(str) == OE_OK);
+    OE_TEST(wcscmp(str, L"Goodbye\n") == 0);
+
+    // Restore value.
+    swprintf(str, 50, L"%S", str_value);
+
+    // char* user check.
+    OE_TEST(ocall_wstring_fun5(str) == OE_OK);
+
+    // char* user check.
+    OE_TEST(ocall_wstring_fun6(str) == OE_OK);
+
+    // Multiple string params. One null.
+    OE_TEST(ocall_wstring_fun7(str, NULL) == OE_OK);
+
+    printf("=== test_wstring_edl_ocalls passed\n");
+}
+
+void ecall_wstring_fun1(wchar_t* s)
+{
+    ecall_wstring_fun1_args_t args;
+    check_type<wchar_t*>(args.s);
+    check_type<size_t>(args.s_len);
+
+    // Check that s has been copied over.
+    size_t s_len = wcslen(s) + 1;
+    OE_TEST(oe_is_within_enclave(s, s_len * sizeof(wchar_t)));
+
+    OE_TEST(wcscmp(s, L"Hello, World\n") == 0);
+}
+
+void ecall_wstring_fun2(const wchar_t* s)
+{
+    ecall_wstring_fun2_args_t args;
+    // constness is discarded when marshaling.
+    check_type<wchar_t*>(args.s);
+    check_type<size_t>(args.s_len);
+
+    // Check that s has been copied over.
+    size_t s_len = wcslen(s) + 1;
+    OE_TEST(oe_is_within_enclave(s, s_len * sizeof(wchar_t)));
+
+    OE_TEST(wcscmp(s, L"Hello, World\n") == 0);
+}
+
+void ecall_wstring_fun3(wchar_t* s)
+{
+    ecall_wstring_fun3_args_t args;
+    check_type<wchar_t*>(args.s);
+
+    check_type<size_t>(args.s_len);
+
+    // Check that s has been copied over.
+    size_t s_len = wcslen(s) + 1;
+    OE_TEST(oe_is_within_enclave(s, s_len * sizeof(wchar_t)));
+
+    OE_TEST(wcscmp(s, L"Hello, World\n") == 0);
+
+    // Write to s. Check on host side for new value.
+    const wchar_t* new_s = L"Goodbye\n";
+    memcpy(s, new_s, (wcslen(new_s) + 1) * sizeof(wchar_t));
+}
+
+void ecall_wstring_fun5(wchar_t* s)
+{
+    ecall_wstring_fun5_args_t args;
+    check_type<wchar_t*>(args.s);
+    // User check implies no s_len field is created.
+    assert_no_field_s_len<ecall_wstring_fun5_args_t>();
+
+    // Check that s has not been copied over.
+    size_t s_len = wcslen(s) + 1;
+    OE_TEST(oe_is_outside_enclave(s, s_len * sizeof(wchar_t)));
+
+    // Change value to Hello.
+    s[5] = L'\0';
+}
+
+void ecall_wstring_fun6(const wchar_t* s)
+{
+    ecall_wstring_fun6_args_t args;
+    // constness is discarded when marshaling.
+    check_type<wchar_t*>(args.s);
+    // User check implies no s_len field is created.
+    assert_no_field_s_len<ecall_wstring_fun6_args_t>();
+
+    // Check that s has not been copied over.
+    size_t s_len = wcslen(s) + 1;
+    OE_TEST(oe_is_outside_enclave(s, s_len * sizeof(wchar_t)));
+}
+
+void ecall_wstring_fun7(wchar_t* s1, wchar_t* s2)
+{
+    ecall_wstring_fun7_args_t args;
+
+    check_type<wchar_t*>(args.s1);
+    check_type<size_t>(args.s1_len);
+    check_type<wchar_t*>(args.s2);
+    check_type<size_t>(args.s2_len);
+
+    OE_TEST(s1 != NULL);
+    OE_TEST(s2 == NULL);
+}

--- a/tests/oeedger8r/host/main.cpp
+++ b/tests/oeedger8r/host/main.cpp
@@ -14,6 +14,7 @@
 
 void test_basic_edl_ecalls(oe_enclave_t* enclave);
 void test_string_edl_ecalls(oe_enclave_t* enclave);
+void test_wstring_edl_ecalls(oe_enclave_t* enclave);
 void test_array_edl_ecalls(oe_enclave_t* enclave);
 void test_pointer_edl_ecalls(oe_enclave_t* enclave);
 void test_struct_edl_ecalls(oe_enclave_t* enclave);
@@ -47,6 +48,9 @@ int main(int argc, const char* argv[])
 
     test_string_edl_ecalls(enclave);
     OE_TEST(test_string_edl_ocalls(enclave) == OE_OK);
+
+    test_wstring_edl_ecalls(enclave);
+    OE_TEST(test_wstring_edl_ocalls(enclave) == OE_OK);
 
     test_array_edl_ecalls(enclave);
     OE_TEST(test_array_edl_ocalls(enclave) == OE_OK);

--- a/tests/oeedger8r/host/testarray.cpp
+++ b/tests/oeedger8r/host/testarray.cpp
@@ -36,16 +36,16 @@ void test_ecall_array_fun(oe_enclave_t* enclave, F ecall_array_fun)
     OE_TEST(ecall_array_fun(enclave, a1, a2, a3, a4) == OE_OK);
     {
         T exp[] = {4, 3, 2, 1};
-        OE_TEST(memcmp(exp, a2, sizeof(a2)) == 0);
+        OE_TEST(array_compare(exp, (T*)a2) == 0);
     }
 
     {
         T exp[] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
-        OE_TEST(memcmp(exp, a3, sizeof(a3)) == 0);
+        OE_TEST(array_compare(exp, (T*)a3) == 0);
     }
     {
         T exp[] = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
-        OE_TEST(memcmp(exp, a4, sizeof(a4)) == 0);
+        OE_TEST(array_compare(exp, (T*)a4) == 0);
     }
 
     // Call with nulls.
@@ -55,6 +55,7 @@ void test_ecall_array_fun(oe_enclave_t* enclave, F ecall_array_fun)
 void test_array_edl_ecalls(oe_enclave_t* enclave)
 {
     test_ecall_array_fun<char>(enclave, ecall_array_char);
+    test_ecall_array_fun<wchar_t>(enclave, ecall_array_wchar_t);
     test_ecall_array_fun<short>(enclave, ecall_array_short);
     test_ecall_array_fun<int>(enclave, ecall_array_int);
     test_ecall_array_fun<float>(enclave, ecall_array_float);
@@ -70,6 +71,8 @@ void test_array_edl_ecalls(oe_enclave_t* enclave)
     test_ecall_array_fun<uint16_t>(enclave, ecall_array_uint16_t);
     test_ecall_array_fun<uint32_t>(enclave, ecall_array_uint32_t);
     test_ecall_array_fun<uint64_t>(enclave, ecall_array_uint64_t);
+    test_ecall_array_fun<long long>(enclave, ecall_array_long_long);
+    test_ecall_array_fun<long double>(enclave, ecall_array_long_double);
 
     OE_TEST(ecall_array_assert_all_called(enclave) == OE_OK);
     printf("=== test_array_edl_ecalls passed\n");
@@ -99,7 +102,7 @@ void ocall_array_fun_impl(T a1[2], T a2[2][2], T a3[3][3], T a4[4][4])
     if (a2)
     {
         T exp[] = {1, 2, 3, 4};
-        OE_TEST(memcmp(exp, a2, sizeof(T) * 2 * 2) == 0);
+        OE_TEST(array_compare(exp, (T*)a2) == 0);
         reverse((T*)a2, 4);
     }
 
@@ -120,6 +123,15 @@ void ocall_array_fun_impl(T a1[2], T a2[2][2], T a3[3][3], T a4[4][4])
 }
 
 void ocall_array_char(char a1[2], char a2[2][2], char a3[3][3], char a4[4][4])
+{
+    ocall_array_fun_impl(a1, a2, a3, a4);
+}
+
+void ocall_array_wchar_t(
+    wchar_t a1[2],
+    wchar_t a2[2][2],
+    wchar_t a3[3][3],
+    wchar_t a4[4][4])
 {
     ocall_array_fun_impl(a1, a2, a3, a4);
 }
@@ -251,9 +263,27 @@ void ocall_array_uint64_t(
     ocall_array_fun_impl(a1, a2, a3, a4);
 }
 
+void ocall_array_long_long(
+    long long a1[2],
+    long long a2[2][2],
+    long long a3[3][3],
+    long long a4[4][4])
+{
+    ocall_array_fun_impl(a1, a2, a3, a4);
+}
+
+void ocall_array_long_double(
+    long double a1[2],
+    long double a2[2][2],
+    long double a3[3][3],
+    long double a4[4][4])
+{
+    ocall_array_fun_impl(a1, a2, a3, a4);
+}
+
 void ocall_array_assert_all_called()
 {
-    // Each of the 16 functions above is called twice.
+    // Each of the 19 functions above is called twice.
     // Once with arrays and then with nulls.
-    OE_TEST(num_ocalls == 32);
+    OE_TEST(num_ocalls == 38);
 }

--- a/tests/oeedger8r/host/testbasic.cpp
+++ b/tests/oeedger8r/host/testbasic.cpp
@@ -14,7 +14,7 @@ void test_basic_edl_ecalls(oe_enclave_t* enclave)
         ecall_basic_types(
             enclave,
             '?',
-            // '\x3b1',
+            ohm,
             3,
             4,
             3.1415f,
@@ -29,12 +29,20 @@ void test_basic_edl_ecalls(oe_enclave_t* enclave)
             14,
             15,
             16,
-            17) == OE_OK);
+            17,
+            18,
+            19) == OE_OK);
 
     {
         char ret = 0;
         OE_TEST(ecall_ret_char(enclave, &ret) == OE_OK);
         OE_TEST(ret == '?');
+    }
+
+    {
+        wchar_t ret = 0;
+        OE_TEST(ecall_ret_wchar_t(enclave, &ret) == OE_OK);
+        OE_TEST(ret == ohm);
     }
 
     {
@@ -126,12 +134,25 @@ void test_basic_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(ecall_ret_uint64_t(enclave, &ret) == OE_OK);
         OE_TEST(ret == 171717);
     }
+
+    {
+        long long ret = 0;
+        OE_TEST(ecall_ret_long_long(enclave, &ret) == OE_OK);
+        OE_TEST(ret == 181818);
+    }
+
+    {
+        long double ret = 0;
+        OE_TEST(ecall_ret_long_double(enclave, &ret) == OE_OK);
+        OE_TEST(ret == 0.191919);
+    }
+
     printf("=== test_basic_edl_ecalls passed\n");
 }
 
 void ocall_basic_types(
     char arg1,
-    // wchar_t arg2,
+    wchar_t arg2,
     short arg3,
     int arg4,
     float arg5,
@@ -146,13 +167,15 @@ void ocall_basic_types(
     uint8_t arg14,
     uint16_t arg15,
     uint32_t arg16,
-    uint64_t arg17)
+    uint64_t arg17,
+    long long arg18,
+    long double arg19)
 {
     ecall_basic_types_args_t args;
 
     // Assert types of fields of the marshaling struct.
     check_type<char>(args.arg1);
-    // check_type<wchar_t>(args.arg2);
+    check_type<wchar_t>(args.arg2);
     check_type<short>(args.arg3);
     check_type<int>(args.arg4);
     check_type<int>(args.arg4);
@@ -169,9 +192,11 @@ void ocall_basic_types(
     check_type<uint16_t>(args.arg15);
     check_type<uint32_t>(args.arg16);
     check_type<uint64_t>(args.arg17);
+    check_type<long long>(args.arg18);
+    check_type<long double>(args.arg19);
 
     OE_TEST(arg1 == '?');
-    // OE_TEST(arg2 == '\x3b1');
+    OE_TEST(arg2 == ohm);
     OE_TEST(arg3 = 3);
     OE_TEST(arg4 = 4);
     OE_TEST(arg5 = 3.1415f);
@@ -187,12 +212,20 @@ void ocall_basic_types(
     OE_TEST(arg15 = 15);
     OE_TEST(arg16 = 16);
     OE_TEST(arg17 = 17);
+    OE_TEST(arg18 = 18);
+    OE_TEST(arg19 = 19);
 }
 
 char ocall_ret_char()
 {
     check_return_type<ocall_ret_char_args_t, char>();
     return '?';
+}
+
+wchar_t ocall_ret_wchar_t()
+{
+    check_return_type<ocall_ret_wchar_t_args_t, wchar_t>();
+    return ohm;
 }
 
 short ocall_ret_short()
@@ -283,4 +316,16 @@ uint64_t ocall_ret_uint64_t()
 {
     check_return_type<ocall_ret_uint64_t_args_t, uint64_t>();
     return 171717;
+}
+
+long long ocall_ret_long_long()
+{
+    check_return_type<ocall_ret_long_long_args_t, long long>();
+    return 181818;
+}
+
+long double ocall_ret_long_double()
+{
+    check_return_type<ocall_ret_long_double_args_t, long double>();
+    return 0.191919;
 }

--- a/tests/oeedger8r/host/testpointer.cpp
+++ b/tests/oeedger8r/host/testpointer.cpp
@@ -81,7 +81,7 @@ static void test_ecall_pointer_fun(oe_enclave_t* enclave, F ecall_pointer_fun)
 
         // p5 is reversed.
         T exp[] = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
-        OE_TEST(memcmp(exp, p5, sizeof(exp)) == 0);
+        OE_TEST(array_compare(exp, p5) == 0);
 
         // p6 is initialized
         for (size_t i = 0; i < 16; ++i)
@@ -163,6 +163,7 @@ static void test_ecall_pointer_fun(oe_enclave_t* enclave, F ecall_pointer_fun)
 void test_pointer_edl_ecalls(oe_enclave_t* enclave)
 {
     test_ecall_pointer_fun<char>(enclave, ecall_pointer_char);
+    test_ecall_pointer_fun<wchar_t>(enclave, ecall_pointer_wchar_t);
     test_ecall_pointer_fun<short>(enclave, ecall_pointer_short);
     test_ecall_pointer_fun<int>(enclave, ecall_pointer_int);
     test_ecall_pointer_fun<float>(enclave, ecall_pointer_float);
@@ -178,6 +179,8 @@ void test_pointer_edl_ecalls(oe_enclave_t* enclave)
     test_ecall_pointer_fun<uint16_t>(enclave, ecall_pointer_uint16_t);
     test_ecall_pointer_fun<uint32_t>(enclave, ecall_pointer_uint32_t);
     test_ecall_pointer_fun<uint64_t>(enclave, ecall_pointer_uint64_t);
+    test_ecall_pointer_fun<long long>(enclave, ecall_pointer_long_long);
+    test_ecall_pointer_fun<long double>(enclave, ecall_pointer_long_double);
 
     OE_TEST(ecall_pointer_assert_all_called(enclave) == OE_OK);
     printf("=== test_pointer_edl_ecalls passed\n");
@@ -248,7 +251,7 @@ static T* ocall_pointer_fun_impl(
         // in
         if (p4)
         {
-            OE_TEST(memcmp(p4, exp, sizeof(T) * 16) == 0);
+            OE_TEST(array_compare(exp, p4) == 0);
 
             // change p4. Should not have any effect on enclave.
             memset(p4, 0, sizeof(T) * 16);
@@ -257,7 +260,7 @@ static T* ocall_pointer_fun_impl(
         // in-out
         if (p5)
         {
-            OE_TEST(memcmp(p5, exp, sizeof(T) * 16) == 0);
+            OE_TEST(array_compare(exp, p5) == 0);
             reverse(p5, 16);
         }
 
@@ -270,14 +273,14 @@ static T* ocall_pointer_fun_impl(
 
     // size specified as 80 (lcm of sizeof(double), sizeof(long))
     {
-        size_t count = 80 / sizeof(T);
+        const size_t count = 80 / sizeof(T);
         T exp[count];
         for (size_t i = 0; i < count; ++i)
             exp[i] = i + 1;
 
         if (p7)
         {
-            OE_TEST(memcmp(p7, exp, 80) == 0);
+            OE_TEST(array_compare(exp, p7) == 0);
 
             // change p7. Should not have any effect on enclave.
             memset(p7, 0, 80);
@@ -286,7 +289,7 @@ static T* ocall_pointer_fun_impl(
         // in-out
         if (p8)
         {
-            OE_TEST(memcmp(p8, exp, 80) == 0);
+            OE_TEST(array_compare(exp, p8) == 0);
             reverse(p8, count);
         }
 
@@ -390,6 +393,47 @@ char* ocall_pointer_char(
     char* p14,
     char* p15,
     char* p16,
+    int pcount,
+    int psize)
+{
+    return ocall_pointer_fun_impl(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+        p16,
+        pcount,
+        psize);
+}
+
+wchar_t* ocall_pointer_wchar_t(
+    wchar_t* p1,
+    wchar_t* p2,
+    wchar_t* p3,
+    wchar_t* p4,
+    wchar_t* p5,
+    wchar_t* p6,
+    wchar_t* p7,
+    wchar_t* p8,
+    wchar_t* p9,
+    wchar_t* p10,
+    wchar_t* p11,
+    wchar_t* p12,
+    wchar_t* p13,
+    wchar_t* p14,
+    wchar_t* p15,
+    wchar_t* p16,
     int pcount,
     int psize)
 {
@@ -1029,12 +1073,94 @@ uint64_t* ocall_pointer_uint64_t(
         psize);
 }
 
+long long* ocall_pointer_long_long(
+    long long* p1,
+    long long* p2,
+    long long* p3,
+    long long* p4,
+    long long* p5,
+    long long* p6,
+    long long* p7,
+    long long* p8,
+    long long* p9,
+    long long* p10,
+    long long* p11,
+    long long* p12,
+    long long* p13,
+    long long* p14,
+    long long* p15,
+    long long* p16,
+    int pcount,
+    int psize)
+{
+    return ocall_pointer_fun_impl(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+        p16,
+        pcount,
+        psize);
+}
+
+long double* ocall_pointer_long_double(
+    long double* p1,
+    long double* p2,
+    long double* p3,
+    long double* p4,
+    long double* p5,
+    long double* p6,
+    long double* p7,
+    long double* p8,
+    long double* p9,
+    long double* p10,
+    long double* p11,
+    long double* p12,
+    long double* p13,
+    long double* p14,
+    long double* p15,
+    long double* p16,
+    int pcount,
+    int psize)
+{
+    return ocall_pointer_fun_impl(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+        p16,
+        pcount,
+        psize);
+}
+
 void ocall_pointer_assert_all_called()
 {
-    // Each of the 16 functions above is called twice.
+    // Each of the 19 functions above is called twice.
     // Once with arrays and then with nulls.
-    OE_TEST(num_ocalls == 32);
-    OE_TEST(num_null_ocalls == 16);
+    OE_TEST(num_ocalls == 38);
+    OE_TEST(num_null_ocalls == 19);
 }
 
 // The following functions exists to make sure there are no
@@ -1057,6 +1183,9 @@ void ocall_count_attribute_all_types(
     int* b14,
     int* b15,
     int* b16,
+    int* b17,
+    int* b18,
+    int* b19,
     char char_count,
     short short_count,
     int int_count,
@@ -1072,7 +1201,10 @@ void ocall_count_attribute_all_types(
     uint8_t uint8_t_count,
     uint16_t uint16_t_count,
     uint32_t uint32_t_count,
-    uint64_t uint64_t_count)
+    uint64_t uint64_t_count,
+    wchar_t wchar_t_count,
+    long long long_long_count,
+    long double long_double_count)
 {
 }
 
@@ -1093,6 +1225,9 @@ void ocall_size_attribute_all_types(
     int* b14,
     int* b15,
     int* b16,
+    int* b17,
+    int* b18,
+    int* b19,
     char char_size,
     short short_size,
     int int_size,
@@ -1108,6 +1243,9 @@ void ocall_size_attribute_all_types(
     uint8_t uint8_t_size,
     uint16_t uint16_t_size,
     uint32_t uint32_t_size,
-    uint64_t uint64_t_size)
+    uint64_t uint64_t_size,
+    wchar_t wchar_t_size,
+    long long long_long_size,
+    long double long_double_size)
 {
 }

--- a/tests/oeedger8r/host/teststring.cpp
+++ b/tests/oeedger8r/host/teststring.cpp
@@ -5,6 +5,7 @@
 
 #include <openenclave/host.h>
 #include <openenclave/internal/tests.h>
+#include <wchar.h>
 #include "string_u.c"
 
 void test_string_edl_ecalls(oe_enclave_t* enclave)
@@ -109,6 +110,114 @@ void ocall_string_fun7(char* s1, char* s2)
     check_type<char*>(args.s1);
     check_type<size_t>(args.s1_len);
     check_type<char*>(args.s2);
+    check_type<size_t>(args.s2_len);
+
+    OE_TEST(s1 != NULL);
+    OE_TEST(s2 == NULL);
+}
+
+void test_wstring_edl_ecalls(oe_enclave_t* enclave)
+{
+    const wchar_t* str_value = L"Hello, World\n";
+
+    wchar_t str[50];
+    swprintf(str, 50, L"%S", str_value);
+
+    // wchar_t*
+    OE_TEST(ecall_wstring_fun1(enclave, str) == OE_OK);
+    OE_TEST(wcscmp(str, str_value) == 0);
+
+    // const wchar_t*. (wchar_t* is passed in)
+    OE_TEST(ecall_wstring_fun2(enclave, str) == OE_OK);
+    OE_TEST(wcscmp(str, str_value) == 0);
+
+    // wchar_t* in/out
+    OE_TEST(ecall_wstring_fun3(enclave, str) == OE_OK);
+    OE_TEST(wcscmp(str, L"Goodbye\n") == 0);
+
+    // Restore value.
+    swprintf(str, 50, L"%S", str_value);
+
+    // wchar_t* user check.
+    OE_TEST(ecall_wstring_fun5(enclave, str) == OE_OK);
+    OE_TEST(wcscmp(str, L"Hello") == 0);
+
+    // wchar_t* user check.
+    OE_TEST(ecall_wstring_fun6(enclave, str) == OE_OK);
+    OE_TEST(wcscmp(str, L"Hello") == 0);
+
+    // Multiple wstring params. One null.
+    OE_TEST(ecall_wstring_fun7(enclave, str, NULL) == OE_OK);
+
+    printf("=== test_string_edl_ecalls passed\n");
+}
+
+void ocall_wstring_fun1(wchar_t* s)
+{
+    ocall_wstring_fun1_args_t args;
+    check_type<wchar_t*>(args.s);
+    check_type<size_t>(args.s_len);
+
+    // Check that s has been copied over.
+    // strcmp should not crash.
+    OE_TEST(wcscmp(s, L"Hello, World\n") == 0);
+}
+
+void ocall_wstring_fun2(const wchar_t* s)
+{
+    ocall_wstring_fun2_args_t args;
+    // constness is discarded when marshaling.
+    check_type<wchar_t*>(args.s);
+    check_type<size_t>(args.s_len);
+
+    // Check that s has been copied over.
+    // strcmp should not crash.
+    OE_TEST(wcscmp(s, L"Hello, World\n") == 0);
+}
+
+void ocall_wstring_fun3(wchar_t* s)
+{
+    ocall_wstring_fun3_args_t args;
+    check_type<wchar_t*>(args.s);
+
+    check_type<size_t>(args.s_len);
+
+    // Check that s has been copied over.
+    // strcmp should not crash.
+    OE_TEST(wcscmp(s, L"Hello, World\n") == 0);
+
+    // Write to s. Check on enclave side for new value.
+    const wchar_t* new_s = L"Goodbye\n";
+    memcpy(s, new_s, (wcslen(new_s) + 1) * sizeof(wchar_t));
+}
+
+void ocall_wstring_fun5(wchar_t* s)
+{
+    ocall_wstring_fun5_args_t args;
+    check_type<wchar_t*>(args.s);
+    // User check implies no s_len field is created.
+    assert_no_field_s_len<ocall_wstring_fun5_args_t>();
+
+    // Change value to Hello.
+    s[5] = L'\0';
+}
+
+void ocall_wstring_fun6(const wchar_t* s)
+{
+    ocall_wstring_fun6_args_t args;
+    // constness is discarded when marshaling.
+    check_type<wchar_t*>(args.s);
+    // User check implies no s_len field is created.
+    assert_no_field_s_len<ocall_wstring_fun6_args_t>();
+}
+
+void ocall_wstring_fun7(wchar_t* s1, wchar_t* s2)
+{
+    ocall_wstring_fun7_args_t args;
+
+    check_type<wchar_t*>(args.s1);
+    check_type<size_t>(args.s1_len);
+    check_type<wchar_t*>(args.s2);
     check_type<size_t>(args.s2_len);
 
     OE_TEST(s1 != NULL);

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -636,19 +636,19 @@ let validate_oe_support (ec: enclave_content) (ep: edger8r_params) =
     (if f.Ast.tf_is_switchless then
         failwithf "Function '%s': switchless ecalls and ocalls are not yet supported by Open Enclave SDK." f.Ast.tf_fdecl.fname);  
     (if uses_wchar_t_params f.Ast.tf_fdecl then
-        printf "Warning: Function '%s': wchar_t has different sizes on windows and linux." f.Ast.tf_fdecl.fname);     
+        printf "Warning: Function '%s': wchar_t has different sizes on windows and linux.\n" f.Ast.tf_fdecl.fname);     
   ) ec.tfunc_decls;
   List.iter (fun f -> 
     (if f.Ast.uf_fattr.fa_convention <> Ast.CC_NONE then
         failwithf "Function '%s': Calling conventions for ocalls are not supported by oeedger8r." f.Ast.uf_fdecl.fname);
     (if f.Ast.uf_fattr.fa_dllimport then
-        failwithf "Function '%s': dllimport is supported by oeedger8r." f.Ast.uf_fdecl.fname);
+        failwithf "Function '%s': dllimport is not supported by oeedger8r." f.Ast.uf_fdecl.fname);
     (if f.Ast.uf_allow_list != [] then
-        printf "Warning: Function '%s': Reentrant ocalls are not supported by Open Enclave.Allow list ignored." f.Ast.uf_fdecl.fname);
+        printf "Warning: Function '%s': Reentrant ocalls are not supported by Open Enclave. Allow list ignored.\n" f.Ast.uf_fdecl.fname);
     (if f.Ast.uf_is_switchless then
         failwithf "Function '%s': switchless ecalls and ocalls are not yet supported by Open Enclave SDK." f.Ast.uf_fdecl.fname);
     (if uses_wchar_t_params f.Ast.uf_fdecl then
-        printf "Warning: Function '%s': wchar_t has different sizes on windows and linux." f.Ast.uf_fdecl.fname);          
+        printf "Warning: Function '%s': wchar_t has different sizes on windows and linux.\n" f.Ast.uf_fdecl.fname);          
   ) ec.ufunc_decls
 
   (*


### PR DESCRIPTION
… long double.

In test code, instead of using memcmp, use typed comparison of values.
For long double, even though two values may be equal, they may not have the same bit pattern (the last few ulps are not used for equality operator). The compiler can generate load-store operations behind the scenes while manipulating long double values, which can subtly change the bit pattern of the value. 