### PR TITLE
Update docs to include link to  windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ release, start here for instructions to install and use the SDK package:
 - [Ubuntu 18.04 with SGX hardware](docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md)
 - [Ubuntu 16.04 with SGX hardware](docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md)
 - [Ubuntu 18.04 or 16.04 in simulation mode](docs/GettingStartedDocs/install_oe_sdk-Simulation.md)
+- Windows Release Package coming soon
 
 If you would like to modify and build the Open Enclave SDK from sources, refer
 to the documents for [getting started](docs/GettingStartedDocs/Contributors/building_oe_sdk.md).

--- a/docs/GettingStartedDocs/Contributors/building_oe_sdk.md
+++ b/docs/GettingStartedDocs/Contributors/building_oe_sdk.md
@@ -33,16 +33,21 @@ Please refer to the following [documentation](/docs/GettingStartedDocs/SGXSuppor
    | SGX1                       | SGX1 or SGX1+FLC                    |
    | Simulator                  | Any level                           |
 
-   If your target system does not have any SGX hardware support, you may want to choose "Simulator" mode.
+   On Linux, if your target system does not have any SGX hardware support, you may want to choose "Simulator" mode.
+   On Windows, Open Enclave SDK does not support "Simulator" mode.
 
 #### 3. Build, install and run
 
    Choose an operating mode that is compatible with the SGX support level of your target system.
    The links below contain instructions on how to set up Open Enclave SDK environment for a given mode.
 
+On Linux
   - [Setup Open Enclave SDK for SGX1+FLC mode](SGX1FLCGettingStarted.md)
   - [Setup Open Enclave SDK for SGX1 mode](SGX1GettingStarted.md)
   - [Setup Open Enclave SDK for Simulator mode](SimulatorGettingStarted.md)
+
+On Windows
+ - [Set up Open Enclave SDK](/docs/GettingStartedDocs/GettingStarted.Windows.md)
 
 ## Samples
 

--- a/docs/GettingStartedDocs/GettingStarted.Windows.md
+++ b/docs/GettingStartedDocs/GettingStarted.Windows.md
@@ -8,6 +8,10 @@ This document is a work in progress. It describes how to use experimental
 support in the Open Enclave SDK to build Windows host applications that can
 load ELF enclaves built using clang.
 
+Please refer to the following [documentation](/docs/GettingStartedDocs/SGXSupportLevel.md) to determine the SGX support level for your target system. The instructions below work for systems with SGX1+FLC support. Instructions for systems with SGX1 but no FLC support are coming soon. 
+
+'Simulator' mode is not available in Windows.
+
 Prerequisites
 -------------
 


### PR DESCRIPTION
Patching docs to include link for windows installation.  A reorganization of docs(including splitting instructions into Windows instructions/Linux instructions) with additional information related to using tools on Windows is coming soon. 