### PR TITLE
CI improvements - Run E2E CI tests for Ubuntu

### DIFF
--- a/.jenkins/Dockerfile.deploy
+++ b/.jenkins/Dockerfile.deploy
@@ -9,6 +9,7 @@ ARG UID=1000
 ARG GID=1000
 
 COPY scripts/ansible /ansible
+ADD scripts/install-windows-prereqs.ps1 /
 
 RUN apt-get update && \
     apt-get -y upgrade && \
@@ -21,9 +22,10 @@ RUN apt-get update && \
     apt-get -y install apt-transport-https azure-cli unzip && \
     curl https://oejenkins.blob.core.windows.net/oejenkins/oe-engine -o /usr/bin/oe-engine  && \
     chmod +x /usr/bin/oe-engine && \
-    wget https://releases.hashicorp.com/packer/1.3.5/packer_1.3.5_linux_amd64.zip && \
-    unzip packer_1.3.5_linux_amd64.zip -d /usr/sbin && \
-    rm packer_1.3.5_linux_amd64.zip && \
+    wget https://releases.hashicorp.com/packer/1.4.2/packer_1.4.2_linux_amd64.zip && \
+    unzip packer_1.4.2_linux_amd64.zip -d /usr/sbin && \
+    rm packer_1.4.2_linux_amd64.zip && \
     groupadd --gid ${GID} ${GNAME} && \
     useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME} && \
+    chown ${UID}:${GID} -R /ansible && \
     /ansible/install-ansible.sh

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,21 +1,19 @@
 @Library("OpenEnclaveCommon") _
 oe = new jenkins.common.Openenclave()
 
