### PR TITLE
Extend assert() to print the call stack (backtrace).

### DIFF
--- a/enclave/core/assert.c
+++ b/enclave/core/assert.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <openenclave/enclave.h>
+#include <openenclave/internal/backtrace.h>
 #include <openenclave/internal/print.h>
 
 void __oe_assert_fail(
@@ -12,5 +13,6 @@ void __oe_assert_fail(
 {
     oe_host_printf(
         "Assertion failed: %s (%s: %s: %d)\n", expr, file, function, line);
+    oe_print_backtrace();
     oe_abort();
 }

--- a/libc/assert.c
+++ b/libc/assert.c
@@ -1,0 +1,15 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+
+/* Called by assert(condition) when the condition is zero-valued. */
+void __assert_fail(
+    const char* expr,
+    const char* file,
+    int line,
+    const char* func)
+{
+    /* Delegate to __oe_assert_fail(), which prints a backtrace. */
+    __oe_assert_fail(expr, file, line, func);
+}


### PR DESCRIPTION
This PR extends **assert()** to print the call stack in addition to the assertion message. This works for both **assert()** and **oe_assert()**.

See issue #2048.