### PR TITLE
Converge crypto implementations

### DIFF
--- a/common/cert.c
+++ b/common/cert.c
@@ -211,6 +211,33 @@ done:
     return result;
 }
 
+oe_result_t oe_cert_chain_get_root_cert(
+    const oe_cert_chain_t* chain,
+    oe_cert_t* cert)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    size_t length = 0;
+
+    OE_CHECK(oe_cert_chain_get_length(chain, &length));
+    if (length == 0)
+        OE_RAISE(OE_NOT_FOUND);
+    OE_CHECK(oe_cert_chain_get_cert(chain, length - 1, cert));
+    result = OE_OK;
+
+done:
+    return result;
+}
+
+oe_result_t oe_cert_chain_get_leaf_cert(
+    const oe_cert_chain_t* chain,
+    oe_cert_t* cert)
+{
+    oe_result_t result = oe_cert_chain_get_cert(chain, 0, cert);
+    if (result == OE_OUT_OF_BOUNDS)
+        result = OE_NOT_FOUND;
+    return result;
+}
+
 oe_result_t oe_cert_write_public_key_pem(
     const oe_cert_t* cert,
     uint8_t* pem_data,

--- a/enclave/crypto/cert.c
+++ b/enclave/crypto/cert.c
@@ -1012,22 +1012,6 @@ done:
     return result;
 }
 
-oe_result_t oe_cert_chain_get_root_cert(
-    const oe_cert_chain_t* chain,
-    oe_cert_t* cert)
-{
-    oe_result_t result = OE_UNEXPECTED;
-    size_t length;
-
-    OE_CHECK(oe_cert_chain_get_length(chain, &length));
-    OE_CHECK(oe_cert_chain_get_cert(chain, length - 1, cert));
-
-    result = OE_OK;
-
-done:
-    return result;
-}
-
 oe_result_t oe_cert_find_extension(
     const oe_cert_t* cert,
     const char* oid,
@@ -1055,21 +1039,6 @@ oe_result_t oe_cert_find_extension(
         result = args.result;
         goto done;
     }
-
-done:
-    return result;
-}
-
-oe_result_t oe_cert_chain_get_leaf_cert(
-    const oe_cert_chain_t* chain,
-    oe_cert_t* cert)
-{
-    oe_result_t result = OE_UNEXPECTED;
-    size_t length;
-
-    OE_CHECK(oe_cert_chain_get_length(chain, &length));
-    OE_CHECK(oe_cert_chain_get_cert(chain, 0, cert));
-    result = OE_OK;
 
 done:
     return result;

--- a/host/crypto/magic.h
+++ b/host/crypto/magic.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef _OE_HOST_CRYPTO_MAGIC_H
+#define _OE_HOST_CRYPTO_MAGIC_H
+
+/* oe_crypto magic numbers for host types are shared
+ * between OpenSSL and BCrypt implementations */
+
+#define OE_CERT_MAGIC 0xbc8e184285de4d2a
+#define OE_CERT_CHAIN_MAGIC 0xa5ddf70fb28f4480
+#define OE_CRL_MAGIC 0xe8c993b1cca24906
+
+#define OE_EC_PRIVATE_KEY_MAGIC 0x19a751419ae04bbc
+#define OE_EC_PUBLIC_KEY_MAGIC 0xb1d39580c1f14c02
+#define OE_RSA_PRIVATE_KEY_MAGIC 0x7bf635929a714b2c
+#define OE_RSA_PUBLIC_KEY_MAGIC 0x8f8f72170025426d
+
+#endif /* _OE_HOST_CRYPTO_MAGIC_H */

--- a/host/crypto/openssl/cert.c
+++ b/host/crypto/openssl/cert.c
@@ -6,7 +6,6 @@
 #include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/asn1.h>
 #include <openenclave/internal/cert.h>
-#include <openenclave/internal/hexdump.h>
 #include <openenclave/internal/pem.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/utils.h>
@@ -16,9 +15,8 @@
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
 #include <openssl/x509v3.h>
-#include <pthread.h>
-#include <stdio.h>
 #include <string.h>
+#include "../magic.h"
 #include "crl.h"
 #include "ec.h"
 #include "init.h"
@@ -31,9 +29,6 @@
 **
 **==============================================================================
 */
-
-/* Randomly generated magic number */
-#define OE_CERT_MAGIC 0xbc8e184285de4d2a
 
 typedef struct _cert
 {
@@ -63,9 +58,6 @@ static void _cert_clear(Cert* impl)
         impl->x509 = NULL;
     }
 }
