### PR TITLE
Use dlerror() message when calling dlopen()

### DIFF
--- a/host/sgx/linux/sgxquoteproviderloader.c
+++ b/host/sgx/linux/sgxquoteproviderloader.c
@@ -74,7 +74,7 @@ void oe_load_quote_provider()
         else
         {
             OE_TRACE_ERROR(
-                "sgxquoteprovider: libdcap_quoteprov.so not found \n");
+		"sgxquoteprovider: libdcap_quoteprov.so %s\n", dlerror());	    
         }
     }
 }

--- a/host/sgx/linux/sgxquoteproviderloader.c
+++ b/host/sgx/linux/sgxquoteproviderloader.c
@@ -74,7 +74,7 @@ void oe_load_quote_provider()
         else
         {
             OE_TRACE_ERROR(
-		"sgxquoteprovider: libdcap_quoteprov.so %s\n", dlerror());	    
+                "sgxquoteprovider: libdcap_quoteprov.so %s\n", dlerror());
         }
     }
 }


### PR DESCRIPTION
[Problem]
Error message is not clear when calling dlopen. Using "not
found" as error message will mislead people because sometimes the issue
is caused by missing dependency shared library.

[Solution]
Print out dlerror() string instead of using "not found"

[Test]
Tried to downgrade the openssl from 1.1.1 to 1.1.0. So
libdcap_quoteprov.so will not be able to link to openssl properly.
Instead of showing "libdcap_quoteprov.so not found", now it shows
"libdcap_quoteprov.so /usr/local/lib/libssl.so.1.1: version
`OPENSSL_1_1_1' not found (required by /usr/lib/x86_64-linux-gnu/libcurl.so.4)"