### PR TITLE
[cmake][build] Remove hard -fno-builtin and disable only specific builtin functions

### DIFF
--- a/cmake/maybe_build_using_clangw.cmake
+++ b/cmake/maybe_build_using_clangw.cmake
@@ -36,7 +36,7 @@ function(maybe_build_using_clangw OE_TARGET)
         -Wall -Werror -Wpointer-arith -Wconversion -Wextra -Wno-missing-field-initializers
         -fno-strict-aliasing
         -mxsave
-        -fno-builtin-malloc -fno-builtin-calloc -fno-builtin
+        -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-floor -fno-builtin-floorf -fno-builtin-rint -fno-builtin-rintf
         -mllvm -x86-speculative-load-hardening)
 
     # Setup library names variables

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -149,7 +149,7 @@ target_compile_options(oecore PUBLIC
     # symbol error when a built-in was inlined. However, we only do
     # this for our code as we don't want to force these flags on the
     # user. There are valid reasons for an end user to use built-ins.
-    $<BUILD_INTERFACE:-fno-builtin-malloc -fno-builtin-calloc -fno-builtin>)
+    $<BUILD_INTERFACE:-fno-builtin-malloc -fno-builtin-calloc -fno-builtin-floor -fno-builtin-floorf -fno-builtin-rint -fno-builtin-rintf>)
 
 target_compile_options(oecore INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 


### PR DESCRIPTION
Follow-up from the thread: https://github.com/microsoft/openenclave/pull/1429#issuecomment-461501215

Disable only specific functions `floor`, `floorf`, `rint` and `rintf`.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>