### PR TITLE
Edger8r changes for switchless ecalls and ocalls.

### DIFF
--- a/enclave/core/hostcalls.c
+++ b/enclave/core/hostcalls.c
@@ -197,7 +197,9 @@ int oe_host_fprintf(int device, const char* fmt, ...)
     return n;
 }
 
-// Function used by oeedger8r for allocating ocall buffers.
+// Function used by oeedger8r for allocating ocall buffers. This function can be
+// optimized by allocating a buffer for making ocalls and pass it in to the
+// ecall and making it available for use here.
 void* oe_allocate_ocall_buffer(size_t size)
 {
     return oe_host_malloc(size);
@@ -205,6 +207,28 @@ void* oe_allocate_ocall_buffer(size_t size)
 
 // Function used by oeedger8r for freeing ocall buffers.
 void oe_free_ocall_buffer(void* buffer)
+{
+    oe_host_free(buffer);
+}
+
+// Function used by oeedger8r for allocating switchless ocall buffers.
+// There are two possible approaches to implementing this function:
+//    1. Preallocate a pool of host memory per thread for switchless ocalls
+//       and then allocate memory from that pool. Since OE does not support
+//       reentrant ecalls in the same thread, there can at most be one ecall
+//       and one ocall active in a thread. This can enable implementing
+//       host memory pools more efficiently.
+//   2. The alternative is to allocate the  buffer in enclave memory.
+//      Then while issuing the underling SDK call to make the switchless ocall,
+//      use a ring-buffer to transfer the contents of the memory to the host
+//      and to transfer the results back.
+void* oe_allocate_switchless_ocall_buffer(size_t size)
+{
+    return oe_host_malloc(size);
+}
+
+// Function used by oeedger8r for freeing ocall buffers.
+void oe_free_switchless_ocall_buffer(void* buffer)
 {
     oe_host_free(buffer);
 }

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -701,6 +701,32 @@ oe_result_t oe_call_host_function(
 /*
 **==============================================================================
 **
+** oe_switchless_call_host_function()
+** This is the preferred way to call host functions switchlessly.
+**
+**==============================================================================
+*/
+
+oe_result_t oe_switchless_call_host_function(
+    size_t function_id,
+    const void* input_buffer,
+    size_t input_buffer_size,
+    void* output_buffer,
+    size_t output_buffer_size,
+    size_t* output_bytes_written)
+{
+    OE_UNUSED(function_id);
+    OE_UNUSED(input_buffer);
+    OE_UNUSED(input_buffer_size);
+    OE_UNUSED(output_buffer);
+    OE_UNUSED(output_buffer_size);
+    OE_UNUSED(output_bytes_written);
+    return OE_UNSUPPORTED;
+}
+
+/*
+**==============================================================================
+**
 ** __oe_handle_main()
 **
 **     This function is called by oe_enter(), which is called by the EENTER

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -870,6 +870,61 @@ done:
 /*
 **==============================================================================
 **
+** oe_switchless_call_enclave_function_by_table_id()
+**
+** Switchlessly call the enclave function specified by the given table-id and
+*function-id.
+**
+**==============================================================================
+*/
+
+static oe_result_t oe_switchless_call_enclave_function_by_table_id(
+    oe_enclave_t* enclave,
+    uint64_t table_id,
+    uint64_t function_id,
+    const void* input_buffer,
+    size_t input_buffer_size,
+    void* output_buffer,
+    size_t output_buffer_size,
+    size_t* output_bytes_written)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    oe_call_enclave_function_args_t args;
+
+    /* Reject invalid parameters */
+    if (!enclave)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    /* Initialize the call_enclave_args structure */
+    {
+        args.table_id = table_id;
+        args.function_id = function_id;
+        args.input_buffer = input_buffer;
+        args.input_buffer_size = input_buffer_size;
+        args.output_buffer = output_buffer;
+        args.output_buffer_size = output_buffer_size;
+        args.output_bytes_written = 0;
+        args.result = OE_UNEXPECTED;
+    }
+
+    /* TODO: @EMumau Perform the Switchless ECALL */
+    {
+        OE_RAISE(OE_UNSUPPORTED);
+    }
+
+    /* Check the result */
+    OE_CHECK(args.result);
+
+    *output_bytes_written = args.output_bytes_written;
+    result = OE_OK;
+
+done:
+    return result;
+}
+
+/*
+**==============================================================================
+**
 ** oe_call_enclave_function()
 **
 ** Call the enclave function specified by the given function-id in the default
@@ -888,6 +943,36 @@ oe_result_t oe_call_enclave_function(
     size_t* output_bytes_written)
 {
     return oe_call_enclave_function_by_table_id(
+        enclave,
+        OE_UINT64_MAX,
+        function_id,
+        input_buffer,
+        input_buffer_size,
+        output_buffer,
+        output_buffer_size,
+        output_bytes_written);
+}
+
+/*
+**==============================================================================
+**
+** oe_switchless_call_enclave_function()
+**
+** Switchlessly call the enclave function specified by the given function-id in
+** the default function table.
+**
+**==============================================================================
+*/
+oe_result_t oe_switchless_call_enclave_function(
+    oe_enclave_t* enclave,
+    uint32_t function_id,
+    const void* input_buffer,
+    size_t input_buffer_size,
+    void* output_buffer,
+    size_t output_buffer_size,
+    size_t* output_bytes_written)
+{
+    return oe_switchless_call_enclave_function_by_table_id(
         enclave,
         OE_UINT64_MAX,
         function_id,

--- a/include/openenclave/edger8r/enclave.h
+++ b/include/openenclave/edger8r/enclave.h
@@ -74,6 +74,45 @@ oe_result_t oe_call_host_function(
     size_t* output_bytes_written);
 
 /**
+ * Perform a high-level host function call (OCALL) switchlessly.
+ *
+ * Call the host function whose matching the given function_id.
+ * The host function is expected to have the following signature:
+ *
+ *     void (const uint8_t* input_buffer,
+ *           size_t input_buffer_size,
+ *           uint8_t* output_buffer,
+ *           size_t output_buffer_size,
+ *           size_t* output_bytes_written);
+ *
+ * Note that the return value of this function only indicates the success of
+ * the call and not of the underlying function. The OCALL implementation must
+ * define its own error reporting scheme via the arguments or return value.
+ *
+ * @param function_id The id of the host function that will be called.
+ * @param input_buffer Buffer containing inputs data.
+ * @param input_buffer_size Size of the input data buffer.
+ * @param output_buffer Buffer where the outputs of the host function are
+ * written to.
+ * @param output_buffer_size Size of the output buffer.
+ * @param output_bytes_written Number of bytes written in the output buffer.
+ *
+ * @return OE_OK the call was successful.
+ * @return OE_NOT_FOUND if the function_id does not correspond to a function.
+ * @return OE_INVALID_PARAMETER a parameter is invalid.
+ * @return OE_FAILURE the call failed.
+ * @return OE_BUFFER_TOO_SMALL the input or output buffer was smaller than
+ * expected.
+ */
+oe_result_t oe_switchless_call_host_function(
+    size_t function_id,
+    const void* input_buffer,
+    size_t input_buffer_size,
+    void* output_buffer,
+    size_t output_buffer_size,
+    size_t* output_bytes_written);
+
+/**
  * Allocate a buffer of given size for doing an ocall.
  *
  * The buffer may or may not be allocated in host memory.
@@ -91,6 +130,25 @@ void* oe_allocate_ocall_buffer(size_t size);
  * @param buffer The buffer allocated via oe_allocate_ocall_buffer.
  */
 void oe_free_ocall_buffer(void* buffer);
+
+/**
+ * Allocate a buffer of given size for doing a switchless ocall.
+ *
+ * The buffer may or may not be allocated in host memory.
+ * The buffer should be treated as untrusted.
+ *
+ * @param size The size in bytes of the buffer.
+ * @returns pointer to the allocated buffer.
+ * @return NULL if allocation failed.
+ */
+void* oe_allocate_switchless_ocall_buffer(size_t size);
+
+/**
+ * Free the buffer allocated for switchless ocalls.
+ *
+ * @param buffer The buffer allocated via oe_allocate_ocall_buffer.
+ */
+void oe_free_switchless_ocall_buffer(void* buffer);
 
 /**
  * For hand-written enclaves, that use the older calling mechanism, define empty

--- a/include/openenclave/edger8r/host.h
+++ b/include/openenclave/edger8r/host.h
@@ -66,6 +66,18 @@ oe_result_t oe_call_enclave_function(
     size_t output_buffer_size,
     size_t* output_bytes_written);
 
+/**
+ * Placeholder.
+ */
+oe_result_t oe_switchless_call_enclave_function(
+    oe_enclave_t* enclave,
+    uint32_t function_id,
+    const void* input_buffer,
+    size_t input_buffer_size,
+    void* output_buffer,
+    size_t output_buffer_size,
+    size_t* output_bytes_written);
+
 OE_EXTERNC_END
 
 #endif // _OE_EDGER8R_HOST_H

--- a/tests/oeedger8r/edl/all.edl
+++ b/tests/oeedger8r/edl/all.edl
@@ -13,6 +13,7 @@ enclave  {
     from "pointer.edl"  import *;
     from "string.edl"   import *;
     from "struct.edl"   import *;
+    from "switchless.edl" import *;
     
     from "foo.edl" import 
         enc_foo1,

--- a/tests/oeedger8r/edl/switchless.edl
+++ b/tests/oeedger8r/edl/switchless.edl
@@ -5,5 +5,11 @@ enclave {
   trusted {
     public int ecall_sum(int a, int b);
     public int switchless_ecall_sum(int a, int b) transition_using_threads;
+
+    public void test_switchless_edl_ocalls();
+  };
+  untrusted {
+    int ocall_sum(int a, int b);
+    int switchless_ocall_sum(int a, int b) transition_using_threads;
   };
 };

--- a/tests/oeedger8r/edl/switchless.edl
+++ b/tests/oeedger8r/edl/switchless.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    public int ecall_sum(int a, int b);
+    public int switchless_ecall_sum(int a, int b) transition_using_threads;
+  };
+};

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -17,6 +17,7 @@ add_custom_command(
   ../edl/pointer.edl
   ../edl/string.edl
   ../edl/struct.edl
+  ../edl/switchless.edl
   COMMAND edger8r --experimental --trusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
 
 # Dummy target used for generating from EDL on demand.
@@ -44,7 +45,8 @@ add_enclave(TARGET edl_enc UUID e71cbbea-a638-4653-b46e-2e58a2ca3408 CXX
     testforeign.cpp
     testpointer.cpp
     teststring.cpp
-    teststruct.cpp)
+    teststruct.cpp
+    testswitchless.cpp)
 
 # The tests intentionally use floats etc in size context.
 # Disable warnings.

--- a/tests/oeedger8r/enc/testswitchless.cpp
+++ b/tests/oeedger8r/enc/testswitchless.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "all_t.h"
+
+int ecall_sum(int a, int b)
+{
+    return a + b;
+}
+
+int switchless_ecall_sum(int a, int b)
+{
+    return a + b;
+}

--- a/tests/oeedger8r/enc/testswitchless.cpp
+++ b/tests/oeedger8r/enc/testswitchless.cpp
@@ -1,6 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#include <openenclave/enclave.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+
 #include "all_t.h"
+
+void test_switchless_edl_ocalls()
+{
+    int c = 0;
+    OE_TEST(ocall_sum(&c, 5, 6) == OE_OK);
+
+    // Switchless calls are not yet implemented
+    OE_TEST(switchless_ocall_sum(&c, 5, 6) == OE_UNSUPPORTED);
+
+    printf("=== test_switchless_edl_ocalls passed\n");
+}
 
 int ecall_sum(int a, int b)
 {

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -17,6 +17,7 @@ add_custom_command(
   ../edl/pointer.edl
   ../edl/string.edl
   ../edl/struct.edl
+  ../edl/switchless.edl
   COMMAND edger8r --experimental --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
 
 add_custom_command(
@@ -46,6 +47,7 @@ add_executable(edl_host
     testpointer.cpp
     teststring.cpp
     teststruct.cpp
+    testswitchless.cpp
 )
 
 # The tests intentionally use floats etc in size context.

--- a/tests/oeedger8r/host/main.cpp
+++ b/tests/oeedger8r/host/main.cpp
@@ -24,6 +24,7 @@ void test_enum_edl_ecalls(oe_enclave_t* enclave);
 void test_foreign_edl_ecalls(oe_enclave_t* enclave);
 void test_other_edl_ecalls(oe_enclave_t* enclave);
 void test_deepcopy_edl_ecalls(oe_enclave_t* enclave);
+void test_switchless_edl_ecalls(oe_enclave_t* enclave);
 
 int main(int argc, const char* argv[])
 {
@@ -97,6 +98,7 @@ int main(int argc, const char* argv[])
 
     test_deepcopy_edl_ecalls(enclave);
 
+    test_switchless_edl_ecalls(enclave);
 done:
     oe_terminate_enclave(enclave);
 

--- a/tests/oeedger8r/host/main.cpp
+++ b/tests/oeedger8r/host/main.cpp
@@ -99,6 +99,7 @@ int main(int argc, const char* argv[])
     test_deepcopy_edl_ecalls(enclave);
 
     test_switchless_edl_ecalls(enclave);
+    OE_TEST(test_switchless_edl_ocalls(enclave) == OE_OK);
 done:
     oe_terminate_enclave(enclave);
 

--- a/tests/oeedger8r/host/testswitchless.cpp
+++ b/tests/oeedger8r/host/testswitchless.cpp
@@ -16,3 +16,13 @@ void test_switchless_edl_ecalls(oe_enclave_t* enclave)
 
     printf("=== test_switchless_edl_ecalls passed\n");
 }
+
+int ocall_sum(int a, int b)
+{
+    return a + b;
+}
+
+int switchless_ocall_sum(int a, int b)
+{
+    return a + b;
+}

--- a/tests/oeedger8r/host/testswitchless.cpp
+++ b/tests/oeedger8r/host/testswitchless.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/tests.h>
+
+#include "all_u.h"
+
+void test_switchless_edl_ecalls(oe_enclave_t* enclave)
+{
+    int c = 0;
+    OE_TEST(ecall_sum(enclave, &c, 5, 6) == OE_OK);
+
+    // Switchless calls are not yet implemented
+    OE_TEST(switchless_ecall_sum(enclave, &c, 5, 6) == OE_UNSUPPORTED);
+
+    printf("=== test_switchless_edl_ecalls passed\n");
+}


### PR DESCRIPTION
- Minimal change in generated code. For switchless ecalls, oe_switchless_call_enclave_function is called instead of oe_call_enclave_function. Similarly for switchless ocalls, oe_switchless_call_host_function is called.
- Switchless (transition_using_threads keyword) is supported only if --experimental option is passed in.
- Placeholder implementation. Always returns OE_UNSUPPORTED
- Behavior locked down with test.
- For switchless ocalls, oe_allocate_switchless_ocall_buffer and oe_free_switchless_ocall_buffer functions are used to allocate and free memory for making ocalls. These functions can use a host memory pool to allocate memory. Alternatively, these functions can allocate buffers in enclave memory and then use a ring buffer to transfer contents to the host.
