### PR TITLE
Fix errors in Windows documentations

### DIFF
--- a/docs/GettingStartedDocs/Contributors/WindowsInstallInfo.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsInstallInfo.md
@@ -5,8 +5,17 @@ You can locally install the SDK from the compiled Open Enclave tree by specifyin
 the install-prefix to the cmake call before calling `ninja install`.
 From the build subfolder in your source tree:
 
+For SGX1 + FLC targets:
+
 ```cmd
-cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=ON
+cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave
+ninja install
+```
+
+For SGX1 targets:
+
+```cmd
+cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=OFF
 ninja install
 ```
 
@@ -18,7 +27,7 @@ Please note that NUGET_PACKAGE_PATH in the above command points to the directory
 To create a redistributable NuGet package use the following command from your build subfolder:
 
 ```cmd
-cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\your\path\to\intel_and_dcap_nuget_packages -DCPACK_GENERATOR=NuGet -DHAS_QUOTE_PROVIDER=ON
+cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\your\path\to\intel_and_dcap_nuget_packages -DCPACK_GENERATOR=NuGet
 ninja package
 ```
 

--- a/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
@@ -6,7 +6,8 @@
  Note: To check if your system has support for SGX1 with or without FLC, please look [here](../SGXSupportLevel.md).
  
 - A version of Windows OS with native support for SGX features:
-   - Windows Server 2016
+   - For server: Windows Server 2016
+   - For client: Windows 10 64-bit version 1709 or newer
    - To check your Windows version, run `winver` on the command line.
 
 ## Software prerequisites
@@ -18,7 +19,7 @@
 
 ## Prerequisites specific to SGX support on your system
 
