### PR TITLE
Fix polymorphic exceptions caught by value

### DIFF
--- a/tests/cppException/enc/cppException.cpp
+++ b/tests/cppException/enc/cppException.cpp
@@ -177,7 +177,7 @@ bool BasicVerification()
     {
         return false;
     }
-    catch (BarClass01 ex_obj)
+    catch (BarClass01& ex_obj)
     {
         if (ex_obj.i != 0XFFFF)
         {
@@ -243,11 +243,11 @@ bool BasicVerification()
     {
         return false;
     }
-    catch (BarClass01)
+    catch (BarClass01&)
     {
         return false;
     }
-    catch (BarClass02 ex_obj)
+    catch (BarClass02& ex_obj)
     {
         if (ex_obj.i != 0XFFFFF)
         {
@@ -280,7 +280,7 @@ bool BasicVerification()
     {
         return false;
     }
-    catch (BarClass01)
+    catch (BarClass01&)
     {
         return false;
     }
@@ -318,11 +318,11 @@ bool BasicVerification()
     {
         return false;
     }
-    catch (BarClass01)
+    catch (BarClass01&)
     {
         return false;
     }
-    catch (BarClass02 ex_obj)
+    catch (BarClass02& ex_obj)
     {
         if (ex_obj.i != 0XFFFFFF)
         {
@@ -409,7 +409,7 @@ void bar02()
         BarClass02 obj(0XFFFFF);
         throw obj;
     }
-    catch (BarClass03)
+    catch (BarClass03&)
     {
         return;
     }
@@ -421,7 +421,7 @@ void bar01()
     {
         bar02();
     }
-    catch (BarClass01)
+    catch (BarClass01&)
     {
         return;
     }
@@ -436,7 +436,7 @@ bool NestedException()
         BarClass01 obj(0XF);
         throw obj;
     }
-    catch (BarClass01 ex_obj)
+    catch (BarClass01& ex_obj)
     {
         if (ex_obj.i != 0XF)
         {
@@ -487,12 +487,12 @@ bool NestedException()
                 return false;
             }
         }
-        catch (BarClass01)
+        catch (BarClass01&)
         {
             return false;
         }
     }
-    catch (BarClass02 ex_obj)
+    catch (BarClass02& ex_obj)
     {
         if (ex_obj.i != 0XFFFF)
         {

--- a/tests/stdcxx/enc/enc.cpp
+++ b/tests/stdcxx/enc/enc.cpp
@@ -204,7 +204,7 @@ int enc_test(bool* caught, bool* dynamic_cast_works, size_t* n_constructions)
                 int* p = new int[64];
                 ptrs.push_back(p);
             }
-            catch (std::bad_alloc)
+            catch (std::bad_alloc&)
             {
                 bad_alloc_caught = true;
                 printf("std::bad_alloc caught\n");


### PR DESCRIPTION
When compiling with gcc 8 (build defaults to gcc when clang is not installed) with -Wall, catching polymorphic exceptions by value is treated as a build error. This PR fixes all instances which cause a build using gcc 8 to fail.

In general it is good practice to catch C++ exceptions by reference, even if they don't fail the build. See this blog post for why: https://blog.knatten.org/2010/04/02/always-catch-exceptions-by-reference/