### PR TITLE
Add instructions for using Windows Nuget package

### DIFF
--- a/docs/GettingStartedDocs/Contributors/WindowsInstallInfo.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsInstallInfo.md
@@ -8,14 +8,14 @@ From the build subfolder in your source tree:
 For SGX1 + FLC targets:
 
 ```cmd
-cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave
+cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=C:\oe_prereqs -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave
 ninja install
 ```
 
 For SGX1 targets:
 
 ```cmd
-cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=OFF
+cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=C:\oe_prereqs -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=OFF
 ninja install
 ```
 
@@ -27,7 +27,7 @@ Please note that NUGET_PACKAGE_PATH in the above command points to the directory
 To create a redistributable NuGet package use the following command from your build subfolder:
 
 ```cmd
-cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\your\path\to\intel_and_dcap_nuget_packages -DCPACK_GENERATOR=NuGet
+cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=C:\oe_prereqs -DCPACK_GENERATOR=NuGet
 ninja package
 ```
 

--- a/docs/GettingStartedDocs/Contributors/WindowsInstallInfo.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsInstallInfo.md
@@ -5,7 +5,7 @@ You can locally install the SDK from the compiled Open Enclave tree by specifyin
 the install-prefix to the cmake call before calling `ninja install`.
 From the build subfolder in your source tree:
 
-For SGX1 + FLC targets:
+For SGX1 + FLC targets, assuming that the Intel and Azure DCAP NuGet packages are installed to `C:\oe_prereqs` and the Open Enclave SDK is installed to `C:\openenclave`:
 
 ```cmd
 cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=C:\oe_prereqs -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
@@ -47,7 +47,7 @@ The following summary will assume that the contents were extracted to `C:\Intel 
       ```
     - Note that `devcon.exe` is usually installed to `C:\Program Files (x86)\Windows Kits\10\tools\x64` which is not in the PATH environment variable by default.
 4. Install the DCAP nuget packages:
-    - The standalone `nuget.exe` [CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) can be used to do this from the command prompt(assuming you would like to install the NuGet packages to `C:\oe_prereqs`):
+    - The standalone `nuget.exe` [CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) can be used to do this from the command prompt:
       ```cmd
       nuget.exe install DCAP_Components -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory c:\oe_prereqs
       nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory c:\oe_prereqs

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
@@ -10,11 +10,13 @@ C:\Intel SGX PSW for Windows v2.4.100.51291\PSW_EXE_RS2_and_before\Intel(R)_SGX_
 ## [Azure DCAP client for Windows](https://github.com/Microsoft/Azure-DCAP-Client/tree/master/src/Windows) [optional]
 
 Note that this is optional since you can choose an alternate implementation of the DCAP client or create your own.
