### PR TITLE
Update all docs and ansible/scripts to use latest Intel drops.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to [openenclave/openenclave](https://github.com/openenclave/openenclave).
 - Change debugging contract for oegdb. Enclaves and hosts built prior to this
   release cannot be debugged with this version of oegdb and vice versa.
-- Update Intel DCAP library dependencies to 1.2.
-- Update Intel PSW dependencies to 2.6 on Linux and 2.4 on Windows.
+- Update Intel DCAP library dependencies to 1.3.
+- Update Intel PSW dependencies to 2.7 on Linux and 2.5 on Windows.
 - SGX1 configurations always take build dependency on Intel SGX enclave common library.
 - Update LLVM libcxx to version 8.0.0.
 - Update mbedTLS to version 2.16.2.

--- a/docs/GettingStartedDocs/Contributors/BuildingInADockerContainer.md
+++ b/docs/GettingStartedDocs/Contributors/BuildingInADockerContainer.md
@@ -9,11 +9,11 @@
 1. Install Docker CE by following these instructions: https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce
 
 2. Install the appropriate Intel SGX Driver for your platform. For example, if you're running on an SGX1 with FLC system, you'll probably want to install the Intel SGX DCAP Driver for your platfrom: https://01.org/intel-software-guard-extensions/downloads
-    - If you're running on an SGX with FLC system, you'll probably want to install the Intel SGX DCAP Driver for your platfrom: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-dcap-linux-1.2-release
-    - If you're running on an SGX without FLC system, you'll want to install the Intel SGX Driver for your platform: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-linux-2.6-release
-    - The driver you're looking for is a ".bin" file, for either Ubuntu 16.04 or 18.04 releases. It will be named something like: `sgx_linux_x64_driver_1.12_c110012.bin`
+    - If you're running on an SGX with FLC system, you'll probably want to install the Intel SGX DCAP Driver for your platfrom: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-dcap-linux-1.3-release
+    - If you're running on an SGX without FLC system, you'll want to install the Intel SGX Driver for your platform: https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-linux-2.7-release
+    - The driver you're looking for is a ".bin" file, for either Ubuntu 16.04 or 18.04 releases. It will be named something like: `sgx_linux_x64_driver_1.13.bin`
     - To install this driver, simply run it as root like this:
-        - `sudo bash ./sgx_linux_x64_driver_1.12_c110012.bin`
+        - `sudo bash ./sgx_linux_x64_driver_1.13.bin`
 
 3. Pull the latest oetools-full image for Open Enclave from *either* of these two distributions:
     - https://hub.docker.com/r/oeciteam/oetools-full-16.04

--- a/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
@@ -19,9 +19,9 @@
 
 ## Prerequisites specific to SGX support on your system
 
-For systems with support for SGX1  - [Intel's PSW 2.4, Intel Enclave Common API library](WindowsManualSGX1Prereqs.md)
+For systems with support for SGX1  - [Intel's PSW 2.5, Intel Enclave Common API library](WindowsManualSGX1Prereqs.md)
 
-For systems with support for SGX1 + FLC - [Intel's PSW 2.4, Intel's Data Center Attestation Primitives and related dependencies](WindowsManualSGX1FLCDCAPPrereqs.md)
+For systems with support for SGX1 + FLC - [Intel's PSW 2.5, Intel's Data Center Attestation Primitives and related dependencies](WindowsManualSGX1FLCDCAPPrereqs.md)
 
 ## Microsoft Visual Studio Build Tools 2019
 Install [Visual Studio Build Tools 2019](https://aka.ms/vs/16/release/vs_buildtools.exe). Choose the "C++ build tools" workload. Visual Studio Build Tools 2019 has support for CMake Version 3.15 (CMake ver 3.12 or above is required for building Open Enclave SDK). For more information about CMake support, look [here](https://blogs.msdn.microsoft.com/vcblog/2016/10/05/cmake-support-in-visual-studio/).

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
@@ -1,10 +1,10 @@
 # SGX1 with Flexible Launch Control (FLC) Prerequisites on Windows
 
-## [Intel Platform Software for Windows (PSW) v2.4](http://registrationcenter-download.intel.com/akdlm/irc_nas/15654/Intel%20SGX%20PSW%20for%20Windows%20v2.4.100.51291.exe)
+## [Intel Platform Software for Windows (PSW) v2.5](http://registrationcenter-download.intel.com/akdlm/irc_nas/15929/Intel%20SGX%20PSW%20for%20Windows%20v2.5.100.2.exe)
 
 After unpacking the self-extracting ZIP executable, install the *PSW_EXE_RS2_and_before* version:
 ```cmd
-C:\Intel SGX PSW for Windows v2.4.100.51291\PSW_EXE_RS2_and_before\Intel(R)_SGX_Windows_x64_PSW_2.4.100.51291.exe"
+C:\Intel SGX PSW for Windows v2.5.100.2\PSW_EXE_RS2_and_before\Intel(R)_SGX_Windows_x64_PSW_2.5.100.2.exe"
 ```
 
 ## [Azure DCAP client for Windows](https://github.com/Microsoft/Azure-DCAP-Client/tree/master/src/Windows) [optional]
@@ -14,19 +14,19 @@ The Azure DCAP client for Windows is necessary if you would like to perform encl
 This example assumes that `C:\oe_prereqs` is where you would like the prerequisites to be installed.
 
 ```cmd
-nuget.exe install Azure.DCAP.Windows -ExcludeVersion -Version 0.0.2 -OutputDirectory C:\oe_prereqs
+nuget.exe install Azure.DCAP.Windows -ExcludeVersion -Version 0.0.3 -OutputDirectory C:\oe_prereqs
 ```
 This example assumes you would like to install the package to `C:\oe_prereqs`.
 
-##### [Intel Data Center Attestation Primitives (DCAP) Libraries v1.2](http://registrationcenter-download.intel.com/akdlm/irc_nas/15650/Intel%20SGX%20DCAP%20for%20Windows%20v1.2.100.49925.exe)
+##### [Intel Data Center Attestation Primitives (DCAP) Libraries v1.3](http://registrationcenter-download.intel.com/akdlm/irc_nas/16014/Intel%20SGX%20DCAP%20for%20Windows%20v1.3.100.4.exe)
 After unpacking the self-extracting ZIP executable, you can refer to the *Intel SGX DCAP Windows SW Installation Guide.pdf*
 for more details on how to install the contents of the package.
 
-The following summary will assume that the contents were extracted to `C:\Intel SGX DCAP for Windows v1.2.100.49925`:
+The following summary will assume that the contents were extracted to `C:\Intel SGX DCAP for Windows v1.3.100.4`:
 
 1. Unzip the required drivers from the extracted subfolders:
-    - `LC_driver_WinServer2016\Signed_1152921504628095185.zip`
-    - `DCAP_INF\WinServer2016\Signed_1152921504628099289.zip`
+    - `LC_driver_WinServer2016\Signed_*.zip`
+    - `DCAP_INF\WinServer2016\Signed_*.zip`
 
    The following instructions will assume that these have been unzipped into the `LC_driver` and `DCAP_INF` folders respectively.
 
@@ -49,7 +49,7 @@ The following summary will assume that the contents were extracted to `C:\Intel 
 4. Install the DCAP nuget packages:
     - The standalone `nuget.exe` [CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) can be used to do this from the command prompt:
       ```cmd
-      nuget.exe install DCAP_Components -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory c:\oe_prereqs
-      nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory c:\oe_prereqs
+      nuget.exe install DCAP_Components -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.3.100.4\nuget" -OutputDirectory c:\oe_prereqs
+      nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.3.100.4\nuget" -OutputDirectory c:\oe_prereqs
       ```
     - *Note:* EnclaveCommonAPI should be installed as the *very last* nuget package as a temporary workaround for a dependency issue. Please see issue #2170, for more details.

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
@@ -8,15 +8,15 @@ command line.
 
 Windows Server 2016 image for an Azure Confidential Compute VM has a Windows version
 lower than 1709, and therefore you need to install PSW v2.4 or above manually.
-You can download [PSW v2.4](http://registrationcenter-download.intel.com/akdlm/irc_nas/15654/Intel%20SGX%20PSW%20for%20Windows%20v2.4.100.51291.exe),
+You can download [PSW v2.5](http://registrationcenter-download.intel.com/akdlm/irc_nas/15929/Intel%20SGX%20PSW%20for%20Windows%20v2.5.100.2.exe),
 extract the zipped files, and run the executable under folder **PSW_EXE_RS2_and_before**
-to install PSW 2.4.
+to install PSW 2.5.
 
 You can verify that the correct version of Intel SGX PSW is installed by using
 Windows Explorer to open `C:\Windows\System32`. You should be able to find
 file `sgx_urts.dll` if PSW is installed. Right click on `sgx_urts.dll`,
 choose `Properties` and then find `Product version` on the `Details` tab.
-The version should be "2.4.xxx.xxx" or above.
+The version should be "2.5.xxx.xxx" or above.
 
 To verify that Intel SGX PSW is running, use the following command:
 
@@ -38,13 +38,17 @@ The Intel Enclave Common API library is necessary for creating, initializing, an
 It does not supporting quoting, and consequentially, attestation which is based on quoting. The lack
 of quoting capability is a limitation of SGX1 machines which don't have FLC support.
 
-Firstly we download Intel SGX and DCAP library from [here](http://registrationcenter-download.intel.com/akdlm/irc_nas/15650/Intel%20SGX%20DCAP%20for%20Windows%20v1.2.100.49925.exe). Run the executable to unzip files to a specified location.
-The following summary will assume that the contents were extracted to `C:\Intel SGX DCAP for Windows v1.2.100.49925`:
+Firstly we download the Intel SGX DCAP self-extracting executable from [here](http://registrationcenter-download.intel.com/akdlm/irc_nas/16014/Intel%20SGX%20DCAP%20for%20Windows%20v1.3.100.4.exe). Run the executable to unzip files to a specified location.
+The following summary will assume that the contents were extracted to `C:\Intel SGX DCAP for Windows v1.3.100.4`:
 
 Make sure you have [nuget cli tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) installed and in your path,
 run the following command from a command prompt (assuming you would like the package to be installed to `C:\oe_prereqs`):
 ```cmd
+<<<<<<< HEAD
 nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory C:\oe_prereqs
+=======
+nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.3.100.4\nuget" -OutputDirectory C:\path\to\where\you\would\like\to\install\intel_nuget_packages
+>>>>>>> Update all docs and ansible to use latest Intel SGX versions
 ```
 
 You can verify that the library is installed properly by checking whether `sgx_enclave_common.lib` exists in the folder `C:\oe_prereqs`.

--- a/docs/GettingStartedDocs/Windows_vscode.md
+++ b/docs/GettingStartedDocs/Windows_vscode.md
@@ -50,7 +50,7 @@ Open Workspace Settings by pressing Ctrl+Shift+P and typing "Open Workspace Sett
 
 ![Open Workspace Settings](images/VSCodeOpenWorkspaceSettings.png)
 
-Search for the setting "CMake Configure Args" and add an item `-DNUGET_PACKAGE_PATH=path-to-openenclave-nuget-packages\prereqs\nuget`.
+Search for the setting "CMake Configure Args" and add an item `-DNUGET_PACKAGE_PATH=path-to-openenclave-nuget-packages`.
 Add another item `-DOpenEnclave_DIR=YourOpenEnclaveInstallFolder\lib\openenclave\cmake`
 
 ![CMake Configure Args](images/VSCodeCMakeConfigureArgs.png)
@@ -61,7 +61,7 @@ For example, if you ran install-windows-prereqs.ps1 with -InstallPath C:\openenc
 {
     "cmake.cmakePath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\CMake\\bin\\cmake.exe",
     "cmake.configureArgs": [
-        "-DNUGET_PACKAGE_PATH=C:\\openenclave_prereqs\\prereqs\\nuget",
+        "-DNUGET_PACKAGE_PATH=C:\\openenclave_prereqs",
         "-DOpenEnclave_DIR=C:\\openenclave\\lib\\openenclave\\cmake"
     ]
 }
@@ -95,7 +95,7 @@ If you installed the Open Enclave SDK at `C:\openenclave`, the Settings.json wou
 {
     "cmake.cmakePath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\CMake\\bin\\cmake.exe",
     "cmake.configureArgs": [
-        "-DNUGET_PACKAGE_PATH=C:\\openenclave_prereqs\\prereqs\\nuget",
+        "-DNUGET_PACKAGE_PATH=C:\\openenclave_prereqs",
         "-DOpenEnclave_DIR=C:\\openenclave\\lib\\openenclave\\cmake"
     ],
     "C_Cpp.default.includePath": ["C:\\openenclave\\include"],

--- a/docs/GettingStartedDocs/Windows_windbg.md
+++ b/docs/GettingStartedDocs/Windows_windbg.md
@@ -29,7 +29,7 @@ Change to the directory containing your Open Enclave Application. Make a build f
 cd YourApplicationFolder
 mkdir build
 cd build
-cmake -G Ninja -DOpenEnclave_DIR=your-open-enclave-install-path\lib\openenclave\cmake -DNUGET_PACKAGE_PATH=your-openenclave-nuget-packages-path\prereqs\nuget ..
+cmake -G Ninja -DOpenEnclave_DIR=your-open-enclave-install-path\lib\openenclave\cmake -DNUGET_PACKAGE_PATH=your-openenclave-nuget-packages-path ..
 ```
 
 ![Configure](images/WinDbgConfigure.png)

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
@@ -26,7 +26,7 @@ wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add 
 ```bash
 sudo apt update
 sudo apt -y install dkms
-wget https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_1.12_c110012.bin -O sgx_linux_x64_driver.bin
+wget https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.13.bin -O sgx_linux_x64_driver.bin
 chmod +x sgx_linux_x64_driver.bin
 sudo ./sgx_linux_x64_driver.bin
 ```

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
@@ -26,7 +26,7 @@ wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add 
 ```bash
 sudo apt update
 sudo apt -y install dkms
-wget https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_1.12_c110012.bin -O sgx_linux_x64_driver.bin
+wget https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.13.bin -O sgx_linux_x64_driver.bin
 chmod +x sgx_linux_x64_driver.bin
 sudo ./sgx_linux_x64_driver.bin
 ```

--- a/scripts/ansible/oe-windows-acc-setup.yml
+++ b/scripts/ansible/oe-windows-acc-setup.yml
@@ -8,12 +8,10 @@
   tasks:
     - name: OE setup | Set installer URLs from the OE storage account
       set_fact:
-        intel_psw_2_2_url:   "https://oejenkins.blob.core.windows.net/oejenkins/intel_sgx_win_2.2.100.47975_PV.zip"
-        intel_psw_2_2_hash:  "EB479D1E029D51E48E534C284FCF5CCA3A937DA43052DCB2F4C71E5F354CA623"
-        intel_psw_2_4_url:   "https://oejenkins.blob.core.windows.net/oejenkins/Intel%20SGX%20PSW%20for%20Windows%20v2.4.100.51291.exe"
-        intel_psw_2_4_hash:  "79AE32E984B5511CE4BF7568403333F837FBCE7E8D5730271C5D68F55BBF251D"
-        intel_dcap_url:      "https://oejenkins.blob.core.windows.net/oejenkins/Intel%20SGX%20DCAP%20for%20Windows%20v1.2.100.49925.exe"
-        intel_dcap_hash:     "F31E4451CA32E19CA3DCB0AFC49AFE9F4963C47BF62AAF24A8AE436BDA14FD8B"
+        intel_psw_url:       "https://oejenkins.blob.core.windows.net/oejenkins/Intel%20SGX%20PSW%20for%20Windows%20v2.5.100.2.exe"
+        intel_psw_hash:      "744B52C2DEDA3EC2AAC495A4F671FE574C506C35523028584A74469911FB0707"
+        intel_dcap_url:      "https://oejenkins.blob.core.windows.net/oejenkins/Intel%20SGX%20DCAP%20for%20Windows%20v1.3.100.4.exe"
+        intel_dcap_hash:     "B74C12B68BBDB942A6FB74A14BBCEDE05E37B3388693CB3EEA2D7DB520E83572"
         git_url:             "https://oejenkins.blob.core.windows.net/oejenkins/Git-2.19.1-64-bit.exe"
         git_hash:            "5E11205840937DD4DFA4A2A7943D08DA7443FAA41D92CCC5DAFBB4F82E724793"
         seven_zip_url:       "https://oejenkins.blob.core.windows.net/oejenkins/7z1806-x64.msi"
@@ -38,8 +36,8 @@
         -InstallPath         "C:\openenclave"
         -LaunchConfiguration "{{ 'SGX1FLC' if dcap_testing_node is defined and dcap_testing_node == 'true' else 'SGX1' }}"
         -DCAPClientType      "{{ 'Azure' }}"
-        -IntelPSWURL         "{{ intel_psw_2_4_url if dcap_testing_node is defined and dcap_testing_node == 'true' else intel_psw_2_2_url }}"
-        -IntelPSWHash        "{{ intel_psw_2_4_hash if dcap_testing_node is defined and dcap_testing_node == 'true' else intel_psw_2_2_hash }}"
+        -IntelPSWURL         "{{ intel_psw_url }}"
+        -IntelPSWHash        "{{ intel_psw_hash }}"
         -IntelDCAPURL        "{{ intel_dcap_url }}"
         -IntelDCAPHash       "{{ intel_dcap_hash }}"
         -GitURL              "{{ git_url }}"

--- a/scripts/ansible/roles/linux/intel/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/intel/vars/bionic.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_1.12_c110012.bin"
-intel_sgx1_driver_url: "https://download.01.org/intel-sgx/linux-2.6/ubuntu18.04-server/sgx_linux_x64_driver_2.5.0_2605efa.bin"
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.13.bin"
+intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.7/distro/ubuntu18.04-server/sgx_linux_x64_driver_2.6.0_4f5bb63.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf10"

--- a/scripts/ansible/roles/linux/intel/vars/xenial.yml
+++ b/scripts/ansible/roles/linux/intel/vars/xenial.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_1.12_c110012.bin"
-intel_sgx1_driver_url: "https://download.01.org/intel-sgx/linux-2.6/ubuntu16.04-server/sgx_linux_x64_driver_2.5.0_2605efa.bin"
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.13.bin"
+intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.7/distro/ubuntu16.04-server/sgx_linux_x64_driver_2.6.0_4f5bb63.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf9v5"

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -16,16 +16,16 @@ Param(
     [string]$OCamlHash = '369F900F7CDA543ABF674520ED6004CC75008E10BEED0D34845E8A42866D0F3A',
     [string]$Clang7URL = 'http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe',
     [string]$Clang7Hash = '672E4C420D6543A8A9F8EC5F1E5F283D88AC2155EF4C57232A399160A02BFF57',
-    [string]$IntelPSWURL = 'http://registrationcenter-download.intel.com/akdlm/irc_nas/15654/Intel%20SGX%20PSW%20for%20Windows%20v2.4.100.51291.exe',
-    [string]$IntelPSWHash = '79AE32E984B5511CE4BF7568403333F837FBCE7E8D5730271C5D68F55BBF251D',
+    [string]$IntelPSWURL = 'http://registrationcenter-download.intel.com/akdlm/irc_nas/15929/Intel%20SGX%20PSW%20for%20Windows%20v2.5.100.2.exe',
+    [string]$IntelPSWHash = '744B52C2DEDA3EC2AAC495A4F671FE574C506C35523028584A74469911FB0707',
     [string]$ShellCheckURL = 'https://shellcheck.storage.googleapis.com/shellcheck-v0.7.0.zip',
     [string]$ShellCheckHash = '02CFA14220C8154BB7C97909E80E74D3A7FE2CBB7D80AC32ADCAC7988A95E387',
     [string]$NugetURL = 'https://www.nuget.org/api/v2/package/NuGet.exe/3.4.3',
     [string]$NugetHash = '2D4D38666E5C7D27EE487C60C9637BD9DD63795A117F0E0EDC68C55EE6DFB71F',
     [string]$DevconURL = 'https://download.microsoft.com/download/7/D/D/7DD48DE6-8BDA-47C0-854A-539A800FAA90/wdk/Installers/787bee96dbd26371076b37b13c405890.cab',
     [string]$DevconHash = 'A38E409617FC89D0BA1224C31E42AF4344013FEA046D2248E4B9E03F67D5908A',
-    [string]$IntelDCAPURL = 'http://registrationcenter-download.intel.com/akdlm/irc_nas/15650/Intel%20SGX%20DCAP%20for%20Windows%20v1.2.100.49925.exe',
-    [string]$IntelDCAPHash = 'F31E4451CA32E19CA3DCB0AFC49AFE9F4963C47BF62AAF24A8AE436BDA14FD8B',
+    [string]$IntelDCAPURL = 'http://registrationcenter-download.intel.com/akdlm/irc_nas/16014/Intel%20SGX%20DCAP%20for%20Windows%20v1.3.100.4.exe',
+    [string]$IntelDCAPHash = 'B74C12B68BBDB942A6FB74A14BBCEDE05E37B3388693CB3EEA2D7DB520E83572',
     [string]$VCRuntime2012URL = 'https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe',
     [string]$VCRuntime2012Hash = '681BE3E5BA9FD3DA02C09D7E565ADFA078640ED66A0D58583EFAD2C1E3CC4064',
     [string]$AzureDCAPNupkgURL = 'https://www.nuget.org/api/v2/package/Azure.DCAP.Windows/0.0.3',
@@ -40,7 +40,7 @@ Param(
 $ErrorActionPreference = "Stop"
 
 $PACKAGES_DIRECTORY = Join-Path $env:TEMP "packages"
-$OE_NUGET_DIR = Join-Path $InstallPath "prereqs\nuget"
+$OE_NUGET_DIR = $InstallPath
 
 $PACKAGES = @{
     "git" = @{


### PR DESCRIPTION
This also updates install-windows-prereqs.ps1 to use the Intel SGX PSW 2.5.

It also removes the "prereqs\nuget" subdirectories inserted after InstallPath.