### PR TITLE
Minor edger8r and oeedl_file tweaks.

### DIFF
--- a/cmake/oeedl_file.cmake
+++ b/cmake/oeedl_file.cmake
@@ -9,31 +9,53 @@
 # Usage:
 #
 #       oeedl_file(
-#               <edl_file> <type> <out_files_var>
+#               <edl_file> <type> <out_files_var> [--edl-search-dir dir]
 #
 # Arguments:
 # edl_file - name of the EDL file
-# type - type of files to genreate ("enclave" or "host")
+# type - type of files to genreate ("enclave" or "host" or "enclave-headers" or "host-headers")
 # out_files_var - variable to get the generated files added to
-#
+# --edl-search-dir dir - Additional folder relative to the source directory to look for imported edl files.
 function(oeedl_file EDL_FILE TYPE OUT_FILES_VAR)
+	get_filename_component(idl_base ${EDL_FILE} NAME_WE)
+	get_filename_component(in_path ${EDL_FILE} PATH)
+
 	if(${TYPE} STREQUAL "enclave")
 		set(type_id "t")
 		set(type_opt "--trusted")
 		set(dir_opt  "--trusted-dir")
+		set(headers_only "")
+		set(c_file ${CMAKE_CURRENT_BINARY_DIR}/${idl_base}_${type_id}.c)
 	elseif(${TYPE} STREQUAL "host")
 		set(type_id "u")
 		set(type_opt "--untrusted")
 		set(dir_opt  "--untrusted-dir")
+		set(headers_only "")
+		set(c_file ${CMAKE_CURRENT_BINARY_DIR}/${idl_base}_${type_id}.c)
+	elseif(${TYPE} STREQUAL "enclave-headers")
+		set(type_id "t")
+		set(type_opt "--trusted")
+		set(dir_opt  "--trusted-dir")
+		set(headers_only "--header-only")
+		set(c_file "")
+	elseif(${TYPE} STREQUAL "host-headers")
+		set(type_id "u")
+		set(type_opt "--untrusted")
+		set(dir_opt  "--untrusted-dir")
+		set(headers_only "--header-only")
+		set(c_file "")
 	else()
 		message(FATAL_ERROR "unknown EDL generation type ${TYPE} - must be \"enclave\" or \"host\"")
 	endif()
 
-	get_filename_component(idl_base ${EDL_FILE} NAME_WE)
-	get_filename_component(in_path ${EDL_FILE} PATH)
+	if(${ARGC} EQUAL 5)
+		if (${ARGV3} STREQUAL "--edl-search-dir")
+			set(edl_search_path --search-path ${CMAKE_CURRENT_SOURCE_DIR}/${ARGV4})
+		endif()
+	endif()
+
 
 	set(h_file ${CMAKE_CURRENT_BINARY_DIR}/${idl_base}_${type_id}.h)
-	set(c_file ${CMAKE_CURRENT_BINARY_DIR}/${idl_base}_${type_id}.c)
 
 	if (UNIX)
 		set(OEEDGER8R_COMMAND oeedger8r)
@@ -50,7 +72,7 @@ function(oeedl_file EDL_FILE TYPE OUT_FILES_VAR)
 		# will rebuild the edger8r if it is out of date, but will not invoke the newly build edger8r
 		# on the edl file.
 		DEPENDS ${EDL_FILE} oeedger8r ${OE_BINDIR}/${OEEDGER8R_COMMAND}
-		COMMAND ${OE_BINDIR}/${OEEDGER8R_COMMAND} ${type_opt} ${dir_opt} ${CMAKE_CURRENT_BINARY_DIR} ${EDL_FILE}
+		COMMAND ${OE_BINDIR}/${OEEDGER8R_COMMAND} ${type_opt} ${headers_only} ${dir_opt} ${CMAKE_CURRENT_BINARY_DIR} ${EDL_FILE} --search-path ${in_path} ${edl_search_path}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		)
 

