### PR TITLE
Remove strcmp weak alias (one-line change)

### DIFF
--- a/enclave/core/string.c
+++ b/enclave/core/string.c
@@ -148,8 +148,6 @@ char* oe_strdup(const char* s)
     return p;
 }
 
-OE_WEAK_ALIAS(oe_strcmp, strcmp);
-
 char* oe_strchr(const char* s, int c)
 {
     while (*s && *s != c)


### PR DESCRIPTION
This PR removes the following line from **enclave/core/string.c**.

```C++
OE_WEAK_ALIAS(oe_strcmp, strcmp);
```

This was reported by Peter from the **SGX-LKL** team (issue #2040). The intent of this line was probably to provide a **strcmp** definition when **MUSL** is not present to provide it.

