### PR TITLE
[Ansible] Ignore preinstalled ocamlbuild

### DIFF
--- a/scripts/ansible/roles/linux/openenclave/tasks/opam-setup.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/opam-setup.yml
@@ -65,7 +65,11 @@
       export MANPATH="{{ opam_root }}/default/man"
 
 - name: Install ocamlformat via OPAM
-  shell: "source /etc/profile && opam install ocamlformat -y"
+  shell: |
+    set -e
+    source /etc/profile
+    CHECK_IF_PREINSTALLED=false opam install ocamlbuild -y
+    opam install ocamlformat -y
   args:
     executable: /bin/bash
   retries: 10


### PR DESCRIPTION
The package `ocamlbuild` is required when installing `ocamlformat`
via `opam`.

However, if `ocamlbuild` is preinstalled, the `ocamlbuild` installation
from `opam` will fail unless forced to ignore the preinstalled
package.