### PR TITLE
DebugRt: Stack of thread bindings (oe_debug_thread_bindings_list)

### DIFF
--- a/debugger/debugrt/host/host.c
+++ b/debugger/debugrt/host/host.c
@@ -3,6 +3,7 @@
 
 #include <openenclave/internal/debugrt/host.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /**
@@ -29,6 +30,11 @@ static void spin_lock()
 static void spin_unlock()
 {
     InterlockedExchange(&_lock, 0);
+}
+
+static uint64_t get_current_thread_id()
+{
+    return (uint64_t)GetCurrentThreadId();
 }
 
 static bool raise_debugger_events()
@@ -112,6 +118,8 @@ void oe_notify_debugger_enclave_termination(const oe_debug_enclave_t* enclave)
 
 #elif defined __GNUC__
 
+#include <pthread.h>
+
 static uint8_t _lock = 0;
 
 static void spin_lock()
@@ -125,6 +133,11 @@ static void spin_lock()
 static void spin_unlock()
 {
     __atomic_clear(&_lock, __ATOMIC_SEQ_CST);
+}
+
+static uint64_t get_current_thread_id()
+{
+    return (uint64_t)pthread_self();
 }
 
 /*
@@ -165,6 +178,7 @@ OE_NO_OPTIMIZE_END
 uint32_t oe_debugger_contract_version = 1;
 
 oe_debug_enclave_t* oe_debug_enclaves_list = NULL;
+oe_debug_thread_binding_t* oe_debug_thread_bindings_list = NULL;
 
 oe_result_t oe_debug_notify_enclave_created(oe_debug_enclave_t* enclave)
 {
@@ -229,6 +243,84 @@ oe_result_t oe_debug_notify_enclave_terminated(oe_debug_enclave_t* enclave)
     result = OE_OK;
 
     oe_notify_debugger_enclave_termination(enclave);
+
+done:
+    if (locked)
+        spin_unlock();
+
+    return result;
+}
+
+oe_result_t oe_debug_push_thread_binding(
+    oe_debug_enclave_t* enclave,
+    struct _sgx_tcs* tcs)
+{
+    oe_result_t result = OE_FAILURE;
+    bool locked = false;
+    oe_debug_thread_binding_t* binding = NULL;
+
+    if (enclave == NULL || tcs == NULL)
+    {
+        result = OE_INVALID_PARAMETER;
+        goto done;
+    }
+
+    binding = (oe_debug_thread_binding_t*)malloc(sizeof(*binding));
+    if (binding == NULL)
+    {
+        result = OE_OUT_OF_MEMORY;
+        goto done;
+    }
+
+    spin_lock();
+    locked = true;
+
+    binding->magic = OE_DEBUG_THREAD_BINDING_MAGIC;
+    binding->version = 1;
+    binding->enclave = enclave;
+    binding->tcs = tcs;
+    binding->thread_id = get_current_thread_id();
+
+    binding->next = oe_debug_thread_bindings_list;
+    oe_debug_thread_bindings_list = binding;
+    result = OE_OK;
+
+done:
+    if (locked)
+        spin_unlock();
+
+    return result;
+}
+
+oe_result_t oe_debug_pop_thread_binding()
+{
+    oe_result_t result = OE_FAILURE;
+    bool locked = false;
+    oe_debug_thread_binding_t* binding = NULL;
+
+    uint64_t thread_id = get_current_thread_id();
+
+    spin_lock();
+    locked = true;
+
+    oe_debug_thread_binding_t** itr = &oe_debug_thread_bindings_list;
+    while (*itr)
+    {
+        if ((*itr)->thread_id == thread_id)
+            break;
+        itr = &(*itr)->next;
+    }
+
+    if (*itr == NULL)
+    {
+        result = OE_NOT_FOUND;
+        goto done;
+    }
+
+    binding = *itr;
+    *itr = binding->next;
+    free(binding);
+    result = OE_OK;
 
 done:
     if (locked)

--- a/include/openenclave/internal/debugrt/host.h
+++ b/include/openenclave/internal/debugrt/host.h
@@ -56,6 +56,27 @@ OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_enclave_t, tcs_array) == 56);
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_enclave_t, num_tcs) == 64);
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_enclave_t, flags) == 72);
 
+#define OE_DEBUG_THREAD_BINDING_MAGIC 0x24cb0317d077d636
+
+typedef struct _debug_thread_binding_t
+{
+    uint64_t magic;
+    uint64_t version;
+
+    uint64_t thread_id;
+    oe_debug_enclave_t* enclave;
+    struct _sgx_tcs* tcs;
+
+    struct _debug_thread_binding_t* next;
+} oe_debug_thread_binding_t;
+
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, magic) == 0);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, version) == 8);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, thread_id) == 16);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, enclave) == 24);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, tcs) == 32);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, next) == 40);
+
 ////////////////////////////////////////////////////////////////////////////////
 /////////////// Symbols Exported by the Runtime ////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,6 +98,13 @@ OE_EXPORT extern uint32_t oe_debugger_contract_version;
  * and configure the enclaves for debugging.
  */
 OE_EXPORT extern oe_debug_enclave_t* oe_debug_enclaves_list;
+
+/**
+ * The list of active thread bindings.
+ * The debugger can scan this list to find the list of bindings.
+ * Note: Ideally, this list could be stored per thread in thread-local storage.
+ */
+OE_EXPORT extern oe_debug_thread_binding_t* oe_debug_thread_bindings_list;
 
 ////////////////////////////////////////////////////////////////////////////////
 /////////////// Events Raised for Windows Debuggers/////////////////////////////
@@ -128,6 +156,17 @@ oe_debug_notify_enclave_created(oe_debug_enclave_t* enclave);
  */
 OE_EXPORT oe_result_t
 oe_debug_notify_enclave_terminated(oe_debug_enclave_t* enclave);
+
+/**
+ * Notify debugrt about a new binding for current thread.
+ */
+OE_EXPORT oe_result_t
+oe_debug_push_thread_binding(oe_debug_enclave_t* enclave, struct _sgx_tcs* tcs);
+
+/**
+ * Pop the last binding for the current thread.
+ */
+OE_EXPORT oe_result_t oe_debug_pop_thread_binding();
 
 OE_EXTERNC_END
 


### PR DESCRIPTION
Everytime an ecall is made, a new triplet is created
   (current-thread-id, debug-enclave*, tcs)
and pushed into a stack maintained by the debug runtime.

When the ecall returns, the top most binding for the current
thread is popped.

A debugger can scan this global stack (actually a list)
of bindings an can figure out the tcs-es for the enclave in/out
transitions in all the threads.

Note: In future, we may need to push ecall/ocall landing frames
rather than just the triplet.