--- a/tests/oeedger8r/edl/all.edl
+++ b/tests/oeedger8r/edl/all.edl
@@ -11,6 +11,10 @@ enclave  {
     from "string.edl"  import *;
     from "struct.edl"  import *;
     
+    from "foo.edl" import 
+        enc_foo1,
+        host_foo1;
+    
     trusted {};
 
     untrusted {};

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -1,39 +1,24 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-add_custom_command(
-    # Produce single untrusted file
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/all_t.c
+include(oeedl_file)
 
-    # Run edger8r
-    COMMAND 
-        ${OE_BINDIR}/oeedger8r ${CMAKE_CURRENT_SOURCE_DIR}/../edl/all.edl 
-            --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl
-            --trusted
-
-    # Regenerate if any edl file changes or oeedger8r changes
-    # Temorary workaround:
-    # Add explict dependency to oeedger8r binary.
-    # oeedger8r custom target cannot declare its output binary.
-    # Without the explicity dependecy to the binary below, running make on a test
-    # will rebuild the edger8r if it is out of date, but will not invoke the newly build edger8r
-    # on the edl file.
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../edl/*.edl oeedger8r ${OE_BINDIR}/oeedger8r
+oeedl_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/../edl/all.edl 
+    enclave
+    all_t
+    --edl-search-dir ../moreedl
 )
 
-# Copy generated c file to cpp file.
-add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/all_t.cpp
-    COMMAND 
-        ${CMAKE_COMMAND} -E copy
-                ${CMAKE_CURRENT_BINARY_DIR}/all_t.c
-                ${CMAKE_CURRENT_BINARY_DIR}/all_t.cpp
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/all_t.c
+oeedl_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl/bar.edl 
+    enclave-headers
+    bar_t
 )
-
-include(add_enclave_executable)
 
 add_executable(edl_enc
+    bar.cpp
+    foo.cpp
     testarray.cpp
     testbasic.cpp 
     testenum.cpp 
@@ -41,7 +26,8 @@ add_executable(edl_enc
     testpointer.cpp
     teststring.cpp
     teststruct.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/all_t.cpp
+    ${all_t}
+    ${bar_t}
     )
 
 target_include_directories(edl_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/tests/oeedger8r/enc/bar.cpp
+++ b/tests/oeedger8r/enc/bar.cpp
@@ -1,0 +1,8 @@
+
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "bar_t.h"
+
+// No need to implement any functions since
+// bar.edl is header-only.

--- a/tests/oeedger8r/enc/foo.cpp
+++ b/tests/oeedger8r/enc/foo.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "all_t.h"
+
+// Implement functions in foo.edl.
+// Only enc_foo1 is implemented since
+// it is the only imported function.
+void enc_foo1()
+{
+}
+
+// No need to implement enc_foo2 since
+// it is not imported
+// void enc_foo2()
+// {
+// }

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -1,28 +1,26 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-add_custom_command(
-    # Produce single untrusted file
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/all_u.c
+include(oeedl_file)
 
-    # Run edger8r
-    COMMAND 
-        ${OE_BINDIR}/oeedger8r ${CMAKE_CURRENT_SOURCE_DIR}/../edl/all.edl 
-            --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl
-            --untrusted
-
-    # Regenerate if any edl file changes or oeedger8r changes
-    # Temorary workaround:
-    # Add explict dependency to oeedger8r binary.
-    # oeedger8r custom target cannot declare its output binary.
-    # Without the explicity dependecy to the binary below, running make on a test
-    # will rebuild the edger8r if it is out of date, but will not invoke the newly build edger8r
-    # on the edl file.    
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../edl/*.edl oeedger8r ${OE_BINDIR}/oeedger8r
+oeedl_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/../edl/all.edl 
+    host
+    all_u
+    --edl-search-dir ../moreedl
 )
+
+oeedl_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl/bar.edl 
+    host-headers
+    bar_u
+)
+
 
 add_executable(edl_host 
     main.cpp
+    bar.cpp
+    foo.cpp
     testarray.cpp
     testbasic.cpp
     testenum.cpp
@@ -30,7 +28,8 @@ add_executable(edl_host
     testpointer.cpp
     teststring.cpp
     teststruct.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/all_u.c  
+    ${all_u}
+    ${bar_u}
 )
 
 target_include_directories(edl_host PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/tests/oeedger8r/host/bar.cpp
+++ b/tests/oeedger8r/host/bar.cpp
@@ -1,0 +1,8 @@
+
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "bar_u.h"
+
+// No need to implement any functions since
+// bar.edl is header-only.

--- a/tests/oeedger8r/host/foo.cpp
+++ b/tests/oeedger8r/host/foo.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "all_u.h"
+
+// Implement functions in foo.edl.
+// Only host_foo1 is implemented since
+// it is the only imported function.
+void host_foo1()
+{
+}
+
+// No need to implement host_foo2 since
+// it is not imported
+// void host_foo2()
+// {
+// }

--- a/tests/oeedger8r/moreedl/bar.edl
+++ b/tests/oeedger8r/moreedl/bar.edl
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This edl is compiled only in header only mode.
+// Hence there is no need to provide any implementation.
+enclave {
+    trusted {
+        public void enc_bar();
+    };
+
+    untrusted {
+        void host_bar();
+    };
+};

--- a/tests/oeedger8r/moreedl/foo.edl
+++ b/tests/oeedger8r/moreedl/foo.edl
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave  {
+    trusted {
+        public void enc_foo1();
+
+        // This is not imported by all.edl.
+        // Hence not implementation is needed.
+        public void enc_foo2();
+    };
+
+    untrusted {
+        void host_foo1();
+
+        // This is not imported by all.edl.
+        // Hence not implementation is needed.
+        void host_foo2();
+    };
+};

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -844,7 +844,6 @@ let warn_non_portable_types (fd:Ast.func_decl) =
 let validate_oe_support (ec: enclave_content) (ep: edger8r_params) =
   (* check supported options *)
   if ep.use_prefix then failwithf "--use_prefix option is not supported by oeedger8r.";
-  if ep.header_only then failwithf "--header_only option is not supported by oeedger8r.";
   List.iter (fun f -> 
     (if f.Ast.tf_is_priv then 
         failwithf "Function '%s': 'private' specifier is not supported by oeedger8r" f.Ast.tf_fdecl.fname);
@@ -989,12 +988,14 @@ let gen_enclave_code (ec: enclave_content) (ep: edger8r_params) =
   if ep.gen_trusted then(
     oe_gen_args_header ec ep.trusted_dir;
     gen_t_h ec ep;
-    gen_t_c ec ep;
+    if not ep.header_only then
+      gen_t_c ec ep;
   );
   if ep.gen_untrusted then (
     oe_gen_args_header ec ep.untrusted_dir;
     gen_u_h ec ep;
-    gen_u_c ec ep;
+    if not ep.header_only then
+      gen_u_c ec ep;
   );
   printf "Success.\n"
 


### PR DESCRIPTION
 1. Enable --header-only option.
 2. Add --edl-search-dir option to oeedl_file.
 3. Lockdown selective import of functions in an edl file in search-dir.