-
-/* Randomly generated magic number */
-#define OE_CERT_CHAIN_MAGIC 0xa5ddf70fb28f4480
 
 typedef struct _cert_chain
 {
@@ -892,36 +884,6 @@ oe_result_t oe_cert_chain_get_cert(
 
 done:
 
-    return result;
-}
-
-oe_result_t oe_cert_chain_get_root_cert(
-    const oe_cert_chain_t* chain,
-    oe_cert_t* cert)
-{
-    oe_result_t result = OE_UNEXPECTED;
-    size_t length;
-
-    OE_CHECK(oe_cert_chain_get_length(chain, &length));
-    OE_CHECK(oe_cert_chain_get_cert(chain, length - 1, cert));
-    result = OE_OK;
-
-done:
-    return result;
-}
-
-oe_result_t oe_cert_chain_get_leaf_cert(
-    const oe_cert_chain_t* chain,
-    oe_cert_t* cert)
-{
-    oe_result_t result = OE_UNEXPECTED;
-    size_t length;
-
-    OE_CHECK(oe_cert_chain_get_length(chain, &length));
-    OE_CHECK(oe_cert_chain_get_cert(chain, 0, cert));
-    result = OE_OK;
-
-done:
     return result;
 }
 

--- a/host/crypto/openssl/crl.c
+++ b/host/crypto/openssl/crl.c
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "crl.h"
 #include <limits.h>
 #include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/crypto/crl.h>
@@ -13,8 +12,8 @@
 #include <string.h>
 #include <time.h>
 
-/* Randomly generated magic number */
-#define OE_CRL_MAGIC 0xe8c993b1cca24906
+#include "../magic.h"
+#include "crl.h"
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 /* Needed for compatibility with ssl1.1 */

--- a/host/crypto/openssl/ec.c
+++ b/host/crypto/openssl/ec.c
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "ec.h"
-#include <openenclave/bits/safecrt.h>
-#include <openenclave/internal/defs.h>
-#include <openenclave/internal/hexdump.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/utils.h>
 #include <openssl/obj_mac.h>
 #include <openssl/pem.h>
-#include <string.h>
+
+#include "../magic.h"
+#include "ec.h"
 #include "init.h"
 #include "key.h"
 
@@ -25,11 +23,7 @@ static int ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s)
     sig->s = s;
     return 1;
 }
-
 #endif
-/* Magic numbers for the EC key implementation structures */
-static const uint64_t _PRIVATE_KEY_MAGIC = 0x19a751419ae04bbc;
-static const uint64_t _PUBLIC_KEY_MAGIC = 0xb1d39580c1f14c02;
 
 OE_STATIC_ASSERT(sizeof(oe_public_key_t) <= sizeof(oe_ec_public_key_t));
 OE_STATIC_ASSERT(sizeof(oe_private_key_t) <= sizeof(oe_ec_private_key_t));
