### PR TITLE
Clean up oe_memalign semantics in enclave.

### DIFF
--- a/common/oe_host_stdlib.h
+++ b/common/oe_host_stdlib.h
@@ -43,12 +43,7 @@ void* oe_realloc(void* ptr, size_t size)
     return realloc(ptr, size);
 }
 
-/* oe_memalign has an implementation on the host side.
- * TODO: oehost implements this to split between Win32 & Linux impls,
- * but expects that oe_memalign is paired with oe_memalign_free for Win32.
- * This will be a problem for common code shared between host & enclave,
- * though as of v0.41, nothing in common uses oe_memalign.
- */
+/* oe_memalign & oe_memalign_free have implementations on the host side. */
 
 OE_INLINE
 int oe_posix_memalign(void** memptr, size_t alignment, size_t size)

--- a/enclave/core/malloc.c
+++ b/enclave/core/malloc.c
@@ -88,6 +88,11 @@ void oe_free(void* ptr)
     FREE(ptr);
 }
 
+void oe_memalign_free(void* ptr)
+{
+    FREE(ptr);
+}
+
 void* oe_calloc(size_t nmemb, size_t size)
 {
     void* p = CALLOC(nmemb, size);

--- a/include/openenclave/corelibc/stdlib.h
+++ b/include/openenclave/corelibc/stdlib.h
@@ -31,6 +31,8 @@ void* oe_calloc(size_t nmemb, size_t size);
 
 void* oe_realloc(void* ptr, size_t size);
 
+void oe_memalign_free(void* ptr);
+
 void* oe_memalign(size_t alignment, size_t size);
 
 int oe_posix_memalign(void** memptr, size_t alignment, size_t size);


### PR DESCRIPTION
- Add oe_memalign_free in enclave.
- Remove redundant `public_key_pem` and `private_key_pem` globals in ec_tests.c
- Update ec_tests.c to dynamically allocate aligned memory for `_test_crl_distribution_points()`

Fixes #1444
