### PR TITLE
Revisit OE SDK package settings

### DIFF
--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -11,12 +11,14 @@ set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 set(CPACK_PACKAGE_VERSION ${OE_VERSION})
 set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsgx-enclave-common (>=2.3.100.46354-1), libsgx-enclave-common-dev (>=2.3.100.0-1), libsgx-dcap-ql (>=1.0.100.46460-1.0), libsgx-dcap-ql-dev (>=1.0.100.46460-1.0)")
+set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "pkg-config")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 
 # CPack variables for the non-enclave host verification package.
 # We match the naming convention of the OE SDK package by setting the
 # CPACK_DEBIAN_OEHOSTVERIFY_FILE_NAME field.
 set(CPACK_DEBIAN_OEHOSTVERIFY_PACKAGE_NAME "open-enclave-hostverify")
+set(CPACK_DEBIAN_OEHOSTVERIFY_PACKAGE_RECOMMENDS "pkg-config")
 set(CPACK_DEBIAN_OEHOSTVERIFY_FILE_NAME DEB-DEFAULT)
 set(CPACK_COMPONENT_OEHOSTVERIFY_DESCRIPTION "Open Enclave Report Verification Host Library")
 include(CPack)

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -10,7 +10,7 @@ set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/README.md")
 set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 set(CPACK_PACKAGE_VERSION ${OE_VERSION})
 set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsgx-enclave-common (>=2.3.100.46354-1), libsgx-enclave-common-dev (>=2.3.100.0-1), libsgx-dcap-ql (>=1.0.100.46460-1.0), libsgx-dcap-ql-dev (>=1.0.100.46460-1.0), pkg-config")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsgx-enclave-common (>=2.3.100.46354-1), libsgx-enclave-common-dev (>=2.3.100.0-1), libsgx-dcap-ql (>=1.0.100.46460-1.0), libsgx-dcap-ql-dev (>=1.0.100.46460-1.0)")
 
 # CPack variables for the non-enclave host verification package.
 # We match the naming convention of the OE SDK package by setting the
@@ -18,5 +18,4 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsgx-enclave-common (>=2.3.100.46354-1), lib
 set(CPACK_DEBIAN_OEHOSTVERIFY_PACKAGE_NAME "open-enclave-hostverify")
 set(CPACK_DEBIAN_OEHOSTVERIFY_FILE_NAME "${CPACK_DEBIAN_OEHOSTVERIFY_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-Linux.deb")
 set(CPACK_COMPONENT_OEHOSTVERIFY_DESCRIPTION "Open Enclave Report Verification Host Library")
-set(CPACK_DEBIAN_OEHOSTVERIFY_PACKAGE_DEPENDS "pkg-config")
 include(CPack)

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -11,11 +11,12 @@ set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 set(CPACK_PACKAGE_VERSION ${OE_VERSION})
 set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsgx-enclave-common (>=2.3.100.46354-1), libsgx-enclave-common-dev (>=2.3.100.0-1), libsgx-dcap-ql (>=1.0.100.46460-1.0), libsgx-dcap-ql-dev (>=1.0.100.46460-1.0)")
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 
 # CPack variables for the non-enclave host verification package.
 # We match the naming convention of the OE SDK package by setting the
 # CPACK_DEBIAN_OEHOSTVERIFY_FILE_NAME field.
 set(CPACK_DEBIAN_OEHOSTVERIFY_PACKAGE_NAME "open-enclave-hostverify")
-set(CPACK_DEBIAN_OEHOSTVERIFY_FILE_NAME "${CPACK_DEBIAN_OEHOSTVERIFY_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-Linux.deb")
+set(CPACK_DEBIAN_OEHOSTVERIFY_FILE_NAME DEB-DEFAULT)
 set(CPACK_COMPONENT_OEHOSTVERIFY_DESCRIPTION "Open Enclave Report Verification Host Library")
 include(CPack)


### PR DESCRIPTION
Revisited OE SDK package settings, removal of unneeded dependency and revised Debian file naming scheme to reflect recommended default naming scheme which includes architecture version.

Fix #2107