### PR TITLE
Jenkins CI to test OE Windows with DCAP libraries

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -161,16 +161,25 @@ def win2016LinuxElfBuild(String version, String compiler, String build_type) {
     }
 }
 
-def win2016CrossCompile(String build_type) {
-    stage("Windows ${build_type}") {
-        node('SGXFLC-Windows') {
+def win2016CrossCompile(String build_type, String use_libsgx = 'OFF') {
+    def node_label = 'SGXFLC-Windows'
+    if (use_libsgx == "ON") {
+        node_label = 'SGXFLC-Windows-DCAP'
+    }
+    stage("Windows ${build_type} with SGX ${use_libsgx}") {
+        node(node_label) {
             timeout(GLOBAL_TIMEOUT) {
                 cleanWs()
                 checkout scm
                 dir("build/X64-${build_type}") {
+
+                  /* We need to copy nuget into the expected location
+                  https://github.com/microsoft/openenclave/blob/a982b46cf440def8fb66e94f2622a4f81e2b350b/host/CMakeLists.txt#L188-L197 */
+                  powershell 'Copy-Item -Recurse C:\\openenclave\\prereqs\\nuget ${env:WORKSPACE}\\prereqs'
+
                   bat """
                       vcvars64.bat x64 && \
-                      cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -Wdev && \
+                      cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DUSE_LIBSGX=${use_libsgx} -Wdev && \
                       ninja.exe && \
                       ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT}
                       """
@@ -223,4 +232,6 @@ parallel "Check Developer Experience Ubuntu 16.04" :            { checkDevFlows(
          "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build" : { win2016LinuxElfBuild('18.04', 'clang-7', 'Release') },
          "Win2016 Ubuntu1804 gcc Debug Linux-Elf-build" :       { win2016LinuxElfBuild('18.04', 'gcc', 'Debug') },
          "Win2016 Debug Cross Compile" :                        { win2016CrossCompile('Debug') },
-         "Win2016 Release Cross Compile" :                      { win2016CrossCompile('Release') }
+         "Win2016 Release Cross Compile" :                      { win2016CrossCompile('Release') },
+         "Win2016 Debug Cross Compile with DCAP libs" :         { win2016CrossCompile('Debug', 'ON') },
+         "Win2016 Release Cross Compile with DCAP libs" :       { win2016CrossCompile('Release', 'ON') }


### PR DESCRIPTION
- Re-write win2016CrossCompile function to accept use_libsgx parameter.
- Copy nuget files into the expected location: https://github.com/microsoft/openenclave/blob/a982b46cf440def8fb66e94f2622a4f81e2b350b/host/CMakeLists.txt#L188-L197
- Added 2 more stages for Testing Windows Builds with DCAP Libraries