### PR TITLE
Add a release manager selection process to Releasing.md

### DIFF
--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -4,15 +4,19 @@ Open Enclave SDK Release Procedures
 This document covers how we handle creating a release. Let's look at it from an
 example:
 
+Selecting a Release Manager
+---------------------------
+
+The Community Governance Committee will select a release manager from one of the
+Committers by submitting a Pull Request that adds a "Release" tag to that
+Committer's "Area" in [Committers.md](Committers.md).
+
 Version Bump
 ------------
 
 > A note on naming: please prepend the `v` for consistency. Tags are `v0.7.0`
 > and branches are `v0.7.x`. We follow [Semantic
 > Versioning](https://semver.org/spec/v2.0.0.html).
-
-We want to release `v0.7.0` in about a week, so we choose a release manager from
-the committers.
 
 The initial announcement of the upcoming release will be a PR by the release
 manager to the `master` branch with the commit to bump the [VERSION


### PR DESCRIPTION
This adds a stop-gap process for nominating and selecting a release manager to unblock us for the upcoming release.

I chose 3 days for discussion as a minimum acceptable time period. We could increase that to 7 days (or more) if people wish!