### PR TITLE
Preserve Windows & Linux ABI expectations on ECALL

### DIFF
--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -119,6 +119,23 @@ oe_enter:
     mov %rsp, %rbp
 
 .call_function:
+    // Set the MXCSR according to the Linux x86_64 ABI
+    mov $ABI_MXCSR_INIT, %r10
+    push %r10
+    ldmxcsr (%rsp)
+    pop %r10
+
+    // Set the FPU Control Word according to the Linux x86_64 ABI
+    mov $ABI_FPUCW_INIT, %r10
+    push %r10
+    fldcw (%rsp)
+    pop %r10
+
+    // Initialize the RFLAGS prior to calling enclave functions
+    // This only clears the DF and state flag bits since
+    // the system flags and reserved bits are not writable here
+    push $0
+    popfq
 
     // Get the host stack pointer.
     mov %gs:td_host_rsp, %r8

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -175,6 +175,7 @@ if (OE_SGX)
       sgx/windows/aesm.c
       sgx/windows/enter.asm
       sgx/windows/entersim.asm
+      sgx/windows/host_context.asm
       sgx/windows/exception.c
       sgx/windows/xstate.c)
   endif()

--- a/host/sgx/windows/host_context.asm
+++ b/host/sgx/windows/host_context.asm
@@ -1,0 +1,78 @@
+;; Copyright (c) Microsoft Corporation. All rights reserved.
+;; Licensed under the MIT License.
+
+OE_CONTEXT_FLAGS    EQU 00
+OE_CONTEXT_RBX      EQU 08
+OE_CONTEXT_RDI      EQU 16
+OE_CONTEXT_RSI      EQU 24
+OE_CONTEXT_R12      EQU 32
+OE_CONTEXT_R13      EQU 40
+OE_CONTEXT_R14      EQU 48
+OE_CONTEXT_R15      EQU 56
+OE_CONTEXT_FLOAT    EQU 64
+
+.CODE
+
+PUBLIC oe_save_host_context
+oe_save_host_context PROC
+    ;; Subroutine prologue
+    push rbp
+    mov rbp, rsp
+
+    ;; Save the flags to stack.
+    pushf
+    mov rax, [rsp]
+    mov [rcx+OE_CONTEXT_FLAGS], rax
+    popf
+
+    ;; Save general registers.
+    mov [rcx+OE_CONTEXT_RBX], rbx
+    mov [rcx+OE_CONTEXT_RDI], rdi
+    mov [rcx+OE_CONTEXT_RSI], rsi
+    mov [rcx+OE_CONTEXT_R12], r12
+    mov [rcx+OE_CONTEXT_R13], r13
+    mov [rcx+OE_CONTEXT_R14], r14
+    mov [rcx+OE_CONTEXT_R15], r15
+
+    ;; Save x87 FPU, MMX and SSE state (includes MXCSR and XMM registers).
+    fxsave [rcx+OE_CONTEXT_FLOAT]
+
+    ;; Subroutine epilogue
+    mov rsp, rbp
+    pop rbp
+    ret
+
+oe_save_host_context ENDP
+
+PUBLIC oe_restore_host_context
+oe_restore_host_context PROC
+
+    ;; Subroutine prologue
+    push rbp
+    mov rbp, rsp
+
+    ;; Restore the flags to stack.
+    push [rcx+OE_CONTEXT_FLAGS]
+    popfq
+
+    ;; Restore general registers.
+    mov rbx, [rcx+OE_CONTEXT_RBX]
+    mov rdi, [rcx+OE_CONTEXT_RDI]
+    mov rsi, [rcx+OE_CONTEXT_RSI]
+    mov r12, [rcx+OE_CONTEXT_R12]
+    mov r13, [rcx+OE_CONTEXT_R13]
+    mov r14, [rcx+OE_CONTEXT_R14]
+    mov r15, [rcx+OE_CONTEXT_R15]
+
+    ;; Restore x87 FPU, MMX and SSE state (includes MXCSR and XMM registers).
+    fxrstor [rcx+OE_CONTEXT_FLOAT]
+
+    ;; Subroutine epilogue
+    mov rsp, rbp
+    pop rbp
+    ret
+
+oe_restore_host_context ENDP
+
+END
+

--- a/include/openenclave/internal/constants_x64.h
+++ b/include/openenclave/internal/constants_x64.h
@@ -71,4 +71,10 @@
 //  AMD64 ABI needs a 128 bytes red zone.
 #define ABI_REDZONE_BYTE_SIZE 0x80
 
+// MXCSR initialization value for Linux x86_64 ABI in enclave
+#define ABI_MXCSR_INIT 0x1F80
+
+// x87 FPU control word initialization value for Linux x86_64 ABI in enclave
+#define ABI_FPUCW_INIT 0x037F
+
 #endif /* _OE_INTERNAL_CONSTANTS_X64_H */


### PR DESCRIPTION
This changeset addresses some of the issues in #1520 by reconciling some of the ABI inconsistencies when calling from a Windows host process into an Linux-based enclave. This includes:

- Initialize the MXCSR, RFLAGS and x87 FPU control word on ECALL to ensure that
  the enclave can expect the Linux x86_64 ABI-specified initial process state.

- Preserve the Windows x64 ABI-specified callee-preserved registers, x87 FPU,
  MMX, XMM and MXCSR states before each ECALL and restore them on return or
  OCALL.

- Update return_from_ecall to use r10 instead of callee-preserved rbx register
  as a temporary register.