### PR TITLE
Remove esy on-the-fly installation from CI containers

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -50,10 +50,6 @@ def simulationTest(String version, String platform_mode, String build_type) {
                 checkout scm
                 withEnv(["OE_SIMULATION=1"]) {
                     def task = """
-                               pushd ${WORKSPACE}/scripts/ansible
-                               sudo ./install-ansible.sh
-                               sudo ansible-playbook oe-linux-esy-setup.yml
-                               popd
                                cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DHAS_QUOTE_PROVIDER=${has_quote_provider} -Wdev
                                ninja -v
                                ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
@@ -72,10 +68,6 @@ def AArch64GNUTest(String version, String build_type) {
                 cleanWs()
                 checkout scm
                 def task = """
-                            pushd ${WORKSPACE}/scripts/ansible
-                            sudo ./install-ansible.sh
-                            sudo ansible-playbook oe-linux-esy-setup.yml
-                            popd
                             cmake ${WORKSPACE}                                                     \
                                 -G Ninja                                                           \
                                 -DCMAKE_BUILD_TYPE=${build_type}                                   \
@@ -98,10 +90,6 @@ def ACCContainerTest(String label, String version) {
                 cleanWs()
                 checkout scm
                 def task = """
-                           pushd ${WORKSPACE}/scripts/ansible
-                           sudo ./install-ansible.sh
-                           sudo ansible-playbook oe-linux-esy-setup.yml
-                           popd
                            cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -Wdev
                            ninja -v
                            ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
@@ -119,10 +107,6 @@ def ACCPackageTest(String label, String version) {
                 cleanWs()
                 checkout scm
                 def task = """
-                           pushd ${WORKSPACE}/scripts/ansible
-                           sudo ./install-ansible.sh
-                           sudo ansible-playbook oe-linux-esy-setup.yml
-                           popd
                            cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -Wdev -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave' -DCPACK_GENERATOR=DEB
                            ninja -v
                            ninja -v package
@@ -155,10 +139,6 @@ def checkDevFlows(String version) {
                 cleanWs()
                 checkout scm
                 def task = """
-                           pushd ${WORKSPACE}/scripts/ansible
-                           sudo ./install-ansible.sh
-                           sudo ansible-playbook oe-linux-esy-setup.yml
-                           popd
                            cmake ${WORKSPACE} -G Ninja -DHAS_QUOTE_PROVIDER=OFF -Wdev --warn-uninitialized -Werror=dev
                            ninja -v
                            """
@@ -189,10 +169,6 @@ def win2016LinuxElfBuild(String version, String compiler, String build_type) {
                 cleanWs()
                 checkout scm
                 def task = """
-                           pushd ${WORKSPACE}/scripts/ansible
-                           sudo ./install-ansible.sh
-                           sudo ansible-playbook oe-linux-esy-setup.yml
-                           popd
                            cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DHAS_QUOTE_PROVIDER=ON -Wdev
                            ninja -v
                            """
@@ -261,10 +237,6 @@ def ACCHostVerificationTest(String version, String build_type) {
 
                     println("Generating certificates and reports ...")
                     def task = """
-                            pushd ${WORKSPACE}/scripts/ansible
-                            sudo ./install-ansible.sh
-                            sudo ansible-playbook oe-linux-esy-setup.yml
-                            popd
                             cmake ${WORKSPACE} -G Ninja -DHAS_QUOTE_PROVIDER=ON -DCMAKE_BUILD_TYPE=${build_type} -Wdev
                             ninja -v
                             pushd tests/host_verify/host
@@ -311,10 +283,6 @@ def ACCHostVerificationTest(String version, String build_type) {
                     checkout scm
                     unstash "linux_host_verify-${build_type}-${BUILD_NUMBER}"
                     def task = """
-                            pushd ${WORKSPACE}/scripts/ansible
-                            sudo ./install-ansible.sh
-                            sudo ansible-playbook oe-linux-esy-setup.yml
-                            popd
                             cmake ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=OFF -DCMAKE_BUILD_TYPE=${build_type} -Wdev
                             ninja -v
                             ctest -R host_verify --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}


### PR DESCRIPTION
I built new docker images with the latest code from master, tagged them as latest and now are being used in the CI

Esy is already installed in Docker as part of the environment-setup
Removed redundant on-the-fly esy install from CI containers.