### PR TITLE
Add design documents folder and template

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -32,9 +32,18 @@ We welcome all questions and suggestions. Everyone is encouraged to open issues
 on GitHub to ask or discuss anything related to the Open Enclave SDK. However,
 security issues and bugs are an exception (see above)!
 
+Design Discussion
+-----------------
+
 You are encouraged to start a discussion with us through a GitHub issue before
 implementing any major changes. We want your contributions, but we also want to
 make sure the community is in agreement before you invest your time.
+
+You may be asked by maintainers to provide a design document before writing an
+implementation. The simplest way to provide this is through a Pull Request to
+our repository with a Markdown style document (like this one) to the
+[docs/DesignDocs](DesignDocs) folder, and see its [readme](DesignDocs/README.md)
+for a template.
 
 Help Wanted
 ------------

--- a/docs/DesignDocs/README.md
+++ b/docs/DesignDocs/README.md
@@ -1,0 +1,45 @@
+Design Documents
+================
+
+This folder contains design documents for various aspects of the Open Enclave
+SDK. To propose a complicated change, please open a Pull Request to this folder
+with a new Markdown document. See below for a suggested template. The PR will be
+used to provide commentary and iterations to the design. When it is accepted,
+implementation can safely begin (however, feel free to prototype in order to
+experiment and provide more details).
+
+___
+
+Title
+=====
+
+What does this design document describe?
+
+Motivation
+----------
+
+Who needs this?
+
+Why do they need it?
+
+User Experience
+---------------
+
+What will the use of this look like?
+
+Specification
+-------------
+
+What are the design details?
+
+Alternates
+----------
+
+What other designs were considers?
+
+Why were they discarded in favor of this design?
+
+Authors
+-------
+
+Who are you and how can we contact you in the future?


### PR DESCRIPTION
This adds a basic suggestion for how to provide design documents (AKA RFCs) to us, and how we can review and iterate on those.