### PR TITLE
Fixed issue with decrypting the encryption key with the password key

### DIFF
--- a/samples/file-encryptor/enclave/encryptor.cpp
+++ b/samples/file-encryptor/enclave/encryptor.cpp
@@ -38,6 +38,7 @@ int ecall_dispatcher::initialize(
         encrypt ? "encrypting" : "decrypting");
 
     m_encrypt = encrypt;
+    memset((void*)m_encryption_key, 0, ENCRYPTION_KEY_SIZE_IN_BYTES);
 
     ret = process_encryption_header(encrypt, password, password_len, header);
     if (ret != 0)

--- a/samples/file-encryptor/enclave/keys.cpp
+++ b/samples/file-encryptor/enclave/keys.cpp
@@ -226,7 +226,12 @@ int ecall_dispatcher::cipher_encryption_key(
     mbedtls_aes_init(&aescontext);
 
     // set aes key
-    ret = mbedtls_aes_setkey_enc(&aescontext, encrypt_key, ENCRYPTION_KEY_SIZE);
+    if (encrypt){
+        ret = mbedtls_aes_setkey_enc(&aescontext, encrypt_key, ENCRYPTION_KEY_SIZE);
+    }
+    else {
+        ret = mbedtls_aes_setkey_dec(&aescontext, encrypt_key, ENCRYPTION_KEY_SIZE);
+    }
     if (ret != 0)
     {
         TRACE_ENCLAVE("mbedtls_aes_setkey_enc failed with %d", ret);
@@ -371,8 +376,8 @@ int ecall_dispatcher::parse_encryption_header(
         DECRYPT_OPERATION,
         header->encrypted_key,
         ENCRYPTION_KEY_SIZE_IN_BYTES,
-        (unsigned char*)m_encryption_key,
         password_key,
+        (unsigned char*)m_encryption_key,
         ENCRYPTION_KEY_SIZE_IN_BYTES);
     if (ret != 0)
     {

--- a/samples/file-encryptor/enclave/keys.cpp
+++ b/samples/file-encryptor/enclave/keys.cpp
@@ -226,10 +226,12 @@ int ecall_dispatcher::cipher_encryption_key(
     mbedtls_aes_init(&aescontext);
 
     // set aes key
-    if (encrypt){
+    if (encrypt)
+    {
         ret = mbedtls_aes_setkey_enc(&aescontext, encrypt_key, ENCRYPTION_KEY_SIZE);
     }
-    else {
+    else
+    {
         ret = mbedtls_aes_setkey_dec(&aescontext, encrypt_key, ENCRYPTION_KEY_SIZE);
     }
     if (ret != 0)

--- a/samples/file-encryptor/enclave/keys.cpp
+++ b/samples/file-encryptor/enclave/keys.cpp
@@ -228,15 +228,17 @@ int ecall_dispatcher::cipher_encryption_key(
     // set aes key
     if (encrypt)
     {
-        ret = mbedtls_aes_setkey_enc(&aescontext, encrypt_key, ENCRYPTION_KEY_SIZE);
+        ret = mbedtls_aes_setkey_enc(
+            &aescontext, encrypt_key, ENCRYPTION_KEY_SIZE);
     }
     else
     {
-        ret = mbedtls_aes_setkey_dec(&aescontext, encrypt_key, ENCRYPTION_KEY_SIZE);
+        ret = mbedtls_aes_setkey_dec(
+            &aescontext, encrypt_key, ENCRYPTION_KEY_SIZE);
     }
     if (ret != 0)
     {
-        TRACE_ENCLAVE("mbedtls_aes_setkey_enc failed with %d", ret);
+        TRACE_ENCLAVE("mbedtls_aes_setkey_enc/dec failed with %d", ret);
         goto exit;
     }
 


### PR DESCRIPTION
The current code was using the previous encryption key generated from previous encrypt operation which was cached in the global dispatcher object. The decrypt operation didn't alter the encryption key due to couple of reasons.