### PR TITLE
Publish location of CGC minutes

### DIFF
--- a/docs/Committers.md
+++ b/docs/Committers.md
@@ -21,6 +21,8 @@ be prevented from making any decisions at the meeting.
 All decisions by vote, whether during a meeting or otherwise, require a super majority
 vote of all members of the Community Governance Committee.
 
+The running minutes for the Community Governance Community meetings are located
+at [aka.ms/openenclave/cgc](https://aka.ms/openenclave/cgc).
 
 Committee Members
 -----------------


### PR DESCRIPTION
While the minutes were already public, we hadn't made their whereabouts
widely known, so here they are. Note that the public can read and
comment, but only CGC members can edit the document (admin invites just
went out to all the CGC members).

Signed-off-by: Andrew Schwartzmeyer <andrew@schwartzmeyer.com>