### PR TITLE
Update Linux docs and ansible to use new Intel SGX DCAP 1.2 driver.

### DIFF
--- a/docs/GettingStartedDocs/Contributors/BuildingInADockerContainer.md
+++ b/docs/GettingStartedDocs/Contributors/BuildingInADockerContainer.md
@@ -23,6 +23,9 @@
 ```bash
 sudo docker run --device /dev/sgx:/dev/sgx -i -t oeciteam/oetools-full-18.04 bash
 ```
+  - If you're using the Intel SGX (non-DCAP) driver, you'll want to do two things:
+    - The device name is different (isgx as opposed to sgx), so you'll want this option instead:  `--device /dev/isgx:/dev/isgx`
+    - The aesm service will need to be running on the container host, and then its socket file directory will need to be exposed to the container as a volume by adding the `-v /var/run/aesmd:/var/run/aesmd` option.
 
 5. Clone the Open Enclave repository from within this container and run the build and tests. For example, if your system has the SGX DCAP driver installed and it has been made available to the container:
 ```bash

--- a/docs/GettingStartedDocs/Contributors/BuildingInADockerContainer.md
+++ b/docs/GettingStartedDocs/Contributors/BuildingInADockerContainer.md
@@ -10,7 +10,7 @@
 
 2. Install the appropriate Intel SGX Driver for your platform. For example, if you're running on an SGX1 with FLC system, you'll probably want to install the Intel SGX DCAP Driver for your platfrom: https://01.org/intel-software-guard-extensions/downloads
     - If you're running on an SGX with FLC system, you'll probably want to install the Intel SGX DCAP Driver for your platfrom: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-dcap-linux-1.2-release
-    - If you're running on an SGX without FLC system, you'll want to install the Intel SGX Driver for your platform: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-linux-2.5-release
+    - If you're running on an SGX without FLC system, you'll want to install the Intel SGX Driver for your platform: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-linux-2.6-release
     - The driver you're looking for is a ".bin" file, for either Ubuntu 16.04 or 18.04 releases. It will be named something like: `sgx_linux_x64_driver_1.12_c110012.bin`
     - To install this driver, simply run it as root like this:
         - `sudo bash ./sgx_linux_x64_driver_1.12_c110012.bin`

--- a/docs/GettingStartedDocs/Contributors/BuildingInADockerContainer.md
+++ b/docs/GettingStartedDocs/Contributors/BuildingInADockerContainer.md
@@ -9,11 +9,11 @@
 1. Install Docker CE by following these instructions: https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce
 
 2. Install the appropriate Intel SGX Driver for your platform. For example, if you're running on an SGX1 with FLC system, you'll probably want to install the Intel SGX DCAP Driver for your platfrom: https://01.org/intel-software-guard-extensions/downloads
-    - If you're running on an SGX with FLC system, you'll probably want to install the Intel SGX DCAP Driver for your platfrom: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-dcap-linux-1.1-release
+    - If you're running on an SGX with FLC system, you'll probably want to install the Intel SGX DCAP Driver for your platfrom: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-dcap-linux-1.2-release
     - If you're running on an SGX without FLC system, you'll want to install the Intel SGX Driver for your platform: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-linux-2.5-release
-    - The driver you're looking for is a ".bin" file, for either Ubuntu 16.04 or 18.04 releases. It will be named something like: `sgx_linux_x64_driver_dcap_1.1.100.2786ad8.bin`
+    - The driver you're looking for is a ".bin" file, for either Ubuntu 16.04 or 18.04 releases. It will be named something like: `sgx_linux_x64_driver_1.12_c110012.bin`
     - To install this driver, simply run it as root like this:
-        - `sudo bash ./sgx_linux_x64_driver_dcap_1.1.100.2786ad8.bin`
+        - `sudo bash ./sgx_linux_x64_driver_1.12_c110012.bin`
 
 3. Pull the latest oetools-full image for Open Enclave from *either* of these two distributions:
     - https://hub.docker.com/r/oeciteam/oetools-full-16.04

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
@@ -26,7 +26,7 @@ wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add 
 ```bash
 sudo apt update
 sudo apt -y install dkms
-wget https://download.01.org/intel-sgx/dcap-1.1/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_dcap_1.1.100.2786ad8.bin -O sgx_linux_x64_driver.bin
+wget https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_1.12_c110012.bin -O sgx_linux_x64_driver.bin
 chmod +x sgx_linux_x64_driver.bin
 sudo ./sgx_linux_x64_driver.bin
 ```

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
@@ -26,7 +26,7 @@ wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add 
 ```bash
 sudo apt update
 sudo apt -y install dkms
-wget https://download.01.org/intel-sgx/dcap-1.1/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_dcap_1.1.100.2786ad8.bin -O sgx_linux_x64_driver.bin
+wget https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_1.12_c110012.bin -O sgx_linux_x64_driver.bin
 chmod +x sgx_linux_x64_driver.bin
 sudo ./sgx_linux_x64_driver.bin
 ```

--- a/scripts/ansible/roles/linux/intel/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/intel/vars/bionic.yml
@@ -2,6 +2,6 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.1/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_dcap_1.1.100.2786ad8.bin"
+intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_1.12_c110012.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf10"

--- a/scripts/ansible/roles/linux/intel/vars/xenial.yml
+++ b/scripts/ansible/roles/linux/intel/vars/xenial.yml
@@ -2,6 +2,6 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.1/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_dcap_1.1.100.2786ad8.bin"
+intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_1.12_c110012.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf9v5"


### PR DESCRIPTION
This doesn't include updates to the Windows docs/ansible/script. I wasn't able to find the new DCAP release on Intel's SGX download page for Windows. Is that released to a different location?

After this merges into master, we should merge it to the v0.6.x release branch.