### PR TITLE
Debugger Contract: Notifications

### DIFF
--- a/debugger/debugrt/host/host.c
+++ b/debugger/debugrt/host/host.c
@@ -45,8 +45,10 @@ static bool raise_debugger_events()
             if (version != NULL)
             {
                 int v = 0;
-                sscanf(version, "%d", &v);
-                oe_debugger_contract_version = (uint32_t)v;
+                if (sscanf(version, "%d", &v) == 1)
+                {
+                    oe_debugger_contract_version = (uint32_t)v;
+                }
             }
 
             initialized = true;

--- a/debugger/debugrt/host/host.c
+++ b/debugger/debugrt/host/host.c
@@ -39,10 +39,8 @@ static bool raise_debugger_events()
     {
         if (!initialized)
         {
-            // Set oe_debugger_contract_version from the environment.
-            // Normally the debugger would set the value depending on
-            // the version it supports. Setting it from the environment
-            // allows using a specific version of the contract.
+            // If specified, override oe_debugger_contract_version from the
+            // environment.
             char* version = getenv("OE_DEBUGGER_CONTRACT_VERSION");
             if (version != NULL)
             {
@@ -157,7 +155,13 @@ OE_NO_OPTIMIZE_END
 
 #endif
 
-uint32_t oe_debugger_contract_version = 0;
+/**
+ * The version of the debugger contract supported by the runtime.
+ * For development purposes, this value can be overridden by setting
+ * the OE_DEBUGGER_CONTRACT_VERSION enviroment variable.
+ */
+uint32_t oe_debugger_contract_version = 1;
+
 oe_debug_enclave_t* oe_debug_enclaves_list = NULL;
 
 oe_result_t oe_debug_notify_enclave_created(oe_debug_enclave_t* enclave)

--- a/debugger/debugrt/host/host.c
+++ b/debugger/debugrt/host/host.c
@@ -66,12 +66,23 @@ void oe_notify_debugger_enclave_creation(const oe_debug_enclave_t* enclave)
 {
     if (raise_debugger_events())
     {
-        ULONG_PTR args[1] = {(ULONG_PTR)enclave};
-        RaiseException(
-            OE_DEBUGRT_ENCLAVE_CREATED_EVENT,
-            0, // dwFlags
-            1, // number of args
-            args);
+        __try
+        {
+            ULONG_PTR args[1] = {(ULONG_PTR)enclave};
+            RaiseException(
+                OE_DEBUGRT_ENCLAVE_CREATED_EVENT,
+                0, // dwFlags
+                1, // number of args
+                args);
+        }
+        __except (
+            GetExceptionCode() == OE_DEBUGRT_ENCLAVE_CREATED_EVENT
+                ? EXCEPTION_EXECUTE_HANDLER
+                : EXCEPTION_CONTINUE_SEARCH)
+        {
+            // Debugger attached but did not handle the event.
+            // Ignore and continue execution.
+        }
     }
 }
 
@@ -79,12 +90,23 @@ void oe_notify_debugger_enclave_termination(const oe_debug_enclave_t* enclave)
 {
     if (raise_debugger_events())
     {
-        ULONG_PTR args[1] = {(ULONG_PTR)enclave};
-        RaiseException(
-            OE_DEBUGRT_ENCLAVE_TERMINATED_EVENT,
-            0, // dwFlags
-            1, // number of args
-            args);
+        __try
+        {
+            ULONG_PTR args[1] = {(ULONG_PTR)enclave};
+            RaiseException(
+                OE_DEBUGRT_ENCLAVE_TERMINATED_EVENT,
+                0, // dwFlags
+                1, // number of args
+                args);
+        }
+        __except (
+            GetExceptionCode() == OE_DEBUGRT_ENCLAVE_TERMINATED_EVENT
+                ? EXCEPTION_EXECUTE_HANDLER
+                : EXCEPTION_CONTINUE_SEARCH)
+        {
+            // Debugger attached but did not handle the event.
+            // Ignore and continue execution.
+        }
     }
 }
 

--- a/debugger/pythonExtension/gdb_sgx_plugin.py
+++ b/debugger/pythonExtension/gdb_sgx_plugin.py
@@ -341,7 +341,7 @@ def oe_debugger_init():
     bps = gdb.breakpoints()
     if bps != None:
         for bp in bps:
-            if bp.location == "oe_notify_gdb_enclave_creation" and bp.is_valid():
+            if bp.location == "oe_notify_debugger_enclave_creation" and bp.is_valid():
                 return
 
     # Cleanup and set breakpoints.

--- a/debugger/pythonExtension/gdb_sgx_plugin.py
+++ b/debugger/pythonExtension/gdb_sgx_plugin.py
@@ -243,7 +243,7 @@ def update_untrusted_ocall_frame(frame_pointer, ocallcontext_tuple):
 
 class EnclaveCreationBreakpoint(gdb.Breakpoint):
     def __init__(self):
-        gdb.Breakpoint.__init__ (self, spec="oe_notify_gdb_enclave_creation", internal=1)
+        gdb.Breakpoint.__init__ (self, spec="oe_notify_debugger_enclave_creation", internal=1)
 
     def stop(self):
         enclave_addr = int(gdb.parse_and_eval("$rdi"))
@@ -252,7 +252,7 @@ class EnclaveCreationBreakpoint(gdb.Breakpoint):
 
 class EnclaveTerminationBreakpoint(gdb.Breakpoint):
     def __init__(self):
-        gdb.Breakpoint.__init__ (self, spec="oe_notify_gdb_enclave_termination", internal=1)
+        gdb.Breakpoint.__init__ (self, spec="oe_notify_debugger_enclave_termination", internal=1)
 
     def stop(self):
         enclave_addr = int(gdb.parse_and_eval("$rdi"))

--- a/include/openenclave/internal/debugrt/host.h
+++ b/include/openenclave/internal/debugrt/host.h
@@ -61,14 +61,13 @@ OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_enclave_t, flags) == 72);
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * The current version of the debugger contract.
- * Defaults to 0 or the value of OE_DEBUGGER_CONTRACT_VERSION environment
- * variable.
+ * The current version of the debugger contract supported by the application
+ * (debugrt).
  *
- * The debugger is expected to set the value of this variable to
- * tell the runtime which version of the contract it supports.
- * The runtime will send notifications appropriate to the version of the
- * debugger.
+ * The debugger is expected to check the value of this variable to determine
+ * if it can debug the application or not. If it cannot debug the application,
+ * the debugger is expected to advise the user to use a newer version of the
+ * that understands the specific version of the contract.
  */
 OE_EXPORT extern uint32_t oe_debugger_contract_version;
 
@@ -83,7 +82,7 @@ OE_EXPORT extern oe_debug_enclave_t* oe_debug_enclaves_list;
 /////////////// Events Raised for Windows Debuggers/////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
 
 /**
  * The following event is raised by the runtime when an enclave is created:

--- a/include/openenclave/internal/debugrt/host.h
+++ b/include/openenclave/internal/debugrt/host.h
@@ -56,11 +56,77 @@ OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_enclave_t, tcs_array) == 56);
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_enclave_t, num_tcs) == 64);
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_enclave_t, flags) == 72);
 
+////////////////////////////////////////////////////////////////////////////////
+/////////////// Symbols Exported by the Runtime ////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * The current version of the debugger contract.
+ * Defaults to 0 or the value of OE_DEBUGGER_CONTRACT_VERSION environment
+ * variable.
+ *
+ * The debugger is expected to set the value of this variable to
+ * tell the runtime which version of the contract it supports.
+ * The runtime will send notifications appropriate to the version of the
+ * debugger.
+ */
+OE_EXPORT extern uint32_t oe_debugger_contract_version;
+
+/**
+ * The list of loaded enclaves.
+ * Upon attaching to an application, the debugger can scan this list
+ * and configure the enclaves for debugging.
+ */
 OE_EXPORT extern oe_debug_enclave_t* oe_debug_enclaves_list;
 
+////////////////////////////////////////////////////////////////////////////////
+/////////////// Events Raised for Windows Debuggers/////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+#if defined(WIN32) || defined(_WIN32)
+
+/**
+ * The following event is raised by the runtime when an enclave is created:
+ *   ULONG_PTR args[1] = { oe_debug_enclave_t_ptr };
+ *   RaiseException(OE_DEBUGRT_ENCLAVE_CREATED_EVENT,
+ *                  0,  // dwExceptionFlags
+ *                  1,  // always 1 (number of argument)
+ *                  args)
+ * The oe_debug_enclave_t structure corresponding to the created enclave is
+ * passed as the sole element of the argument array.
+ */
+#define OE_DEBUGRT_ENCLAVE_CREATED_EVENT 0x0edeb646
+
+/**
+ * The following event is raised by the runtime after an enclave has been
+ * terminated:
+ *   ULONG_PTR args[1] = { oe_debug_enclave_t_ptr };
+ *   RaiseException(OE_DEBUGRT_ENCLAVE_TERMINATED_EVENT,
+ *                  0,  // dwExceptionFlags
+ *                  1,  // always 1 (number of argument)
+ *                  args)
+ * The oe_debug_enclave_t structure corresponding to the created enclave is
+ * passed as the sole element of the argument array.
+ */
+#define OE_DEBUGRT_ENCLAVE_TERMINATED_EVENT 0x0edeb647
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+/////////////// Functions called by OE SDK  ////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Notify debugrt that an enclave has been created.
+ * This notification must be done before initializing the enclave.
+ */
 OE_EXPORT oe_result_t
 oe_debug_notify_enclave_created(oe_debug_enclave_t* enclave);
 
+/**
+ * Notify debugrt that and enclave has been terminated.
+ * This notification must be done after calling enclave destructors.
+ */
 OE_EXPORT oe_result_t
 oe_debug_notify_enclave_terminated(oe_debug_enclave_t* enclave);
 


### PR DESCRIPTION
- Send Enclave Creation/Termination notifications on Windows
- oe_debugger_contract version is initialized to 1 or the value
  of OE_DEBUGGER_CONTRACT_VERSION environment variable
  If version >= 1, then notifications are sent to the debugger.