-// The below timeout is set in minutes
-GLOBAL_TIMEOUT = 240
-// ctest timeout is set in seconds
-CTEST_TIMEOUT = 480
+GLOBAL_TIMEOUT_MINUTES = 240
+CTEST_TIMEOUT_SECONDS = 480
 
 def ACCTest(String label, String compiler, String build_type) {
     stage("${label} ${compiler} SGX1FLC ${build_type}") {
         node("${label}") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 def task = """
                            cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -Wdev
                            ninja -v
-                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT}
+                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                            """
                 oe.Run(compiler, task)
             }
@@ -26,13 +24,13 @@ def ACCTest(String label, String compiler, String build_type) {
 def ACCGNUTest() {
     stage("ACC1804 GNU gcc SGX1FLC") {
         node("ACC-1804") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 def task = """
                            cmake ${WORKSPACE} -DUSE_LIBSGX=ON
                            make
-                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT}
+                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                            """
                 oe.Run("gcc", task)
             }
@@ -47,14 +45,14 @@ def simulationTest(String version, String platform_mode, String build_type) {
     }
     stage("Sim clang-7 Ubuntu${version} ${platform_mode} ${build_type}") {
         node("nonSGX") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 withEnv(["OE_SIMULATION=1"]) {
                     def task = """
                                cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DUSE_LIBSGX=${use_libsgx} -Wdev
                                ninja -v
-                               ctest --output-on-failure --timeout ${CTEST_TIMEOUT}
+                               ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                                """
                     oe.ContainerRun("oetools-full-${version}", "clang-7", task, "--cap-add=SYS_PTRACE")
                 }
@@ -66,7 +64,7 @@ def simulationTest(String version, String platform_mode, String build_type) {
 def AArch64GNUTest(String version, String build_type) {
     stage("AArch64 GNU gcc Ubuntu${version} ${build_type}") {
         node("nonSGX") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 def task = """
@@ -88,13 +86,13 @@ def AArch64GNUTest(String version, String build_type) {
 def ACCContainerTest(String label, String version) {
     stage("${label} Container RelWithDebInfo") {
         node("${label}") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 def task = """
                            cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -Wdev
                            ninja -v
-                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT}
+                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                            """
                 oe.ContainerRun("oetools-full-${version}", "clang-7", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx")
             }
@@ -105,7 +103,7 @@ def ACCContainerTest(String label, String version) {
 def checkDevFlows(String version) {
     stage('Default compiler') {
         node("nonSGX") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 def task = """
@@ -121,7 +119,7 @@ def checkDevFlows(String version) {
 def checkCI() {
     stage('Check CI') {
         node("nonSGX") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 // At the moment, the check-ci script assumes that it's executed from the
@@ -135,7 +133,7 @@ def checkCI() {
 def win2016LinuxElfBuild(String version, String compiler, String build_type) {
     stage("Ubuntu ${version} SGX1 ${compiler} ${build_type}}") {
         node("nonSGX") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 def task = """
@@ -149,7 +147,7 @@ def win2016LinuxElfBuild(String version, String compiler, String build_type) {
     }
     stage("Windows ${build_type}") {
         node('SGXFLC-Windows') {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 unstash "linux-${compiler}-${build_type}-${version}-${BUILD_NUMBER}"
@@ -159,7 +157,7 @@ def win2016LinuxElfBuild(String version, String compiler, String build_type) {
                       vcvars64.bat x64 && \
                       cmake.exe ${WORKSPACE} -G \"Visual Studio 15 2017 Win64\" -DADD_WINDOWS_ENCLAVE_TESTS=ON -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -DLINUX_BIN_DIR=${WORKSPACE}\\linuxbin\\tests -Wdev && \
                       msbuild ALL_BUILD.vcxproj -p:Configuration=${build_type} && \
-                      ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT}
+                      ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT_SECONDS}
                       """
                 }
             }
@@ -174,7 +172,7 @@ def win2016CrossCompile(String build_type, String use_libsgx = 'OFF') {
     }
     stage("Windows ${build_type} with SGX ${use_libsgx}") {
         node(node_label) {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 dir("build/X64-${build_type}") {
@@ -187,7 +185,7 @@ def win2016CrossCompile(String build_type, String use_libsgx = 'OFF') {
                       vcvars64.bat x64 && \
                       cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DUSE_LIBSGX=${use_libsgx} -Wdev && \
                       ninja.exe && \
-                      ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT}
+                      ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT_SECONDS}
                       """
                 }
             }

--- a/.jenkins/Nightly_packages_testing.Jenkinsfile
+++ b/.jenkins/Nightly_packages_testing.Jenkinsfile
@@ -1,8 +1,7 @@
 @Library("OpenEnclaveCommon") _
 oe = new jenkins.common.Openenclave()
 
-// The below timeout is set in minutes
-GLOBAL_TIMEOUT = 240
+GLOBAL_TIMEOUT_MINUTES = 240
 
 XENIAL_RG = "oe-deb-test-${BUILD_NUMBER}-1604"
 BIONIC_RG = "oe-deb-test-${BUILD_NUMBER}-1804"
@@ -10,7 +9,7 @@ BIONIC_RG = "oe-deb-test-${BUILD_NUMBER}-1804"
 def ACCDeployVM(String agent_name, String agent_type, String region, String resource_group, String vhd_url) {
     stage("Deploy ${agent_name}") {
         node("nonSGX") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 withEnv(["REGION=${region}", "RESOURCE_GROUP=${resource_group}", "AGENT_NAME=${agent_name}", "AGENT_TYPE=${agent_type}", "VHD_URL=${vhd_url}"]) {
@@ -42,7 +41,7 @@ def AccDebTesting(String version, String region, String deb_url) {
 
     stage("OE Nightly Package Testing ${version}") {
         node("nonSGX") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 oe.azureEnvironment("${script}")
@@ -53,7 +52,7 @@ def AccDebTesting(String version, String region, String deb_url) {
 
 def cleanup(){
     node("nonSGX") {
-        timeout(GLOBAL_TIMEOUT) {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
             cleanWs()
             checkout scm
             oe.deleteRG([XENIAL_RG, BIONIC_RG])

--- a/.jenkins/Packaging.Jenkinsfile
+++ b/.jenkins/Packaging.Jenkinsfile
@@ -1,21 +1,19 @@
 @Library("OpenEnclaveCommon") _
 oe = new jenkins.common.Openenclave()
 
-// The below timeout is set in minutes
-GLOBAL_TIMEOUT = 240
-// ctest timeout is set in seconds
-CTEST_TIMEOUT = 480
+GLOBAL_TIMEOUT_MINUTES = 240
+CTEST_TIMEOUT_SECONDS = 480
 
 def packageUpload(String version, String build_type) {
     stage("Ubuntu${version} SGX1FLC Package ${build_type}") {
         node("ACC-${version}") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 def task = """
                            cmake ${WORKSPACE} -DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave' -DCPACK_GENERATOR=DEB
                            make
-                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT}
+                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                            make package
                            """
                 oe.Run("clang-7", task)
@@ -29,7 +27,7 @@ def packageUpload(String version, String build_type) {
 def WindowsUpload() {
     stage('Windows Release') {
         node('SGXFLC-Windows') {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 dir('build') {

--- a/.jenkins/build_docker_images.Jenkinsfile
+++ b/.jenkins/build_docker_images.Jenkinsfile
@@ -55,12 +55,12 @@ def buildDockerImages() {
             }
             stage("Push to OE Docker Hub Registry") {
                 docker.withRegistry('', OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID) {
-                    puboefull1604.push()
-                    puboefull1804.push()
-                    puboeminimal1604.push()
-                    puboeminimal1804.push()
-                    puboeDeploy.push()
                     if(TAG_LATEST == "true") {
+                        puboefull1604.push()
+                        puboefull1804.push()
+                        puboeminimal1604.push()
+                        puboeminimal1804.push()
+                        puboeDeploy.push()
                         puboefull1604.push('latest')
                         puboefull1804.push('latest')
                         puboeminimal1604.push('latest')

--- a/.jenkins/build_docker_images.Jenkinsfile
+++ b/.jenkins/build_docker_images.Jenkinsfile
@@ -1,8 +1,7 @@
 @Library("OpenEnclaveCommon") _
 oe = new jenkins.common.Openenclave()
 
-// The below timeout is set in minutes
-GLOBAL_TIMEOUT = 240
+GLOBAL_TIMEOUT_MINUTES = 240
 
 OETOOLS_REPO = "https://oejenkinscidockerregistry.azurecr.io"
 OETOOLS_REPO_CREDENTIAL_ID = "oejenkinscidockerregistry"
@@ -10,7 +9,7 @@ OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID = "oeciteamdockerhub"
 
 def buildDockerImages() {
     node("nonSGX") {
-        timeout(GLOBAL_TIMEOUT) {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
             stage("Checkout") {
                 cleanWs()
                 checkout scm

--- a/.jenkins/build_vhd.Jenkinsfile
+++ b/.jenkins/build_vhd.Jenkinsfile
@@ -1,12 +1,11 @@
 @Library("OpenEnclaveCommon") _
 oe = new jenkins.common.Openenclave()
 
-// The below timeout is set in minutes
-GLOBAL_TIMEOUT = 240
+GLOBAL_TIMEOUT_MINUTES = 240
 
 def buildVHD(String os_type, String version, String imageName) {
     node("nonSGX") {
-        timeout(GLOBAL_TIMEOUT) {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
             cleanWs()
             checkout scm
 

--- a/.jenkins/build_vhd.Jenkinsfile
+++ b/.jenkins/build_vhd.Jenkinsfile
@@ -4,7 +4,7 @@ oe = new jenkins.common.Openenclave()
 // The below timeout is set in minutes
 GLOBAL_TIMEOUT = 240
 
-def buildVHD(String version) {
+def buildVHD(String os_type, String version, String imageName) {
     node("nonSGX") {
         timeout(GLOBAL_TIMEOUT) {
             cleanWs()
@@ -16,14 +16,25 @@ def buildVHD(String version) {
                              azureStorage(credentialsId: 'oe_jenkins_storage_account_westeurope',
                                           storageAccountKeyVariable: 'WESTEUROPE_STORAGE_ACCOUNT_KEY',
                                           storageAccountNameVariable: 'WESTEUROPE_STORAGE_ACCOUNT_NAME')]) {
-                withEnv(["REGION=eastus", "DEST_VHD_NAME=${VHD_NAME_PREFIX}-${version}.vhd", "CONTAINER_NAME=disks"]) {
+                withEnv(["REGION=eastus", "DEST_VHD_NAME=${VHD_NAME_PREFIX}-${os_type}-${version}.vhd", "CONTAINER_NAME=disks"]) {
                     dir("${WORKSPACE}/.jenkins/provision") {
                         oe.azureEnvironment("""
-                                            packer build -var-file=templates/packer/ubuntu-${version}-variables.json templates/packer/packer.json 2>&1 | tee packer.log
+                                            packer build -var-file=templates/packer/${os_type}-${version}-variables.json templates/packer/packer-${os_type}.json 2>&1 | tee packer.log
                                             export SOURCE_URI=\$(cat packer.log | grep OSDiskUri: | awk '{print \$2}')
                                             az storage blob copy start --source-uri \$SOURCE_URI --destination-blob \$DEST_VHD_NAME --destination-container \$CONTAINER_NAME --account-key \$EASTUS_STORAGE_ACCOUNT_KEY --account-name \$EASTUS_STORAGE_ACCOUNT_NAME
                                             az storage blob copy start --source-uri \$SOURCE_URI --destination-blob \$DEST_VHD_NAME --destination-container \$CONTAINER_NAME --account-key \$WESTEUROPE_STORAGE_ACCOUNT_KEY --account-name \$WESTEUROPE_STORAGE_ACCOUNT_NAME
-                                            """)
+                                            blob_status=\$(az storage blob show --name \$DEST_VHD_NAME --container-name \$CONTAINER_NAME \
+                                              --account-key \$WESTEUROPE_STORAGE_ACCOUNT_KEY --account-name \$WESTEUROPE_STORAGE_ACCOUNT_NAME \
+                                              --output json | jq -r .properties.copy.status)
+                                            while [ "\${blob_status}" != "success" ]
+                                            do
+                                            echo Waiting for \$DEST_VHD_NAME to finish copying ...
+                                            sleep 10
+                                            blob_status=\$(az storage blob show --name \$DEST_VHD_NAME --container-name \$CONTAINER_NAME \
+                                              --account-key \$WESTEUROPE_STORAGE_ACCOUNT_KEY --account-name \$WESTEUROPE_STORAGE_ACCOUNT_NAME \
+                                              --output json | jq -r .properties.copy.status)
+                                            done
+                                            """, imageName)
                     }
                 }
             }
@@ -31,5 +42,5 @@ def buildVHD(String version) {
     }
 }
 
-parallel "Build Ubuntu 16.04" : { buildVHD("16.04") },
-         "Build Ubuntu 18.04" : { buildVHD("18.04") }
+parallel "Build Ubuntu 16.04" : { buildVHD("ubuntu", "16.04", OE_DEPLOY_IMAGE) },
+         "Build Ubuntu 18.04" : { buildVHD("ubuntu", "18.04", OE_DEPLOY_IMAGE) }

--- a/.jenkins/cleanup.Jenkinsfile
+++ b/.jenkins/cleanup.Jenkinsfile
@@ -4,12 +4,11 @@ import hudson.model.*
 @Library("OpenEnclaveCommon") _
 oe = new jenkins.common.Openenclave()
 
-// The below timeout is set in minutes
-GLOBAL_TIMEOUT = 30
+GLOBAL_TIMEOUT_MINUTES = 30
 
 def cleanup(List resourceGroups){
     node("nonSGX") {
-        timeout(GLOBAL_TIMEOUT) {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
             cleanWs()
             checkout scm
             oe.deleteRG(resourceGroups, OE_DEPLOY_IMAGE)

--- a/.jenkins/cleanup.Jenkinsfile
+++ b/.jenkins/cleanup.Jenkinsfile
@@ -1,0 +1,33 @@
+import hudson.slaves.*
+import hudson.model.*
+
+@Library("OpenEnclaveCommon") _
+oe = new jenkins.common.Openenclave()
+
+// The below timeout is set in minutes
+GLOBAL_TIMEOUT = 30
+
+def cleanup(List resourceGroups){
+    node("nonSGX") {
+        timeout(GLOBAL_TIMEOUT) {
+            cleanWs()
+            checkout scm
+            oe.deleteRG(resourceGroups, OE_DEPLOY_IMAGE)
+        }
+    }
+}
+
+def unregisterJenkinsSlaves(List jenkinsLabels) {
+    stage("Unregister Jenkins Slaves") {
+        node("nonSGX") {
+            for (s in hudson.model.Hudson.instance.slaves) {
+                if(jenkinsLabels.contains(s.getLabelString())) {
+                    s.getComputer().doDoDelete()
+                }
+            }
+        }
+    }
+}
+
+cleanup(RESOURCE_GROUPS.tokenize(","))
+unregisterJenkinsSlaves(AGENT_LABELS.tokenize(","))

--- a/.jenkins/custom_label.Jenkinsfile
+++ b/.jenkins/custom_label.Jenkinsfile
@@ -1,0 +1,79 @@
+@Library("OpenEnclaveCommon") _
+oe = new jenkins.common.Openenclave()
+
+// The below timeout is set in minutes
+GLOBAL_TIMEOUT = 240
+// ctest timeout is set in seconds
+CTEST_TIMEOUT = 480
+
+def ACCTest(String label, String compiler, String build_type) {
+    stage("${label} ${compiler} SGX1FLC ${build_type}") {
+        node("${label}") {
+            timeout(GLOBAL_TIMEOUT) {
+                cleanWs()
+                checkout scm
+                def task = """
+                           cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -Wdev
+                           ninja -v
+                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT}
+                           """
+                oe.Run(compiler, task)
+            }
+        }
+    }
+}
+
+def ACCContainerTest(String label, String version) {
+    stage("${label} Container RelWithDebInfo") {
+        node("${label}") {
+            timeout(GLOBAL_TIMEOUT) {
+                cleanWs()
+                checkout scm
+                def task = """
+                           cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -Wdev
+                           ninja -v
+                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT}
+                           """
+                oe.ContainerRun("oetools-full-${version}", "clang-7", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx")
+            }
+        }
+    }
+}
+
+def win2016CrossCompile(String build_type, String use_libsgx = 'OFF') {
+    stage("Windows ${build_type} with SGX ${use_libsgx}") {
+        node(WINDOWS_2016_CUSTOM_LABEL) {
+            timeout(GLOBAL_TIMEOUT) {
+                cleanWs()
+                checkout scm
+                dir("build/X64-${build_type}") {
+
+                  /* We need to copy nuget into the expected location
+                  https://github.com/microsoft/openenclave/blob/a982b46cf440def8fb66e94f2622a4f81e2b350b/host/CMakeLists.txt#L188-L197 */
+                  powershell 'Copy-Item -Recurse C:\\openenclave\\prereqs\\nuget ${env:WORKSPACE}\\prereqs'
+
+                  bat """
+                      vcvars64.bat x64 && \
+                      cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DUSE_LIBSGX=${use_libsgx} -Wdev && \
+                      ninja.exe && \
+                      ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT}
+                      """
+                }
+            }
+        }
+    }
+}
+
+
+properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
+                                      artifactNumToKeepStr: '180',
+                                      daysToKeepStr: '90',
+                                      numToKeepStr: '180')),
+            [$class: 'JobRestrictionProperty']])
+
+parallel "ACC1604 clang-7 RelWithDebInfo" :                     { ACCTest(UBUNTU_1604_CUSTOM_LABEL, 'clang-7', 'RelWithDebInfo') },
+         "ACC1604 gcc RelWithDebInfo" :                         { ACCTest(UBUNTU_1604_CUSTOM_LABEL, 'gcc', 'RelWithDebInfo') },
+         "ACC1604 Container RelWithDebInfo" :                   { ACCContainerTest(UBUNTU_1604_CUSTOM_LABEL, '16.04') },
+         "ACC1804 clang-7 RelWithDebInfo" :                     { ACCTest(UBUNTU_1804_CUSTOM_LABEL, 'clang-7', 'RelWithDebInfo') },
+         "ACC1804 gcc RelWithDebInfo" :                         { ACCTest(UBUNTU_1804_CUSTOM_LABEL, 'gcc', 'RelWithDebInfo') },
+         "ACC1804 Container RelWithDebInfo" :                   { ACCContainerTest(UBUNTU_1804_CUSTOM_LABEL, '18.04') }

--- a/.jenkins/deploy_agent.Jenkinsfile
+++ b/.jenkins/deploy_agent.Jenkinsfile
@@ -1,13 +1,12 @@
 @Library("OpenEnclaveCommon") _
 oe = new jenkins.common.Openenclave()
 
-// The below timeout is set in minutes
-GLOBAL_TIMEOUT = 240
+GLOBAL_TIMEOUT_MINUTES = 240
 
 def ACCDeployVM() {
     stage("Deploy ${AGENT_NAME}") {
         node("nonSGX") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 dir("${WORKSPACE}/.jenkins/provision") {
@@ -61,7 +60,7 @@ def generateVariablesFile() {
 def registerJenkinsSlave() {
     stage("Register Jenkins Slave") {
         node("nonSGX") {
-            timeout(GLOBAL_TIMEOUT) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 withCredentials([usernamePassword(credentialsId: 'oe-ci',
@@ -101,7 +100,7 @@ def registerJenkinsSlave() {
 
 def cleanup() {
     node("nonSGX") {
-        timeout(GLOBAL_TIMEOUT) {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
             cleanWs()
             checkout scm
             oe.deleteRG([RESOURCE_GROUP])

--- a/.jenkins/deploy_agent.Jenkinsfile
+++ b/.jenkins/deploy_agent.Jenkinsfile
@@ -1,0 +1,119 @@
+@Library("OpenEnclaveCommon") _
+oe = new jenkins.common.Openenclave()
+
+// The below timeout is set in minutes
+GLOBAL_TIMEOUT = 240
+
+def ACCDeployVM() {
+    stage("Deploy ${AGENT_NAME}") {
+        node("nonSGX") {
+            timeout(GLOBAL_TIMEOUT) {
+                cleanWs()
+                checkout scm
+                dir("${WORKSPACE}/.jenkins/provision") {
+                    oe.azureEnvironment("./deploy-agent.sh", OE_DEPLOY_IMAGE)
+                }
+            }
+        }
+    }
+}
+
+def generateInventory() {
+    if (agent_type == "windows") {
+        sh """
+           echo "[windows-agents]" > inventory/hosts
+           echo ${AGENT_NAME.toLowerCase()}.${REGION}.cloudapp.azure.com >> inventory/hosts
+           """
+    } else {
+        sh """
+           echo "[linux-agents]" > inventory/hosts
+           echo ${AGENT_NAME.toLowerCase()}.${REGION}.cloudapp.azure.com >> inventory/hosts
+           """
+    }
+}
+
+def generateVariablesFile() {
+    def var_file = "inventory/host_vars/${AGENT_NAME.toLowerCase()}.${REGION}.cloudapp.azure.com"
+    if (agent_type == "windows") {
+      sh """{
+         echo jenkins_agent_name: ${AGENT_NAME}
+         echo jenkins_agent_label: ${AGENT_LABEL}
+         echo jenkins_url: ${JENKINS_PRIVATE_URL}
+         echo jenkins_admin_name: ${JENKINS_ADMIN_NAME}
+         echo jenkins_admin_password: ${JENKINS_ADMIN_PASSWORD}
+         echo ansible_user: ${WINDOWS_ADMIN_USERNAME}
+         echo ansible_password: "${WINDOWS_ADMIN_PASSWORD}"
+         echo ansible_become_pass: "${WINDOWS_ADMIN_PASSWORD}"
+         } > ${var_file} """
+    } else {
+      sh """
+         {
+         echo jenkins_agent_name: ${AGENT_NAME}
+         echo jenkins_agent_label: ${AGENT_LABEL}
+         echo jenkins_url: ${JENKINS_PRIVATE_URL}
+         echo jenkins_admin_name: ${JENKINS_ADMIN_NAME}
+         echo jenkins_admin_password: ${JENKINS_ADMIN_PASSWORD}
+         echo ansible_ssh_private_key_file: inventory/id-rsa-oe-test
+         } > ${var_file} """
+    }
+}
+
+def registerJenkinsSlave() {
+    stage("Register Jenkins Slave") {
+        node("nonSGX") {
+            timeout(GLOBAL_TIMEOUT) {
+                cleanWs()
+                checkout scm
+                withCredentials([usernamePassword(credentialsId: 'oe-ci',
+                                                  passwordVariable: 'JENKINS_ADMIN_PASSWORD',
+                                                  usernameVariable: 'JENKINS_ADMIN_NAME'),
+                                 usernamePassword(credentialsId: 'acc-vm-windows-azureuser',
+                                                  passwordVariable: 'WINDOWS_ADMIN_PASSWORD',
+                                                  usernameVariable: 'WINDOWS_ADMIN_USERNAME'),
+                                 string(credentialsId: 'JENKINS_PRIVATE_URL',
+                                        variable: 'JENKINS_PRIVATE_URL')]) {
+                    withEnv(["ANSIBLE_HOST_KEY_CHECKING=False"]) {
+                        dir("scripts/ansible") {
+                            generateInventory()
+                            generateVariablesFile()
+                            if (agent_type != "windows") {
+                                /*
+                                Writing private key data to inventory/id-rsa-oe-test
+                                Here we need to use single quotes so Jenkins doesn't interpret variables.
+                                SERVICE_PRINCIPAL variables are set into environment by oe.azureEnvironment function
+                                */
+                                def task = '''
+                                  az login --service-principal -u "${SERVICE_PRINCIPAL_ID}" -p "${SERVICE_PRINCIPAL_PASSWORD}" --tenant "${TENANT_ID}" --output table
+                                  az account set --subscription "${SUBSCRIPTION_ID}"
+                                  az keyvault secret show --vault-name 'oe-ci-test-kv' --name 'id-rsa-oe-test' | jq -r .value | base64 -d > inventory/id-rsa-oe-test
+                                  chmod 600 inventory/id-rsa-oe-test
+                                  '''
+                                oe.azureEnvironment(task , OE_DEPLOY_IMAGE)
+                            }
+                            oe.azureEnvironment("ansible-playbook jenkins-agents-register.yml", OE_DEPLOY_IMAGE )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+def cleanup() {
+    node("nonSGX") {
+        timeout(GLOBAL_TIMEOUT) {
+            cleanWs()
+            checkout scm
+            oe.deleteRG([RESOURCE_GROUP])
+        }
+    }
+}
+
+try {
+    ACCDeployVM()
+    registerJenkinsSlave()
+} catch (e) {
+    println(e)
+    cleanup()
+    throw e
+}

--- a/.jenkins/provision/templates/packer/packer-ubuntu.json
+++ b/.jenkins/provision/templates/packer/packer-ubuntu.json
@@ -38,20 +38,12 @@
   }],
   "provisioners": [
     {
-      "type": "file",
-      "source": "/ansible/requirements.txt",
-      "destination": "/tmp/requirements.txt"
-    },
-    {
-      "type": "shell",
-      "execute_command": "echo 'packer' | sudo -S env {{ .Vars }} {{ .Path }}",
-      "script": "/ansible/install-ansible.sh",
-      "pause_before": "10s"
-    },
-    {
-      "type": "ansible-local",
-      "playbook_file": "/ansible/oe-contributors-acc-setup.yml",
-      "role_paths": ["/ansible/roles/common","/ansible/roles/linux"]
+      "type": "ansible",
+      "groups": ["{{ user `ansible_group` }}"],
+      "playbook_file": "{{ user `playbook_file` }}",
+      "ansible_env_vars": [
+          "ANSIBLE_ROLES_PATH=/ansible/roles"
+      ]
     },
     {
      "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",

--- a/.jenkins/provision/templates/packer/ubuntu-16.04-variables.json
+++ b/.jenkins/provision/templates/packer/ubuntu-16.04-variables.json
@@ -6,5 +6,8 @@
     "image_publisher": "Canonical",
     "image_offer": "confidential-compute-preview",
     "image_sku": "16.04-LTS",
-    "vm_size": "Standard_DC2s"
+    "vm_size": "Standard_DC2s",
+    "communicator": "ssh",
+    "ansible_group": "linux-agents",
+    "playbook_file": "/ansible/oe-linux-acc-setup.yml"
 }

--- a/.jenkins/provision/templates/packer/ubuntu-18.04-variables.json
+++ b/.jenkins/provision/templates/packer/ubuntu-18.04-variables.json
@@ -6,5 +6,8 @@
     "image_publisher": "Canonical",
     "image_offer": "UbuntuServer",
     "image_sku": "18.04-LTS",
-    "vm_size": "Standard_DC2s"
+    "vm_size": "Standard_DC2s",
+    "communicator": "ssh",
+    "ansible_group": "linux-agents",
+    "playbook_file": "/ansible/oe-linux-acc-setup.yml"
 }

--- a/.jenkins/test.Jenkinsfile
+++ b/.jenkins/test.Jenkinsfile
@@ -1,0 +1,75 @@
+// Build Docker images triggering 'OpenEnclave-Docker-Images' job with code from current branch and repository
+stage("Build Docker Images") {
+    build job: 'OpenEnclave-Docker-Images' ,
+          parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
+                       string(name: 'BRANCH_SPECIFIER', value: env.BRANCH),
+                       string(name: 'DOCKER_TAG', value: env.BUILD_TAG),
+                       booleanParam(name: 'TAG_LATEST',value: false)]
+}
+
+/*
+Build VHD images triggering 'OpenEnclave-jenkins-agents-VHDs' job with code from current branch and repository
+Here we will use the oe-deploy docker image with the tag we just built in previous job
+*/
+stage("Build Jenkins Agents VHDs") {
+    build job: 'OpenEnclave-jenkins-agents-VHDs' ,
+          parameters: [string(name: 'OE_DEPLOY_IMAGE', value: "oetools-deploy:${env.BUILD_TAG}"),
+                       string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
+                       string(name: 'BRANCH_SPECIFIER', value: env.BRANCH),
+                       string(name: 'VHD_NAME_PREFIX', value: env.BUILD_TAG)]
+}
+
+try {
+  /*
+  Deploy Jenkins agents with the custom VHD
+  Register the new Jenkins agents into our CI with custom label.
+  */
+  stage("Deploy and register Jenkins Agent") {
+      parallel (
+          "Ubuntu 16.04" : {
+              build job: 'OpenEnclave-deploy-jenkins-agent-test',
+                    parameters: [string(name: 'OE_DEPLOY_IMAGE', value: "oetools-deploy:${env.BUILD_TAG}"),
+                                 string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
+                                 string(name: 'BRANCH_SPECIFIER', value: env.BRANCH),
+                                 string(name: 'VHD_URL', value: "https://oejenkins.blob.core.windows.net/disks/${env.BUILD_TAG}-ubuntu-16.04.vhd"),
+                                 string(name: 'REGION', value: "eastus"),
+                                 string(name: 'RESOURCE_GROUP', value: "xenial-${env.BUILD_TAG}"),
+                                 string(name: 'AGENT_NAME', value: "xenial-${env.BUILD_NUMBER}-1"),
+                                 string(name: 'AGENT_LABEL', value: "xenial-${env.BUILD_TAG}"),
+                                 string(name: 'AGENT_TYPE', value: 'xenial')]
+          },
+          "Ubuntu 18.04" : {
+              build job: 'OpenEnclave-deploy-jenkins-agent-test',
+                    parameters: [string(name: 'OE_DEPLOY_IMAGE', value: "oetools-deploy:${env.BUILD_TAG}"),
+                                 string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
+                                 string(name: 'BRANCH_SPECIFIER', value: env.BRANCH),
+                                 string(name: 'VHD_URL', value: "https://oejenkinswesteurope.blob.core.windows.net/disks/${env.BUILD_TAG}-ubuntu-18.04.vhd"),
+                                 string(name: 'REGION', value: "westeurope"),
+                                 string(name: 'RESOURCE_GROUP', value: "bionic-${env.BUILD_TAG}"),
+                                 string(name: 'AGENT_NAME', value: "bionic-${env.BUILD_NUMBER}-1"),
+                                 string(name: 'AGENT_LABEL', value: "bionic-${env.BUILD_TAG}"),
+                                 string(name: 'AGENT_TYPE', value: 'bionic')]
+          }
+      )
+  }
+  stage("Run tests on new Agents") {
+      build job: 'OpenEnclave-custom_label-test',
+            parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
+                         string(name: 'BRANCH_SPECIFIER', value: env.BRANCH),
+                         string(name: 'UBUNTU_1604_CUSTOM_LABEL', value: "xenial-${env.BUILD_TAG}"),
+                         string(name: 'UBUNTU_1804_CUSTOM_LABEL', value: "bionic-${env.BUILD_TAG}")]
+  }
+
+} finally {
+    /*
+    Cleanup Azure RG and remove Jenkins Agents from CI
+    */
+    stage("Cleanup Resource Groups and Jenkins Agents") {
+        build job: "OpenEnclave-jenkins-agents-cleanup",
+              parameters: [string(name: 'OE_DEPLOY_IMAGE', value: "oetools-deploy:${env.BUILD_TAG}"),
+                           string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
+                           string(name: 'BRANCH_SPECIFIER', value: env.BRANCH),
+                           string(name: "AGENT_LABELS", value: "xenial-${env.BUILD_TAG},bionic-${env.BUILD_TAG}"),
+                           string(name: "RESOURCE_GROUPS", value: "xenial-${env.BUILD_TAG},bionic-${env.BUILD_TAG}")]
+    }
+}

--- a/scripts/ansible/requirements.txt
+++ b/scripts/ansible/requirements.txt
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-ansible==2.7.10
+ansible==2.8.0
 pywinrm==0.2.1


### PR DESCRIPTION
- [x] Add Packer support for building Windows Images
- [x] Add deploy_agent.Jenkinsfile used for new Jenkins job to deploy single agent
- [x] Add cleanup.Jenkinsfile used for cleaning up Azure Resource Groups and remove Jenkins Agents from CI
- [x] Add test.Jenkinsfile used to trigger multiple builds:
1. - [x] Build Docker images
2. - [x] Build Jenkins agents VHD's
3. - [x] Deploy new Agents and register them in CI
4. - [x] Run Tests on the newly created Jenkins Agents
5. - [x] Cleanup resources

Jenkins job:  https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/OpenEnclave-sandbox/detail/OpenEnclave-sandbox/1671

Windows builds will be added after : https://github.com/microsoft/oe-engine/issues/52 is fixed
partially fixes #1992