### PR TITLE
Added package for verifying reports on non-TEE environments.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,3 +221,8 @@ endif()
 
 install(FILES LICENSE THIRD_PARTY_NOTICES
   DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/licenses)
+
+# Configure all the CPACK settings. This must be last because
+# CPack must be aware of all the component information in order
+# for it to create different component based packages.
+include(cpack_settings)

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# CPack variables for the regular OE SDK.
+include(InstallRequiredSystemLibraries)
+set(CPACK_PACKAGE_NAME "open-enclave")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Open Enclave SDK")
+set(CPACK_PACKAGE_CONTACT "openenclave@microsoft.com")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/README.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+set(CPACK_PACKAGE_VERSION ${OE_VERSION})
+set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsgx-enclave-common (>=2.3.100.46354-1), libsgx-enclave-common-dev (>=2.3.100.0-1), libsgx-dcap-ql (>=1.0.100.46460-1.0), libsgx-dcap-ql-dev (>=1.0.100.46460-1.0), pkg-config")
+
+# CPack variables for the non-enclave host verification package.
+# We match the naming convention of the OE SDK package by setting the
+# CPACK_DEBIAN_OEHOSTVERIFY_FILE_NAME field.
+set(CPACK_DEBIAN_OEHOSTVERIFY_PACKAGE_NAME "open-enclave-hostverify")
+set(CPACK_DEBIAN_OEHOSTVERIFY_FILE_NAME "${CPACK_DEBIAN_OEHOSTVERIFY_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-Linux.deb")
+set(CPACK_COMPONENT_OEHOSTVERIFY_DESCRIPTION "Open Enclave Report Verification Host Library")
+set(CPACK_DEBIAN_OEHOSTVERIFY_PACKAGE_DEPENDS "pkg-config")
+include(CPack)

