### PR TITLE
[CMAKE] Replace special characters in test-case name

### DIFF
--- a/cmake/get_testcase_name.cmake
+++ b/cmake/get_testcase_name.cmake
@@ -19,6 +19,8 @@ function(get_testcase_name FILENAME NAMEVAR PREFIX)
   endif ()
   string(REGEX REPLACE "[/=]" "_" n ${n})
   string(REGEX REPLACE "[\!]" "-" n ${n})
+  string(REGEX REPLACE "[\[]" "__" n ${n})
+  string(REGEX REPLACE "[\]]" "__" n ${n})
 
   # Encrypted filesystems on Linux have a smaller limit on the
   # maximum file name length. Limit the testcase name to the


### PR DESCRIPTION
During the bump from LLVM v7 to v8 a new test with a special was encountered:
https://github.com/openenclave/openenclave/pull/2026/commits/a457286615b53e8e2e1ef653fa98c492fd9de3db

This patch replaces "[" and "]" with "__".

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>