### PR TITLE
Update project to use DCO instead of CLA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
   # Install Git pre-commit hook
   if (NOT WIN32)
     file(
-      COPY scripts/pre-commit
+      COPY scripts/pre-commit scripts/commit-msg
       DESTINATION "${PROJECT_SOURCE_DIR}/.git/hooks")
   endif ()
 endif ()

--- a/README.md
+++ b/README.md
@@ -55,10 +55,9 @@ started guides, see
 Contributing
 ------------
 
-This project welcomes contributions and suggestions. Most contributions require
-you to agree to a Contributor License Agreement (CLA) declaring that you have
-the right to, and actually do, grant us the rights to use your contribution. For
-details, see [Contributing to Open Enclave](docs/Contributing.md).
+This project welcomes contributions and suggestions. All contributions to the Open Enclave SDK
+must adhere to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+For details, see [Contributing to Open Enclave](docs/Contributing.md).
 
 This project has adopted the
 [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -217,21 +217,70 @@ commits with incorrect author information, you can fix them as follows:
 1. Choose to `edit` the commits with incorrect authorship.
    1. For each edit, use `git commit --amend --reset-author`.
 
-Contributor License Agreement
------------------------------
+Developer Certificate of Origin
+------------------------------
+All contributions to the Open Enclave SDK must adhere to the terms of the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/):
 
-You must sign a [Microsoft Contribution License Agreement (CLA)](
-https://opensource.microsoft.com/pdf/microsoft-contribution-license-agreement.pdf)
-before your PR will be merged. This is a one-time requirement for Open Enclave.
-You can read more about [Contribution License Agreements (CLA)](
-http://en.wikipedia.org/wiki/Contributor_License_Agreement) on Wikipedia.
+> Developer Certificate of Origin
+> Version 1.1
+>
+> Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+> 1 Letterman Drive
+> Suite D4700
+> San Francisco, CA, 94129
+>
+> Everyone is permitted to copy and distribute verbatim copies of this
+> license document, but changing it is not allowed.
+>
+> Developer's Certificate of Origin 1.1
+>
+> By making a contribution to this project, I certify that:
+>
+> (a) The contribution was created in whole or in part by me and I
+>    have the right to submit it under the open source license
+>    indicated in the file; or
+>
+> (b) The contribution is based upon previous work that, to the best
+>    of my knowledge, is covered under an appropriate open source
+>    license and I have the right under that license to submit that
+>    work with modifications, whether created in whole or in part
+>    by me, under the same open source license (unless I am
+>    permitted to submit under a different license), as indicated
+>    in the file; or
+>
+> (c) The contribution was provided directly to me by some other
+>    person who certified (a), (b) or (c) and I have not modified
+>    it.
+>
+> (d) I understand and agree that this project and the contribution
+>    are public and that a record of the contribution (including all
+>    personal information I submit with it, including my sign-off) is
+>    maintained indefinitely and may be redistributed consistent with
+>    this project or the open source license(s) involved.
 
-You don't have to do this up-front. You can simply clone, fork, and submit your
-pull request as usual. When your pull request is created, it is classified by a
-CLA bot. If the change is trivial (for example, you just fixed a typo), then the
-PR is labelled with `cla-not-required`. Otherwise it's classified as
-`cla-required`. Once you signed a CLA, the current and all future pull requests
-will be labelled as `cla-signed`.
+Contributors need to sign-off that they adhere to these requirements by adding
+a `Signed-off-by:` line to each commit message:
+
+```
+Author: John Doe <johndoe@example.com>
+Date:   Wed Nov 6 11:30 2019 +0000
+
+    This is my commit message.
+
+    Signed-off-by: John Doe <johndoe@example.com>
+```
+
+Commits without this sign-off cannot be accepted, and the name in the
+`Signed-off-by` and `Author` fields should match.
+
+If you have configured your `user.name` and `user.email` via `git config`,
+the `Signed-off-by` line can be automatically appended to your commit message
+using the `-s` option:
+
+```
+$ git commit -s -m "This is my commit message."
+```
 
 Copying Files from Other Projects
 ---------------------------------

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,9 @@ This directory contains the following scripts.
   and code linting have been met before changes should be merged
 - [check-license][] - Prints a list of sources missing the license header
 - [check-linters][] - Runs ShellCheck across scripts to lint them
+- [commit-msg][] - A [Git pre-commit hook](https://git-scm.com/docs/githooks)
+  to ensure that commit messages contain a [DCO](https://developercertificate.org)
+  sign-off
 - [deploy-docs][] - Deploys HTML documentation to GitHub pages
 - [format-code][] - Formats Open Enclave C/C++ code using `clang-format`
 - [pre-commit][] - A [Git pre-commit hook](https://git-scm.com/docs/githooks)

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -o errexit
+
+exit_() {
+    echo ""
+    echo "$1"
+    echo ""
+    echo "This hook can be skipped if needed with 'git commit --no-verify'"
+    echo "See '.git/hooks/commit-msg', installed from 'scripts/commit-msg'"
+    exit 1
+}
+
+sign_offs="$(grep '^Signed-off-by: ' "$1" || test $? = 1 )"
+
+if [[ -z $sign_offs ]]; then
+    exit_ "Commit failed: please sign-off on the DCO with 'git commit -s'"
+fi
+
+if [[ -n $(echo "$sign_offs" | sort | uniq -c | sed -e '/^[ 	]*1[ 	]/d') ]]; then
+    exit_ "Commit failed: please remove duplicate Signed-off-by lines"
+fi


### PR DESCRIPTION
- Replace references to the CLA requirement from contribution documents
  with information about the new DCO requirements.

- Add a git hook to enforce that all commit messages must include a sign-off
  for the DCO.

Signed-off-by: Simon Leet <simon.leet@microsoft.com>
