### PR TITLE
Add master info page for VS extension

### DIFF
--- a/docs/GettingStartedDocs/HyperVLinuxVMSetup.md
+++ b/docs/GettingStartedDocs/HyperVLinuxVMSetup.md
@@ -18,8 +18,7 @@ To set up a Linux VM on your Windows machine, do the following:
 1. If using an SGX-capable machine, enable SGX for the VM as follows (this cannot be done from Hyper-V Manager):
    - Download [VirtualMachineSgxSettings.psm1](https://raw.githubusercontent.com/microsoft/openenclave/f28cedce63be9673e20fe54563987189f2565637/new_platforms/scripts/VirtualMachineSgxSettings.psm1)
    - Open an elevated PowerShell window (e.g., type "powershell" and click Run as Administrator)
-   - Invoke the following commands, using the path to where you downloaded the file, and replacing MyVM with your VM nam
-e:
+   - Invoke the following commands, using the path to where you downloaded the file, and replacing MyVM with your VM name:
    ```
    Set-ExecutionPolicy Bypass -Scope Process
    Import-Module Drive:\Path\to\VirtualMachineSgxSettings.psm1

--- a/docs/GettingStartedDocs/HyperVLinuxVMSetup.md
+++ b/docs/GettingStartedDocs/HyperVLinuxVMSetup.md
@@ -16,8 +16,7 @@ To set up a Linux VM on your Windows machine, do the following:
   and select Settings... -> Security and uncheck Enable Secure Boot.
 1. Uncheck "Enable checkpoints" under the VM's Settings -> Checkpoints, since SGX will not work with checkpoints.
 1. If using an SGX-capable machine, enable SGX for the VM as follows (this cannot be done from Hyper-V Manager):
-   - Download [VirtualMachineSgxSettings.psm1](https://raw.githubusercontent.com/microsoft/openenclave/f28cedce63be9673e
-20fe54563987189f2565637/new_platforms/scripts/VirtualMachineSgxSettings.psm1)
+   - Download [VirtualMachineSgxSettings.psm1](https://raw.githubusercontent.com/microsoft/openenclave/f28cedce63be9673e20fe54563987189f2565637/new_platforms/scripts/VirtualMachineSgxSettings.psm1)
    - Open an elevated PowerShell window (e.g., type "powershell" and click Run as Administrator)
    - Invoke the following commands, using the path to where you downloaded the file, and replacing MyVM with your VM nam
 e:

--- a/docs/GettingStartedDocs/HyperVLinuxVMSetup.md
+++ b/docs/GettingStartedDocs/HyperVLinuxVMSetup.md
@@ -1,0 +1,31 @@
+# Setting up a Linux VM on Windows
+
+_Note: Hyper-V support for SGX is not yet fully supported, but can be used as a "Preview" with the limitations
+mentioned below._
+
+To set up a Linux VM on your Windows machine, do the following:
+
+1. Download an ISO for Ubuntu [18.04](http://releases.ubuntu.com/18.04/) or [16.04](http://releases.ubuntu.com/16.04/).
+   A "Server install image" is sufficient.
+1. Create a VM as follows.  Open "Hyper-V Manager", and do Action -> New -> Virtual Machine....
+   - On the Specify Generation screen, choose Generation 2.
+   - On the Configure Networking screen, choose Default Switch to ensure you can connect to it with a debugger.
+   - On the Installation Options screen, choose the ISO file you downloaded.
+   - All other options can be either left as the defaults or changed as desired.
+1. Disable Secure Boot as follows.  In Hyper-V Manager, right click on the VM you created while it is stopped,
+  and select Settings... -> Security and uncheck Enable Secure Boot.
+1. Uncheck "Enable checkpoints" under the VM's Settings -> Checkpoints, since SGX will not work with checkpoints.
+1. If using an SGX-capable machine, enable SGX for the VM as follows (this cannot be done from Hyper-V Manager):
+   - Download [VirtualMachineSgxSettings.psm1](https://raw.githubusercontent.com/microsoft/openenclave/f28cedce63be9673e
+20fe54563987189f2565637/new_platforms/scripts/VirtualMachineSgxSettings.psm1)
+   - Open an elevated PowerShell window (e.g., type "powershell" and click Run as Administrator)
+   - Invoke the following commands, using the path to where you downloaded the file, and replacing MyVM with your VM nam
+e:
+   ```
+   Set-ExecutionPolicy Bypass -Scope Process
+   Import-Module Drive:\Path\to\VirtualMachineSgxSettings.psm1
+   Set-VMSgx -VmName MyVM -IsSgxEnabled $True -SgxSize 32
+   ```
+1. Start the VM and connect to it (right click, Connect...), finish the initial setup, reboot, and login.
+   - Enable OpenSSH server installation when given the choice during setup.
+   - All other options are sufficient to leave as the defaults or changed as desired.

--- a/docs/GettingStartedDocs/VisualStudioLinux.md
+++ b/docs/GettingStartedDocs/VisualStudioLinux.md
@@ -19,7 +19,8 @@ To develop Linux applications using a Windows development machine, you will need
 - [Open Enclave Wizard - Preview](https://marketplace.visualstudio.com/items?itemName=MS-TCPS.OpenEnclaveSDK-VSIX)
   Visual Studio extension, v0.5 or later.  The extension can be installed via that marketplace link, or from within
   Visual Studio.  (For VS2017, do Tools -> Extensions and Updates -> Online -> search for "enclave".  For VS2019,
-  do Extensions -> Manage Extensions -> Online -> search for "enclave".)
+  do Extensions -> Manage Extensions -> Online -> search for "enclave".)  You must restart Visual Studio after
+  installing the extension.
 
 You will also need a build machine running Ubuntu 16.04 (64-bit) or Ubuntu 18.04.  This can be
 a remote Linux machine, or can simply be a "Generation 2" Linux VM on the Windows

--- a/docs/GettingStartedDocs/VisualStudioLinux.md
+++ b/docs/GettingStartedDocs/VisualStudioLinux.md
@@ -23,33 +23,13 @@ To develop Linux applications using a Windows development machine, you will need
   installing the extension.
 
 You will also need a build machine running Ubuntu 16.04 (64-bit) or Ubuntu 18.04.  This can be
-a remote Linux machine, or can simply be a "Generation 2" Linux VM on the Windows
-development machine.  Ideally, the machine should be SGX capable (see [here](https://github.com/microsoft/openenclave/blob/master/docs/GettingStartedDocs/SGXSupportLevel.md) for how to
-determine this), but a non-SGX machine can still be used in simulation mode.  To set up a Linux VM
-on your Windows machine, do the following:
+any of the following:
+- a remote Linux machine
+- an [Azure Confidential Computing VM](https://azure.microsoft.com/en-us/solutions/confidential-compute/)
+- a [Linux VM running on the Windows development machine](HyperVLinuxVMSetup.md)
 
-1. Download an ISO for Ubuntu [18.04](http://releases.ubuntu.com/18.04/) or [16.04](http://releases.ubuntu.com/16.04/).
-   A "Server install image" is sufficient.
-1. Create a VM as follows.  Open "Hyper-V Manager", and do Action -> New -> Virtual Machine....  
-   - On the Specify Generation screen, choose Generation 2.
-   - On the Configure Networking screen, choose Default Switch to ensure you can connect to it with a debugger.
-   - On the Installation Options screen, choose the ISO file you downloaded.
-   - All other options can be either left as the defaults or changed as desired.
-1. Disable Secure Boot as follows.  In Hyper-V Manager, right click on the VM you created while it is stopped,
-  and select Settings... -> Security and uncheck Enable Secure Boot.
-1. Uncheck "Enable checkpoints" under the VM's Settings -> Checkpoints, since SGX will not work with checkpoints.
-1. If using an SGX-capable machine, enable SGX for the VM as follows (this cannot be done from Hyper-V Manager):
-   - Download [VirtualMachineSgxSettings.psm1](https://raw.githubusercontent.com/microsoft/openenclave/f28cedce63be9673e20fe54563987189f2565637/new_platforms/scripts/VirtualMachineSgxSettings.psm1)
-   - Open an elevated PowerShell window (e.g., type "powershell" and click Run as Administrator)
-   - Invoke the following commands, using the path to where you downloaded the file, and replacing MyVM with your VM name:
-   ```
-   Set-ExecutionPolicy Bypass -Scope Process
-   Import-Module Drive:\Path\to\VirtualMachineSgxSettings.psm1
-   Set-VMSgx -VmName MyVM -IsSgxEnabled $True -SgxSize 32
-   ```
-1. Start the VM and connect to it (right click, Connect...), finish the initial setup, reboot, and login.
-   - Enable OpenSSH server installation when given the choice during setup.
-   - All other options are sufficient to leave as the defaults or changed as desired.
+Ideally, the machine should be SGX capable (see [here](https://github.com/microsoft/openenclave/blob/master/docs/GettingStartedDocs/SGXSupportLevel.md) for how to
+determine this), but a non-SGX machine can still be used in simulation mode.  
 
 On the Linux build machine, or after opening an ssh session into the VM:
 

--- a/docs/GettingStartedDocs/VisualStudioLinux.md
+++ b/docs/GettingStartedDocs/VisualStudioLinux.md
@@ -29,7 +29,7 @@ any of the following:
 - a [Linux VM running on the Windows development machine](HyperVLinuxVMSetup.md)
 
 Ideally, the machine should be SGX capable (see [here](https://github.com/microsoft/openenclave/blob/master/docs/GettingStartedDocs/SGXSupportLevel.md) for how to
-determine this), but a non-SGX machine can still be used in simulation mode.  
+determine this), but a non-SGX machine can still be used in simulation mode.
 
 On the Linux build machine, or after opening an ssh session into the VM:
 
@@ -53,7 +53,7 @@ We will now walk through the process of creating a C/C++ application that uses a
    it is called "Console App" (note: NOT the "Console App (.NET Core)") with the Linux
    keyword.  (If it is not immediately visible, the template can be found under
    Installed -> Visual C++ -> Cross Platform -> Linux.)
-   Give the project a name, LinuxApp for example.  This will create a "Hello World" console application.  
+   Give the project a name, LinuxApp for example.  This will create a "Hello World" console application.
    Alternatively, if you already have such a Linux application using a Visual Studio project
    file (.vcxproj file), you can start from your existing application.
 2. Configure the application project to use your Linux build environment, by right clicking
@@ -110,7 +110,7 @@ int main()
 The solution will have three configurations: Debug, SGX-Simulation-Debug, and Release.
 The SGX-Simulation-Debug will work the same as Debug, except that SGX support will be emulated
 rather than using hardware support.  This allows debugging on hardware that does not support SGX.
-The Debug and Release configurations can only be run (whether natively or in a VM) successfully on 
+The Debug and Release configurations can only be run (whether natively or in a VM) successfully on
 SGX-capable hardware.
 
 For the platform, use x64, since Open Enclave currently only supports 64-bit enclaves.

--- a/new_platforms/docs/VisualStudioWindows.md
+++ b/new_platforms/docs/VisualStudioWindows.md
@@ -1,0 +1,70 @@
+Developing your own enclave using Visual Studio
+=============
+
+## Using Open Enclave from Windows
+
+This section covers how to use this SDK to develop your own enclave that can run
+on both SGX and OP-TEE, and use it from your own application.
+
+**Prerequisites:**
+1. Install the Open Enclave Visual Studio Extension
+2. To develop for SGX, install the [Prerequisites for SGX](win_sgx_dev.md)
+2. To develop for OP-TEE, install the [Prerequisites for OP-TEE](ta_debugging_wsl.md)
+
+**To create your own enclave:**
+1. In Visual Studio, add a new Visual C++ "Open Enclave TEE Project".  If you want
+to build for OP-TEE (whether in addition to, or instead of, SGX) you will need
+to select the path to the ta\_dev\_kit.mk file in the output of an OP-TEE build.
+For example, this might be in a optee\_os\out\arm-plat-vexpress\export-ta\_arm64\mk
+directory.
+2. Edit the _YourProjectName_.edl file. Define any trusted APIs (called "ECALLs")
+you want to call from your application in the trusted{} section,
+and in the untrusted{} section, define any application APIs (called "OCALLs")
+that you want to call from your enclave. Definitions must be described using the
+[EDL file syntax](https://software.intel.com/en-us/sgx-sdk-dev-reference-enclave-definition-language-file-syntax).
+3. Edit the ecalls.c file, and fill in implementations of the ECALL(s) you added.
+
+**To call your enclave from an application project:**
+1. In Visual Studio, create a new Visual C++ project, or open an existing
+one, that will build a normal application that will call your enclave APIs.
+2. Right click on your application project, select
+"Open Enclave Configuration"->"Import Enclave", and select the
+_YourProjectName_.edl file from your enclave project.
+3. Add code in your app to call oe\_create\__YourEDLFileName_\_enclave(),
+any ECALLs you added, and oe\_terminate\_enclave(). The file _YourEDLFileName_\_host.c
+will be added to your project with sample code to do this.
+
+OP-TEE only allows one thread per TA to be in an ECALL (i.e., a call into
+a TA from a host app).  Even if it has an OCALL (i.e., an out-call
+back into the host app) in progress, the ECALL must complete before
+another ECALL can enter the TA.  SGX, on the other hand, would allow a
+second ECALL to enter.  So if you want them to function identically, host apps
+can pass the OE\_ENCLAVE\_FLAG\_SERIALIZE\_ECALLS
+flag when creating an enclave to automatically get the OP-TEE like behavior
+for both SGX and TrustZone.
+
+
+**Then to build the enclave for OP-TEE:**
+
+1. Using the [Bash on Ubuntu on Windows](https://docs.microsoft.com/en-us/windows/wsl/about) shell,
+cd to your enclave project's "optee" subdirectory.  If you added additional
+source files to your enclave project in Visual Studio, also add them to the
+sub.mk in that directory.
+2. By default, the project is configured to build for the vexpress-qemu\_armv8a flavor of OP-TEE.
+If you want to build for vexpress-qemu\_virt or ls-ls1012grapeboard, edit the sub.mk
+file in the project's "optee" subdirectory, and change the 'libdirs' line accordingly.
+For vexpress-qemu\_virt, you will also need to change the CROSS_COMPILE line in linux\_gcc.mak
+to "CROSS\_COMPILE=arm-linux-gnueabihf-" since it is 32-bit not 64-bit.
+3. Do "make -f linux\_gcc.mak" to build the enclave.
+4. On the destination machine (if Windows), apply the uuids.reg file
+("reg.exe import uuids.reg") and reboot.
+
+## Debugging
+
+**For SGX:** You can use Visual Studio for debugging, including the SGX
+simulator, that comes with the Intel SGX SDK.  Simply use the Debug
+configuration in Visual Studio if you have SGX-capable hardware, or
+the SGX-Simulation-Debug configuration in Visual Studio for software emulation.
+
+**For TrustZone:** You can use a basic software emulation environment with OP-TEE.
+Simply use the OPTEE-Simulation-Debug configuration in Visual Studio.

--- a/new_platforms/docs/visualstudio_dev.md
+++ b/new_platforms/docs/visualstudio_dev.md
@@ -6,5 +6,5 @@ including ARM TrustZone and Intel SGX, with a Windows or Linux host application.
 includes support for testing your enclave under simulation when developing for SGX or TrustZone.
 
 ## Getting Started Guides
-- [Developing Linux applications](../../docs/GettingStarted/VisualStudioLinux.md)
+- [Developing Linux applications](../../docs/GettingStartedDocs/VisualStudioLinux.md)
 - [Developing Windows applications](VisualStudioWindows.md)

--- a/new_platforms/docs/visualstudio_dev.md
+++ b/new_platforms/docs/visualstudio_dev.md
@@ -1,70 +1,10 @@
-Developing your own enclave using Visual Studio
+Open Enclave Wizard - Preview
 =============
 
-## Using Open Enclave from Windows
+This Visual Studio extension includes preview support for Trusted Execution Environment (TEE) platforms,
+including ARM TrustZone and Intel SGX, with a Windows or Linux host application. In addition, this preview
+includes support for testing your enclave under simulation when developing for SGX or TrustZone.
 
-This section covers how to use this SDK to develop your own enclave that can run
-on both SGX and OP-TEE, and use it from your own application.
-
-**Prerequisites:**
-1. Install the Open Enclave Visual Studio Extension
-2. To develop for SGX, install the [Prerequisites for SGX](win_sgx_dev.md)
-2. To develop for OP-TEE, install the [Prerequisites for OP-TEE](ta_debugging_wsl.md)
-
-**To create your own enclave:**
-1. In Visual Studio, add a new Visual C++ "Open Enclave TEE Project".  If you want
-to build for OP-TEE (whether in addition to, or instead of, SGX) you will need
-to select the path to the ta\_dev\_kit.mk file in the output of an OP-TEE build.
-For example, this might be in a optee\_os\out\arm-plat-vexpress\export-ta\_arm64\mk
-directory.
-2. Edit the _YourProjectName_.edl file. Define any trusted APIs (called "ECALLs")
-you want to call from your application in the trusted{} section,
-and in the untrusted{} section, define any application APIs (called "OCALLs")
-that you want to call from your enclave. Definitions must be described using the
-[EDL file syntax](https://software.intel.com/en-us/sgx-sdk-dev-reference-enclave-definition-language-file-syntax).
-3. Edit the ecalls.c file, and fill in implementations of the ECALL(s) you added.
-
-**To call your enclave from an application project:**
-1. In Visual Studio, create a new Visual C++ project, or open an existing
-one, that will build a normal application that will call your enclave APIs.
-2. Right click on your application project, select
-"Open Enclave Configuration"->"Import Enclave", and select the
-_YourProjectName_.edl file from your enclave project.
-3. Add code in your app to call oe\_create\__YourEDLFileName_\_enclave(),
-any ECALLs you added, and oe\_terminate\_enclave(). The file _YourEDLFileName_\_host.c
-will be added to your project with sample code to do this.
-
-OP-TEE only allows one thread per TA to be in an ECALL (i.e., a call into
-a TA from a host app).  Even if it has an OCALL (i.e., an out-call
-back into the host app) in progress, the ECALL must complete before
-another ECALL can enter the TA.  SGX, on the other hand, would allow a
-second ECALL to enter.  So if you want them to function identically, host apps
-can pass the OE\_ENCLAVE\_FLAG\_SERIALIZE\_ECALLS
-flag when creating an enclave to automatically get the OP-TEE like behavior
-for both SGX and TrustZone.
-
-
-**Then to build the enclave for OP-TEE:**
-
-1. Using the [Bash on Ubuntu on Windows](https://docs.microsoft.com/en-us/windows/wsl/about) shell,
-cd to your enclave project's "optee" subdirectory.  If you added additional
-source files to your enclave project in Visual Studio, also add them to the
-sub.mk in that directory.
-2. By default, the project is configured to build for the vexpress-qemu\_armv8a flavor of OP-TEE.
-If you want to build for vexpress-qemu\_virt or ls-ls1012grapeboard, edit the sub.mk
-file in the project's "optee" subdirectory, and change the 'libdirs' line accordingly.
-For vexpress-qemu\_virt, you will also need to change the CROSS_COMPILE line in linux\_gcc.mak
-to "CROSS\_COMPILE=arm-linux-gnueabihf-" since it is 32-bit not 64-bit.
-3. Do "make -f linux\_gcc.mak" to build the enclave.
-4. On the destination machine (if Windows), apply the uuids.reg file
-("reg.exe import uuids.reg") and reboot.
-
-## Debugging
-
-**For SGX:** You can use Visual Studio for debugging, including the SGX
-simulator, that comes with the Intel SGX SDK.  Simply use the Debug
-configuration in Visual Studio if you have SGX-capable hardware, or
-the SGX-Simulation-Debug configuration in Visual Studio for software emulation.
-
-**For TrustZone:** You can use a basic software emulation environment with OP-TEE.
-Simply use the OPTEE-Simulation-Debug configuration in Visual Studio.
+## Getting Started Guides
+- [Developing Linux applications](../../docs/GettingStarted/VisualStudioLinux.md)
+- [Developing Windows applications](VisualStudioWindows.md)


### PR DESCRIPTION
This is the page that the VS extension would point to (via an aka.ms link) for more information.
Main walkthrough content is unchanged, just the filename is renamed.
The original filename now contains minimal content that just points to the appropriate walkthrough for Linux or Windows.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>