### PR TITLE
Fix file-encryptor README

### DIFF
--- a/samples/file-encryptor/README.md
+++ b/samples/file-encryptor/README.md
@@ -17,7 +17,6 @@ It has the following properties:
   - mbedtls_entropy_*
   - mbedtls_ctr_drbg_*
   - mbedtls_sha256_*
-  - oe_is_outside_enclave
 - Also runs in OE simulation mode
 
 ## Host application


### PR DESCRIPTION
The file-encryptor sample doesn't use oe_is_outside_enclave API. This
patch fixes the README file for this sample.

Signed-off-by: Radoslav Gerganov <rgerganov@vmware.com>