### PR TITLE
OE_AEP_ADDRESS variable to obtain precise location of ENCLU.

### DIFF
--- a/host/sgx/asmdefs.h
+++ b/host/sgx/asmdefs.h
@@ -37,7 +37,7 @@ void oe_enter(
     uint64_t* arg4,
     oe_enclave_t* enclave);
 
-void OE_AEP(void);
+extern const uint64_t OE_AEP_ADDRESS;
 #endif
 
 #ifndef __ASSEMBLER__

--- a/host/sgx/asmdefs.h
+++ b/host/sgx/asmdefs.h
@@ -30,7 +30,7 @@ typedef struct _oe_enclave oe_enclave_t;
 #ifndef __ASSEMBLER__
 void oe_enter(
     void* tcs,
-    void (*aep)(void),
+    uint64_t aep,
     uint64_t arg1,
     uint64_t arg2,
     uint64_t* arg3,
@@ -43,7 +43,7 @@ extern const uint64_t OE_AEP_ADDRESS;
 #ifndef __ASSEMBLER__
 void oe_enter_sim(
     void* tcs,
-    void (*aep)(void),
+    uint64_t aep,
     uint64_t arg1,
     uint64_t arg2,
     uint64_t* arg3,

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -775,7 +775,7 @@ oe_result_t oe_ecall(
     OE_CHECK(_do_eenter(
         enclave,
         tcs,
-        OE_AEP,
+        (void (*)())OE_AEP_ADDRESS,
         code,
         func,
         arg,

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -104,7 +104,7 @@ ThreadBinding* GetThreadBinding()
 static oe_result_t _enter_sim(
     oe_enclave_t* enclave,
     void* tcs_,
-    void (*aep)(void),
+    uint64_t aep,
     uint64_t arg1,
     uint64_t arg2,
     uint64_t* arg3,
@@ -178,7 +178,7 @@ OE_ALWAYS_INLINE
 static oe_result_t _do_eenter(
     oe_enclave_t* enclave,
     void* tcs,
-    void (*aep)(void),
+    uint64_t aep,
     oe_code_t code_in,
     uint16_t func_in,
     uint64_t arg_in,
@@ -775,7 +775,7 @@ oe_result_t oe_ecall(
     OE_CHECK(_do_eenter(
         enclave,
         tcs,
-        (void (*)())OE_AEP_ADDRESS,
+        OE_AEP_ADDRESS,
         code,
         func,
         arg,

--- a/host/sgx/exception.c
+++ b/host/sgx/exception.c
@@ -5,6 +5,7 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/calls.h>
 #include <stdio.h>
+#include "asmdefs.h"
 #include "enclave.h"
 
 /**
@@ -12,8 +13,6 @@
  * since asmdefs.h is too linux specific at the moment.
  */
 #define ENCLU_ERESUME 3
-
-extern void OE_AEP(void);
 
 oe_enclave_t* oe_query_enclave_instance(void* tcs);
 
@@ -25,7 +24,7 @@ uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
     uint64_t exit_address = context->rip;
 
     // Check if the signal happens inside the enclave.
-    if ((exit_address == (uint64_t)OE_AEP) && (exit_code == ENCLU_ERESUME))
+    if ((exit_address == OE_AEP_ADDRESS) && (exit_code == ENCLU_ERESUME))
     {
         // Check if the enclave exception happens inside the first pass
         // exception handler.

--- a/host/sgx/linux/aep.S
+++ b/host/sgx/linux/aep.S
@@ -42,7 +42,7 @@ OE_AEP:
 //     thunks that wrap the function. For example, when incremental linking is
 //     enabled, the linker on windows creates an entry in the ILT table for
 //     each function and uses that wherever the function is referenced.
-//     Thus OE_AEP would endup pointing to the thunk in the ILT which is not
+//     Thus OE_AEP would end up pointing to the thunk in the ILT which is not
 //     what we want. The OE_AEP_ADDRESS variable gives the precise location of
 //     the ENCLU instruction.
 //

--- a/host/sgx/linux/aep.S
+++ b/host/sgx/linux/aep.S
@@ -16,9 +16,6 @@
 //     the host stack region used by enclave host stack allocaiton routines.
 //
 //==============================================================================
-
-.globl OE_AEP
-.type OE_AEP, @function
 OE_AEP:
 .cfi_startproc
 
@@ -34,3 +31,23 @@ OE_AEP:
     ud2
 
 .cfi_endproc
+
+
+//==============================================================================
+//
+// uint64_t OE_AEP_ADDRESS
+//
+//     The address of the ENCLU instruction is stored in this variable.
+//     If the OE_AEP function were to be used in code, the linker could create
+//     thunks that wrap the function. For example, when incremental linking is
+//     enabled, the linker on windows creates an entry in the ILT table for
+//     each function and uses that wherever the function is referenced.
+//     Thus OE_AEP would endup pointing to the thunk in the ILT which is not
+//     what we want. The OE_AEP_ADDRESS variable gives the precise location of
+//     the ENCLU instruction.
+//
+//==============================================================================
+.globl OE_AEP_ADDRESS
+.section .rodata
+.align 8
+OE_AEP_ADDRESS:	.quad .aep

--- a/host/sgx/linux/enter.S
+++ b/host/sgx/linux/enter.S
@@ -8,7 +8,7 @@
 //
 // void __morestack(
 //     [IN] void* tcs,                  /* RDI */
-//     [IN] void (*aep)(),              /* RSI */
+//     [IN] uint64_t aep,               /* RSI */
 //     [IN] uint64_t arg1,              /* RDX */
 //     [IN] uint64_t arg2,              /* RCX */
 //     [OUT] uint64_t* arg3,            /* R8 */

--- a/host/sgx/linux/entersim.S
+++ b/host/sgx/linux/entersim.S
@@ -8,7 +8,7 @@
 //
 // void oe_enter_sim(
 //     [IN] void* tcs,
-//     [IN] void (*aep)(),
+//     [IN] uint64_t aep,
 //     [IN] uint64_t arg1,
 //     [IN] uint64_t arg2,
 //     [OUT] uint64_t* arg3,

--- a/host/sgx/windows/aep.asm
+++ b/host/sgx/windows/aep.asm
@@ -48,7 +48,7 @@ NESTED_END OE_AEP, _TEXT$00
 ;;     thunks that wrap the function. For example, when incremental linking is
 ;;     enabled, the linker on windows creates an entry in the ILT table for
 ;;     each function and uses that wherever the function is referenced.
-;;     Thus OE_AEP would endup pointing to the thunk in the ILT which is not
+;;     Thus OE_AEP would end up pointing to the thunk in the ILT which is not
 ;;     what we want. The OE_AEP_ADDRESS variable gives the precise location of
 ;;     the ENCLU instruction.
 ;;

--- a/host/sgx/windows/aep.asm
+++ b/host/sgx/windows/aep.asm
@@ -24,7 +24,8 @@ include ksamd64.inc
 NESTED_ENTRY OE_AEP, _TEXT$00
     END_PROLOGUE
 
-aep:
+
+aep LABEL FAR
     ;; ATTN: port not complete but these are probably not needed
     ;; mov rax, ENCLU_ERESUME
     ;; mov rbx, fs:[ThreadBinding_tcs]
@@ -36,5 +37,27 @@ aep:
     BEGIN_EPILOGUE
     ret
 NESTED_END OE_AEP, _TEXT$00
+
+
+;;==============================================================================
+;;
+;; uint64_t OE_AEP_ADDRESS
+;;
+;;     The address of the ENCLU instruction is stored in this variable.
+;;     If the OE_AEP function were to be used in code, the linker could create
+;;     thunks that wrap the function. For example, when incremental linking is
+;;     enabled, the linker on windows creates an entry in the ILT table for
+;;     each function and uses that wherever the function is referenced.
+;;     Thus OE_AEP would endup pointing to the thunk in the ILT which is not
+;;     what we want. The OE_AEP_ADDRESS variable gives the precise location of
+;;     the ENCLU instruction.
+;;
+;;==============================================================================
+;;
+;;
+PUBLIC OE_AEP_ADDRESS; OE_AEP_ADDRESS
+_DATA SEGMENT
+OE_AEP_ADDRESS DQ aep
+_DATA ENDS
 
 END

--- a/host/sgx/windows/enter.asm
+++ b/host/sgx/windows/enter.asm
@@ -9,7 +9,7 @@ extern __oe_dispatch_ocall:proc
 ;;
 ;; void oe_enter(
 ;;     [IN] void* tcs,
-;;     [IN] void (*aep)(),
+;;     [IN] uint64_t aep,
 ;;     [IN] uint64_t arg1,
 ;;     [IN] uint64_t arg2,
 ;;     [OUT] uint64_t* arg3,

--- a/host/sgx/windows/entersim.asm
+++ b/host/sgx/windows/entersim.asm
@@ -9,7 +9,7 @@ extern __oe_dispatch_ocall:proc
 ;;
 ;; void oe_enter_sim(
 ;;     [IN] void* tcs,
-;;     [IN] void (*aep)(),
+;;     [IN] uint64_t aep,
 ;;     [IN] uint64_t arg1,
 ;;     [IN] uint64_t arg2,
 ;;     [OUT] uint64_t* arg3,


### PR DESCRIPTION
For single-step debugging to work, OE_AEP must exacly point to the
ENCLU instruction.
If used as a function with type void (void), the linker could emit
thunks to wrap the OE_AEP function (say for incremental linking).
To obtain the precise location of the ENCLU, the OE_AEP_ADDRESS
variable is used to store the computed address of the ENCLU instruction.

Note: OE_AEP is not a proper C function. It does not confirm to the
Linux/Windows ABI.