### PR TITLE
Rename Community Maintenance Committee

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -39,7 +39,7 @@ You are encouraged to start a discussion with us through a GitHub issue before
 implementing any major changes. We want your contributions, but we also want to
 make sure the community is in agreement before you invest your time.
 
-You may be asked by maintainers to provide a design document before writing an
+You may be asked by Committers to provide a design document before writing an
 implementation. The simplest way to provide this is through a Pull Request to
 our repository with a Markdown style document (like this one) to the
 [docs/DesignDocs](DesignDocs) folder, and see its [readme](DesignDocs/README.md)
@@ -81,7 +81,7 @@ Please do:
 
 - **DO** submit all code changes via pull requests (PRs) rather than through a
   direct commit. PRs will be reviewed and potentially merged by the repo
-  maintainers after a peer review that includes at least one maintainer.
+  Committers after a peer review that includes at least one Committer.
 - **DO** give PRs short-but-descriptive names (e.g. "Improve code coverage for
   System.Console by 10%", not "Fix #1234").
 - **DO** add breaking changes, new features, deprecations, and bug
@@ -134,7 +134,7 @@ Merging Pull Requests
 Instead of merging pull requests with "the big green button" on GitHub, we use
 an automated system called [Bors](https://bors.tech/). The Bors bot is the
 _only_ approved mechanism of merging code to `master`. When a PR is ready to be
-merged, a maintainer will comment on it with `bors r+`.
+merged, a Committer will comment on it with `bors r+`.
 
 Bors will automatically:
 1. Apply the PR's commits to a `staging` branch based on `master`.

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -97,7 +97,7 @@ in that file takes precedence.
 Note that we _no longer_ use `CamelCase` nor double underscores (`__`), but you
 may find remnants and so again should prefer the local style. This is especially
 the case for classes, which are still using `PascalCase`. For now, follow the
-existing style. The project maintainers prefer to fix style issues in bulk using
+existing style. The project Committers prefer to fix style issues in bulk using
 automation, so avoid submitting PRs intended to fix only a few instances of the
 inconsistent style.
 

--- a/docs/GovernanceModel.md
+++ b/docs/GovernanceModel.md
@@ -41,7 +41,7 @@ Remember that security issues should be reported through a separate channel, and
 will receive a response within 24 hours. See [Reporting Security
 Issues](Contributing.md#reporting-security-issues).
 
-Community Maintenance Commitee Members, Committers, and Contributors
+Community Governance Committee Members, Committers, and Contributors
 --------------------------------------------------------------------
 
 A "committer" is anyone with direct write access to the Open Enclave repository on

--- a/docs/GovernanceModel.md
+++ b/docs/GovernanceModel.md
@@ -17,9 +17,9 @@ In order to maintain a pleasant and welcoming environment, we want to reiterate
 that it is imperative that all community members adhere to our
 [Code of Conduct](Contributing.md#code-of-conduct).
 Anyone failing to follow the Code of Conduct will be removed from the community
-by the [Maintainers Group](Maintainers.md). If you are made to
+by the [Community Governance Committee](Maintainers.md). If you are made to
 feel uncomfortable, or have any concerns about behavior within the community, we
-encourage you to reach out to members of the Maintainers Group.
+encourage you to reach out to members of the Community Governance Committee.
 
 Design and Development Discussions
 ----------------------------------
@@ -41,20 +41,18 @@ Remember that security issues should be reported through a separate channel, and
 will receive a response within 24 hours. See [Reporting Security
 Issues](Contributing.md#reporting-security-issues).
 
-Maintainers, Committers, and Contributors
------------------------------------------
+Community Maintenance Commitee Members, Committers, and Contributors
+--------------------------------------------------------------------
 
-We define "maintainer" as members of the Open Enclave "Maintainers
-Group", as listed in the [maintainers document](Maintainers.md). A
-"committer" is anyone with direct write access to the Open Enclave repository on
-GitHub, as granted by the Maintainers Group. All maintainers are committers, but not all
-committers are maintainers. Finally, "contributor" is anyone else making
+A "committer" is anyone with direct write access to the Open Enclave repository on
+GitHub, as granted by the Committee. All Committee members are committers, but not all
+committers are Committee members. Finally, "contributor" is anyone else making
 contributions to the project, including: creating or commenting on issues,
 opening or reviewing pull requests, or other useful contributions such as
 providing support in forums or chats.
 
-See the [maintainers document](Maintainers.md) for the Maintainers
-Group, our process for adding new committers and maintainers, as well the
+See the [Community Governance Committee document](Maintainers.md) for more information
+on the Community Governance Committee, our process for adding new committers and maintainers, as well the
 areas of expertise for each of the committers.
 
 Accepting Contributions
@@ -69,11 +67,11 @@ Committers may revert changes if they are found to be breaking.
 We make most decisions through a consensus seeking process, rather than a formal
 voting process. For example, committers can merge contributions that were
 reviewed without objections. If there are objections that cannot be resolved, an
-issue can be escalated to the Maintaines Group to make a
+issue can be escalated to the Community Governance Committee to make a
 decision, which handles issues as discussed in the
-[maintainers document](Maintainers.md).
+[Community Governance Committee document](Maintainers.md).
 
-See the [maintainers document](Maintainers.md) for the list of project
+See the [Community Governance Committee document](Maintainers.md) for the list of project
 committers, and how to become one.
 
 Community Approval of Releases

--- a/docs/GovernanceModel.md
+++ b/docs/GovernanceModel.md
@@ -52,7 +52,7 @@ opening or reviewing pull requests, or other useful contributions such as
 providing support in forums or chats.
 
 See the [Community Governance Committee document](Maintainers.md) for more information
-on the Community Governance Committee, our process for adding new committers and maintainers, as well the
+on the Community Governance Committee, our process for adding new committers and Committee members, as well the
 areas of expertise for each of the committers.
 
 Accepting Contributions

--- a/docs/GovernanceModel.md
+++ b/docs/GovernanceModel.md
@@ -17,9 +17,9 @@ In order to maintain a pleasant and welcoming environment, we want to reiterate
 that it is imperative that all community members adhere to our
 [Code of Conduct](Contributing.md#code-of-conduct).
 Anyone failing to follow the Code of Conduct will be removed from the community
-by the [Community Maintenance Committee](Maintainers.md). If you are made to
+by the [Maintainers Group](Maintainers.md). If you are made to
 feel uncomfortable, or have any concerns about behavior within the community, we
-encourage you to reach out to members of the Community Maintenance Committee.
+encourage you to reach out to members of the Maintainers Group.
 
 Design and Development Discussions
 ----------------------------------
@@ -44,17 +44,17 @@ Issues](Contributing.md#reporting-security-issues).
 Maintainers, Committers, and Contributors
 -----------------------------------------
 
-We define "maintainer" as members of the Open Enclave "Community Maintenance
-Committee", as listed in the [maintainers document](Maintainers.md). A
+We define "maintainer" as members of the Open Enclave "Maintainers
+Group", as listed in the [maintainers document](Maintainers.md). A
 "committer" is anyone with direct write access to the Open Enclave repository on
-GitHub, as granted by the Committee. All maintainers are committers, but not all
+GitHub, as granted by the Maintainers Group. All maintainers are committers, but not all
 committers are maintainers. Finally, "contributor" is anyone else making
 contributions to the project, including: creating or commenting on issues,
 opening or reviewing pull requests, or other useful contributions such as
 providing support in forums or chats.
 
-See the [maintainers document](Maintainers.md) for the Community Maintenance
-Committee, our process for adding new committers and maintainers, as well the
+See the [maintainers document](Maintainers.md) for the Maintainers
+Group, our process for adding new committers and maintainers, as well the
 areas of expertise for each of the committers.
 
 Accepting Contributions
@@ -69,7 +69,7 @@ Committers may revert changes if they are found to be breaking.
 We make most decisions through a consensus seeking process, rather than a formal
 voting process. For example, committers can merge contributions that were
 reviewed without objections. If there are objections that cannot be resolved, an
-issue can be escalated to the Community Maintenance Committee to make a
+issue can be escalated to the Maintaines Group to make a
 decision, which handles issues as discussed in the
 [maintainers document](Maintainers.md).
 

--- a/docs/Maintainers.md
+++ b/docs/Maintainers.md
@@ -1,8 +1,7 @@
 Community Governance Committee
 ==============================
 
-This document describes the Open Enclave Community Governance Committee, which in some open source
-projects is also known as a Technical Steering Committee. By
+This document describes the Open Enclave Community Governance Committee. By
 our liberal contribution policy outlined in our
 [governance model](GovernanceModel.md), Committee members are committers that are
 trusted to grant new committer rights, and grant new membership into the

--- a/docs/Maintainers.md
+++ b/docs/Maintainers.md
@@ -1,21 +1,21 @@
-Maintainers Group
-=================
+Community Governance Committee
+==============================
 
-This document describes the Open Enclave Maintainers Group, which in some open source
+This document describes the Open Enclave Community Governance Committee, which in some open source
 projects is also known as a Technical Steering Committee. By
 our liberal contribution policy outlined in our
 [governance model](GovernanceModel.md), maintainers are committers that are
 trusted to grant new committer rights, and grant new membership into the
-Maintainers Group.
+Committee.
 
-When making decisions, the Maintainers Group uses a "consensus
+When making decisions, the Community Governance Committee uses a "consensus
 seeking" process. This means that most decisions should be reached by consensus,
-but when that fails, the Maintainers Group calls for a vote where the super majority
+but when that fails, the Committee calls for a vote where the super majority
 (two-thirds) wins. This is to prevent obstructionism by removing the possibility
 of a one person veto.
 
-Maintainers
------------
+Committee Members
+-----------------
 
 | Name                 | Company   | Email                         | GitHub Alias   |
 |----------------------|-----------|-------------------------------|----------------|
@@ -28,33 +28,33 @@ Maintainers
 | Mike Brasher         | Microsoft | mikbras@microsoft.com         | mikbras        |
 | Simon Leet           | Microsoft | simon.leet@microsoft.com      | CodeMonkeyLeet |
 
-Responsibilities
-----------------
+Committee Responsibilities
+--------------------------
 
-The primary responsibility of the Maintainers Group is to grant new committer rights
+The primary responsibility of the Committee is to grant new committer rights
 (that is, write access to the main Open Enclave SDK repository or related
-repositories), and to grant new membership into the Maintainers Group. Conversely, the
-Group must also remove committer rights and membership from those found to
+repositories), and to grant new membership into the Committee. Conversely, the
+Commitee must also remove committer rights and membership from those found to
 be violating the project's Code of Conduct or otherwise negatively affecting the
 project's community health.
 
-This Group is not intended to make every technical decision, as those should
+This Committee is not intended to make every technical decision, as those should
 generally be made by agreement among committers as PRs are reviewed and merged.
 Where disagreements take place and need further resolution, those can be brought
-up with the Group as part of its responsibility to maintain the project's
+up with the Committee as part of its responsibility to maintain the project's
 community health. Otherwise technical decisions are left to the active
 committers (by virtue of the liberal contribution policy).
 
-The Maintainers Group should meet regularly, for example, once a
+The Community Governance Committee should meet regularly, for example, once a
 month. This meeting is a private meeting among just the maintainers to nominate
 new committers and maintainer members. Priority consideration should be given to
-those actively contributing to the project. The Group uses the consensus
+those actively contributing to the project. The Committee uses the consensus
 seeking process outlined above when making decisions, including adding or
-removing any members. The Group should also discuss the community's health
+removing any members. The Committee should also discuss the community's health
 and work to resolve any negative issues.
 
 In order to maintain a healthy developer community, it is recommended that the
-Group also host a regular public community meeting. This meeting should be
+Committee also host a regular public community meeting. This meeting should be
 open all members of the community, and start with an open forum to hear
 questions or concerns from the community. Any remaining time in the meeting
 should be used to discuss and review open pull requests or issues (especially
@@ -64,12 +64,12 @@ Project Committers
 ==================
 
 The following people have been granted commit permissions (that is, write
-access) to the Open Enclave SDK by the Maintainers Group. The area
+access) to the Open Enclave SDK by the Community Governance Committee. The area
 column describes which technical areas each committer is most interested in, and
 therefore should usually be consulted for changes relating to that area.
 However, it is up to each committer to determine who should review which PR, and
 when to merge it. Remember that a PR must not be merged if a committer objects;
-instead, it should be brought up with the Maintainers Group.
+instead, it should be brought up with the Community Governance Committee.
 
 | Name                  | GitHub Alias        | Area                           |
 |-----------------------|---------------------|--------------------------------|

--- a/docs/Maintainers.md
+++ b/docs/Maintainers.md
@@ -1,20 +1,21 @@
-Community Maintenance Committee
-===============================
+Maintainers Group
+=================
 
-This document describes the Community Maintenance Committee of Open Enclave. By
+This document describes the Open Enclave Maintainers Group, which in some open source
+projects is also known as a Technical Steering Committee. By
 our liberal contribution policy outlined in our
 [governance model](GovernanceModel.md), maintainers are committers that are
 trusted to grant new committer rights, and grant new membership into the
-Committee.
+Maintainers Group.
 
-When making decisions, the Community Maintenance Committee uses a "consensus
+When making decisions, the Maintainers Group uses a "consensus
 seeking" process. This means that most decisions should be reached by consensus,
-but when that fails, the Committee calls for a vote where the super majority
+but when that fails, the Maintainers Group calls for a vote where the super majority
 (two-thirds) wins. This is to prevent obstructionism by removing the possibility
 of a one person veto.
 
-Committee Members
------------------
+Maintainers
+-----------
 
 | Name                 | Company   | Email                         | GitHub Alias   |
 |----------------------|-----------|-------------------------------|----------------|
@@ -27,33 +28,33 @@ Committee Members
 | Mike Brasher         | Microsoft | mikbras@microsoft.com         | mikbras        |
 | Simon Leet           | Microsoft | simon.leet@microsoft.com      | CodeMonkeyLeet |
 
-Committee Responsibilities
---------------------------
+Responsibilities
+----------------
 
-The primary responsibility of the Committee is to grant new committer rights
+The primary responsibility of the Maintainers Group is to grant new committer rights
 (that is, write access to the main Open Enclave SDK repository or related
-repositories), and to grant new membership into the committee. Conversely, the
-Committee must also remove committer rights and membership from those found to
+repositories), and to grant new membership into the Maintainers Group. Conversely, the
+Group must also remove committer rights and membership from those found to
 be violating the project's Code of Conduct or otherwise negatively affecting the
 project's community health.
 
-This Committee is not intended to make every technical decision, as those should
+This Group is not intended to make every technical decision, as those should
 generally be made by agreement among committers as PRs are reviewed and merged.
 Where disagreements take place and need further resolution, those can be brought
-up with the Committee as part of its responsibility to maintain the project's
+up with the Group as part of its responsibility to maintain the project's
 community health. Otherwise technical decisions are left to the active
 committers (by virtue of the liberal contribution policy).
 
-The Community Maintenance Committee should meet regularly, for example, once a
+The Maintainers Group should meet regularly, for example, once a
 month. This meeting is a private meeting among just the maintainers to nominate
 new committers and maintainer members. Priority consideration should be given to
-those actively contributing to the project. The Committee uses the consensus
+those actively contributing to the project. The Group uses the consensus
 seeking process outlined above when making decisions, including adding or
-removing any members. The Committee should also discuss the community's health
+removing any members. The Group should also discuss the community's health
 and work to resolve any negative issues.
 
 In order to maintain a healthy developer community, it is recommended that the
-Committee also host a regular public community meeting. This meeting should be
+Group also host a regular public community meeting. This meeting should be
 open all members of the community, and start with an open forum to hear
 questions or concerns from the community. Any remaining time in the meeting
 should be used to discuss and review open pull requests or issues (especially
@@ -63,12 +64,12 @@ Project Committers
 ==================
 
 The following people have been granted commit permissions (that is, write
-access) to the Open Enclave SDK by the Community Maintenance Committee. The area
+access) to the Open Enclave SDK by the Maintainers Group. The area
 column describes which technical areas each committer is most interested in, and
 therefore should usually be consulted for changes relating to that area.
 However, it is up to each committer to determine who should review which PR, and
 when to merge it. Remember that a PR must not be merged if a committer objects;
-instead, it should be brought up with the Community Maintenance Committee.
+instead, it should be brought up with the Maintainers Group.
 
 | Name                  | GitHub Alias        | Area                           |
 |-----------------------|---------------------|--------------------------------|

--- a/docs/Maintainers.md
+++ b/docs/Maintainers.md
@@ -4,7 +4,7 @@ Community Governance Committee
 This document describes the Open Enclave Community Governance Committee, which in some open source
 projects is also known as a Technical Steering Committee. By
 our liberal contribution policy outlined in our
-[governance model](GovernanceModel.md), maintainers are committers that are
+[governance model](GovernanceModel.md), Committee members are committers that are
 trusted to grant new committer rights, and grant new membership into the
 Committee.
 
@@ -46,8 +46,8 @@ community health. Otherwise technical decisions are left to the active
 committers (by virtue of the liberal contribution policy).
 
 The Community Governance Committee should meet regularly, for example, once a
-month. This meeting is a private meeting among just the maintainers to nominate
-new committers and maintainer members. Priority consideration should be given to
+month. This meeting is a private meeting among just the Committee members to nominate
+new committers and Committee members. Priority consideration should be given to
 those actively contributing to the project. The Committee uses the consensus
 seeking process outlined above when making decisions, including adding or
 removing any members. The Committee should also discuss the community's health

--- a/docs/Maintainers.md
+++ b/docs/Maintainers.md
@@ -34,7 +34,7 @@ Committee Responsibilities
 The primary responsibility of the Committee is to grant new committer rights
 (that is, write access to the main Open Enclave SDK repository or related
 repositories), and to grant new membership into the Committee. Conversely, the
-Commitee must also remove committer rights and membership from those found to
+Committee must also remove committer rights and membership from those found to
 be violating the project's Code of Conduct or otherwise negatively affecting the
 project's community health.
 


### PR DESCRIPTION
Given the confusion between Maintainer vs CMC member, Maintainers Group
for example might be clearer.  Mike and John indicated initial support
for this term.

Another term used by many projects is "Technical Steering Committee",
which is the term that also appears in Stephen Walli's doc.   I would
be ok with that term, just for consistency with other open source
projects, if the group prefers that term.  However, it has the same
confusion between Maintainer vs TSC member.   One way that could be
resolved, should the TSC name be used, would be to remove the term
"Maintainer" and only use "TSC member", "Committer", and "Contributor"
as roles, which is the approach Stephen's doc takes.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>