### PR TITLE
Update Visual Studio builds to support DCAP libraries

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -31,7 +31,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${workspaceRoot}\\build\\x64-Debug",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1",
+      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1 -DUSE_LIBSGX=1",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     },
@@ -42,7 +42,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${workspaceRoot}\\build\\x64-RelWithDebInfo",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1",
+      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1 -DUSE_LIBSGX=1",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     },
@@ -53,7 +53,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${workspaceRoot}\\build\\x64-Release",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1",
+      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1 -DUSE_LIBSGX=1",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     }

--- a/host/sgx/windows/sgxquoteproviderloader.c
+++ b/host/sgx/windows/sgxquoteproviderloader.c
@@ -6,8 +6,6 @@
 #include <stdlib.h>
 #include "../sgxquoteprovider.h"
 
-#ifdef OE_USE_LIBSGX
-
 oe_sgx_quote_provider_t provider = {0};
 
 static void _unload_quote_provider()
@@ -87,5 +85,3 @@ void oe_load_quote_provider()
         }
     }
 }
-
-#endif

--- a/scripts/clangw
+++ b/scripts/clangw
@@ -41,10 +41,12 @@ function call_clang {
         [ "$a" == "/RTC1" ]         && continue
         [ "$a" == "/FS" ]           && continue
         [ "$a" == "/showIncludes" ] && continue
+        [ "$a" == "/JMC" ]          && continue
 
         # Map the following arguments
         [ "$a" == "/DNDEBUG" ]   && args+="-DNDEBUG "   && continue
-        [ "$a" == "/Zi" ]        && args+="-g "        && continue
+        [ "$a" == "/Zi" ]        && args+="-g "         && continue
+        [ "$a" == "/ZI" ]        && args+="-g "         && continue
         [ "$a" == "/O2" ]        && args+="-O2 "        && continue
         [ "$a" == "-std:c++11" ] && args+="-std=c++11 " && continue
         [ "$a" == "-std:c++14" ] && args+="-std=c++14 " && continue


### PR DESCRIPTION
- Add `-DUSE_LIBSGX=1` option to all CMakeSettings.json build configuration.
- Update build of sgxquoteprovider.c to be independent of `OE_USE_LIBSGX`
- Update scripts/clangw to support VS2019