### PR TITLE
Installing windows nuget prereqs under the repo directory

### DIFF
--- a/docs/GettingStartedDocs/GettingStarted.Windows.md
+++ b/docs/GettingStartedDocs/GettingStarted.Windows.md
@@ -29,7 +29,7 @@ To deploy all the prerequisities for building Open Enclave, you can run the ```s
 
 ```powershell
 cd scripts
-.\install-windows-prereqs.ps1
+.\install-windows-prereqs.ps1 <target path for nuget packages>
 ```
 
 To deploy each prerequisite individually, refer to the sections below.

--- a/scripts/ansible/oe-windows-acc-setup.yml
+++ b/scripts/ansible/oe-windows-acc-setup.yml
@@ -22,7 +22,7 @@
         az_dcap_client_url: "https://oejenkins.blob.core.windows.net/oejenkins/Microsoft.Azure.DCAP.Client.1.0.0.nupkg"
 
     - name: OE setup | Run the install-windows-prereqs.ps1 script (this may take a while)
-      script: ../install-windows-prereqs.ps1
+      script: ../install-windows-prereqs.ps1 C:\openenclave\prereqs\nuget
         -IntelPSWURL       "{{ intel_psw_2_3_url if dcap_testing_node is defined and dcap_testing_node == true else intel_psw_2_2_url }}"
         -IntelDCAPURL      "{{ intel_dcap_url }}"
         -GitURL            "{{ git_url }}"

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 Param(
+    [Parameter(Mandatory=$true)][string]$nugetInstallPath,
     [string]$GitURL = 'https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/Git-2.19.1-64-bit.exe',
     [string]$SevenZipURL = 'https://www.7-zip.org/a/7z1806-x64.msi',
     [string]$VSBuildToolsURL = 'https://aka.ms/vs/15/release/vs_buildtools.exe',
@@ -19,7 +20,8 @@ Param(
 $ErrorActionPreference = "Stop"
 
 $PACKAGES_DIRECTORY = Join-Path $env:TEMP "packages"
-$OE_NUGET_DIR = Join-Path ${env:SystemDrive} "openenclave\prereqs\nuget"
+$OE_NUGET_DIR = $nugetInstallPath
+Write-Host "Installing nuget dependencies to $OE_NUGET_DIR"
 
 $PACKAGES = @{
     "git" = @{


### PR DESCRIPTION
Previously, when building with -DUSE_LIBSGX=1 cmake would failed because it was not able to find the SGX library files.  The windows install script install-windows-prereqs.ps1 was installing the dependencies under <windows system drive>:\openenclave\prereqs.  This change resolves this issue.

Fixes #2094 
