### PR TITLE
Support for deep copying out (and in/out) parameters

### DIFF
--- a/include/openenclave/edger8r/common.h
+++ b/include/openenclave/edger8r/common.h
@@ -51,7 +51,7 @@ OE_INLINE oe_result_t oe_add_size(size_t* total, size_t size)
         goto done;
     }
 
-    // Add rounded-size and check for overlow.
+    // Add rounded-size and check for overflow.
     sum = *total + rsize;
     if (sum < *total)
     {

--- a/tests/oeedger8r/CMakeLists.txt
+++ b/tests/oeedger8r/CMakeLists.txt
@@ -10,4 +10,6 @@ endif()
 add_enclave_test(tests/oeedger8r edl_host edl_enc)
 add_enclave_test(tests/oeedger8r_other edl_host edl_other_enc)
 
+add_custom_target(edl_gen DEPENDS edl_enc_gen edl_host_gen)
+
 add_subdirectory(behavior)

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -41,6 +41,11 @@ enclave {
     [count=3] CountStruct* array_of_struct;
   };
 
+  struct SuperNestedStruct {
+    // TODO: We should eventually support count being a member of the struct.
+    [count=2] NestedStruct* more_structs;
+  };
+
   trusted {
     // Since `s` is passed by value, `s.ptr` is not deep copied.
     public void deepcopy_value(ShallowStruct s, [user_check] uint64_t* ptr);
@@ -90,6 +95,9 @@ enclave {
 
     // Maybe test for recursive copying.
     public void deepcopy_nested([in, out, count=1] NestedStruct* n);
+
+    // Really stress the recursion.
+    public void deepcopy_super_nested([in, out, count=n] SuperNestedStruct* s, size_t n);
 
     // Test handling of null values.
     public void deepcopy_null([in, out, count=1] CountStruct* s);

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -46,6 +46,12 @@ enclave {
     [count=2] NestedStruct* more_structs;
   };
 
+  struct IOVEC
+  {
+    [size=len] void *base;
+    size_t len;
+  };
+
   trusted {
     // Since `s` is passed by value, `s.ptr` is not deep copied.
     public void deepcopy_value(ShallowStruct s, [user_check] uint64_t* ptr);
@@ -105,5 +111,8 @@ enclave {
     // Deep copy of one `CountStruct` with an embedded array out
     // should take place.
     public void deepcopy_out_count([in, out, count=1] CountStruct* s);
+
+    // Test a real-world scenario.
+    public void deepcopy_iovec([in, out, count=n] IOVEC* iov, size_t n);
   };
 };

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -47,46 +47,46 @@ enclave {
 
     // Although `s` is passed by pointer, because `s.ptr` does not
     // have any attribute, it is still not deep copied.
-    public void deepcopy_shallow([in, count=1] ShallowStruct* s, [user_check] uint64_t* ptr);
+    public void deepcopy_shallow([in, out, count=1] ShallowStruct* s, [user_check] uint64_t* ptr);
 
     // Deep copy of one `CountStruct` with an embedded array should
     // take place.
-    public void deepcopy_count([in, count=1] CountStruct* s);
+    public void deepcopy_count([in, out, count=1] CountStruct* s);
 
     // Deep copy of one `CountParamStruct` with an embedded array
     // should take place.
-    public void deepcopy_countparam([in, count=1] CountParamStruct* s);
+    public void deepcopy_countparam([in, out, count=1] CountParamStruct* s);
 
     // TODO: We should have a `SizeStruct` to test deep copying where
     // the size attribute is correctly used with a hard-coded value.
 
     // Deep copy of one `SizeParamStruct` with an embedded array
     // should take place.
-    public void deepcopy_sizeparam([in, count=1] SizeParamStruct* s);
+    public void deepcopy_sizeparam([in, out, count=1] SizeParamStruct* s);
 
     // Deep copy of one `CountSizeParamStruct` with an embedded array
     // should take place.
-    public void deepcopy_countsizeparam([in, count=1] CountSizeParamStruct* s);
+    public void deepcopy_countsizeparam([in, out, count=1] CountSizeParamStruct* s);
 
     // Deep copy of one `CountSizeParamStruct` with an embedded array
     // should take place, tests with `size * 1`.
-    public void deepcopy_countsizeparam_size([in, count=1] CountSizeParamStruct* s);
+    public void deepcopy_countsizeparam_size([in, out, count=1] CountSizeParamStruct* s);
 
     // Deep copy of one `CountSizeParamStruct` with an embedded array
     // should take place, tests with `count * 1`.
-    public void deepcopy_countsizeparam_count([in, count=1] CountSizeParamStruct* s);
+    public void deepcopy_countsizeparam_count([in, out, count=1] CountSizeParamStruct* s);
 
     // Deep copy of two `CountParamStruct`s each with an embedded
     // array and different counts should take place.
-    public void deepcopy_countparamarray([in, count=2] CountParamStruct* s);
+    public void deepcopy_countparamarray([in, out, count=2] CountParamStruct* s);
 
     // Deep copy of two `SizeParamStruct`s each with an embedded
     // array and different sizes should take place.
-    public void deepcopy_sizeparamarray([in, count=2] SizeParamStruct* s);
+    public void deepcopy_sizeparamarray([in, out, count=2] SizeParamStruct* s);
 
     // Deep copy of two `CountSizeParamStruct`s each with an embedded
     // array and different counts should take place.
-    public void deepcopy_countsizeparamarray([in, count=2] CountSizeParamStruct* s);
+    public void deepcopy_countsizeparamarray([in, out, count=2] CountSizeParamStruct* s);
 
     // Maybe test for recursive copying.
     public void deepcopy_nested([in, count=1] NestedStruct* n);

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -93,5 +93,9 @@ enclave {
 
     // Test handling of null values.
     public void deepcopy_null([in, count=1] CountStruct* s);
+
+    // Deep copy of one `CountStruct` with an embedded array out
+    // should take place.
+    public void deepcopy_out_count([in, out, count=1] CountStruct* s);
   };
 };

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -89,10 +89,10 @@ enclave {
     public void deepcopy_countsizeparamarray([in, out, count=2] CountSizeParamStruct* s);
 
     // Maybe test for recursive copying.
-    public void deepcopy_nested([in, count=1] NestedStruct* n);
+    public void deepcopy_nested([in, out, count=1] NestedStruct* n);
 
     // Test handling of null values.
-    public void deepcopy_null([in, count=1] CountStruct* s);
+    public void deepcopy_null([in, out, count=1] CountStruct* s);
 
     // Deep copy of one `CountStruct` with an embedded array out
     // should take place.

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -20,13 +20,15 @@ add_custom_command(
   ../edl/switchless.edl
   COMMAND edger8r --experimental --trusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
 
-# Dummy target used for generating from EDL on demand.
-add_custom_target(edl_enc_trusted DEPENDS all_t.h all_t.c all_args.h)
-
 add_custom_command(
   OUTPUT bar_t.h bar_args.h
   DEPENDS ../moreedl/bar.edl
   COMMAND edger8r --trusted --header-only --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl bar.edl)
+
+# Dummy target used for generating from EDL on demand.
+add_custom_target(edl_enc_gen DEPENDS
+  all_t.h all_t.c all_args.h
+  bar_t.h bar_args.h)
 
 add_enclave(TARGET edl_enc UUID e71cbbea-a638-4653-b46e-2e58a2ca3408 CXX
     SOURCES

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -3,8 +3,11 @@
 
 #include "../edltestutils.h"
 
+#include <openenclave/corelibc/stdio.h>
+#include <openenclave/corelibc/string.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/tests.h>
+#include <string.h>
 #include "all_t.h"
 
 static uint64_t data[8] = {0x1112131415161718,
@@ -202,4 +205,32 @@ void deepcopy_out_count(CountStruct* s)
     s->size = 64;
     for (size_t i = 0; i < 3; ++i)
         s->ptr[i] = data[i];
+}
+
+void deepcopy_iovec(IOVEC* iov, size_t n)
+{
+    OE_TEST(!(n && !iov));
+    OE_TEST(n == 2);
+
+    for (size_t i = 0; i < n; i++)
+    {
+        char* str = (char*)iov[i].base;
+        size_t len = iov[i].len;
+
+        switch (i)
+        {
+            case 0:
+                OE_TEST(len == 8);
+                OE_TEST(oe_strcmp(str, "red") == 0);
+                memcpy(str, "0000000", 8);
+                break;
+            case 1:
+                OE_TEST(len == 0);
+                OE_TEST(str == NULL);
+                break;
+            default:
+                OE_TEST(false);
+                break;
+        }
+    }
 }

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -180,3 +180,15 @@ void deepcopy_null(CountStruct* s)
 {
     OE_UNUSED(s);
 }
+
+void deepcopy_out_count(CountStruct* s)
+{
+    OE_TEST(s->count == 0);
+    OE_TEST(s->size == 0);
+    for (size_t i = 0; i < 3; ++i)
+        OE_TEST(s->ptr[i] == 0);
+    s->count = 7;
+    s->size = 64;
+    for (size_t i = 0; i < 3; ++i)
+        s->ptr[i] = data[i];
+}

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -176,6 +176,17 @@ void deepcopy_nested(NestedStruct* n)
         deepcopy_count(&(n->array_of_struct[i]));
 }
 
+void deepcopy_super_nested(SuperNestedStruct* s, size_t n)
+{
+    OE_TEST(oe_is_within_enclave(s, n * sizeof(SuperNestedStruct)));
+    // This test exists to check that the produced size of `_ptrs` is
+    // `n * (1 + 2 * (1 + 1 + 3))`.
+    OE_TEST(oe_is_within_enclave(
+        s[0].more_structs[0].array_of_struct, 3 * sizeof(CountStruct)));
+    OE_TEST(oe_is_outside_enclave(
+        s[0].more_structs[0].shallow_struct, sizeof(ShallowStruct)));
+}
+
 void deepcopy_null(CountStruct* s)
 {
     OE_UNUSED(s);

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -30,6 +30,12 @@ add_custom_command(
   DEPENDS ../edl/other.edl
   COMMAND edger8r --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl other.edl)
 
+# Dummy target used for generating from EDL on demand.
+add_custom_target(edl_host_gen DEPENDS
+  all_u.h all_u.c all_args.h
+  bar_u.h bar_args.h
+  other_u.h other_u.c other_args.h)
+
 add_executable(edl_host
     all_u.c
     bar_u.h

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -144,7 +144,7 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         NestedStruct ns[]{p, n};
         SuperNestedStruct u[]{{ns}, {ns}};
 
-        OE_TEST(deepcopy_super_nested(enclave, u, 2) == OE_OK);
+        OE_TEST(deepcopy_super_nested(enclave, u, OE_COUNTOF(u)) == OE_OK);
         OE_TEST(deepcopy_nested(enclave, &n) == OE_OK);
 
         for (size_t i = 0; i < 4; ++i)
@@ -176,6 +176,19 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(s.count == 7);
         OE_TEST(s.size == 64);
         test_struct(s, 3);
+    }
+
+    {
+        IOVEC iov[2];
+        char buf0[8] = "red";
+
+        iov[0].base = (void*)buf0;
+        iov[0].len = sizeof(buf0);
+        iov[1].base = NULL;
+        iov[1].len = 0;
+
+        OE_TEST(deepcopy_iovec(enclave, iov, OE_COUNTOF(iov)) == OE_OK);
+        OE_TEST(memcmp(buf0, "0000000", 8) == 0);
     }
 
     printf("=== test_deepcopy_edl_ecalls passed\n");

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -18,13 +18,32 @@ static uint64_t data[8] = {0x1112131415161718,
                            0x8182838485868788};
 
 template <typename T>
+void test_struct(const T& s, size_t size = 8, size_t offset = 0)
+{
+    for (size_t i = 0; i < size; ++i)
+        OE_TEST(s.ptr[i] == data[offset + i]);
+}
+
+template <typename T>
+void test_structs(const std::array<T, 2>& s)
+{
+    test_struct(s[0]);
+    test_struct(s[1], 4, 4);
+}
+
+template <typename T>
+T init_struct()
+{
+    T s = T{7ULL, 64ULL, data};
+    test_struct(s);
+    return s;
+}
+
+template <typename T>
 std::array<T, 2> init_structs()
 {
-    std::array<T, 2> s = {T{7ULL, 64ULL, data}, T{3ULL, 32ULL, &data[4]}};
-    OE_TEST(s[0].ptr[0] == data[0]);
-    OE_TEST(s[0].ptr[7] == data[7]);
-    OE_TEST(s[1].ptr[0] == data[4]);
-    OE_TEST(s[1].ptr[3] == data[7]);
+    std::array<T, 2> s = {init_struct<T>(), T{3ULL, 32ULL, &data[4]}};
+    test_structs(s);
     return s;
 }
 
@@ -33,55 +52,65 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
     {
         // NOTE: These test backwards-compatibility and so should
         // succeed without deep copy support.
-        auto s = init_structs<ShallowStruct>();
-        OE_TEST(deepcopy_value(enclave, s[0], data) == OE_OK);
-        OE_TEST(deepcopy_shallow(enclave, &s[0], data) == OE_OK);
+        auto s = init_struct<ShallowStruct>();
+        OE_TEST(deepcopy_value(enclave, s, data) == OE_OK);
+        test_struct(s);
+        OE_TEST(deepcopy_shallow(enclave, &s, data) == OE_OK);
+        test_struct(s);
     }
 
     {
-        auto s = init_structs<CountStruct>();
-        OE_TEST(deepcopy_count(enclave, &s[0]) == OE_OK);
+        auto s = init_struct<CountStruct>();
+        OE_TEST(deepcopy_count(enclave, &s) == OE_OK);
+        test_struct(s);
     }
 
     {
-        auto s = init_structs<CountParamStruct>();
-        OE_TEST(deepcopy_countparam(enclave, &s[0]) == OE_OK);
+        auto s = init_struct<CountParamStruct>();
+        OE_TEST(deepcopy_countparam(enclave, &s) == OE_OK);
+        test_struct(s);
     }
 
     {
-        auto s = init_structs<SizeParamStruct>();
-        OE_TEST(deepcopy_sizeparam(enclave, &s[0]) == OE_OK);
+        auto s = init_struct<SizeParamStruct>();
+        OE_TEST(deepcopy_sizeparam(enclave, &s) == OE_OK);
+        test_struct(s);
     }
 
     {
-        auto s = init_structs<CountSizeParamStruct>();
-        s[0].count = 8;
-        s[0].size = 4;
-        OE_TEST(deepcopy_countsizeparam(enclave, &s[0]) == OE_OK);
+        auto s = init_struct<CountSizeParamStruct>();
+        s.count = 8;
+        s.size = 4;
+        OE_TEST(deepcopy_countsizeparam(enclave, &s) == OE_OK);
+        test_struct(s);
     }
 
     {
-        auto s = init_structs<CountSizeParamStruct>();
-        s[0].count = 1;
-        s[0].size = 4 * sizeof(uint64_t);
-        OE_TEST(deepcopy_countsizeparam_size(enclave, &s[0]) == OE_OK);
+        auto s = init_struct<CountSizeParamStruct>();
+        s.count = 1;
+        s.size = 4 * sizeof(uint64_t);
+        OE_TEST(deepcopy_countsizeparam_size(enclave, &s) == OE_OK);
+        test_struct(s);
     }
 
     {
-        auto s = init_structs<CountSizeParamStruct>();
-        s[0].count = 4;
-        s[0].size = sizeof(uint64_t);
-        OE_TEST(deepcopy_countsizeparam_count(enclave, &s[0]) == OE_OK);
+        auto s = init_struct<CountSizeParamStruct>();
+        s.count = 4;
+        s.size = sizeof(uint64_t);
+        OE_TEST(deepcopy_countsizeparam_count(enclave, &s) == OE_OK);
+        test_struct(s);
     }
 
     {
         auto s = init_structs<CountParamStruct>();
         OE_TEST(deepcopy_countparamarray(enclave, s.data()) == OE_OK);
+        test_structs(s);
     }
 
     {
         auto s = init_structs<SizeParamStruct>();
         OE_TEST(deepcopy_sizeparamarray(enclave, s.data()) == OE_OK);
+        test_structs(s);
     }
 
     {
@@ -91,15 +120,27 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         s[1].count = 3;
         s[1].size = 8;
         OE_TEST(deepcopy_countsizeparamarray(enclave, s.data()) == OE_OK);
+        test_structs(s);
     }
 
     {
-        auto s = init_structs<CountStruct>();
+        auto s = init_struct<CountStruct>();
         int ints[]{0, 1, 2, 3};
         ShallowStruct shallow{1, 8, nullptr};
-        CountStruct counts[]{s[0], s[0], s[0]};
+        CountStruct counts[]{s, s, s};
         NestedStruct n{13, ints, &shallow, counts};
+
         OE_TEST(deepcopy_nested(enclave, &n) == OE_OK);
+
+        for (size_t i = 0; i < 4; ++i)
+            OE_TEST(n.array_of_int[i] == static_cast<int>(i));
+
+        OE_TEST(n.shallow_struct == &shallow);
+        OE_TEST(n.array_of_struct == counts);
+
+        for (size_t i = 0; i < 3; ++i)
+            for (size_t j = 0; j < 8; ++j)
+                OE_TEST(n.array_of_struct[i].ptr[j] == data[j]);
     }
 
     {
@@ -109,6 +150,7 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
     {
         CountStruct s{7, 64, nullptr};
         OE_TEST(deepcopy_null(enclave, &s) == OE_OK);
+        OE_TEST(s.ptr == nullptr);
     }
 
     printf("=== test_deepcopy_edl_ecalls passed\n");

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -140,7 +140,11 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         ShallowStruct shallow{1, 8, nullptr};
         CountStruct counts[]{s, s, s};
         NestedStruct n{13, ints, &shallow, counts};
+        NestedStruct p{7, ints, &shallow, counts};
+        NestedStruct ns[]{p, n};
+        SuperNestedStruct u[]{{ns}, {ns}};
 
+        OE_TEST(deepcopy_super_nested(enclave, u, 2) == OE_OK);
         OE_TEST(deepcopy_nested(enclave, &n) == OE_OK);
 
         for (size_t i = 0; i < 4; ++i)

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -164,5 +164,15 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(s.ptr == nullptr);
     }
 
+    {
+        CountStruct s{};
+        uint64_t p[3] = {0, 0, 0};
+        s.ptr = p;
+        OE_TEST(deepcopy_out_count(enclave, &s) == OE_OK);
+        OE_TEST(s.count == 7);
+        OE_TEST(s.size == 64);
+        test_struct(s, 3);
+    }
+
     printf("=== test_deepcopy_edl_ecalls passed\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -62,19 +62,21 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
     {
         auto s = init_struct<CountStruct>();
         OE_TEST(deepcopy_count(enclave, &s) == OE_OK);
-        test_struct(s);
+        test_struct(s, 3);
     }
 
     {
         auto s = init_struct<CountParamStruct>();
         OE_TEST(deepcopy_countparam(enclave, &s) == OE_OK);
-        test_struct(s);
+        OE_TEST(s.count == 7);
+        test_struct(s, s.count);
     }
 
     {
         auto s = init_struct<SizeParamStruct>();
         OE_TEST(deepcopy_sizeparam(enclave, &s) == OE_OK);
-        test_struct(s);
+        OE_TEST(s.size == 64);
+        test_struct(s, s.size / sizeof(uint64_t));
     }
 
     {
@@ -82,7 +84,9 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         s.count = 8;
         s.size = 4;
         OE_TEST(deepcopy_countsizeparam(enclave, &s) == OE_OK);
-        test_struct(s);
+        OE_TEST(s.count == 8);
+        OE_TEST(s.size == 4);
+        test_struct(s, (s.count * s.size) / sizeof(uint64_t));
     }
 
     {
@@ -90,7 +94,9 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         s.count = 1;
         s.size = 4 * sizeof(uint64_t);
         OE_TEST(deepcopy_countsizeparam_size(enclave, &s) == OE_OK);
-        test_struct(s);
+        OE_TEST(s.count == 1);
+        OE_TEST(s.size == 4 * sizeof(uint64_t));
+        test_struct(s, 4);
     }
 
     {
@@ -98,19 +104,23 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         s.count = 4;
         s.size = sizeof(uint64_t);
         OE_TEST(deepcopy_countsizeparam_count(enclave, &s) == OE_OK);
-        test_struct(s);
+        OE_TEST(s.count == 4);
+        OE_TEST(s.size == sizeof(uint64_t));
+        test_struct(s, 4);
     }
 
     {
         auto s = init_structs<CountParamStruct>();
         OE_TEST(deepcopy_countparamarray(enclave, s.data()) == OE_OK);
-        test_structs(s);
+        test_struct(s[0], 7);
+        test_struct(s[1], 3, 4);
     }
 
     {
         auto s = init_structs<SizeParamStruct>();
         OE_TEST(deepcopy_sizeparamarray(enclave, s.data()) == OE_OK);
-        test_structs(s);
+        test_struct(s[0], s[0].size / sizeof(uint64_t));
+        test_struct(s[1], s[1].size / sizeof(uint64_t), 4);
     }
 
     {
@@ -120,7 +130,8 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         s[1].count = 3;
         s[1].size = 8;
         OE_TEST(deepcopy_countsizeparamarray(enclave, s.data()) == OE_OK);
-        test_structs(s);
+        test_struct(s[0], (s[0].count * s[0].size) / sizeof(uint64_t));
+        test_struct(s[1], (s[1].count * s[1].size) / sizeof(uint64_t), 4);
     }
 
     {

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -671,7 +671,6 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
         in
         gen_c_for (List.length args) count
           ( [ [ sprintf "if (%s)"
-                  (* TODO: Check hd[i] too. *)
                   (String.concat " && " (List.rev (arg :: args))) ]
             ; [sprintf "    OE_ADD_SIZE(%s, %s);" buffer size]
             ; (let param_count = oe_get_param_count (ptype, decl, argstruct) in
@@ -709,7 +708,6 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
         gen_c_for (List.length args) count
           ( [ (* NOTE: This makes the embedded check in the `OE_` macro superfluous. *)
               [ sprintf "if (%s)"
-                  (* TODO: Check hd[i] too. *)
                   (String.concat " && " (List.rev (arg :: args))) ]
             ; [ sprintf "    OE_WRITE_%s_PARAM(%s, %s, %s);"
                   (if is_in_ptr ptype then "IN" else "IN_OUT")
@@ -842,8 +840,7 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
                match args with
                | [] -> [s]
                | _ ->
-                   [ (* TODO: Check hd[i] too. *)
-                     sprintf "if (%s)" (String.concat " && " (List.rev args))
+                   [ sprintf "if (%s)" (String.concat " && " (List.rev args))
                    ; "{"
                    ; "    /* Restore original pointer. */"
                    ; sprintf "    %s = _ptrs[_ptrs_index++];" arg
@@ -982,7 +979,8 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
       oe_gen_out_and_inout_setters fd.plist
     ; ""
     ; "    /* Check that in/in-out strings are null terminated. */"
-      (* TODO: Fix for deep copy. *)
+      (* NOTE: We do not support deep copy for strings, so there is not
+         (yet) anything to do here. *)
     ; (let params =
          List.map
            (fun (ptype, decl) ->

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -840,10 +840,11 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
                match args with
                | [] -> [s]
                | _ ->
+                   let tystr = get_cast_to_mem_expr (ptype, decl) true in
                    [ sprintf "if (%s)" (String.concat " && " (List.rev args))
                    ; "{"
                    ; "    /* Restore original pointer. */"
-                   ; sprintf "    %s = _ptrs[_ptrs_index++];" arg
+                   ; sprintf "    %s = %s_ptrs[_ptrs_index++];" arg tystr
                    ; "    " ^ s
                    ; "}" ])
             ; (let param_count = oe_get_param_count (ptype, decl, argstruct) in

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -220,9 +220,7 @@ let get_param_count (ptype, decl, argstruct) =
 let oe_get_param_count (ptype, decl, argstruct) =
   match get_param_count (ptype, decl, argstruct) with
   | Some count -> count
-  (* TODO: This is hit only in tests, not when code is generated. It
-     should instead be [failwithf]. *)
-  | None -> sprintf "/* Error: no count for '%s' */" decl.identifier
+  | None -> failwithf "Error: No count for " ^ decl.identifier
 
 (** Generate the prototype for a given function. *)
 let oe_gen_prototype (fd : func_decl) =

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -758,9 +758,9 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
   in
   let gen_times count body =
     (* The first two conditionals check for the multiplicative identity
-     and prevent unnecessary expressions from being generated.
-     Otherwise we multiply the sum of [body] by [count]. *)
-    if count = "1" then body
+       and prevent unnecessary expressions from being generated.
+       Otherwise we multiply the sum of [body] by [count]. *)
+    if count = "1" || body = [] then body
     else if List.length body = 1 && List.hd body = "1" then [count]
     else [count ^ " * (" ^ String.concat " + " body ^ ")"]
   in
@@ -984,8 +984,8 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
     ; (* Prepare in and in-out parameters *)
       oe_gen_in_and_inout_setters fd.plist
     ; ""
-    ; (* Prepare out and in-out parameters. The in-out parameter is copied
-           to output buffer. *)
+    ; (* Prepare out and in-out parameters. The in-out parameter is
+         copied to output buffer. *)
       oe_gen_out_and_inout_setters fd.plist
     ; ""
     ; "    /* Check that in/in-out strings are null terminated. */"

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -1008,31 +1008,53 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
       (List.filter is_out_or_inout_ptr fd.plist)
   in
   (* Generate host ECALL wrapper function. *)
+  let gen_times count body =
+    (* The first two conditionals check for the multiplicative identity
+     and prevent unnecessary expressions from being generated.
+     Otherwise we multiply the sum of [body] by [count]. *)
+    if count = "1" then body
+    else if List.length body = 1 && List.hd body = "1" then [count]
+    else [count ^ " * (" ^ String.concat " + " body ^ ")"]
+  in
   let rec gen_ptr_count args count (ptype, decl) =
+    let id = decl.identifier in
     let argstruct =
       match args with
       | [] -> "_args."
       | hd :: _ -> "_args." ^ hd ^ gen_c_deref count
     in
     let arg =
-      match args with
-      | [] -> decl.identifier
-      | hd :: _ -> hd ^ gen_c_deref count ^ decl.identifier
+      match args with [] -> id | hd :: _ -> hd ^ gen_c_deref count ^ id
     in
+    let param_count = oe_get_param_count (ptype, decl, argstruct) in
     let members = get_deepcopy_members (get_param_atype ptype) in
-    match members with
-    | [] -> []
-    | _ ->
-        let param_count = oe_get_param_count (ptype, decl, argstruct) in
-        param_count
-        :: flatten_map (gen_ptr_count (arg :: args) param_count) members
+    (* Ignore top-level arguments without members to deep copy. *)
+    if args = [] && members = [] then []
+    else if is_marshalled_ptr ptype then
+      (* This is the base case: a pointer that is meant to be
+         deep-copied but does not point to another struct with more
+         members, and is not the top-level argument (which does not
+         need to be saved/restored).
+
+         Otherwise we recurse and check if we need to multiply. *)
+      if args <> [] && members = [] then ["1"]
+      else
+        (* This is the edge case where we need to count the pointer to
+           the struct to be deep copied, plus its count times the
+           (recursive) number of members inside that struct. But we
+           again explicitly don't count the top-level argument. *)
+        (if args <> [] then ["1"] else [])
+        @ gen_times param_count
+            (flatten_map (gen_ptr_count (arg :: args) param_count) members)
+    else []
   in
   let gen_ptr_array (plist : pdecl list) =
     let count =
-      List.map (gen_ptr_count [] "1") (List.filter is_out_or_inout_ptr plist)
-      |> List.flatten |> String.concat " * "
+      flatten_map (gen_ptr_count [] "1")
+        (List.filter is_out_or_inout_ptr plist)
     in
-    if count <> "" then sprintf "void* _ptrs[%s]; (void)_ptrs;" count
+    if count <> [] then
+      sprintf "void* _ptrs[%s]; (void)_ptrs;" (String.concat " + " count)
     else "/* No pointers to deep copy. */"
   in
   let oe_gen_host_ecall_wrapper (tf : trusted_func) =

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -608,10 +608,10 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
     ; "#include <stdint.h>"
     ; "#include <stdlib.h> /* for wchar_t */"
     ; ""
-    ; ( if with_errno then "#include <errno.h>"
-      else
-        "/* #include <errno.h> - Errno propagation not enabled so not \
-         included. */" )
+    ; (let s = "#include <errno.h>" in
+       if with_errno then s
+       else
+         sprintf "/* %s - Errno propagation not enabled so not included. */" s)
     ; ""
     ; "#include <openenclave/bits/result.h>"
     ; ""

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -1077,7 +1077,9 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
   let oe_gen_host_ecall_wrapper (tf : trusted_func) =
     let fd = tf.tf_fdecl in
     let oe_ecall_function =
-      if tf.tf_is_switchless then "oe_switchless_call_enclave_function" else "oe_call_enclave_function" in
+      if tf.tf_is_switchless then "oe_switchless_call_enclave_function"
+      else "oe_call_enclave_function"
+    in
     [ oe_gen_wrapper_prototype fd true
     ; "{"
     ; "    oe_result_t _result = OE_FAILURE;"
@@ -1131,15 +1133,15 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
   (* Generate enclave OCALL wrapper function. *)
   let oe_gen_enclave_ocall_wrapper (uf : untrusted_func) =
     let fd = uf.uf_fdecl in
-    let (allocate_buffer, call_function, free_buffer) =
-    (if uf.uf_is_switchless then
-      ("oe_allocate_switchless_ocall_buffer",
-       "oe_switchless_call_host_function",
-       "oe_free_switchless_ocall_buffer")
+    let allocate_buffer, call_function, free_buffer =
+      if uf.uf_is_switchless then
+        ( "oe_allocate_switchless_ocall_buffer"
+        , "oe_switchless_call_host_function"
+        , "oe_free_switchless_ocall_buffer" )
       else
-      ("oe_allocate_ocall_buffer",
-       "oe_call_host_function",
-       "oe_free_ocall_buffer"))
+        ( "oe_allocate_ocall_buffer"
+        , "oe_call_host_function"
+        , "oe_free_ocall_buffer" )
     in
     [ oe_gen_wrapper_prototype fd false
     ; "{"
@@ -1172,8 +1174,7 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
     ; "    " ^ String.concat "\n    " (gen_fill_marshal_struct fd)
     ; ""
     ; "    "
-      ^ String.concat "\n    "
-          (oe_prepare_input_buffer fd allocate_buffer)
+      ^ String.concat "\n    " (oe_prepare_input_buffer fd allocate_buffer)
     ; ""
     ; "    /* Call host function. */"
     ; "    if ((_result = " ^ call_function ^ "("

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -812,7 +812,11 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
     let params =
       flatten_map
         (oe_gen_set_pointers [] "1" (fun p ->
-             if is_inout_ptr p then "SET_IN_OUT" else "SET_IN" ))
+             (* TODO: Right now we assume all nested pointers should
+                be [SET_IN_OUT], since nested pointers don't actually
+                satisfy either [is_in_ptr] or [is_inout_ptr]
+                predicates. *)
+             if is_in_ptr p then "SET_IN" else "SET_IN_OUT" ))
         (List.filter is_in_or_inout_ptr plist)
     in
     "    "
@@ -825,7 +829,11 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
     let params =
       flatten_map
         (oe_gen_set_pointers [] "1" (fun p ->
-             if is_inout_ptr p then "COPY_AND_SET_IN_OUT" else "SET_OUT" ))
+             (* TODO: Right now we assume all nested pointers should
+                be [COPY_AND_SET_IN_OUT], since nested pointers don't
+                actually satisfy either [is_out_ptr] or [is_inout_ptr]
+                predicates. *)
+             if is_out_ptr p then "SET_OUT" else "COPY_AND_SET_IN_OUT" ))
         (List.filter is_out_or_inout_ptr plist)
     in
     "    "

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -773,8 +773,8 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
        nested parameter are not yet supported. *)
     let argstruct =
       match args with
-      | [] -> "_args."
-      | hd :: _ -> "_args." ^ hd ^ gen_c_deref (List.length args) count
+      | [] -> ""
+      | hd :: _ -> hd ^ gen_c_deref (List.length args) count
     in
     let arg =
       match args with


### PR DESCRIPTION
This PR adds experimental support for `out` and `in/out` parameters. A couple known limitations:

In the edge case of struct A having an array of struct B, and struct B has some array C with size D as a member of struct B, the current implementation will not generate correct code. Note that this does not affect struct A having an array E with size F as a member of struct A, even where the function declares an array of struct A, as the issues lies in expression generated to count host side pointers, and function argument pointers do not need to be counted.

Another limitation is that we do not pass the original direction of a pointer that is being deep copied, and so we assume all pointers underneath are `in/out` even if they were in fact only `in` or `out`. This must be fixed before this is moved out of the experimental stage.