--- a/cmake/package_settings.cmake
+++ b/cmake/package_settings.cmake
@@ -39,30 +39,21 @@ write_basic_package_version_file(
 install(
   FILES ${CMAKE_BINARY_DIR}/cmake/openenclave-config.cmake
   ${CMAKE_BINARY_DIR}/cmake/openenclave-config-version.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
+  COMPONENT OEHOSTVERIFY)
 install(
   EXPORT openenclave-targets
   NAMESPACE openenclave::
   # Note that this is used in `openenclaverc` to set the path for
   # users of the SDK and so must remain consistent.
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
-  FILE openenclave-targets.cmake)
+  FILE openenclave-targets.cmake
+  COMPONENT OEHOSTVERIFY)
 install(
   FILES ${PROJECT_SOURCE_DIR}/cmake/sdk_cmake_targets_readme.md
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
-  RENAME README.md)
-
-# CPack package handling
-include(InstallRequiredSystemLibraries)
-set(CPACK_PACKAGE_NAME "open-enclave")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Open Enclave SDK")
-set(CPACK_PACKAGE_CONTACT "openenclave@microsoft.com")
-set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/README.md")
-set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
-set(CPACK_PACKAGE_VERSION ${OE_VERSION})
-set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsgx-enclave-common (>=2.3.100.46354-1), libsgx-enclave-common-dev (>=2.3.100.0-1), libsgx-dcap-ql (>=1.0.100.46460-1.0), libsgx-dcap-ql-dev (>=1.0.100.46460-1.0), pkg-config")
-include(CPack)
+  RENAME README.md
+  COMPONENT OEHOSTVERIFY)
 
 # Generate the openenclaverc script.
 configure_file(
@@ -74,4 +65,5 @@ configure_file(
 install(FILES
     ${CMAKE_BINARY_DIR}/output/share/openenclave/openenclaverc
     DESTINATION
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/openenclave")
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/openenclave"
+    COMPONENT OEHOSTVERIFY)

--- a/common/sgx/quote.c
+++ b/common/sgx/quote.c
@@ -134,7 +134,7 @@ done:
     return result;
 }
 
-oe_result_t VerifyQuoteImpl(
+oe_result_t oe_verify_quote_internal(
     const uint8_t* quote,
     size_t quote_size,
     const uint8_t* pem_pck_certificate,

--- a/common/sgx/quote.h
+++ b/common/sgx/quote.h
@@ -10,7 +10,7 @@
 
 OE_EXTERNC_BEGIN
 
-oe_result_t VerifyQuoteImpl(
+oe_result_t oe_verify_quote_internal(
     const uint8_t* enc_quote,
     size_t quote_size,
     const uint8_t* enc_pem_pck_certificate,

--- a/common/sgx/tlsverifier.c
+++ b/common/sgx/tlsverifier.c
@@ -127,7 +127,7 @@ oe_result_t oe_verify_attestation_certificate(
 #ifdef OE_BUILD_ENCLAVE
     result = oe_verify_report(report, report_size, &parsed_report);
 #else
-    result = oe_verify_report(NULL, report, report_size, &parsed_report);
+    result = oe_verify_remote_report(report, report_size, &parsed_report);
 #endif
     OE_CHECK(result);
     OE_TRACE_VERBOSE("quote validation succeeded");

--- a/docs/GettingStartedDocs/Contributors/InstallInfo.md
+++ b/docs/GettingStartedDocs/Contributors/InstallInfo.md
@@ -64,3 +64,14 @@ as above. For example, to create a Debian package that will install the SDK to
 cmake -DCMAKE_INSTALL_PREFIX=/opt/openenclave ..
 cpack -G DEB
 ```
+
+## Create the host-only report verification package
+
+The host-only report verification package allows non-enclave applications to
+validate remote reports from enclaves. The process to create this package
+is almost the same as the normal OE SDK. The only difference is the `cpack`
+command as shown below:
+
+```bash
+cpack -G DEB -D CPACK_DEB_COMPONENT_INSTALL=ON  -D CPACK_COMPONENTS_ALL=OEHOSTVERIFY
+```

--- a/enclave/sgx/report.c
+++ b/enclave/sgx/report.c
@@ -66,7 +66,7 @@ oe_result_t oe_verify_report(
 
     if (header->report_type == OE_REPORT_TYPE_SGX_REMOTE)
     {
-        OE_CHECK(VerifyQuoteImpl(
+        OE_CHECK(oe_verify_quote_internal(
             header->report, header->report_size, NULL, 0, NULL, 0, NULL, 0));
     }
     else if (header->report_type == OE_REPORT_TYPE_SGX_LOCAL)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -64,25 +64,27 @@ add_custom_target(syscall_untrusted_edl
 
 # OS specific but arch agnostic files.
 if (UNIX)
-  set(PLATFORM_SRC
-    ../common/asn1.c
+  set(PLATFORM_HOST_ONLY_SRC
     ../common/cert.c
     crypto/openssl/asn1.c
     crypto/openssl/cert.c
     crypto/openssl/crl.c
     crypto/openssl/ec.c
-    crypto/openssl/hmac.c
     crypto/openssl/init.c
     crypto/openssl/key.c
-    crypto/openssl/random.c
     crypto/openssl/rsa.c
     crypto/openssl/sha.c
-    linux/hostthread.c
+    linux/hostthread.c)
+
+  set(PLATFORM_SDK_ONLY_SRC
+    ../common/asn1.c
+    crypto/openssl/hmac.c
+    crypto/openssl/random.c
     linux/syscall.c
     linux/time.c
     linux/windows.c)
 elseif (WIN32)
-  set(PLATFORM_SRC
+  set(PLATFORM_SDK_ONLY_SRC
     ../3rdparty/mbedtls/mbedtls/library/bignum.c
     ../common/asn1.c
     ../common/cert.c
@@ -102,9 +104,9 @@ else()
   message(FATAL_ERROR "Unknown OS. Only supported OSes are Linux and Windows")
 endif()
 
-# SGX specific files
+# SGX specific files.
 if (OE_SGX)
-  list(APPEND PLATFORM_SRC
+  list(APPEND PLATFORM_HOST_ONLY_SRC
     ../common/sgx/qeidentity.c
     ../common/sgx/quote.c
     ../common/sgx/report.c
@@ -112,6 +114,10 @@ if (OE_SGX)
     ../common/sgx/sgxcertextensions.c
     ../common/sgx/tcbinfo.c
     ../common/sgx/tlsverifier.c
+    sgx/hostverify_report.c
+    sgx/sgxquoteprovider.c)
+
+  list(APPEND PLATFORM_SDK_ONLY_SRC
     sgx/calls.c
     sgx/create.c
     sgx/elf.c
@@ -129,23 +135,24 @@ if (OE_SGX)
     sgx/sgxload.c
     sgx/sgxmeasure.c
     sgx/sgxquote.c
-    sgx/sgxquoteprovider.c
     sgx/sgxsign.c
     sgx/sgxtypes.c)
 
   # OS specific as well.
   if (UNIX)
-    list(APPEND PLATFORM_SRC
+    list(APPEND PLATFORM_HOST_ONLY_SRC
+        sgx/linux/sgxquoteproviderloader.c)
+
+    list(APPEND PLATFORM_SDK_ONLY_SRC
       sgx/linux/aep.S
       sgx/linux/aesm.c
       sgx/linux/enter.S
       sgx/linux/entersim.S
       sgx/linux/exception.c
       sgx/linux/sgxioctl.c
-      sgx/linux/sgxquoteproviderloader.c
       sgx/linux/xstate.c)
   else()
-    list(APPEND PLATFORM_SRC
+    list(APPEND PLATFORM_SDK_ONLY_SRC
       sgx/windows/aep.asm
       sgx/windows/aesm.c
       sgx/windows/enter.asm
@@ -157,11 +164,11 @@ if (OE_SGX)
 
   set(PLATFORM_FLAGS "-m64")
 elseif(OE_TRUSTZONE)
-  list(APPEND PLATFORM_SRC
+  list(APPEND PLATFORM_SDK_ONLY_SRC
     optee/log.c)
   
   if (UNIX)
-    list(APPEND PLATFORM_SRC
+    list(APPEND PLATFORM_SDK_ONLY_SRC
       optee/linux/enclave.c)
   else()
     message(FATAL_ERROR "OP-TEE is not yet supported on platforms other than Linux.")
@@ -172,16 +179,22 @@ endif()
 
 if (OE_SGX AND WIN32)
   # oedebugrt is accessed via a bridge on Win32 and need not be linked.    
-  list(APPEND PLATFORM_SRC
+  list(APPEND PLATFORM_SDK_ONLY_SRC
     sgx/windows/debugrtbridge.c)
 endif()
 
-# Combine with all other non platform dependent files.
-add_library(oehost STATIC
+# Common host verification files that work on any OS/architecture.
+list(APPEND PLATFORM_HOST_ONLY_SRC
   ../common/datetime.c
+  ../common/safecrt.c
+  hexdump.c
+  result.c
+  traceh.c)
+
+# Common files that are used in the OE SDK only.
+list(APPEND PLATFORM_SDK_ONLY_SRC
   ../common/kdf.c
   ../common/lockless_queue.c
-  ../common/safecrt.c
   ../common/argv.c
   asym_keys.c
   calls.c
@@ -190,17 +203,23 @@ add_library(oehost STATIC
   error.c
   files.c
   fopen.c
-  hexdump.c
-  syscall_u_wrapper.c
-  tee_u_wrapper.c
   memalign.c
-  result.c
+  syscall_u_wrapper.c
   signkey.c
   strings.c
+  tee_u_wrapper.c
   tests.c
-  traceh.c
-  ${PLATFORM_SRC})
+  traceh_enclave.c)
 
+# Combine the following common code along with the platform specific code and
+# host verification code to get the full oehost target provided by the OE SDK.
+add_library(oehost STATIC
+  ${PLATFORM_HOST_ONLY_SRC}
+  ${PLATFORM_SDK_ONLY_SRC})
+
+add_library(oehostverify STATIC ${PLATFORM_HOST_ONLY_SRC})
+
+target_link_libraries(oehostverify PUBLIC oe_includes)
 target_link_libraries(oehost PUBLIC oe_includes)
 
 if(WIN32)
@@ -215,7 +234,7 @@ endif()
 add_dependencies(oehost syscall_untrusted_edl)
 add_dependencies(oehost tee_untrusted_edl)
 if(OE_SGX)
-    add_dependencies(oehost sgx_untrusted_edl)
+  add_dependencies(oehost sgx_untrusted_edl)
 endif()
 
 # TODO: Replace these with `find_package` and add as dependencies to
@@ -243,6 +262,7 @@ endif ()
 find_package(Threads REQUIRED)
 
 if (UNIX)
+  target_link_libraries(oehostverify PRIVATE crypto dl Threads::Threads)
   target_link_libraries(oehost PRIVATE crypto dl Threads::Threads)
 
   if (OE_TRUSTZONE)
@@ -328,18 +348,31 @@ if (CMAKE_C_COMPILER_ID MATCHES GNU)
   target_compile_options(oehost PRIVATE -Wjump-misses-init)
 endif ()
 
+# Use the same the compile options and definitions from oehost.
+target_compile_options(oehostverify
+  PRIVATE $<TARGET_PROPERTY:oehost,COMPILE_OPTIONS>
+  INTERFACE $<TARGET_PROPERTY:oehost,INTERFACE_COMPILE_OPTIONS>)
+
+target_compile_definitions(oehostverify
+  PRIVATE $<TARGET_PROPERTY:oehost,COMPILE_DEFINITIONS>
+  INTERFACE $<TARGET_PROPERTY:oehost,INTERFACE_COMPILE_DEFINITIONS>)
+
+
 # TODO: Remove this hard coded output directory.
 set_property(TARGET oehost PROPERTY
   ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/openenclave/host)
 
 # Convenience library for creating a host-app (that needs the
-# -rdynamic link flag).
+# -rdynamic link flag). We do this by default for the oehostverify target too.
 add_library(oehostapp INTERFACE)
 
 target_link_libraries(oehostapp INTERFACE oehost)
 
 if (UNIX)
   target_link_libraries(oehostapp INTERFACE
+      -rdynamic
+      -Wl,-z,noexecstack)
+  target_link_libraries(oehostverify INTERFACE
       -rdynamic
       -Wl,-z,noexecstack)
 endif ()
@@ -349,3 +382,7 @@ install(TARGETS oehost EXPORT openenclave-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host)
 
 install(TARGETS oehostapp EXPORT openenclave-targets)
+
+install(TARGETS oehostverify EXPORT openenclave-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host
+  COMPONENT OEHOSTVERIFY)

--- a/host/crypto/openssl/crl.c
+++ b/host/crypto/openssl/crl.c
@@ -9,6 +9,7 @@
 #include <openenclave/internal/utils.h>
 #include <openssl/asn1.h>
 #include <openssl/x509.h>
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 

--- a/host/sgx/hostverify_report.c
+++ b/host/sgx/hostverify_report.c
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/bits/report.h>
+#include <openenclave/bits/result.h>
+#include <openenclave/host.h>
+#include <openenclave/host_verify.h>
+#include <openenclave/internal/raise.h>
+
+#include "../../common/sgx/quote.h"
+#include "sgxquoteprovider.h"
+
+oe_result_t oe_verify_remote_report(
+    const uint8_t* report,
+    size_t report_size,
+    oe_report_t* parsed_report)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    oe_report_t oe_report = {0};
+    oe_report_header_t* header = (oe_report_header_t*)report;
+
+    if (report == NULL)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    if (report_size == 0 || report_size > OE_MAX_REPORT_SIZE)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    // The two host side attestation API's are oe_get_report and
+    // oe_verify_report. Initialize the quote provider in both these APIs.
+    OE_CHECK(oe_initialize_quote_provider());
+
+    // Ensure that the report is parseable before using the header.
+    OE_CHECK(oe_parse_report(report, report_size, &oe_report));
+
+    if (header->report_type != OE_REPORT_TYPE_SGX_REMOTE)
+        OE_RAISE(OE_UNSUPPORTED);
+
+    // Quote attestation can be done entirely on the host side.
+    OE_CHECK(oe_verify_quote_internal(
+        header->report, header->report_size, NULL, 0, NULL, 0, NULL, 0));
+
+    // Optionally return parsed report.
+    if (parsed_report != NULL)
+        OE_CHECK(oe_parse_report(report, report_size, parsed_report));
+
+    result = OE_OK;
+
+done:
+    return result;
+}

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -4,6 +4,7 @@
 #include <openenclave/bits/safecrt.h>
 #include <openenclave/bits/safemath.h>
 #include <openenclave/host.h>
+#include <openenclave/host_verify.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/report.h>
@@ -293,7 +294,7 @@ oe_result_t oe_verify_report(
         OE_CHECK(oe_initialize_quote_provider());
 
         // Quote attestation can be done entirely on the host side.
-        OE_CHECK(VerifyQuoteImpl(
+        OE_CHECK(oe_verify_quote_internal(
             header->report, header->report_size, NULL, 0, NULL, 0, NULL, 0));
     }
     else if (header->report_type == OE_REPORT_TYPE_SGX_LOCAL)

--- a/host/traceh.c
+++ b/host/traceh.c
@@ -14,18 +14,6 @@
 #include <time.h>
 #include "hostthread.h"
 
-#if defined(__x86_64__) || defined(_M_X64)
-#include "sgx/enclave.h"
-#elif defined(__aarch64__) || defined(_M_ARM64)
-#if defined(__linux__)
-#include "optee/linux/enclave.h"
-#else
-#error "OP-TEE is not yet supported on non-Linux platforms."
-#endif
-#else
-#error "Open Enclave is not supported on this architecture."
-#endif
-
 #define LOGGING_FORMAT_STRING "%02d:%02d:%02d:%06ld tid(0x%lx) (%s)[%s]%s"
 static char* _log_level_strings[OE_LOG_LEVEL_MAX] =
     {"NONE", "FATAL", "ERROR", "WARN", "INFO", "VERBOSE"};

--- a/host/traceh.c
+++ b/host/traceh.c
@@ -26,15 +26,13 @@
 #error "Open Enclave is not supported on this architecture."
 #endif
 
-#include "tee_u.h"
-
 #define LOGGING_FORMAT_STRING "%02d:%02d:%02d:%06ld tid(0x%lx) (%s)[%s]%s"
 static char* _log_level_strings[OE_LOG_LEVEL_MAX] =
     {"NONE", "FATAL", "ERROR", "WARN", "INFO", "VERBOSE"};
 static oe_mutex _log_lock = OE_H_MUTEX_INITIALIZER;
 static const char* _log_file_name = NULL;
 static bool _log_creation_failed_before = false;
-static oe_log_level_t _log_level = OE_LOG_LEVEL_ERROR;
+oe_log_level_t _log_level = OE_LOG_LEVEL_ERROR;
 static bool _initialized = false;
 
 static oe_log_level_t _env2log_level(void)
@@ -74,7 +72,7 @@ done:
     return level;
 }
 
-static void _initialize_log_config()
+void initialize_log_config()
 {
     if (!_initialized)
     {
@@ -165,13 +163,6 @@ static void _log_session_header()
     }
 }
 
-oe_result_t oe_log_enclave_init(oe_enclave_t* enclave)
-{
-    _initialize_log_config();
-
-    return oe_log_init_ecall(enclave, enclave->path, _log_level);
-}
-
 oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...)
 {
     oe_result_t result = OE_UNEXPECTED;
@@ -217,7 +208,7 @@ void oe_log_message(bool is_enclave, oe_log_level_t level, const char* message)
 {
     if (!_initialized)
     {
-        _initialize_log_config();
+        initialize_log_config();
         _log_session_header();
     }
     if (_initialized)

--- a/host/traceh_enclave.c
+++ b/host/traceh_enclave.c
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/calls.h>
+#include <openenclave/internal/trace.h>
+
+#if defined(__x86_64__) || defined(_M_X64)
+#include "sgx/enclave.h"
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__linux__)
+#include "optee/linux/enclave.h"
+#else
+#error "OP-TEE is not yet supported on non-Linux platforms."
+#endif
+#else
+#error "Open Enclave is not supported on this architecture."
+#endif
+
+#include "tee_u.h"
+
+/*
+ * This file is separated from traceh.c since the host verification library
+ * should not depend on ECALLS.
+ */
+oe_result_t oe_log_enclave_init(oe_enclave_t* enclave)
+{
+    initialize_log_config();
+
+    return oe_log_init_ecall(enclave, enclave->path, _log_level);
+}

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -8,8 +8,9 @@ add_dependencies(oe_includes oe_includes_place)
 target_include_directories(oe_includes INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>)
-install(DIRECTORY openenclave/bits DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
+install(DIRECTORY openenclave/bits DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/ COMPONENT OEHOSTVERIFY)
 install(DIRECTORY openenclave/edger8r DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(FILES openenclave/enclave.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(FILES openenclave/host.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
+install(FILES openenclave/host_verify.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/ COMPONENT OEHOSTVERIFY)
 install(TARGETS oe_includes EXPORT openenclave-targets)

--- a/include/openenclave/host.h
+++ b/include/openenclave/host.h
@@ -24,6 +24,7 @@
 #include "bits/report.h"
 #include "bits/result.h"
 #include "bits/types.h"
+#include "host_verify.h"
 
 OE_EXTERNC_BEGIN
 
@@ -315,41 +316,6 @@ void oe_free_key(
     size_t key_buffer_size,
     uint8_t* key_info,
     size_t key_info_size);
-
-/**
- * identity validation callback type
- * @param[in] identity a pointer to an enclave's identity information
- * @param[in] arg caller defined context
- */
-typedef oe_result_t (
-    *oe_identity_verify_callback_t)(oe_identity_t* identity, void* arg);
-
-/**
- * oe_verify_attestation_certificate
- *
- * This function perform a custom validation on the input certificate. This
- * validation includes extracting an attestation evidence extension from the
- * certificate before validating this evidence. An optional
- * enclave_identity_callback could be passed in for a calling client to further
- * validate the identity of the enclave creating the quote.
- * @param[in] cert_in_der a pointer to buffer holding certificate contents
- *  in DER format
- * @param[in] cert_in_der_len size of certificate buffer above
- * @param[in] enclave_identity_callback callback routine for custom identity
- * checking
- * @param[in] arg an optional context pointer argument specified by the caller
- * when setting callback
- * @retval OE_OK on a successful validation
- * @retval OE_VERIFY_FAILED on quote failure
- * @retval OE_INVALID_PARAMETER At least one parameter is invalid
- * @retval OE_FAILURE general failure
- * @retval other appropriate error code
- */
-oe_result_t oe_verify_attestation_certificate(
-    uint8_t* cert_in_der,
-    size_t cert_in_der_len,
-    oe_identity_verify_callback_t enclave_identity_callback,
-    void* arg);
 
 OE_EXTERNC_END
 

--- a/include/openenclave/host_verify.h
+++ b/include/openenclave/host_verify.h
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * @file host_verify.h
+ *
+ * This file defines the programming interface verifying reports for remote
+ * attestation.
+ *
+ */
+#ifndef _OE_HOST_VERIFY_H
+#define _OE_HOST_VERIFY_H
+
+#ifdef _OE_ENCLAVE_H
+#error "enclave.h must not be in the same compilation unit as host_verify.h"
+#endif
+
+#include "bits/defs.h"
+#include "bits/report.h"
+#include "bits/result.h"
+
+OE_EXTERNC_BEGIN
+
+/**
+ * Verify the integrity of the remote report and its signature.
+ *
+ * This function verifies that the report signature is valid. It
+ * verifies that the signing authority is rooted to a trusted authority
+ * such as the enclave platform manufacturer.
+ *
+ * @param report The buffer containing the report to verify.
+ * @param report_size The size of the **report** buffer.
+ * @param parsed_report Optional **oe_report_t** structure to populate
+ * with the report properties in a standard format.
+ *
+ * @retval OE_OK The report was successfully verified.
+ * @retval OE_INVALID_PARAMETER At least one parameter is invalid.
+ *
+ */
+oe_result_t oe_verify_remote_report(
+    const uint8_t* report,
+    size_t report_size,
+    oe_report_t* parsed_report);
+
+/**
+ * identity validation callback type
+ * @param[in] identity a pointer to an enclave's identity information
+ * @param[in] arg caller defined context
+ */
+typedef oe_result_t (
+    *oe_identity_verify_callback_t)(oe_identity_t* identity, void* arg);
+
+/**
+ * oe_verify_attestation_certificate
+ *
+ * This function perform a custom validation on the input certificate. This
+ * validation includes extracting an attestation evidence extension from the
+ * certificate before validating this evidence. An optional
+ * enclave_identity_callback could be passed in for a calling client to further
+ * validate the identity of the enclave creating the quote.
+ * @param[in] cert_in_der a pointer to buffer holding certificate contents
+ *  in DER format
+ * @param[in] cert_in_der_len size of certificate buffer above
+ * @param[in] enclave_identity_callback callback routine for custom identity
+ * checking
+ * @param[in] arg an optional context pointer argument specified by the caller
+ * when setting callback
+ * @retval OE_OK on a successful validation
+ * @retval OE_VERIFY_FAILED on quote failure
+ * @retval OE_INVALID_PARAMETER At least one parameter is invalid
+ * @retval OE_FAILURE general failure
+ * @retval other appropriate error code
+ */
+oe_result_t oe_verify_attestation_certificate(
+    uint8_t* cert_in_der,
+    size_t cert_in_der_len,
+    oe_identity_verify_callback_t enclave_identity_callback,
+    void* arg);
+
+OE_EXTERNC_END
+
+#endif

--- a/include/openenclave/internal/trace.h
+++ b/include/openenclave/internal/trace.h
@@ -21,6 +21,8 @@ typedef enum _oe_log_level
     OE_LOG_LEVEL_MAX
 } oe_log_level_t;
 
+extern oe_log_level_t _log_level;
+
 /* Maximum log length */
 #define OE_LOG_MESSAGE_LEN_MAX 2048U
 #define OE_MAX_FILENAME_LEN 256U
@@ -32,6 +34,7 @@ void oe_log_message(bool is_enclave, oe_log_level_t level, const char* message);
 
 oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...);
 oe_log_level_t oe_get_current_logging_level(void);
+void initialize_log_config(void);
 
 #define OE_TRACE(level, ...)        \
     do                              \

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -96,8 +96,10 @@ else()
     set(SGX_LIBS "")
 endif()
 
+set(HOSTVERIFY_CLIBS "-rdynamic -Wl,-z,noexecstack -L\${libdir}/openenclave/host -loehostverify -ldl -lpthread")
 set(HOST_CLIBS "-rdynamic -Wl,-z,noexecstack -L\${libdir}/openenclave/host -loehost -ldl -lpthread ${SGX_LIBS}")
 
+set(HOSTVERIFY_CXXLIBS "${HOSTVERIFY_CLIBS}")
 set(HOST_CXXLIBS "${HOST_CLIBS}")
 
 ##==============================================================================
@@ -166,6 +168,40 @@ install(FILES
 
 ##==============================================================================
 ##
+## oehostverify-gcc.pc:
+##
+##==============================================================================
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/oehostverify-gcc.pc
+    ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehostverify-gcc.pc
+    @ONLY)
+
+install(FILES
+    ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehostverify-gcc.pc
+    DESTINATION
+    "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+    COMPONENT OEHOSTVERIFY)
+
+##==============================================================================
+##
+## oehostverify-g++.pc:
+##
+##==============================================================================
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/oehostverify-g++.pc
+    ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehostverify-g++.pc
+    @ONLY)
+
+install(FILES
+    ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehostverify-g++.pc
+    DESTINATION
+    "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+    COMPONENT OEHOSTVERIFY)
+
+##==============================================================================
+##
 ## oeenclave-clang.pc:
 ##
 ##==============================================================================
@@ -227,3 +263,37 @@ install(FILES
     ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang++.pc
     DESTINATION
     "${CMAKE_INSTALL_DATADIR}/pkgconfig")
+
+##==============================================================================
+##
+## oehostverify-clang.pc:
+##
+##==============================================================================
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/oehostverify-clang.pc
+    ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehostverify-clang.pc
+    @ONLY)
+
+install(FILES
+    ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehostverify-clang.pc
+    DESTINATION
+    "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+    COMPONENT OEHOSTVERIFY)
+
+##==============================================================================
+##
+## oehostverify-clang++.pc:
+##
+##==============================================================================
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/oehostverify-clang++.pc
+    ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehostverify-clang++.pc
+    @ONLY)
+
+install(FILES
+    ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehostverify-clang++.pc
+    DESTINATION
+    "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+    COMPONENT OEHOSTVERIFY)

--- a/pkgconfig/oehostverify-clang++.pc
+++ b/pkgconfig/oehostverify-clang++.pc
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+prefix=@PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: Open Enclave
+Description: Open Enclave clang++ flags and libraries verifying remote reports on hosts.
+Version: @OE_VERSION@
+Requires: openssl
+Cflags: @HOST_CXXFLAGS_CLANG@ @HOST_INCLUDES@
+Libs: @HOSTVERIFY_CXXLIBS@

--- a/pkgconfig/oehostverify-clang.pc
+++ b/pkgconfig/oehostverify-clang.pc
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+prefix=@PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: Open Enclave
+Description: Open Enclave clang flags and libraries verifying remote reports on hosts.
+Version: @OE_VERSION@
+Requires: openssl
+Cflags: @HOST_CFLAGS_CLANG@ @HOST_INCLUDES@
+Libs: @HOSTVERIFY_CLIBS@

--- a/pkgconfig/oehostverify-g++.pc
+++ b/pkgconfig/oehostverify-g++.pc
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+prefix=@PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: Open Enclave
+Description: Open Enclave g++ flags and libraries verifying remote reports on hosts.
+Version: @OE_VERSION@
+Requires: openssl
+Cflags: @HOST_CXXFLAGS_GCC@ @HOST_INCLUDES@
+Libs: @HOSTVERIFY_CXXLIBS@

--- a/pkgconfig/oehostverify-gcc.pc
+++ b/pkgconfig/oehostverify-gcc.pc
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+prefix=@PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: Open Enclave
+Description: Open Enclave gcc flags and libraries verifying remote reports on hosts.
+Version: @OE_VERSION@
+Requires: openssl
+Cflags: @HOST_CFLAGS_GCC@ @HOST_INCLUDES@
+Libs: @HOSTVERIFY_CLIBS@

--- a/samples/attested_tls/non_enc_client/verify_signer_openssl.cpp
+++ b/samples/attested_tls/non_enc_client/verify_signer_openssl.cpp
@@ -5,6 +5,7 @@
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 #include "../common/common.h"
 #include "../common/tls_server_enc_pubkey.h"


### PR DESCRIPTION
This is for Linux only atm. Once the windows attestation PRs are in, we can add Windows support.

To build the package, all you simply do the same process as building the regular OE SDK package aside from the last CPack step, which becomes:
```
cpack -D CPACK_DEB_COMPONENT_INSTALL=ON -DCPACK_COMPONENTS_ALL=OEHOSTVERIFY
```
The CPack command for building the OE SDK remains the same.

Some pending open issues:

1. Name of the package. We internally refer it as the "host verification library" but that probably doesn't make sense to external people.
2. Expected behavior if both the OE SDK and host verification library is installed. 
