### PR TITLE
Modified install-windows-prereq.ps1 input parameters.

### DIFF
--- a/docs/GettingStartedDocs/GettingStarted.Windows.md
+++ b/docs/GettingStartedDocs/GettingStarted.Windows.md
@@ -33,7 +33,7 @@ To deploy all the prerequisities for building Open Enclave, you can run the ```s
 
 ```powershell
 cd scripts
-.\install-windows-prereqs.ps1 -InstallPath YOUR_WORKSPACE_PATH_HERE -WithFLC $true -WithAzureDCAPClient $true
+.\install-windows-prereqs.ps1 -InstallPath YOUR_WORKSPACE_PATH_HERE -LaunchConfiguration SGX1FLC -DCAPClientType Azure
 ```
 
 To deploy each prerequisite individually, refer to the sections below.

--- a/scripts/ansible/oe-windows-acc-setup.yml
+++ b/scripts/ansible/oe-windows-acc-setup.yml
@@ -36,8 +36,8 @@
     - name: OE setup | Run the install-windows-prereqs.ps1 script (this may take a while)
       script: ../install-windows-prereqs.ps1
         -InstallPath         "C:\openenclave"
-        -WithFLC             "{{ 1 if dcap_testing_node is defined and dcap_testing_node == true else 0 }}"
-        -WithAzureDCAPClient "{{ 1 if dcap_testing_node is defined and dcap_testing_node == true else 0 }}"
+        -LaunchConfiguration "{{ SGX1FLC if dcap_testing_node is defined and dcap_testing_node == true else SGX1 }}"
+        -DCAPClientType      "{{ Azure }}"
         -IntelPSWURL         "{{ intel_psw_2_4_url if dcap_testing_node is defined and dcap_testing_node == true else intel_psw_2_2_url }}"
         -IntelPSWHash        "{{ intel_psw_2_4_hash if dcap_testing_node is defined and dcap_testing_node == true else intel_psw_2_2_hash }}"
         -IntelDCAPURL        "{{ intel_dcap_url }}"


### PR DESCRIPTION
This will give an option to copy the Intel DCAP DLLs into windows\system32 instead of installing the drivers (which normally copy the DLLs into windows\system32 as well).

Since simulation mode doesn't work nicely on Windows, this isn't useful for most development scenarios. However it is useful if you want a Windows Docker container to run on a node without SGX and can build the Open Enclave SDK :)