### PR TITLE
Create oedebugrt.dll on Windows

### DIFF
--- a/debugger/debugrt/host/CMakeLists.txt
+++ b/debugger/debugrt/host/CMakeLists.txt
@@ -10,14 +10,15 @@ if (UNIX)
 
   install(TARGETS oedebugrt EXPORT openenclave-targets)
 else()
-  #TODO: Switch to DLL on Windows
-  add_library(oedebugrt OBJECT
+  add_library(oedebugrt SHARED
     host.c)
 
+  target_compile_definitions(oedebugrt PRIVATE
+    OE_BUILDING_DEBUGRT_SHARED_LIBRARY)
+  
   install(TARGETS oedebugrt EXPORT openenclave-targets
     # TODO:Determine DLL install location on Windows
-    # ARCHIVE DESTINATION ${CMAKE_INSTALL_BINDIR}
-    )
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 target_include_directories(oedebugrt PRIVATE

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -163,6 +163,12 @@ elseif(OE_TRUSTZONE)
   set(PLATFORM_FLAGS "")
 endif()
 
+if (OE_SGX AND WIN32)
+  # oedebugrt is accessed via a bridge on Win32 and need not be linked.    
+  list(APPEND PLATFORM_SRC
+    sgx/windows/debugrtbridge.c)
+endif()
+
 # Combine with all other non platform dependent files.
 add_library(oehost STATIC
   ../common/datetime.c
@@ -194,7 +200,8 @@ if(WIN32)
   target_link_libraries(oehost PUBLIC ws2_32)
 endif()
 
-if(OE_SGX)
+if (OE_SGX AND UNIX)
+  # Link oedebugrt static library.
   target_link_libraries(oehost PRIVATE oedebugrt)
 endif()
 

--- a/host/sgx/windows/debugrtbridge.c
+++ b/host/sgx/windows/debugrtbridge.c
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <Windows.h>
+#include <openenclave/internal/debugrt/host.h>
+#include <openenclave/internal/trace.h>
+#include "../../hostthread.h"
+
+static struct
+{
+    oe_once_type once;
+    HMODULE hmodule;
+    oe_result_t (*notify_enclave_created)(oe_debug_enclave_t* enclave);
+    oe_result_t (*notify_enclave_terminated)(oe_debug_enclave_t* enclave);
+    oe_result_t (*push_thread_binding)(
+        oe_debug_enclave_t* enclave,
+        struct _sgx_tcs* tcs);
+    oe_result_t (*pop_thread_binding)(void);
+} _oedebugrt;
+
+static void get_debugrt_function(const char* name, FARPROC* out)
+{
+    *out = GetProcAddress(_oedebugrt.hmodule, name);
+    if (*out == NULL)
+    {
+        OE_TRACE_FATAL("Could not find function %s in oedebugrt.dll", name);
+    }
+}
+
+static void load_oedebugrt(void)
+{
+    if (_oedebugrt.hmodule != NULL)
+    {
+        OE_TRACE_FATAL("oedebugrt.dll has already been loaded. Multiple load "
+                       "attempts detected.");
+    }
+
+#ifndef NDEBUG
+    /**
+     *  In debug mode, give preference to OE_DEBUGRT_PATH.
+     *  This is mainly used for OE SDK development.
+     */
+    {
+        char* debugrtpath = getenv("OE_DEBUGRT_PATH");
+        _oedebugrt.hmodule = LoadLibraryExA(
+            debugrtpath,
+            NULL, /* reserved */
+            /* Search only specified path. */
+            LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    }
+
+#endif
+
+    /* Search for oedebugrt.dll only in the application folder. */
+    if (_oedebugrt.hmodule == NULL)
+    {
+        _oedebugrt.hmodule = LoadLibraryExA(
+            "oedebugrt.dll",
+            NULL, /* reserved */
+            LOAD_LIBRARY_SEARCH_APPLICATION_DIR);
+    }
+
+    if (_oedebugrt.hmodule != NULL)
+    {
+        get_debugrt_function(
+            "oe_debug_notify_enclave_created",
+            (FARPROC*)&_oedebugrt.notify_enclave_created);
+        get_debugrt_function(
+            "oe_debug_notify_enclave_terminated",
+            (FARPROC*)&_oedebugrt.notify_enclave_terminated);
+        get_debugrt_function(
+            "oe_debug_push_thread_binding",
+            (FARPROC*)&_oedebugrt.push_thread_binding);
+        get_debugrt_function(
+            "oe_debug_pop_thread_binding",
+            (FARPROC*)&_oedebugrt.pop_thread_binding);
+
+        OE_TRACE_INFO(
+            "oedebugrtbridge: Loaded oedebugrt.dll. Debugging is available.\n");
+    }
+    else
+    {
+        DWORD error = GetLastError();
+        OE_TRACE_INFO(
+            "oedebugrtbridge: LoadLibraryEx on oedebugrt.dll error"
+            "= %#x. Debugging is unavailable.\n",
+            error);
+    }
+}
+
+static void initialize()
+{
+    oe_once(&_oedebugrt.once, &load_oedebugrt);
+}
+
+oe_result_t oe_debug_notify_enclave_created(oe_debug_enclave_t* enclave)
+{
+    initialize();
+    if (_oedebugrt.notify_enclave_created)
+        return _oedebugrt.notify_enclave_created(enclave);
+
+    return OE_OK;
+}
+
+oe_result_t oe_debug_notify_enclave_terminated(oe_debug_enclave_t* enclave)
+{
+    initialize();
+    if (_oedebugrt.notify_enclave_terminated)
+        return _oedebugrt.notify_enclave_terminated(enclave);
+
+    return OE_OK;
+}
+
+oe_result_t oe_debug_push_thread_binding(
+    oe_debug_enclave_t* enclave,
+    struct _sgx_tcs* tcs)
+{
+    initialize();
+    if (_oedebugrt.push_thread_binding)
+        return _oedebugrt.push_thread_binding(enclave, tcs);
+
+    return OE_OK;
+}
+
+oe_result_t oe_debug_pop_thread_binding()
+{
+    initialize();
+    if (_oedebugrt.pop_thread_binding)
+        return _oedebugrt.pop_thread_binding();
+
+    return OE_OK;
+}

--- a/host/sgx/windows/debugrtbridge.c
+++ b/host/sgx/windows/debugrtbridge.c
@@ -95,7 +95,6 @@ static void initialize()
 
 oe_result_t oe_debug_notify_enclave_created(oe_debug_enclave_t* enclave)
 {
-    initialize();
     if (_oedebugrt.notify_enclave_created)
         return _oedebugrt.notify_enclave_created(enclave);
 
@@ -104,7 +103,6 @@ oe_result_t oe_debug_notify_enclave_created(oe_debug_enclave_t* enclave)
 
 oe_result_t oe_debug_notify_enclave_terminated(oe_debug_enclave_t* enclave)
 {
-    initialize();
     if (_oedebugrt.notify_enclave_terminated)
         return _oedebugrt.notify_enclave_terminated(enclave);
 
@@ -115,7 +113,6 @@ oe_result_t oe_debug_push_thread_binding(
     oe_debug_enclave_t* enclave,
     struct _sgx_tcs* tcs)
 {
-    initialize();
     if (_oedebugrt.push_thread_binding)
         return _oedebugrt.push_thread_binding(enclave, tcs);
 
@@ -124,7 +121,6 @@ oe_result_t oe_debug_push_thread_binding(
 
 oe_result_t oe_debug_pop_thread_binding()
 {
-    initialize();
     if (_oedebugrt.pop_thread_binding)
         return _oedebugrt.pop_thread_binding();
 

--- a/host/sgx/windows/debugrtbridge.c
+++ b/host/sgx/windows/debugrtbridge.c
@@ -4,6 +4,7 @@
 #include <Windows.h>
 #include <openenclave/internal/debugrt/host.h>
 #include <openenclave/internal/trace.h>
+#include <stdlib.h>
 #include "../../hostthread.h"
 
 static struct
@@ -31,8 +32,8 @@ static void load_oedebugrt(void)
 {
     if (_oedebugrt.hmodule != NULL)
     {
-        OE_TRACE_FATAL("oedebugrt.dll has already been loaded. Multiple load "
-                       "attempts detected.");
+        OE_TRACE_WARNING("oedebugrt.dll has already been loaded.");
+        return;
     }
 
 #ifndef NDEBUG
@@ -88,9 +89,18 @@ static void load_oedebugrt(void)
     }
 }
 
+static void cleanup(void)
+{
+    if (_oedebugrt.hmodule != NULL)
+    {
+        FreeLibrary(_oedebugrt.hmodule);
+    }
+}
+
 static void initialize()
 {
     oe_once(&_oedebugrt.once, &load_oedebugrt);
+    atexit(&cleanup);
 }
 
 oe_result_t oe_debug_notify_enclave_created(oe_debug_enclave_t* enclave)

--- a/include/openenclave/internal/debugrt/host.h
+++ b/include/openenclave/internal/debugrt/host.h
@@ -16,6 +16,26 @@
 #include <stdint.h>
 #include <wchar.h>
 
+/**
+ * If debugrt is built as a shared library, then symbols are exported.
+ * Otherwise, symbols are not exported.
+ *
+ * In Linux, debugrt is built as a static library that the host application
+ * links against. The debugrt is subsumed by the host application.
+ *
+ * In Windows, debugrt is built as a shared library. The host application
+ * dynamically loads oedebugrt.dll and calls functions via a bridge.
+ * This allows applications to be executed even when oedeburt.dll is not found
+ * on the system. Additionally, release enclaves are completely decoupled from
+ * oedeburt.dll. See host/sgx/windows/debugrtbridge.c
+ */
+
+#ifdef OE_BUILDING_DEBUGRT_SHARED_LIBRARY
+#define OE_DEBUGRT_EXPORT OE_EXPORT
+#else
+#define OE_DEBUGRT_EXPORT
+#endif
+
 OE_EXTERNC_BEGIN
 
 #define OE_DEBUG_ENCLAVE_VERSION 1
@@ -62,20 +82,19 @@ typedef struct _debug_thread_binding_t
 {
     uint64_t magic;
     uint64_t version;
+    struct _debug_thread_binding_t* next;
 
     uint64_t thread_id;
     oe_debug_enclave_t* enclave;
     struct _sgx_tcs* tcs;
-
-    struct _debug_thread_binding_t* next;
 } oe_debug_thread_binding_t;
 
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, magic) == 0);
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, version) == 8);
-OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, thread_id) == 16);
-OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, enclave) == 24);
-OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, tcs) == 32);
-OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, next) == 40);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, next) == 16);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, thread_id) == 24);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, enclave) == 32);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, tcs) == 40);
 
 ////////////////////////////////////////////////////////////////////////////////
 /////////////// Symbols Exported by the Runtime ////////////////////////////////
