### PR TITLE
Allow any order of certs in a cert chain.

### DIFF
--- a/tests/crypto_crls_cert_chains/README.md
+++ b/tests/crypto_crls_cert_chains/README.md
@@ -39,9 +39,9 @@ The certificates and CRLs were generated using the following openssl commands.
 ==List of Tests==
 
   1. test_cert_chain_positive
-       Asserts the following condition: "In a valid cert chain, each certificate's issuer CA occurs at least once after the certificate".
-       Tests correct ordering, duplicates, two and three level chains.
-  2. test_cert_chain_negative: Negative tests involving incorrect ordering, missing certs etc.
+       Asserts the following condition: "In a valid cert chain, each certificate's issuer is also present in the chain".
+       Tests various ordering, duplicates, two and three level chains.
+  2. test_cert_chain_negative: Negative tests involving missing certs etc.
   3. test_crls.
       1. Assert that verify succeeds when no crls are passed.
       2. Assert that when crls are passed, but don't revoke certs, verify succeeds.

--- a/tests/crypto_crls_cert_chains/common/tests.cpp
+++ b/tests/crypto_crls_cert_chains/common/tests.cpp
@@ -54,13 +54,40 @@ void test_cert_chain_positive(
             std::vector<const char*>{intermediate, root}, &chain) == OE_OK);
 
     // Two leaf certs in chain, but starts at intermediate.
-    // For successful validation, for each cert in the chain, its
-    // ancestor (i.e. its CA certificate) must occur at least once to
-    // its right.
+    // For successful validation, each cert's issuer must also be present in the
+    // chain. The order does not matter. The chain will be reordered internally
+    // to leaf->intermediate->root.
+    //
     OE_TEST(
         create_and_read_chain(
             std::vector<const char*>{
                 intermediate, leaf, leaf2, intermediate, root},
+            &chain) == OE_OK);
+
+    // Incorrect order. This is accepted and fixed internally.
+    OE_TEST(
+        create_and_read_chain(
+            std::vector<const char*>{intermediate, leaf, root}, &chain) ==
+        OE_OK);
+
+    // Reverse order. This is accepted and fixed internally.
+    OE_TEST(
+        create_and_read_chain(
+            std::vector<const char*>{root, intermediate, leaf}, &chain) ==
+        OE_OK);
+
+    // Order rotated 1 time.
+    // As a consequence, root is not last.
+    // This is accepted and fixed internally.
+    OE_TEST(
+        create_and_read_chain(
+            std::vector<const char*>{intermediate, root, leaf}, &chain) ==
+        OE_OK);
+
+    // Incorrect order. Leaf2 is not followed by intermediate.
+    OE_TEST(
+        create_and_read_chain(
+            std::vector<const char*>{leaf, intermediate, leaf2, root},
             &chain) == OE_OK);
 
     oe_cert_chain_free(&chain);
@@ -76,25 +103,6 @@ void test_cert_chain_negative(
 {
     oe_cert_chain_t chain = {0};
 
-    // Incorrect order.
-    OE_TEST(
-        create_and_read_chain(
-            std::vector<const char*>{intermediate, leaf, root}, &chain) ==
-        OE_FAILURE);
-
-    // Reverse order.
-    OE_TEST(
-        create_and_read_chain(
-            std::vector<const char*>{root, intermediate, leaf}, &chain) ==
-        OE_FAILURE);
-
-    // Order rotated 1 time.
-    // As a consequence, root is not last.
-    OE_TEST(
-        create_and_read_chain(
-            std::vector<const char*>{intermediate, root, leaf}, &chain) ==
-        OE_FAILURE);
-
     // Missing cert in chain.
     OE_TEST(
         create_and_read_chain(std::vector<const char*>{leaf, root}, &chain) ==
@@ -106,12 +114,6 @@ void test_cert_chain_negative(
         create_and_read_chain(
             std::vector<const char*>{leaf, intermediate}, &chain) ==
         OE_FAILURE);
-
-    // Incorrect order. Leaf2 is not followed by intermediate.
-    OE_TEST(
-        create_and_read_chain(
-            std::vector<const char*>{leaf, intermediate, leaf2, root},
-            &chain) == OE_FAILURE);
 
     oe_cert_chain_free(&chain);
     printf("===test_cert_chain_negative passed\n");


### PR DESCRIPTION
When the cert chain is read, the certs are arranged in the preferred order: Leaf->intermediate->root