### PR TITLE
Include packages required for AArch64 testing.

### DIFF
--- a/scripts/ansible/roles/linux/openenclave/vars/ubuntu.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/ubuntu.yml
@@ -60,6 +60,9 @@ apt_arm_packages:
   - "python-crypto"
   - "libc6-dev:arm64"
   - "libssl-dev:arm64"
+  - "libfdt1"
+  - "openssh-client"
+  - "sshpass"
 
 validation_directories:
   - "/usr/local/opam"


### PR DESCRIPTION
To run tests on AArch64 during CI without physical ARM TrustZone-capable hardware, an emulator is necessary. The emulator in question is QEMU, which supports full emulation of TrustZone capabilities.

The idea is to include the emulator and associated support files (i.e., firmware, rootfs, etc.) inside the build containers via the devkit inclusion mechanism we readily have in place as added in #1887. After the AArch64 build is complete, we launch the emulator in the container and connect to the latter over SSH, sharing the build output via Plan9. Over the SSH tunnel, we have the emulator run the subset of tests we know work. We already do all this in the `feature.new_platforms` branch.

A preview of how that mechanism works can be found [here](https://github.com/openenclave/openenclave/compare/user/hegatta/arm-trustzone-stage3...user/hegatta/arm-trustzone-stage4). Note that I've had no luck so far getting `ctest` to behave inside the emulator, but it's not out of the question either. However, I've validated locally that this mechanism works fine, but I'd like to try it live in Jenkins, which requires these additions to the build containers.

QEMU requires `libfdt1`, and `openssh-client` and `sshpass` are required to remote into the emulated environment.