### PR TITLE
Remove root_index.txt and intermediate_index.txt from crypto tests on rebuild

### DIFF
--- a/tests/crypto/data/make-test-certs
+++ b/tests/crypto/data/make-test-certs
@@ -131,7 +131,9 @@ openssl x509 -req -in leaf2.csr -CA intermediate.cert.pem -CAkey intermediate.ke
 #  - intermediate_crl is issued by intermediate CA and revokes the leaf cert
 #  - root_crl is issued by root CA and also revokes the leaf cert
 
+rm -f intermediate_index.txt
 touch intermediate_index.txt
+rm -f root_index.txt
 touch root_index.txt
 echo "00" > intermediate_crl_number
 echo "00" > root_crl_number

--- a/tests/crypto_crls_cert_chains/data/make-test-certs
+++ b/tests/crypto_crls_cert_chains/data/make-test-certs
@@ -112,9 +112,13 @@ openssl x509 -req -in leaf2.csr -CA intermediate.cert.pem -CAkey intermediate.ke
 # - intermediate_crl1 revokes no certificates
 # - intermediate_crl2 revokes leaf2
 
+rm -f root_index.txt
 touch root_index.txt
+rm -f root_index2.txt
 touch root_index2.txt
+rm -f intermediate_index.txt
 touch intermediate_index.txt
+rm -f intermediate_index2.txt
 touch intermediate_index2.txt
 echo "00" > root_crl_number
 echo "00" > root_crl_number2


### PR DESCRIPTION
Removes root_index.txt and intermediate_index.txt from crypto and crypto_crls_cert_chains tests on build
fixes #2076 