### PR TITLE
Use GCC (GNU) atomic builtins for acquire-release

### DIFF
--- a/include/openenclave/internal/utils.h
+++ b/include/openenclave/internal/utils.h
@@ -126,8 +126,10 @@ OE_INLINE uint64_t StrCode(const char* s, uint64_t n)
  * understanding see "C++ and the Perils of Double-Checked Locking"
  * http://www.aristeia.com/Papers/DDJ_Jul_Aug_2004_revised.pdf.
  */
-#define OE_ATOMIC_MEMORY_BARRIER_ACQUIRE() asm volatile("" ::: "memory")
-#define OE_ATOMIC_MEMORY_BARRIER_RELEASE() asm volatile("" ::: "memory")
+#define OE_ATOMIC_MEMORY_BARRIER_ACQUIRE() \
+    __atomic_thread_fence(__ATOMIC_ACQUIRE)
+#define OE_ATOMIC_MEMORY_BARRIER_RELEASE() \
+    __atomic_thread_fence(__ATOMIC_RELEASE)
 
 /**
  * oe_secure_zero_fill is intended to be used to zero out secrets.


### PR DESCRIPTION
This will emit the right instructions for all platforms.