-The Azure DCAP client for Windows is necessary if you would like to perform enclave attestation on a Azure Confidential Computing VM. It is available from [nuget.org](https://www.nuget.org/packages/Azure.DCAP.Windows/) and can be installed directly via:
+The Azure DCAP client for Windows is necessary if you would like to perform enclave attestation on a Azure Confidential Computing VM. It is available from [nuget.org](https://www.nuget.org/packages/Azure.DCAP.Windows/) and can be installed directly via command below.
+This example assumes that `C:\oe_prereqs` is where you would like the prerequisites to be installed.
 
 ```cmd
-nuget.exe install Azure.DCAP.Windows -ExcludeVersion -Version 0.0.2 -OutputDirectory C:\path\to\where\you\would\like\to\install\intel_and_dcap_nuget_packages
+nuget.exe install Azure.DCAP.Windows -ExcludeVersion -Version 0.0.2 -OutputDirectory C:\oe_prereqs
 ```
+This example assumes you would like to install the package to `C:\oe_prereqs`.
 
 ##### [Intel Data Center Attestation Primitives (DCAP) Libraries v1.2](http://registrationcenter-download.intel.com/akdlm/irc_nas/15650/Intel%20SGX%20DCAP%20for%20Windows%20v1.2.100.49925.exe)
 After unpacking the self-extracting ZIP executable, you can refer to the *Intel SGX DCAP Windows SW Installation Guide.pdf*
@@ -45,9 +47,9 @@ The following summary will assume that the contents were extracted to `C:\Intel 
       ```
     - Note that `devcon.exe` is usually installed to `C:\Program Files (x86)\Windows Kits\10\tools\x64` which is not in the PATH environment variable by default.
 4. Install the DCAP nuget packages:
-    - The standalone `nuget.exe` [CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) can be used to do this from the command prompt:
+    - The standalone `nuget.exe` [CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) can be used to do this from the command prompt(assuming you would like to install the NuGet packages to `C:\oe_prereqs`):
       ```cmd
-      nuget.exe install DCAP_Components -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory C:\path\to\where\you\would\like\to\install\intel_and_dcap_nuget_packages
-      nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory C:\path\to\where\you\would\like\to\install\intel_and_dcap_nuget_packages
+      nuget.exe install DCAP_Components -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory c:\oe_prereqs
+      nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory c:\oe_prereqs
       ```
     - *Note:* EnclaveCommonAPI should be installed as the *very last* nuget package as a temporary workaround for a dependency issue. Please see issue #2170, for more details.

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
@@ -42,9 +42,9 @@ Firstly we download Intel SGX and DCAP library from [here](http://registrationce
 The following summary will assume that the contents were extracted to `C:\Intel SGX DCAP for Windows v1.2.100.49925`:
 
 Make sure you have [nuget cli tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) installed and in your path,
-run the following command from a command prompt:
+run the following command from a command prompt (assuming you would like the package to be installed to `C:\oe_prereqs`):
 ```cmd
-nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory C:\path\to\where\you\would\like\to\install\intel_nuget_packages
+nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.2.100.49925\nuget" -OutputDirectory C:\oe_prereqs
 ```
 
-You can verify that the library is installed properly by checking whether `sgx_enclave_common.lib` exists in the folder `C:\path\to\where\you\would\like\to\install\intel_nuget_packages\nuget\EnclaveCommonAPI\lib\native\x64-Release`.
+You can verify that the library is installed properly by checking whether `sgx_enclave_common.lib` exists in the folder `C:\oe_prereqs`.

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
@@ -35,25 +35,25 @@ Run the following from Powershell to deploy all the prerequisites for building O
 
 ```scripts/install-windows-prereqs.ps1```
 
-To install the prerequisites along with the Azure DCAP Client, use the below command. The Azure DCAP Client is necessary to perform attestation on an Azure Confidential Computing VM.
+To install the prerequisites along with the Azure DCAP Client, use the below command. The Azure DCAP Client is necessary to perform attestation on an Azure Confidential Computing VM. This command assumes that you would like the prerequisites to be installed to `C:\oe_prereqs`.
 
 ```powershell
 cd scripts
-.\install-windows-prereqs.ps1 -InstallPath C:\path\to\where\you\would\like\to\install\intel_and_dcap_nuget_packages -LaunchConfiguration SGX1FLC -DCAPClientType Azure
+.\install-windows-prereqs.ps1 -InstallPath C:\oe_prereqs -LaunchConfiguration SGX1FLC -DCAPClientType Azure
 ```
 
 If you would like to skip the installation of the Azure DCAP Client, use the command below.
 
 ```powershell
 cd scripts
-.\install-windows-prereqs.ps1 -InstallPath C:\path\to\where\you\would\like\to\install\intel_and_dcap_nuget_packages -LaunchConfiguration SGX1FLC -DCAPClientType None
+.\install-windows-prereqs.ps1 -InstallPath C:\oe_prereqs -LaunchConfiguration SGX1FLC -DCAPClientType None
 ```
 
 As an example, if you cloned the Open Enclave SDK repo into C:\openenclave and want to install the Azure DCAP Client, you would run the following command.
 
 ```powershell
 cd scripts
-.\install-windows-prereqs.ps1 -InstallPath C:\path\to\where\you\would\like\to\install\intel_and_dcap_nuget_packages -LaunchConfiguration SGX1FLC -DCAPClientType Azure
+.\install-windows-prereqs.ps1 -InstallPath C:\oe_prereqs -LaunchConfiguration SGX1FLC -DCAPClientType Azure
 ```
 
 If you prefer to manually install prerequisites, please refer to this [document](WindowsManualInstallPrereqs.md).
@@ -70,7 +70,7 @@ To build debug enclaves:
 cd C:\openenclave
 mkdir build\x64-Debug
 cd build\x64-Debug
-cmake -G Ninja -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave ..\..
+cmake -G Ninja -DNUGET_PACKAGE_PATH=C:\oe_prereqs -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave ..\..
 ninja
 ```
 
@@ -81,7 +81,7 @@ Similarly, to build release enclaves:
 cd C:\openenclave
 mkdir build\x64-Release
 cd build\x64-Release
-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_and_dcap_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave ..\..
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DNUGET_PACKAGE_PATH=C:\oe_prereqs -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave ..\..
 ninja
 ```
 

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
@@ -30,18 +30,18 @@ First, change directory into the openenclave repository:
 cd openenclave
 ```
 
-To deploy all the prerequisities for building Open Enclave, you can run the following from Powershell. Note that the Data Center Attestation Primitives (DCAP) Client is not used for attestation on systems which have support for SGX1 without support for Flexible Launch Control (FLC).
+To deploy all the prerequisities for building Open Enclave, you can run the following from Powershell. Note that the Data Center Attestation Primitives (DCAP) Client is not used for attestation on systems which have support for SGX1 without support for Flexible Launch Control (FLC). The below example assumes you would like to install the packages to `C:\oe_prereqs`.
 
 ```powershell
 cd scripts
-.\install-windows-prereqs.ps1 -InstallPath C:\path\to\where\you\would\like\to\install\intel_nuget_packages -LaunchConfiguration SGX1 -DCAPClientType None
+.\install-windows-prereqs.ps1 -InstallPath C:\oe_prereqs -LaunchConfiguration SGX1 -DCAPClientType None
 ```
 
 As an example, if you cloned Open Enclave SDK repo into `C:\openenclave`, you would run the following:
 
 ```powershell
 cd scripts
-.\install-windows-prereqs.ps1 -InstallPath C:\path\to\where\you\would\like\to\install\intel_nuget_packages -LaunchConfiguration SGX1 -DCAPClientType None
+.\install-windows-prereqs.ps1 -InstallPath C:\oe_prereqs -LaunchConfiguration SGX1 -DCAPClientType None
 ```
 
 If you prefer to manually install prerequisites, please refer to this [document](WindowsManualInstallPrereqs.md).
@@ -58,7 +58,7 @@ Normally this is accessible under the `Visual Studio 2017` folder in the Start M
 cd C:\openenclave
 mkdir build\x64-Debug
 cd build\x64-Debug
-cmake -G Ninja -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=OFF ..\..
+cmake -G Ninja -DNUGET_PACKAGE_PATH=C:\oe_prereqs -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=OFF ..\..
 ninja
 ```
 
@@ -70,7 +70,7 @@ Similarly, to build release enclaves:
 cd C:\openenclave
 mkdir build\x64-Release
 cd build\x64-Release
-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_nuget_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=OFF ..\..
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DNUGET_PACKAGE_PATH=C:\oe_prereqs -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave -DHAS_QUOTE_PROVIDER=OFF ..\..
 ninja
 ```
 

--- a/docs/GettingStartedDocs/Contributors/building_oe_sdk.md
+++ b/docs/GettingStartedDocs/Contributors/building_oe_sdk.md
@@ -69,7 +69,7 @@ See [Open Enclave samples](/samples/README_Linux.md) for details.
 Assuming you install the SDK as below (also described in the [basic install section](WindowsInstallInfo.md#basic-install-on-windows))
 
 ```bash
-cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=c:\path\to\intel_and_dcap_packages -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave"
+cmake .. -G  Ninja -DNUGET_PACKAGE_PATH=C:\oe_prereqs -DCMAKE_INSTALL_PREFIX:PATH=C:\openenclave"
 ninja install
 ```
 Open Enclave samples can be found in c:\openenclave\share\openenclave\samples

--- a/docs/GettingStartedDocs/install_oe_sdk-Windows.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Windows.md
@@ -1,0 +1,73 @@
+# Install the Open Enclave SDK (On Windows Server 2016)
+
+## Platform requirements
+
+- A system with support for SGX1 with Flexible Launch Control (FLC).
+Note: To check if your system has support for SGX1 with or without FLC, please look [here](./SGXSupportLevel.md).
+
+- Windows Server 2016
+
+## Microsoft Visual Studio Build Tools 2019
+
+Install [Visual Studio Build Tools 2019](https://aka.ms/vs/16/release/vs_buildtools.exe). Choose the "C++ build tools" workload. Visual Studio Build Tools 2019 has support for CMake Version 3.15 (CMake ver 3.12 or above is required for building Open Enclave SDK). For more information about CMake support, look [here](https://blogs.msdn.microsoft.com/vcblog/2016/10/05/cmake-support-in-visual-studio/).
+
+## Git for Windows 64-bit
+
+Download [Git for Windows 64-bit](https://git-scm.com/download/win).
+
+Install Git and add Git Bash to the PATH environment variable.
+Typically, Git Bash is located in `C:\Program Files\Git\bin`.
+Currently the Open Enclave SDK build system uses bash scripts to configure
+and build Linux-based 3rd-party libraries.
+
+Open a command prompt and ensure that Git Bash is added to PATH.
+
+```cmd
+C:\>where bash
+C:\Program Files\Git\bin\bash.exe
+```
+
+Tools available in the Git bash environment are also used for test and sample
+builds. For example, OpenSSL is used to generate test certificates, so it is
+also useful to have the `Git\mingw64\bin` folder added to PATH. This can be checked
+from the command prompt as well:
+
+```cmd
+C:\>where openssl
+C:\Program Files\Git\mingw64\bin\openssl.exe
+```
+
+## Clang
+
+Download [Clang/LLVM for Windows 64-bit](http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe).
+Install Clang 7.0.1 and add the LLVM folder (typically C:\Program Files\LLVM\bin)
+to PATH. Open Enclave SDK uses clang to build the enclave binaries.
+
+Open up a command prompt and ensure that clang is added to PATH.
+
+```cmd
+C:\> where clang
+C:\Program Files\LLVM\bin\clang.exe
+C:\> where llvm-ar
+C:\Program Files\LLVM\bin\llvm-ar.exe
+C:\> where ld.lld
+C:\Program Files\LLVM\bin\ld.lld.exe
+```
+
+## SGX1 with Flexible Launch Control (FLC) Prerequisites on Windows
+
+Instructions to install Intel's PSW 2.4, Intel's Data Center Attestation Primitives and related dependencies can be found [here](Contributors/WindowsManualSGX1FLCDCAPPrereqs.md).
+
+## Download and install the Open Enclave SDK NuGet Package
+
+Download the required Windows NuGet Package from [here](https://github.com/openenclave/openenclave/releases) and place it in a directory of your choice. Use the command below to install the NuGet package. In this example, we are placing the NuGet Package in `C:\openenclave_nuget` and installing it to `C:\oe`.
+
+```cmd
+ nuget.exe install open-enclave -Source C:\openenclave_nuget -OutputDirectory C:\oe -ExcludeVersion
+```
+
+Note: If it is an RC package, append `-pre` to the command above.
+
+## Verify the Open Enclave SDK install
+
+See [Using the Open Enclave SDK](Windows_using_oe_sdk.md) for verifying and using the installed SDK.

--- a/docs/GettingStartedDocs/install_oe_sdk-Windows.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Windows.md
@@ -1,4 +1,4 @@
-# Install the Open Enclave SDK (On Windows Server 2016)
+# Install the Open Enclave SDK NuGet Package
 
 ## Platform requirements
 
@@ -7,11 +7,13 @@ Note: To check if your system has support for SGX1 with or without FLC, please l
 
 - Windows Server 2016
 
-## Microsoft Visual Studio Build Tools 2019
+## Software Prerequisites
+
+### Microsoft Visual Studio Build Tools 2019
 
 Install [Visual Studio Build Tools 2019](https://aka.ms/vs/16/release/vs_buildtools.exe). Choose the "C++ build tools" workload. Visual Studio Build Tools 2019 has support for CMake Version 3.15 (CMake ver 3.12 or above is required for building Open Enclave SDK). For more information about CMake support, look [here](https://blogs.msdn.microsoft.com/vcblog/2016/10/05/cmake-support-in-visual-studio/).
 
-## Git for Windows 64-bit
+### Git for Windows 64-bit
 
 Download [Git for Windows 64-bit](https://git-scm.com/download/win).
 
@@ -37,7 +39,7 @@ C:\>where openssl
 C:\Program Files\Git\mingw64\bin\openssl.exe
 ```
 
-## Clang
+### Clang
 
 Download [Clang/LLVM for Windows 64-bit](http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe).
 Install Clang 7.0.1 and add the LLVM folder (typically C:\Program Files\LLVM\bin)
@@ -54,7 +56,7 @@ C:\> where ld.lld
 C:\Program Files\LLVM\bin\ld.lld.exe
 ```
 
-## SGX1 with Flexible Launch Control (FLC) Prerequisites on Windows
+### SGX1 with Flexible Launch Control (FLC) Prerequisites
 
 Instructions to install Intel's PSW 2.4, Intel's Data Center Attestation Primitives and related dependencies can be found [here](Contributors/WindowsManualSGX1FLCDCAPPrereqs.md).
 

--- a/docs/GettingStartedDocs/install_oe_sdk-Windows.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Windows.md
@@ -70,6 +70,6 @@ Download the required Windows NuGet Package from [here](https://github.com/opene
 
 Note: If it is an RC package, append `-pre` to the command above.
 
-## Verify the Open Enclave SDK install
+## Verify the Open Enclave SDK installation
 
 See [Using the Open Enclave SDK](Windows_using_oe_sdk.md) for verifying and using the installed SDK.

--- a/samples/README_Windows.md
+++ b/samples/README_Windows.md
@@ -47,7 +47,7 @@ set OpenEnclave_DIR=C:\openenclave\lib\openenclave\cmake
 ```cmd
 mkdir build
 cd build
-cmake .. -G Ninja -DNUGET_PACKAGE_PATH=C:\your\path\to\intel_and_dcap_nuget_packages
+cmake .. -G Ninja -DNUGET_PACKAGE_PATH=C:\oe_prereqs
 ninja
 ```
 


### PR DESCRIPTION
In this PR
1. add instructions for installing prereqs and using Windows NuGet Package. Please note that most of this was lifted from https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md 
2. Change c:\your\path\to\intel_and_dcap_nuget_packages to c:\oe_prereqs. This is because we have received feedback that the former is confusing and prevents a simple cut and paste work flow. 