### PR TITLE
Initialize oedebugrt bridge.

### DIFF
--- a/host/sgx/windows/debugrtbridge.c
+++ b/host/sgx/windows/debugrtbridge.c
@@ -105,6 +105,7 @@ static void initialize()
 
 oe_result_t oe_debug_notify_enclave_created(oe_debug_enclave_t* enclave)
 {
+    initialize();
     if (_oedebugrt.notify_enclave_created)
         return _oedebugrt.notify_enclave_created(enclave);
 


### PR DESCRIPTION
Add back line accidentally deleted in previous checkin.