@@ -90,21 +109,22 @@ OE_STATIC_ASSERT(OE_OFFSETOF(oe_debug_thread_binding_t, next) == 40);
  * the debugger is expected to advise the user to use a newer version of the
  * that understands the specific version of the contract.
  */
-OE_EXPORT extern uint32_t oe_debugger_contract_version;
+OE_DEBUGRT_EXPORT extern uint32_t oe_debugger_contract_version;
 
 /**
  * The list of loaded enclaves.
  * Upon attaching to an application, the debugger can scan this list
  * and configure the enclaves for debugging.
  */
-OE_EXPORT extern oe_debug_enclave_t* oe_debug_enclaves_list;
+OE_DEBUGRT_EXPORT extern oe_debug_enclave_t* oe_debug_enclaves_list;
 
 /**
  * The list of active thread bindings.
  * The debugger can scan this list to find the list of bindings.
  * Note: Ideally, this list could be stored per thread in thread-local storage.
  */
-OE_EXPORT extern oe_debug_thread_binding_t* oe_debug_thread_bindings_list;
+OE_DEBUGRT_EXPORT extern oe_debug_thread_binding_t*
+    oe_debug_thread_bindings_list;
 
 ////////////////////////////////////////////////////////////////////////////////
 /////////////// Events Raised for Windows Debuggers/////////////////////////////
