### PR TITLE
Remove Windows 10 client as a supported OS

### DIFF
--- a/docs/GettingStartedDocs/Contributors/SGX1GettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/SGX1GettingStarted.md
@@ -93,3 +93,7 @@ For more information refer to the [Advanced Test Info](AdvancedTestInfo.md) docu
 ## Install
 
  Follow the instructions in the [Install Info](LinuxInstallInfo.md) document to install the Open Enclave SDK built above.
+
+## Build and run samples
+
+To build and run the samples, please look [here](/samples/README_Linux.md).

--- a/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
@@ -6,8 +6,7 @@
  Note: To check if your system has support for SGX1 with or without FLC, please look [here](../SGXSupportLevel.md).
  
 - A version of Windows OS with native support for SGX features:
-   - For server: Windows Server 2016
-   - For client: Windows 10 64-bit version 1709 or newer
+   - Windows Server 2016
    - To check your Windows version, run `winver` on the command line.
 
 ## Software prerequisites

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
@@ -2,7 +2,7 @@
 
 ## Intel SGX Platform Software for Windows (PSW) v2.2
 
-The PSW should be installed automatically on Windows 10 version 1709 or newer, or on a Windows Server 2016 image for an Azure ConfidentialCompute VM. You can verify that is the case on the command line as follows:
+The PSW should be installed automatically on a Windows Server 2016 image for an Azure ConfidentialCompute VM. You can verify that is the case on the command line as follows:
 
 ```cmd
 sc query aesmservice

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
@@ -2,7 +2,7 @@
 
 ## Intel SGX Platform Software for Windows (PSW) v2.2
 
-The PSW should be installed automatically on a Windows Server 2016 image for an Azure ConfidentialCompute VM. You can verify that is the case on the command line as follows:
+The PSW should be installed automatically on a Windows Server 2016 image for an Azure Confidential Compute VM. You can verify that is the case on the command line as follows:
 
 ```cmd
 sc query aesmservice

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
@@ -7,8 +7,7 @@ Intel® X86-64bit architecture with SGX1 and Flexible Launch Control (FLC) suppo
 Note: To check if your system has support for SGX1 with FLC, please look [here](../SGXSupportLevel.md).
 
 A version of Windows OS with native support for SGX features:
-- For server: Windows Server 2016
-- For client: Windows 10 64-bit version 1709 or newer
+- Windows Server 2016
 - To check your Windows version, run `winver` on the command line.
 
 ## Install Git and Clone the Open Enclave SDK repo
@@ -125,7 +124,7 @@ ninja install
 
 This installs the SDK in `C:\openenclave`.
 
-### Build and run samples
+## Build and run samples
 
 To build and run the samples, please look [here](/samples/README_Windows.md).
 

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
@@ -8,7 +8,6 @@ Note: To check if your system has support for SGX1, please look [here](../SGXSup
 
 A version of Windows OS with native support for SGX features:
 - For server: Windows Server 2016
-- For client: Windows 10 64-bit version 1709 or newer
 - To check your Windows version, run `winver` on the command line.
 
 ## Install Git and Clone the Open Enclave SDK repo
@@ -35,14 +34,14 @@ To deploy all the prerequisities for building Open Enclave, you can run the foll
 
 ```powershell
 cd scripts
-.\install-windows-prereqs.ps1 -InstallPath C:\path\to\where\you\would\like\to\install\intel_and_dcap_nuget_packages -LaunchConfiguration SGX1 -DCAPClientType None
+.\install-windows-prereqs.ps1 -InstallPath C:\path\to\where\you\would\like\to\install\intel_nuget_packages -LaunchConfiguration SGX1 -DCAPClientType None
 ```
 
 As an example, if you cloned Open Enclave SDK repo into `C:\openenclave`, you would run the following:
 
 ```powershell
 cd scripts
-.\install-windows-prereqs.ps1 -InstallPath C:\path\to\where\you\would\like\to\install\intel_and_dcap_nuget_packages -LaunchConfiguration SGX1 -DCAPClientType None
+.\install-windows-prereqs.ps1 -InstallPath C:\path\to\where\you\would\like\to\install\intel_nuget_packages -LaunchConfiguration SGX1 -DCAPClientType None
 ```
 
 If you prefer to manually install prerequisites, please refer to this [document](WindowsManualInstallPrereqs.md).

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
@@ -8,7 +8,6 @@ Note: To check if your system has support for SGX1, please look [here](../SGXSup
 
 A version of Windows OS with native support for SGX features:
 - For server: Windows Server 2016
-- To check your Windows version, run `winver` on the command line.
 
 ## Install Git and Clone the Open Enclave SDK repo
 

--- a/samples/README_Linux.md
+++ b/samples/README_Linux.md
@@ -1,6 +1,6 @@
 # Building Open Enclave SDK Samples on Linux
 
-All the samples that come with the Open Enclave SDK installation share similar directory structure and build instructions. The section contains general information on how to setup/build/sign/run all samples. It's important that you read information on this page before jumping into any individual sample.
+All the samples that come with the Open Enclave SDK installation share a similar directory structure and build instructions. This document describes how to setup, build, sign and run these samples.
 
 ## Common Sample information
 


### PR DESCRIPTION
See issue #2241 

Windows Update pushed Intel PSW 2.5 onto Windows 10 client systems over the weekend. Windows 10 client systems generally run on SGX1 systems. On these systems, the Open enclave SDK needs Intel PSW 2.2 to launch enclaves. With Intel PSW 2.5, the Open Enclave SDK is unable to launch enclaves on systems with SGX1 support. 

As of now, I am removing Windows 10 as a supported OS.
Once we fix compatibility issues between Open Enclave SDK and Intel PSW 2.5, we can re-introduce Windows 10 client as a supported OS. See issue #1810 
