### PR TITLE
Fix typo in oe_get_qe_identity_info_ocall function name

### DIFF
--- a/common/sgx/sgx.edl
+++ b/common/sgx/sgx.edl
@@ -36,7 +36,7 @@ enclave
             size_t quote_size,
             [out] size_t* quote_size_out);
 
-        oe_result_t oe_get_qe_identify_info_ocall(
+        oe_result_t oe_get_qe_identity_info_ocall(
             [out, size=qe_id_info_size] void* qe_id_info,
             size_t qe_id_info_size,
             [out] size_t* qe_id_info_size_out,

--- a/enclave/sgx/qeidinfo.c
+++ b/enclave/sgx/qeidinfo.c
@@ -40,7 +40,7 @@ oe_result_t oe_get_qe_identity_info(oe_get_qe_identity_info_args_t* args_out)
     args.issuer_chain_size = ISSUER_CHAIN_SIZE;
 
     /* First call (one or more buffers might be too small). */
-    if (oe_get_qe_identify_info_ocall(
+    if (oe_get_qe_identity_info_ocall(
             &retval,
             args.qe_id_info,
             args.qe_id_info_size,
@@ -76,7 +76,7 @@ oe_result_t oe_get_qe_identity_info(oe_get_qe_identity_info_args_t* args_out)
             OE_RAISE(OE_OUT_OF_MEMORY);
         }
 
-        if (oe_get_qe_identify_info_ocall(
+        if (oe_get_qe_identity_info_ocall(
                 &retval,
                 args.qe_id_info,
                 args.qe_id_info_size,

--- a/host/sgx/ocalls.c
+++ b/host/sgx/ocalls.c
@@ -271,7 +271,7 @@ done:
     return result;
 }
 
-oe_result_t oe_get_qe_identify_info_ocall(
+oe_result_t oe_get_qe_identity_info_ocall(
     void* qe_id_info,
     size_t qe_id_info_size,
     size_t* qe_id_info_size_out,
@@ -384,7 +384,7 @@ oe_result_t oe_get_revocation_info_ocall(
     return OE_UNSUPPORTED;
 }
 
-oe_result_t oe_get_qe_identify_info_ocall(
+oe_result_t oe_get_qe_identity_info_ocall(
     void* qe_id_info,
     size_t qe_id_info_size,
     size_t* qe_id_info_size_out,


### PR DESCRIPTION
Rename `oe_get_qe_identify_info_ocall` to `oe_qe_get_identity_info_ocall` for alignment with data structure name.