### PR TITLE
Fix thread_local test.

### DIFF
--- a/tests/thread_local/host/host.cpp
+++ b/tests/thread_local/host/host.cpp
@@ -12,6 +12,11 @@
 #include <thread>
 #include "thread_local_u.h"
 
+void host_usleep(int microseconds)
+{
+    std::this_thread::sleep_for(std::chrono::microseconds(microseconds));
+}
+
 void run_enclave_thread(
     oe_enclave_t* enclave,
     int thread_num,
@@ -70,10 +75,11 @@ int main(int argc, const char* argv[])
     // Run it twice to make sure the enclave thread is correctly reinitialized.
     for (int i = 0; i < 2; ++i)
     {
-        // Clear test data in the enclave.
-        OE_TEST(clear_test_data(enclave) == OE_OK);
-
         const int num_threads = 16;
+
+        // Clear test data in the enclave.
+        OE_TEST(prepare_for_test(enclave, num_threads) == OE_OK);
+
         std::thread threads[num_threads];
         for (int t = 0; t < num_threads; ++t)
         {

--- a/tests/thread_local/thread_local.edl
+++ b/tests/thread_local/thread_local.edl
@@ -3,8 +3,8 @@
 
 enclave {
     trusted {
-        // Clear any data maintained in enclave for testing.
-        public void clear_test_data();
+        // Prepare enclave for testing.
+        public void prepare_for_test(int total_num_threads);
 
         // Launch a thread that tests thread-local variables.
         public void enclave_thread(
@@ -16,5 +16,6 @@ enclave {
 
 
     untrusted {
+        void host_usleep(int microseconds);
     };
 };


### PR DESCRIPTION
1. Wait for all threads to complete performing tests
before returning from each enclave thread.
This ensures that the same thread does not get reused.
Otherwise the test would fail since one enclave thread
would exit and that thread would get reused for another
host thread leading to the same TLS var address already
existing in the global map used to assert unique
addresses for the TLS variables.
