### PR TITLE
Incorrect variable initialization in _do_eenter

### DIFF
--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -196,7 +196,7 @@ static oe_result_t _do_eenter(
         *func_out = 0;
 
     if (result_out)
-        *func_out = 0;
+        *result_out = 0;
 
     if (arg_out)
         *arg_out = 0;


### PR DESCRIPTION
Noticed the incorrect variable initialization in _do_eenter() function in host/sgx/calls.c a while back but never got around to issuing this PR.

-196,7 +196,7 @@ static oe_result_t _do_eenter(
        *func_out = 0;

    if (result_out)
        **func_out = 0;**
   This should be *result_out = 0;

    if (!code_out || !func_out || !result_out || !arg_out)
        OE_RAISE(OE_INVALID_PARAMETER);

Reason we never had an issue with this is because *result_out is always NULL when we enter this routine.