### PR TITLE
Remove vsbuildtools.exe hash check from install-windows-prereqs.ps1

### DIFF
--- a/docs/GettingStartedDocs/GettingStarted.Windows.md
+++ b/docs/GettingStartedDocs/GettingStarted.Windows.md
@@ -28,6 +28,7 @@ Windows.
 - [Git for Windows 64-bit](https://git-scm.com/download/win)
 - [OCaml for Windows 64-bit](https://www.ocamlpro.com/pub/ocpwin/ocpwin-builds/ocpwin64/20160113/)
 - [Clang/LLVM for Windows 64-bit](http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe)
+- [Python 3](https://www.python.org/downloads/windows/)
 
 To deploy all the prerequisities for building Open Enclave, you can run the ```scripts/install-windows-prereqs.ps1```
 
@@ -115,6 +116,12 @@ Open up a command prompt and ensure that ocaml is available in the path:
 C:\> where ocaml
 C:\Program Files\ocpwin64\4.02.1+ocp1-msvc64-20160113\bin\ocaml.exe
 ```
+
+Python 3
+---------------------------------
+Install [Python 3 for Windows](https://www.python.org/downloads/windows/) and ensure that python.exe is available in your PATH.
+
+Python 3 is used as part of the mbedtls tests.
 
 Obtaining the source distribution
 ---------------------------------

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -634,16 +634,6 @@ function Install-AzureDCAPWindows {
     popd
 }
 
-function Install-Python3 {
-    Write-Log "Installing Python3"
-    $tmpDir = Join-Path $PACKAGES_DIRECTORY "Python3"
-    $envPath = Join-Path "$PACKAGES_DIRECTORY\..\.." "Programs\Python\Python37-32"
-    Install-Tool -InstallerPath $PACKAGES["python3"]["local_file"] `
-                 -InstallDirectory $tmpDir `
-                 -ArgumentList @("/quiet", "/passive") `
-                 -EnvironmentPath @($envPath)
-}
-
 try {
     Start-LocalPackagesDownload
 
@@ -657,7 +647,6 @@ try {
     Install-OCaml
     Install-Shellcheck
     Install-PSW
-    Install-Python3
 
     if ($DCAPClientType -eq "Azure")
     {

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -9,6 +9,7 @@ Param(
     [string]$OpenSSLHash = '6AFA17D0768CF91B6F69F31FBC67CAB1AC2E3F40CCAAADB7A9D6C7FC37B38492',
     [string]$SevenZipURL = 'https://www.7-zip.org/a/7z1806-x64.msi',
     [string]$SevenZipHash = 'F00E1588ED54DDF633D8652EB89D0A8F95BD80CCCFC3EED362D81927BEC05AA5',
+    # We skip the hash check for the vs_buildtools.exe file because it is regularly updated without a change to the URL, unfortunately.
     [string]$VSBuildToolsURL = 'https://aka.ms/vs/15/release/vs_buildtools.exe',
     [string]$VSBuildToolsHash = '',
     [string]$OCamlURL = 'https://www.ocamlpro.com/pub/ocpwin/ocpwin-builds/ocpwin64/20160113/ocpwin64-20160113-4.02.1+ocp1-mingw64.zip',

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -10,7 +10,7 @@ Param(
     [string]$SevenZipURL = 'https://www.7-zip.org/a/7z1806-x64.msi',
     [string]$SevenZipHash = 'F00E1588ED54DDF633D8652EB89D0A8F95BD80CCCFC3EED362D81927BEC05AA5',
     [string]$VSBuildToolsURL = 'https://aka.ms/vs/15/release/vs_buildtools.exe',
-    [string]$VSBuildToolsHash = '7D5B0220670BA1C174F0AE1FF2CE87D65A508E66C321431FBD4751F478037E12',
+    [string]$VSBuildToolsHash = '',
     [string]$OCamlURL = 'https://www.ocamlpro.com/pub/ocpwin/ocpwin-builds/ocpwin64/20160113/ocpwin64-20160113-4.02.1+ocp1-mingw64.zip',
     [string]$OCamlHash = '369F900F7CDA543ABF674520ED6004CC75008E10BEED0D34845E8A42866D0F3A',
     [string]$Clang7URL = 'http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe',
@@ -163,13 +163,16 @@ function Start-LocalPackagesDownload {
                            -Destination $PACKAGES[$pkg]["local_file"]
         $downloaded_hash = Get-FileHash $PACKAGES[$pkg]["local_file"]
         $expected_hash = $PACKAGES[$pkg]["hash"]
-        if ($downloaded_hash.Hash -ne $expected_hash)
+        if ($expected_hash -ne "")
         {
-            Throw "Error: Computed hash ($downloaded_hash) does not match expected hash ($expected_hash)"
-        }
-        else
-        {
-            Write-Output "Computed hash ($downloaded_hash) matches expected hash ($expected_hash)"
+            if ($downloaded_hash.Hash -ne $expected_hash)
+            {
+                Throw "Error: Computed hash ($downloaded_hash) does not match expected hash ($expected_hash)"
+            }
+            else
+            {
+                Write-Output "Computed hash ($downloaded_hash) matches expected hash ($expected_hash)"
+            }
         }
     }
     Write-Output "Finished downloading all the packages"


### PR DESCRIPTION
This commit changes install-windows-prereqs.ps1 to now skip a hash check if an empty hash is specified. Unfortunately, the vsbuildtools.exe version can change without the URL changing, so we can't expect its hash to stay consistent, so we've disabled hash checking for vsbuildtools.exe.

Also the OpenSSLHash was missing from the PACKAGES variable, so I set it.