### PR TITLE
Correctly assert aesni instruction set.

### DIFF
--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -142,6 +142,7 @@ static oe_result_t _handle_init_enclave(uint64_t arg_in)
     OE_ATOMIC_MEMORY_BARRIER_ACQUIRE();
     if (o == false)
     {
+        // Assert that arg_in is outside the enclave and is not null.
         if (!oe_is_outside_enclave(
                 (void*)arg_in, sizeof(oe_init_enclave_args_t)))
         {
@@ -154,25 +155,22 @@ static oe_result_t _handle_init_enclave(uint64_t arg_in)
         if (_once == false)
         {
             /* Set the global enclave handle */
-            if (arg_in)
-            {
-                oe_init_enclave_args_t* args = (oe_init_enclave_args_t*)arg_in;
-                oe_init_enclave_args_t safe_args;
+            oe_init_enclave_args_t* args = (oe_init_enclave_args_t*)arg_in;
+            oe_init_enclave_args_t safe_args;
 
-                if (!oe_is_outside_enclave(args, sizeof(*args)))
-                    OE_RAISE(OE_INVALID_PARAMETER);
+            if (!oe_is_outside_enclave(args, sizeof(*args)))
+                OE_RAISE(OE_INVALID_PARAMETER);
 
-                /* Copy structure into enclave memory */
-                safe_args = *args;
+            /* Copy structure into enclave memory */
+            safe_args = *args;
 
-                if (!oe_is_outside_enclave(safe_args.enclave, 1))
-                    OE_RAISE(OE_INVALID_PARAMETER);
+            if (!oe_is_outside_enclave(safe_args.enclave, 1))
+                OE_RAISE(OE_INVALID_PARAMETER);
 
-                oe_enclave = safe_args.enclave;
-            }
+            oe_enclave = safe_args.enclave;
 
             /* Call all enclave state initialization functions */
-            OE_CHECK(oe_initialize_cpuid(arg_in));
+            OE_CHECK(oe_initialize_cpuid(&safe_args));
 
             /* Call global constructors. Now they can safely use simulated
              * instructions like CPUID. */

--- a/enclave/core/sgx/cpuid.c
+++ b/enclave/core/sgx/cpuid.c
@@ -25,7 +25,7 @@ oe_result_t oe_initialize_cpuid(oe_init_enclave_args_t* args)
     oe_result_t result = OE_UNEXPECTED;
 
     if (args == NULL || !oe_is_within_enclave(args, sizeof(*args)))
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_INVALID_PARAMETER);
 
     // Abort the enclave if AESNI support is not present in the cached
     // CPUID Feature information (cpuid leaf of 1)

--- a/enclave/core/sgx/cpuid.h
+++ b/enclave/core/sgx/cpuid.h
@@ -6,8 +6,9 @@
 
 #include <openenclave/bits/result.h>
 #include <openenclave/bits/types.h>
+#include <openenclave/internal/calls.h>
 
-oe_result_t oe_initialize_cpuid(uint64_t arg_in);
+oe_result_t oe_initialize_cpuid(oe_init_enclave_args_t* args);
 
 int oe_emulate_cpuid(
     uint64_t* rax,


### PR DESCRIPTION
- Avoid TOCTOU
- Make function strongly typed.