### PR TITLE
Attested TLS sample: fixed mrsigner error from using wrong header file when mixing CMake and Makefile building environment

### DIFF
--- a/samples/attested_tls/CMakeLists.txt
+++ b/samples/attested_tls/CMakeLists.txt
@@ -25,11 +25,12 @@ add_custom_command(OUTPUT client_private.pem client_public.pem server_private.pe
 # Generate public key header files
 add_custom_command(OUTPUT tls_client_enc_pubkey.h tls_server_enc_pubkey.h
   DEPENDS ${CMAKE_SOURCE_DIR}/scripts/gen_pubkey_header.sh
-  COMMAND ${CMAKE_SOURCE_DIR}/scripts/gen_pubkey_header.sh ${CMAKE_BINARY_DIR}/client/enc/tls_client_enc_pubkey.h ${CMAKE_BINARY_DIR}/client/enc/client_public.pem
-  COMMAND ${CMAKE_SOURCE_DIR}/scripts/gen_pubkey_header.sh ${CMAKE_BINARY_DIR}/server/enc/tls_server_enc_pubkey.h ${CMAKE_BINARY_DIR}/server/enc/server_public.pem
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/server/enc/tls_server_enc_pubkey.h ${CMAKE_BINARY_DIR}/client/enc/tls_server_enc_pubkey.h
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/server/enc/tls_server_enc_pubkey.h ${CMAKE_BINARY_DIR}/non_enc_client/tls_server_enc_pubkey.h
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/client/enc/tls_client_enc_pubkey.h ${CMAKE_BINARY_DIR}/server/enc/tls_client_enc_pubkey.h)
+  COMMAND ${CMAKE_SOURCE_DIR}/scripts/gen_pubkey_header.sh ${CMAKE_SOURCE_DIR}/client/enc/tls_client_enc_pubkey.h ${CMAKE_BINARY_DIR}/client/enc/client_public.pem
+  COMMAND ${CMAKE_SOURCE_DIR}/scripts/gen_pubkey_header.sh ${CMAKE_SOURCE_DIR}/server/enc/tls_server_enc_pubkey.h ${CMAKE_BINARY_DIR}/server/enc/server_public.pem
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/server/enc/tls_server_enc_pubkey.h ${CMAKE_SOURCE_DIR}/client/enc/tls_server_enc_pubkey.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/server/enc/tls_server_enc_pubkey.h ${CMAKE_SOURCE_DIR}/non_enc_client/tls_server_enc_pubkey.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/client/enc/tls_client_enc_pubkey.h ${CMAKE_SOURCE_DIR}/server/enc/tls_client_enc_pubkey.h)
+
 
 add_custom_target(build_common DEPENDS client_private.pem server_public.pem tls_client_enc_pubkey.h tls_server_enc_pubkey.h tls_client_enc_pubkey.h)
 

--- a/samples/attested_tls/non_enc_client/Makefile
+++ b/samples/attested_tls/non_enc_client/Makefile
@@ -32,7 +32,7 @@ build:
 	$(CXX) -o tls_non_enc_client client.o verify_callback.o verify_signer_openssl.o $(LDFLAGS)
 
 clean:
-	rm -f tls_client *.o ../cert.der tls_server_enc_pubkey.h
+	rm -f tls_non_enc_client *.o ../cert.der tls_server_enc_pubkey.h
 
 run:
 	./tls_non_enc_client -server:localhost -port:12341


### PR DESCRIPTION
The changes in this PR is to address the following issues reported when building this sample in the repo tree.

All of our samples support both CMake and Makefile building methods

The build issue reported by anand only repos if building the same sample  in the following sequence. :  

1.Build the sample via CMake
2.Build the sample via Makefile
3.Then build the sample with CMake again— hit this issue

This was because both build system share the  same output directory, some of the CMake targets didn’t get run again in step 3 because output from step 2 confuses CMake. This explains how anand and Anita repros it.
This is a build issue not code code.

If a user installs the SDK sample builds only with Makefile or CMake, it works fine , no matter how many times it’s built. So, It wouldn’t impact normal SDK users, which we do not expect mixing both building methods like our building system does (ctest -V build all sample in CMake followed by Makefile)


