### PR TITLE
Fix incremental rebuild due to `add_custom_target`

### DIFF
--- a/tests/crypto/data/CMakeLists.txt
+++ b/tests/crypto/data/CMakeLists.txt
@@ -10,33 +10,35 @@ else()
     message(FATAL_ERROR "Unknown OS. Only supported OSes are Linux and Windows")
 endif()
 
-add_custom_target(
-    crypto_test_data ALL
+# These are specifically the byproducts that will be directly consumed by crypto tests
+set(CRYPTO_TEST_DATA
+    asn1.cert.pem
+    coordinates.bin
+    ec_cert_with_ext.pem
+    ec_cert_crl_distribution.pem
+    intermediate.crl.der
+    intermediate.cert.pem
+    intermediate.ec.cert.pem
+    intermediate2.cert.pem
+    leaf.key.pem
+    leaf.cert.pem
+    leaf.ec.cert.pem
+    leaf.public.key.pem
+    leaf_modulus.hex
+    leaf2.cert.pem
+    root.crl.der
+    root.cert.pem
+    root.ec.cert.pem
+    root.ec.key.pem
+    root.ec.public.key.pem
+    root2.cert.pem
+    self_signed.cert.der
+    test_ec_signature
+    test_rsa_signature
+    time.txt)
+
+add_custom_command(
     COMMAND ${OE_BASH} -c "${CMAKE_CURRENT_SOURCE_DIR}/make-test-certs ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${BUILD_OPT}"
-    # These are specifically the byproducts that will be directly consumed by crypto tests
-    BYPRODUCTS
-        asn1.cert.pem
-        coordinates.bin
-        ec_cert_with_ext.pem
-        ec_cert_crl_distribution.pem
-        intermediate.crl.der
-        intermediate.cert.pem
-        intermediate.ec.cert.pem
-        intermediate2.cert.pem
-        leaf.key.pem
-        leaf.cert.pem
-        leaf.ec.cert.pem
-        leaf.public.key.pem
-        leaf_modulus.hex
-        leaf2.cert.pem
-        root.crl.der
-        root.cert.pem
-        root.ec.cert.pem
-        root.ec.key.pem
-        root.ec.public.key.pem
-        root2.cert.pem
-        self_signed.cert.der
-        test_ec_signature
-        test_rsa_signature
-        time.txt
-    )
+    OUTPUT ${CRYPTO_TEST_DATA})
+
+add_custom_target(crypto_test_data DEPENDS ${CRYPTO_TEST_DATA})

--- a/tests/crypto_crls_cert_chains/data/CMakeLists.txt
+++ b/tests/crypto_crls_cert_chains/data/CMakeLists.txt
@@ -10,11 +10,8 @@ else()
     message(FATAL_ERROR "Unknown OS. Only supported OSes are Linux and Windows")
 endif()
 
-add_custom_target(
-    crypto_crls_cert_chains_test_data ALL
-    COMMAND ${OE_BASH} -c "${CMAKE_CURRENT_SOURCE_DIR}/make-test-certs ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${BUILD_OPT}"
-    # These are specifically the byproducts that will be directly consumed by crypto_crls_cert_chains tests
-    BYPRODUCTS
+# These are specifically the byproducts that will be directly consumed by crypto_crls_cert_chains tests
+set(CRYPTO_CRLS_DATA
     root.cert.pem
     intermediate.cert.pem
     leaf1.cert.pem
@@ -22,5 +19,10 @@ add_custom_target(
     root_crl1.der
     root_crl2.der
     intermediate_crl1.der
-    intermediate_crl2.der
-    )
+    intermediate_crl2.der)
+
+add_custom_command(
+    COMMAND ${OE_BASH} -c "${CMAKE_CURRENT_SOURCE_DIR}/make-test-certs ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${BUILD_OPT}"
+    OUTPUT ${CRYPTO_CRLS_DATA})
+
+add_custom_target(crypto_crls_cert_chains_test_data DEPENDS ${CRYPTO_CRLS_DATA})


### PR DESCRIPTION
No file dependencies were setup, so repeated invocations of the build
system would cause these keys to be regenerated each time.

This bug was introduced in #2064, which I found via a long `git bisect` session.