### PR TITLE
Updating system PATH environment in registry.

### DIFF
--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -173,7 +173,11 @@ function Add-ToSystemPath {
     if(!$Path) {
         return
     }
-    $systemPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine').Split(';')
+    # Get system PATH environment variable from the registry
+    $regPathKey = "Registry::HKLM\System\CurrentControlSet\Control\Session Manager\Environment"
+    $regPathValue = (Get-ItemProperty -Path $regPathKey -Name PATH).Path
+
+    $systemPath = $regPathValue.Split(';')
     $currentPath = $env:PATH.Split(';')
     foreach($p in $Path) {
         if($p -notin $systemPath) {
@@ -184,6 +188,7 @@ function Add-ToSystemPath {
         }
     }
     $env:PATH = $currentPath -join ';'
+    Set-ItemProperty -Path $regPathKey -Name PATH -Value $systemPath
     setx.exe /M PATH ($systemPath -join ';')
     if($LASTEXITCODE) {
         Throw "Failed to set the new system path"


### PR DESCRIPTION
Previously when running the install-windows-prereqs.ps1 script, it would only update the system PATH environment of the local powershell session.  If you opened another x64 Native developer session the user would have to run the same script again in order to setup the PATH environment.

The install-windows-prereqs.ps1 script also downloads all the install binaries, which does not make sense to have it run every time.

Fixes #2095 