### PR TITLE
Disable qe identity fallback in OE for qe identity support in Azure DCAP client

### DIFF
--- a/common/result.c
+++ b/common/result.c
@@ -33,6 +33,8 @@ const char* oe_result_str(oe_result_t result)
             return "OE_UNEXPECTED";
         case OE_VERIFY_FAILED:
             return "OE_VERIFY_FAILED";
+        case OE_QEIDENTITY_NOT_RETRIEVABLE:
+            return "OE_QEIDENTITY_NOT_RETRIEVABLE";
         case OE_NOT_FOUND:
             return "OE_NOT_FOUND";
         case OE_INTEGER_OVERFLOW:

--- a/common/sgx/qeidentity.c
+++ b/common/sgx/qeidentity.c
@@ -37,7 +37,7 @@ oe_result_t oe_enforce_qe_identity(sgx_report_body_t* qe_report_body)
         // because either get_qe_identity_info API was not supported or
         // unexpected error. Both cases are error conditions.
         OE_RAISE_MSG(
-            OE_VERIFY_FAILED,
+            OE_QEIDENTITY_NOT_RETRIEVABLE,
             "unable to retrieve qe identity from DCAP quote provider",
             NULL);
     }

--- a/common/sgx/qeidentity.c
+++ b/common/sgx/qeidentity.c
@@ -38,7 +38,8 @@ oe_result_t oe_enforce_qe_identity(sgx_report_body_t* qe_report_body)
         // unexpected error. Both cases are error conditions.
         OE_RAISE_MSG(
             OE_VERIFY_FAILED,
-            "unable to retrieve qe identity from DCAP quote provider");
+            "unable to retrieve qe identity from DCAP quote provider",
+            NULL);
     }
     OE_CHECK(result);
 

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -78,6 +78,11 @@ typedef enum _oe_result
     OE_VERIFY_FAILED,
 
     /**
+     * The QE Identity quote verification collateral was unable to be retrieved.
+     */
+    OE_QEIDENTITY_NOT_RETRIEVABLE,
+
+    /**
      * The function failed to find a resource. Examples of resources include
      * files, directories, and functions (ECALL/OCALL), container elements.
      */


### PR DESCRIPTION
This PR removes any fallback for qe identity validation when the DCAP quote provider fails to provide a valid qe identity json file when it is invoked to do so.

As of right now (2019-05-23) qe identity support isn't available in a release of the Azure DCAP client, but when support is available in a released version of the Azure DCAP client (hopefully soon), we can take these changes.

Before these changes get merged, but after a new version of the Azure DCAP client is available, we should validate this change actually works :) I've tried it manually on the update_qeid_url branch in the Azure-DCAP-Client repo, and seems to work great.

@soccerGB did I miss anything in this PR? Does anything else need to change?