-For systems with support for SGX1  - [Intel's PSW 2.2](WindowsManualSGX1Prereqs.md)
+For systems with support for SGX1  - [Intel's PSW 2.4, Intel Enclave Common API library](WindowsManualSGX1Prereqs.md)
 
 For systems with support for SGX1 + FLC - [Intel's PSW 2.4, Intel's Data Center Attestation Primitives and related dependencies](WindowsManualSGX1FLCDCAPPrereqs.md)
 

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
@@ -7,7 +7,7 @@ version no lower than 1709. To check your Windows version, run `winver` on the
 command line.
 
 Windows Server 2016 image for an Azure Confidential Compute VM has a Windows version
-lower than 1709, therefore you need to install PSW v2.4 or above manually.
+lower than 1709, and therefore you need to install PSW v2.4 or above manually.
 You can download [PSW v2.4](http://registrationcenter-download.intel.com/akdlm/irc_nas/15654/Intel%20SGX%20PSW%20for%20Windows%20v2.4.100.51291.exe),
 extract the zipped files, and run the executable under folder **PSW_EXE_RS2_and_before**
 to install PSW 2.4.
@@ -39,11 +39,12 @@ It does not supporting quoting, and consequentially, attestation which is based 
 of quoting capability is a limitation of SGX1 machines which don't have FLC support.
 
 Firstly we download Intel SGX and DCAP library from [here](http://registrationcenter-download.intel.com/akdlm/irc_nas/15650/Intel%20SGX%20DCAP%20for%20Windows%20v1.2.100.49925.exe). Run the executable to unzip files to a specified location.
+The following summary will assume that the contents were extracted to `C:\Intel SGX DCAP for Windows v1.2.100.49925`:
 
-Make sure you have [nuget cli tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) installed,
-run the following command from a Windows prompt:
+Make sure you have [nuget cli tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) installed and in your path,
+run the following command from a command prompt:
 ```cmd
-nuget install EnclaveCommonAPI -Source C:\path\to\the\unzipped\sgx\and\dcap\files\nuget -OutputDirectory C:\path\to\where\you\would\like\to\install\intel_and_dcap_nuget_packages  -ExcludeVersion
+nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory C:\path\to\where\you\would\like\to\install\intel_nuget_packages
 ```
 
-You can verify that the library is installed properly by checking whether `sgx_enclave_coomon.lib` exists in the folder `C:\path\to\where\you\would\like\to\install\intel_and_dcap_nuget_packages\nuget\EnclaveCommonAPI\lib\native\x64-Release`.
+You can verify that the library is installed properly by checking whether `sgx_enclave_common.lib` exists in the folder `C:\path\to\where\you\would\like\to\install\intel_nuget_packages\nuget\EnclaveCommonAPI\lib\native\x64-Release`.

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
@@ -7,7 +7,8 @@ Intel® X86-64bit architecture with SGX1 and Flexible Launch Control (FLC) suppo
 Note: To check if your system has support for SGX1 with FLC, please look [here](../SGXSupportLevel.md).
 
 A version of Windows OS with native support for SGX features:
-- Windows Server 2016
+- For server: Windows Server 2016
+- For client: Windows 10 64-bit version 1709 or newer
 - To check your Windows version, run `winver` on the command line.
 
 ## Install Git and Clone the Open Enclave SDK repo
@@ -69,7 +70,7 @@ To build debug enclaves:
 cd C:\openenclave
 mkdir build\x64-Debug
 cd build\x64-Debug
-cmake -G Ninja -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=ON ..\..
+cmake -G Ninja -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave ..\..
 ninja
 ```
 
@@ -80,7 +81,7 @@ Similarly, to build release enclaves:
 cd C:\openenclave
 mkdir build\x64-Release
 cd build\x64-Release
-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=ON ..\..
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave ..\..
 ninja
 ```
 

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
@@ -8,6 +8,7 @@ Note: To check if your system has support for SGX1, please look [here](../SGXSup
 
 A version of Windows OS with native support for SGX features:
 - For server: Windows Server 2016
+- For client: Windows 10 64-bit version 1709 or newer
 
 ## Install Git and Clone the Open Enclave SDK repo
 
@@ -57,7 +58,7 @@ Normally this is accessible under the `Visual Studio 2017` folder in the Start M
 cd C:\openenclave
 mkdir build\x64-Debug
 cd build\x64-Debug
-cmake -G Ninja -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave ..\..
+cmake -G Ninja -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=OFF ..\..
 ninja
 ```
 
@@ -69,7 +70,7 @@ Similarly, to build release enclaves:
 cd C:\openenclave
 mkdir build\x64-Release
 cd build\x64-Release
-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave ..\..
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=OFF ..\..
 ninja
 ```
 

--- a/docs/GettingStartedDocs/Contributors/building_oe_sdk.md
+++ b/docs/GettingStartedDocs/Contributors/building_oe_sdk.md
@@ -69,7 +69,7 @@ See [Open Enclave samples](/samples/README_Linux.md) for details.
 Assuming you install the SDK as below (also described in the [basic install section](WindowsInstallInfo.md#basic-install-on-windows))
 
 ```bash
-cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\path\to\intel_and_dcap_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave" -DHAS_QUOTE_PROVIDER=ON
+cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\path\to\intel_and_dcap_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave"
 ninja install
 ```
 Open Enclave samples can be found in c:\openenclave\share\openenclave\samples

--- a/docs/GettingStartedDocs/Windows_using_oe_sdk.md
+++ b/docs/GettingStartedDocs/Windows_using_oe_sdk.md
@@ -40,7 +40,7 @@ what each one illustrates, and how to build and run them  can be found in
 
 Additional documentation is also available for:
 - [Building and signing enclaves](/docs/GettingStartedDocs/buildandsign.md)
-- [Debugging enclave memory](/docs/GettingStartedDocs/Debugging.md)
+- [Debugging enclave applications](/docs/GettingStartedDocs/Debugging.md)
 
 ## APIs and supported libraries
 


### PR DESCRIPTION
This PR adds back Windows 10 as a supported platform. It also fixes a few statements in windows get started documents that are no longer true after PR #2250.