### PR TITLE
Relocate __cxa_atexit to oelibc (fixes issue #2151).

### DIFF
--- a/enclave/core/atexit.c
+++ b/enclave/core/atexit.c
@@ -56,17 +56,21 @@ static oe_atexit_entry_t* _new_atexit_entry(void (*func)(void*), void* arg)
 /*
 **==============================================================================
 **
-** __cxa_atexit()
+** oe_cxa_atexit()
 **
 **     Installs a function to be invoked upon exit (enclave termination).
 **
 **     The implementation injects an oe_atexit_entry_t structure onto a list
 **     in reverse order (at the front of the list).
 **
+**     This function is equivalent to __cxa_atexit but is named differently
+**     to avoid conflicts with C runtimes. The oelibc __cxa_atexit is merely
+**     a wrapper for this function.
+**
 **==============================================================================
 */
 
-int __cxa_atexit(void (*func)(void*), void* arg, void* dso_handle)
+int oe_cxa_atexit(void (*func)(void*), void* arg, void* dso_handle)
 {
     oe_atexit_entry_t* entry;
     OE_UNUSED(dso_handle);
@@ -105,7 +109,7 @@ int oe_atexit(void (*function)(void))
      * is pushed on the stack but then ignored by function(), which expects
      * no arguments.
      */
-    return __cxa_atexit((Function)function, NULL, NULL);
+    return oe_cxa_atexit((Function)function, NULL, NULL);
 }
 
 /*

--- a/enclave/core/atexit.c
+++ b/enclave/core/atexit.c
@@ -3,6 +3,7 @@
 
 #include "atexit.h"
 #include <openenclave/enclave.h>
+#include <openenclave/internal/cxa_atexit.h>
 #include <openenclave/internal/syscall/unistd.h>
 #include <openenclave/internal/thread.h>
 

--- a/enclave/core/atexit.h
+++ b/enclave/core/atexit.h
@@ -12,8 +12,6 @@ int oe_atexit(void (*function)(void));
 
 void oe_call_atexit_functions(void);
 
-int oe_cxa_atexit(void (*func)(void*), void* arg, void* dso_handle);
-
 OE_EXTERNC_END
 
 #endif /* _OE_ATEXIT_H */

--- a/enclave/core/atexit.h
+++ b/enclave/core/atexit.h
@@ -12,7 +12,8 @@ int oe_atexit(void (*function)(void));
 
 void oe_call_atexit_functions(void);
 
-int __cxa_atexit(void (*func)(void*), void* arg, void* dso_handle);
+/* Implements __cxa_atexit behavior but ignores dso_handle. */
+int oe_cxa_atexit(void (*func)(void*), void* arg, void* dso_handle);
 
 OE_EXTERNC_END
 

--- a/enclave/core/atexit.h
+++ b/enclave/core/atexit.h
@@ -12,7 +12,6 @@ int oe_atexit(void (*function)(void));
 
 void oe_call_atexit_functions(void);
 
-/* Implements __cxa_atexit behavior but ignores dso_handle. */
 int oe_cxa_atexit(void (*func)(void*), void* arg, void* dso_handle);
 
 OE_EXTERNC_END

--- a/enclave/core/optee/gp.c
+++ b/enclave/core/optee/gp.c
@@ -488,7 +488,7 @@ void TA_CloseSessionEntryPoint(void* sess_ctx)
 
 void TA_DestroyEntryPoint(void)
 {
-    /* Call functions installed by __cxa_atexit() and oe_atexit() */
+    /* Call functions installed by oe_cxa_atexit() and oe_atexit() */
     oe_call_atexit_functions();
 
     /* Call all finalization functions */

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -392,7 +392,7 @@ static void _handle_ecall(
         }
         case OE_ECALL_DESTRUCTOR:
         {
-            /* Call functions installed by __cxa_atexit() and oe_atexit() */
+            /* Call functions installed by oe_cxa_atexit() and oe_atexit() */
             oe_call_atexit_functions();
 
             /* Call all finalization functions */

--- a/include/openenclave/internal/cxa_atexit.h
+++ b/include/openenclave/internal/cxa_atexit.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef _OE_CXA_ATEXIT_H
+#define _OE_CXA_ATEXIT_H
+
+int oe_cxa_atexit(void (*func)(void*), void* arg, void* dso_handle);
+
+#endif /* _OE_CXA_ATEXIT_H */

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(oelibc STATIC
     regcomp.c
     regexec.c
     tre-mem.c
+    __cxa_atexit.c
     __printf_chk.c
     __vfprintf_chk.c
     ${MUSLSRC}/complex/cabs.c

--- a/libc/__cxa_atexit.c
+++ b/libc/__cxa_atexit.c
@@ -4,9 +4,8 @@
 #include "../enclave/core/atexit.h"
 
 /*
- * Registers a function to be called by exit and by oe_call_atexit. This
- * function is used to implement atexit, which calls __cxa_atexit with the
- * following arguments: __cxa_atexit(func, NULL, NULL)
+ * Registers a function to be called by exit and by oe_call_atexit.
+ * This function wraps oe_cxa_atexit, which ignores dso_handle.
  */
 int __cxa_atexit(void (*func)(void*), void* arg, void* dso_handle)
 {

--- a/libc/__cxa_atexit.c
+++ b/libc/__cxa_atexit.c
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "../enclave/core/atexit.h"
+#include <openenclave/internal/cxa_atexit.h>
 
 /*
  * Registers a function to be called by exit and by oe_call_atexit.

--- a/libc/__cxa_atexit.c
+++ b/libc/__cxa_atexit.c
@@ -4,9 +4,9 @@
 #include "../enclave/core/atexit.h"
 
 /*
- * Registers a function to be called by exit and by oe_call_atexit_functions.
- * This function is used to implement atexit, which calls __cxa_atexit with
- * the following arguments: __cxa_atexit(func, NULL, NULL)
+ * Registers a function to be called by exit and by oe_call_atexit. This
+ * function is used to implement atexit, which calls __cxa_atexit with the
+ * following arguments: __cxa_atexit(func, NULL, NULL)
  */
 int __cxa_atexit(void (*func)(void*), void* arg, void* dso_handle)
 {

--- a/libc/__cxa_atexit.c
+++ b/libc/__cxa_atexit.c
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../enclave/core/atexit.h"
+
+/*
+ * Registers a function to be called by exit and by oe_call_atexit_functions.
+ * This function is used to implement atexit, which calls __cxa_atexit with
+ * the following arguments: __cxa_atexit(func, NULL, NULL)
+ */
+int __cxa_atexit(void (*func)(void*), void* arg, void* dso_handle)
+{
+    return oe_cxa_atexit(func, arg, dso_handle);
+}


### PR DESCRIPTION
This PR fixes a symbol conflict described here (#2151).

It makes two simple changes:
- Renames the definition of **__cxa_atexit** in **oecore** to **oe_cxa_atexit**, and
- Adds **__cxa_atexit** function to **oelibc** (which calls **oe_cxa_atexit**).

This is needed by SGX-LKL which introduces its own C runtime. Any system that replaces **oelibc** would have encountered a similar conflict.