@@ -147,26 +167,26 @@ OE_EXPORT extern oe_debug_thread_binding_t* oe_debug_thread_bindings_list;
  * Notify debugrt that an enclave has been created.
  * This notification must be done before initializing the enclave.
  */
-OE_EXPORT oe_result_t
+OE_DEBUGRT_EXPORT oe_result_t
 oe_debug_notify_enclave_created(oe_debug_enclave_t* enclave);
 
 /**
  * Notify debugrt that and enclave has been terminated.
  * This notification must be done after calling enclave destructors.
  */
-OE_EXPORT oe_result_t
+OE_DEBUGRT_EXPORT oe_result_t
 oe_debug_notify_enclave_terminated(oe_debug_enclave_t* enclave);
 
 /**
  * Notify debugrt about a new binding for current thread.
  */
-OE_EXPORT oe_result_t
+OE_DEBUGRT_EXPORT oe_result_t
 oe_debug_push_thread_binding(oe_debug_enclave_t* enclave, struct _sgx_tcs* tcs);
 
 /**
  * Pop the last binding for the current thread.
  */
-OE_EXPORT oe_result_t oe_debug_pop_thread_binding();
+OE_DEBUGRT_EXPORT oe_result_t oe_debug_pop_thread_binding(void);
 
 OE_EXTERNC_END
 


### PR DESCRIPTION
Housing debugger metadata in a separate DLL is best practice on windows.

On Linux:
  oedebugrt is built as a static library. Therefore no symbols are
  exported. OE_DEBUGRT_EXPORT is null. Debugrt is subsumed into
  the oehost library which is expected to have debug symbols for
  debugging to work.

On Windows:
   oedebugrt is built as a separate DLL. oehost does not directly link
   against oedebugrt.dll. Instead it uses a bridge that dynamically
   load oedebugrt.dll via LoadLibraryEx and then calls into it via
   the bridge.
   This has the following benefits:
     a) Enclave applications can run even when oedebugrt.dll is not
        present in the system
     b) Release mode applications are completely decoupled from
        oedebugrt.dll
   The installation/packaging/signing/loading story for oedebugrt.dll
   will be similar to other DLLs that oehost will use.

Also change the order of fields for oe_debug_thread_binding_t.
The next field is grouped together with magic and version fields.
There are the common fields that all structures share.