### PR TITLE
Update CMakeSettings.json with NUGET_PACKAGE_PATH

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -31,7 +31,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${workspaceRoot}\\build\\x64-Debug",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1 -DUSE_LIBSGX=1",
+      "cmakeCommandArgs": "-DBUILD_ENCLAVES=ON -DUSE_LIBSGX=ON -DNUGET_PACKAGE_PATH=${workspaceRoot}\\prereqs\\nuget",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     },
@@ -42,7 +42,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${workspaceRoot}\\build\\x64-RelWithDebInfo",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1 -DUSE_LIBSGX=1",
+      "cmakeCommandArgs": "-DBUILD_ENCLAVES=ON -DUSE_LIBSGX=ON -DNUGET_PACKAGE_PATH=${workspaceRoot}\\prereqs\\nuget",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     },
@@ -53,7 +53,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${workspaceRoot}\\build\\x64-Release",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1 -DUSE_LIBSGX=1",
+      "cmakeCommandArgs": "-DBUILD_ENCLAVES=ON -DUSE_LIBSGX=ON -DNUGET_PACKAGE_PATH=${workspaceRoot}\\prereqs\\nuget",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     }


### PR DESCRIPTION
Commit c3c6dc17 added a requirement to define the `NUGET_PACKAGE_PATH` variable
in CMake for WIN32 builds. This commit updates the CMakeSettings.json file for
Visual Studio users to provide the `NUGET_PACKAGE_PATH` parameter based on the
install path used when running install-windows-prereqs.ps1.