### PR TITLE
Fix dependencies for host and syscall EDL

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -13,7 +13,7 @@ set(EDL_FILE ${EDL_DIR}/syscall.edl)
 
 add_custom_command(
     OUTPUT syscall_u.h syscall_u.c syscall_args.h
-    DEPENDS ${EDL_FILE}
+    DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --search-path ${EDL_DIR} --untrusted ${EDL_FILE})
 
 add_custom_target(syscall_untrusted_edl

--- a/syscall/CMakeLists.txt
+++ b/syscall/CMakeLists.txt
@@ -13,7 +13,7 @@ set(EDL_FILE ${EDL_DIR}/syscall.edl)
 
 add_custom_command(
     OUTPUT syscall_t.h syscall_t.c syscall_args.h
-    DEPENDS ${EDL_FILE}
+    DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --search-path ${EDL_DIR} --trusted ${EDL_FILE})
 
 add_custom_target(syscall_trusted_edl


### PR DESCRIPTION
These need to depend on the edger8r so that when I'm actively developing it, the files get re-generated.