### PR TITLE
[Ansible] Differentiate Windows inventory targets

### DIFF
--- a/scripts/ansible/inventory/host_vars/README.md
+++ b/scripts/ansible/inventory/host_vars/README.md
@@ -20,3 +20,13 @@ jenkins_agent_executors_count: 2
 jenkins_agent_label: "hardware"
 jenkins_agent_root_dir: "/home/jenkins"
 ```
+
+The Windows CI/CD testing takes place for both Open Enclave and DCAP libraries.
+
+Since the SGX Windows machines configuration is slightly different for these
+two scenarios, one must use the following variable to differentiate the
+targeted Ansible Windows nodes when configuring them:
+
+```
+dcap_testing_node: true
+```

--- a/scripts/ansible/oe-windows-acc-setup.yml
+++ b/scripts/ansible/oe-windows-acc-setup.yml
@@ -6,8 +6,16 @@
   any_errors_fatal: true
   become_method: runas
   tasks:
+    - name: OE setup | Set installer URLs from the OE storage account
+      set_fact:
+        intel_psw_2_2_url: "https://oejenkins.blob.core.windows.net/oejenkins/intel_sgx_win_2.2.100.47975_PV.zip"
+        intel_psw_2_3_url: "https://oejenkins.blob.core.windows.net/oejenkins/Intel_SGX_PSW_for_Windows_v2.3.100.49777.exe"
+        intel_dcap_url: "https://oejenkins.blob.core.windows.net/oejenkins/Intel_SGX_DCAP_for_Windows_v1.1.100.49925.exe"
+
     - name: OE setup | Run the install-windows-prereqs.ps1 script (this may take a while)
-      script: ../install-windows-prereqs.ps1 -IntelPSWURL "https://oejenkins.blob.core.windows.net/oejenkins/Intel_SGX_PSW_for_Windows_v2.3.100.49777.exe" -IntelDCAPURL "https://oejenkins.blob.core.windows.net/oejenkins/Intel_SGX_DCAP_for_Windows_v1.1.100.49925.exe"
+      script: ../install-windows-prereqs.ps1
+        -IntelPSWURL "{{ intel_psw_2_3_url if dcap_testing_node is defined and dcap_testing_node == true else intel_psw_2_2_url }}"
+        -IntelDCAPURL "{{ intel_dcap_url }}"
 
     - name: OE setup | Reboot the node
       win_reboot:

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -262,10 +262,13 @@ function Install-7Zip {
 
 function Install-PSW {
     $tempInstallDir = "$PACKAGES_DIRECTORY\Intel_SGX_PSW"
-    Install-Tool -InstallerPath $PACKAGES["psw"]["local_file"] `
-                 -ArgumentList @('/auto', "$PACKAGES_DIRECTORY\Intel_SGX_PSW")
+    if(Test-Path $tempInstallDir) {
+        Remove-Item -Recurse -Force $tempInstallDir
+    }
+    Install-ZipTool -ZipPath $PACKAGES["psw"]["local_file"] `
+                    -InstallDirectory $tempInstallDir
 
-    $installer = Get-Item "$tempInstallDir\Intel SGX PSW for Windows *\PSW_EXE_RS2_and_before\Intel(R)_SGX_Windows_x64_PSW_*.exe"
+    $installer = Get-Item "$tempInstallDir\Intel*SGX*\PSW_EXE*\Intel(R)_SGX_Windows_x64_PSW_*.exe"
     if(!$installer) {
         Throw "Cannot find the installer executable"
     }


### PR DESCRIPTION
Introduce a new variable, `dcap_testing_node`, that allows installing Intel PSW v2.3, mandatory version for DCAP libraries testing, while retaining the default version to v2.2 for Open Enclave testing.

This is meant to have the Ansible inventory Windows targets configured differently, since the requirements for DCAP libraries testing vs Open Enclave testing are different.

Fixes https://github.com/openenclave/openenclave/issues/1940.