### PR TITLE
Update Commiters.md email address for johnkord

### DIFF
--- a/docs/Committers.md
+++ b/docs/Committers.md
@@ -32,7 +32,7 @@ Committee Members
 | Anand Krishnamoorthi | Microsoft | anakrish@microsoft.com        | anakrish       |
 | Andrew Schwartzmeyer | Microsoft | andschwa@microsoft.com        | andschwa       |
 | Dave Thaler          | Microsoft | dthaler@microsoft.com         | dthaler        |
-| John Kordich         | Microsoft | johnkord@microsoft.com        | johnkord       |
+| John Kordich         | Microsoft | jkordich@gmail.com            | johnkord       |
 | Mike Brasher         | Microsoft | mikbras@microsoft.com         | mikbras        |
 | Simon Leet           | Microsoft | simon.leet@microsoft.com      | CodeMonkeyLeet |
 


### PR DESCRIPTION
The johnkord@microsoft.com email address will no longer be functional, so I've updated it to my gmail address!