@@ -146,7 +140,8 @@ static oe_result_t _generate_key_pair(
             OE_RAISE(OE_CRYPTO_ERROR);
 
         /* Initialize the private key */
-        oe_private_key_init(private_key, pkey_private, _PRIVATE_KEY_MAGIC);
+        oe_private_key_init(
+            private_key, pkey_private, OE_RSA_PRIVATE_KEY_MAGIC);
 
         /* Keep these from being freed below */
         ec_private = NULL;
@@ -164,7 +159,7 @@ static oe_result_t _generate_key_pair(
             OE_RAISE(OE_CRYPTO_ERROR);
 
         /* Initialize the public key */
-        oe_public_key_init(public_key, pkey_public, _PUBLIC_KEY_MAGIC);
+        oe_public_key_init(public_key, pkey_public, OE_RSA_PUBLIC_KEY_MAGIC);
 
         /* Keep these from being freed below */
         ec_public = NULL;
@@ -192,8 +187,8 @@ done:
 
     if (result != OE_OK)
     {
-        oe_private_key_free(private_key, _PRIVATE_KEY_MAGIC);
-        oe_public_key_free(public_key, _PUBLIC_KEY_MAGIC);
+        oe_private_key_free(private_key, OE_RSA_PRIVATE_KEY_MAGIC);
+        oe_public_key_free(public_key, OE_RSA_PUBLIC_KEY_MAGIC);
     }
 
     return result;
@@ -212,8 +207,8 @@ static oe_result_t _public_key_equal(
         *equal = false;
 
     /* Reject bad parameters */
-    if (!oe_public_key_is_valid(public_key1, _PUBLIC_KEY_MAGIC) ||
-        !oe_public_key_is_valid(public_key2, _PUBLIC_KEY_MAGIC) || !equal)
+    if (!oe_public_key_is_valid(public_key1, OE_RSA_PUBLIC_KEY_MAGIC) ||
+        !oe_public_key_is_valid(public_key2, OE_RSA_PUBLIC_KEY_MAGIC) || !equal)
         OE_RAISE(OE_INVALID_PARAMETER);
 
     {
@@ -250,14 +245,14 @@ done:
 
 void oe_ec_public_key_init(oe_ec_public_key_t* public_key, EVP_PKEY* pkey)
 {
-    return oe_public_key_init(
-        (oe_public_key_t*)public_key, pkey, _PUBLIC_KEY_MAGIC);
+    oe_public_key_init(
+        (oe_public_key_t*)public_key, pkey, OE_RSA_PUBLIC_KEY_MAGIC);
 }
 
 void oe_ec_private_key_init(oe_ec_private_key_t* private_key, EVP_PKEY* pkey)
 {
-    return oe_private_key_init(
-        (oe_private_key_t*)private_key, pkey, _PRIVATE_KEY_MAGIC);
+    oe_private_key_init(
+        (oe_private_key_t*)private_key, pkey, OE_RSA_PRIVATE_KEY_MAGIC);
 }
 
 oe_result_t oe_ec_private_key_read_pem(
@@ -270,7 +265,7 @@ oe_result_t oe_ec_private_key_read_pem(
         pem_size,
         (oe_private_key_t*)private_key,
         EVP_PKEY_EC,
-        _PRIVATE_KEY_MAGIC);
+        OE_RSA_PRIVATE_KEY_MAGIC);
 }
 
 oe_result_t oe_ec_private_key_write_pem(
@@ -283,7 +278,7 @@ oe_result_t oe_ec_private_key_write_pem(
         pem_data,
         pem_size,
         _private_key_write_pem_callback,
-        _PRIVATE_KEY_MAGIC);
+        OE_RSA_PRIVATE_KEY_MAGIC);
 }
 
 oe_result_t oe_ec_public_key_read_pem(
@@ -296,30 +291,31 @@ oe_result_t oe_ec_public_key_read_pem(
         pem_size,
         (oe_public_key_t*)public_key,
         EVP_PKEY_EC,
-        _PUBLIC_KEY_MAGIC);
+        OE_RSA_PUBLIC_KEY_MAGIC);
 }
 
 oe_result_t oe_ec_public_key_write_pem(
-    const oe_ec_public_key_t* private_key,
+    const oe_ec_public_key_t* public_key,
     uint8_t* pem_data,
     size_t* pem_size)
 {
     return oe_public_key_write_pem(
-        (const oe_public_key_t*)private_key,
+        (const oe_public_key_t*)public_key,
         pem_data,
         pem_size,
-        _PUBLIC_KEY_MAGIC);
+        OE_RSA_PUBLIC_KEY_MAGIC);
 }
 
 oe_result_t oe_ec_private_key_free(oe_ec_private_key_t* private_key)
 {
     return oe_private_key_free(
-        (oe_private_key_t*)private_key, _PRIVATE_KEY_MAGIC);
+        (oe_private_key_t*)private_key, OE_RSA_PRIVATE_KEY_MAGIC);
 }
 
 oe_result_t oe_ec_public_key_free(oe_ec_public_key_t* public_key)
 {
-    return oe_public_key_free((oe_public_key_t*)public_key, _PUBLIC_KEY_MAGIC);
+    return oe_public_key_free(
+        (oe_public_key_t*)public_key, OE_RSA_PUBLIC_KEY_MAGIC);
 }
 
 oe_result_t oe_ec_private_key_sign(
@@ -337,7 +333,7 @@ oe_result_t oe_ec_private_key_sign(
         hash_size,
         signature,
         signature_size,
-        _PRIVATE_KEY_MAGIC);
+        OE_RSA_PRIVATE_KEY_MAGIC);
 }
 
 oe_result_t oe_ec_public_key_verify(
@@ -355,7 +351,7 @@ oe_result_t oe_ec_public_key_verify(
         hash_size,
         signature,
         signature_size,
-        _PUBLIC_KEY_MAGIC);
+        OE_RSA_PUBLIC_KEY_MAGIC);
 }
 
 oe_result_t oe_ec_generate_key_pair(
@@ -554,7 +550,7 @@ oe_result_t oe_ec_public_key_from_coordinates(
 
         /* Initialize the public key */
         {
-            oe_public_key_init(impl, pkey, _PUBLIC_KEY_MAGIC);
+            oe_public_key_init(impl, pkey, OE_RSA_PUBLIC_KEY_MAGIC);
             pkey = NULL;
         }
     }

--- a/include/openenclave/internal/crypto/cert.h
+++ b/include/openenclave/internal/crypto/cert.h
@@ -264,7 +264,7 @@ oe_result_t oe_cert_chain_get_cert(
  *
  * @return OE_OK success
  * @return OE_INVALID_PARAMETER a parameter is invalid
- * @return OE_NOT_FOUND no self-signed certificate was found
+ * @return OE_NOT_FOUND chain is empty or no self-signed certificate was found
  * @return OE_FAILURE general failure
  */
 oe_result_t oe_cert_chain_get_root_cert(
@@ -283,6 +283,7 @@ oe_result_t oe_cert_chain_get_root_cert(
  *
  * @return OE_OK success
  * @return OE_INVALID_PARAMETER a parameter is invalid
+ * @return OE_NOT_FOUND certificate chain is empty
  * @return OE_FAILURE general failure
  */
 oe_result_t oe_cert_chain_get_leaf_cert(


### PR DESCRIPTION
This changeset breaks out some of the refactor changes for supporting BCrypt on windows:

- Add host/crypto/magic.h for magic number reuse between openssl and bcrypt.
- Consolidate `oe_cert_chain_get_root_cert()` and `oe_cert_chain_get_leaf_cert()` implementations in common/cert.c.