### PR TITLE
v0.6.x ansible changes

### DIFF
--- a/scripts/ansible/oe-contributors-acc-setup-no-driver.yml
+++ b/scripts/ansible/oe-contributors-acc-setup-no-driver.yml
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+---
+- hosts: localhost
+  any_errors_fatal: true
+  become: yes
+  tasks:
+    - import_role:
+        name: linux/openenclave
+        tasks_from: environment-setup.yml
+
+    - import_role:
+        name: linux/intel
+        tasks_from: sgx-packages.yml
+
+    - import_role:
+        name: linux/az-dcap-client
+        tasks_from: stable-install.yml

--- a/scripts/ansible/oe-linux-acc-setup-no-driver.yml
+++ b/scripts/ansible/oe-linux-acc-setup-no-driver.yml
@@ -13,10 +13,6 @@
 
     - import_role:
         name: linux/intel
-        tasks_from: sgx-driver.yml
-
-    - import_role:
-        name: linux/intel
         tasks_from: sgx-packages.yml
 
     - import_role:
@@ -26,10 +22,6 @@
     - import_role:
         name: linux/openenclave
         tasks_from: validation.yml
-
-    - import_role:
-        name: linux/intel
-        tasks_from: driver-validation.yml
 
     - import_role:
         name: linux/intel

--- a/scripts/ansible/roles/linux/intel/tasks/driver-validation.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/driver-validation.yml
@@ -13,13 +13,6 @@
 - name: Check for existing required directories
   stat:
     path: "{{ item }}"
-  with_items: "{{ validation_directories }}"
+  with_items: "{{ driver_validation_directories }}"
   register: directory
   failed_when: directory.stat.isdir == False
-
-- name: Check for existing required files
-  stat:
-    path: "{{ item }}"
-  with_items: "{{ validation_files }}"
-  register: file
-  failed_when: file.stat.exists == False

--- a/scripts/ansible/roles/linux/intel/tasks/packages-validation.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/packages-validation.yml
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+---
+- name: Include distribution vars
+  include_vars:
+    file: "{{ ansible_distribution | lower }}.yml"
+
+- name: Include distribution release specific vars
+  include_vars:
+    file: "{{ ansible_distribution_release | lower }}.yml"
+
+- name: Check for existing required directories
+  stat:
+    path: "{{ item }}"
+  with_items: "{{ packages_validation_directories }}"
+  register: directory
+  failed_when: directory.stat.isdir == False
+
+- name: Check for existing required files
+  stat:
+    path: "{{ item }}"
+  with_items: "{{ packages_validation_files }}"
+  register: file
+  failed_when: file.stat.exists == False

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu.yml
@@ -8,9 +8,11 @@ intel_sgx_packages:
   - "libsgx-dcap-ql"
   - "libsgx-dcap-ql-dev"
 
-validation_directories:
+driver_validation_directories:
   - "/opt/intel/sgxdriver"
+
+packages_validation_directories:
   - "/opt/intel/libsgx-enclave-common"
 
-validation_files:
+packages_validation_files:
   - "/usr/lib/x86_64-linux-gnu/libsgx_dcap_ql.so"


### PR DESCRIPTION
We find the playbooks bundled with OpenEnclave tremendously useful to get the right OpenEnclave dependencies without unnecessary duplication. We've been using them (along with playbooks of our own) to keep our development, test and CI VMs up to date.

As we're moving the last parts of our CI that weren't using containers to docker, we've noticed that there wasn't a variant of the playbooks targeted at containers (which typically won't have kernel headers and where the driver install does not make sense).

This PR add "no-driver" variants of the contributor and linux setups, which are aimed at containers but otherwise keep all other dependencies in sync. The validation task is split to allow that.

We'd like to get this into master as well if possible, but we're targeting 0.6 for now, and this seemed like a good place to start. What do you think?