### PR TITLE
Enable tests/crypto/host random tests on Windows

### DIFF
--- a/common/sgx/rand.asm
+++ b/common/sgx/rand.asm
@@ -20,6 +20,6 @@ _rdrand_retry:
 
 	ret
 
-_rdrand ENDP
+oe_rdrand ENDP
 
 END

--- a/tests/crypto/data/CMakeLists.txt
+++ b/tests/crypto/data/CMakeLists.txt
@@ -35,6 +35,7 @@ add_custom_target(
         root.ec.key.pem
         root.ec.public.key.pem
         root2.cert.pem
+        self_signed.cert.der
         test_ec_signature
         test_rsa_signature
         time.txt

--- a/tests/crypto/host/CMakeLists.txt
+++ b/tests/crypto/host/CMakeLists.txt
@@ -1,21 +1,31 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# Disable on Windows until host-side crypto is implemented
+# OS-specific source files
 if (UNIX)
-add_executable(hostcrypto
-    main.c
+  set(PLATFORM_SRC
     ../../../common/sgx/rand.S
-    ../read_file.c
     ../asn1_tests.c
     ../crl_tests.c
     ../ec_tests.c
+    ../read_file.c
+    ../rsa_tests.c
+)
+elseif (WIN32)
+  set(PLATFORM_SRC
+    ../../../common/sgx/rand.asm)
+else()
+  message(FATAL_ERROR "Unknown OS. Only supported OSes are Linux and Windows")
+endif()
+
+add_executable(hostcrypto
+    ${PLATFORM_SRC}
+    main.c
     ../hash.c
     ../hmac_tests.c
     ../kdf_tests.c
     ../random_tests.c
     ../rdrand_test.c
-    ../rsa_tests.c
     ../sha_tests.c
     ../tests.c
     ../utils.c)
@@ -23,5 +33,3 @@ add_executable(hostcrypto
 add_dependencies(hostcrypto crypto_test_data)
 target_link_libraries(hostcrypto oehost)
 add_test(tests/crypto/host hostcrypto)
-
-endif()

--- a/tests/crypto/random_tests.c
+++ b/tests/crypto/random_tests.c
@@ -8,39 +8,41 @@
 #include <openenclave/internal/random.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "tests.h"
+
+#define SEQ_COUNT 64
+#define SEQ_LENGTH 19
 
 void TestRandom(void)
 {
     printf("=== begin %s()\n", __FUNCTION__);
 
-    static const size_t N = 64;
-    static const size_t M = 19;
-    uint8_t buf[N][M];
-
+    uint8_t buf[SEQ_COUNT][SEQ_LENGTH];
     memset(buf, 0, sizeof(buf));
 
-    for (size_t i = 0; i < N; i++)
+    for (size_t i = 0; i < SEQ_COUNT; i++)
     {
         /* Generate a random sequence */
-        OE_TEST(oe_random_internal(buf[i], M * sizeof(uint8_t)) == OE_OK);
+        OE_TEST(
+            oe_random_internal(buf[i], SEQ_LENGTH * sizeof(uint8_t)) == OE_OK);
 
         /* Be sure buffer is not filled with same character */
         {
             size_t m;
             uint8_t c = buf[i][0];
 
-            for (m = 1; m < M && buf[i][m] == c; m++)
+            for (m = 1; m < SEQ_LENGTH && buf[i][m] == c; m++)
                 ;
 
-            OE_TEST(m != M);
+            OE_TEST(m != SEQ_LENGTH);
         }
 
         /* Check whether duplicate of one of the previous calls */
         for (size_t j = 0; j < i; j++)
         {
-            OE_TEST(memcmp(buf[j], buf[i], M * sizeof(uint8_t)) != 0);
+            OE_TEST(memcmp(buf[j], buf[i], SEQ_LENGTH * sizeof(uint8_t)) != 0);
         }
     }
 

--- a/tests/crypto/tests.c
+++ b/tests/crypto/tests.c
@@ -9,10 +9,10 @@ void TestAll()
     TestASN1();
     TestCRL();
     TestEC();
-    TestRandom();
-    TestRdrand();
     TestRSA();
 #endif
+    TestRandom();
+    TestRdrand();
     TestHMAC();
     TestKDF();
     TestSHA();


### PR DESCRIPTION
- Enable `TestRandom()` and `TestRdrand()` on Windows host.
- Fix syntax error in common/sgx/rand.asm
- Fix missing byproduct declaration in tests/crypto/data/CMakelists.txt
- Rename random_tests.c constants for clarity.