### PR TITLE
Added emailing of job status to JENKINSFILE, Packaging and libcxx_tests jenkins files

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -3,6 +3,7 @@ oe = new jenkins.common.Openenclave()
 
 GLOBAL_TIMEOUT_MINUTES = 240
 CTEST_TIMEOUT_SECONDS = 480
+GLOBAL_ERROR = null
 
 def ACCTest(String label, String compiler, String build_type) {
     stage("${label} ${compiler} SGX1FLC ${build_type}") {
@@ -351,38 +352,51 @@ properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
                                       numToKeepStr: '180')),
             [$class: 'JobRestrictionProperty']])
 
-parallel "Check Developer Experience Ubuntu 16.04" :            { checkDevFlows('16.04') },
-         "Check Developer Experience Ubuntu 18.04" :            { checkDevFlows('18.04') },
-         "Check CI" :                                           { checkCI() },
-         "ACC1604 clang-7 Debug" :                              { ACCTest('ACC-1604', 'clang-7', 'Debug') },
-         "ACC1604 clang-7 Release" :                            { ACCTest('ACC-1604', 'clang-7', 'Release') },
-         "ACC1604 gcc Debug" :                                  { ACCTest('ACC-1604', 'gcc', 'Debug') },
-         "ACC1604 gcc Release" :                                { ACCTest('ACC-1604', 'gcc', 'Release') },
-         "ACC1604 Container RelWithDebInfo" :                   { ACCContainerTest('ACC-1604', '16.04') },
-         "ACC1604 Package RelWithDebInfo" :                     { ACCPackageTest('ACC-1604', '16.04') },
-         "ACC1804 clang-7 Debug" :                              { ACCTest('ACC-1804', 'clang-7', 'Debug') },
-         "ACC1804 clang-7 Release" :                            { ACCTest('ACC-1804', 'clang-7', 'Release') },
-         "ACC1804 gcc Debug" :                                  { ACCTest('ACC-1804', 'gcc', 'Debug') },
-         "ACC1804 gcc Release" :                                { ACCTest('ACC-1804', 'gcc', 'Release') },
-         "ACC1804 Container RelWithDebInfo" :                   { ACCContainerTest('ACC-1804', '18.04') },
-         "ACC1804 Package RelWithDebInfo" :                     { ACCPackageTest('ACC-1804', '18.04') },
-         "ACC1804 GNU gcc SGX1FLC" :                            { ACCGNUTest() },
-         "AArch64 1604 GNU gcc Debug" :                         { AArch64GNUTest('16.04', 'Debug')},
-         "AArch64 1604 GNU gcc Release" :                       { AArch64GNUTest('16.04', 'Release')},
-         "AArch64 1804 GNU gcc Debug" :                         { AArch64GNUTest('18.04', 'Debug')},
-         "AArch64 1804 GNU gcc Release" :                       { AArch64GNUTest('18.04', 'Release')},
-         "Sim 1804 clang-7 SGX1 Debug" :                        { simulationTest('18.04', 'SGX1', 'Debug')},
-         "Sim 1804 clang-7 SGX1 Release" :                      { simulationTest('18.04', 'SGX1', 'Release')},
-         "Sim 1804 clang-7 SGX1-FLC Debug" :                    { simulationTest('18.04', 'SGX1FLC', 'Debug')},
-         "Sim 1804 clang-7 SGX1-FLC Release" :                  { simulationTest('18.04', 'SGX1FLC', 'Release')},
-         "Win2016 Ubuntu1604 clang-7 Debug Linux-Elf-build" :   { win2016LinuxElfBuild('16.04', 'clang-7', 'Debug') },
-         "Win2016 Ubuntu1604 clang-7 Release Linux-Elf-build" : { win2016LinuxElfBuild('16.04', 'clang-7', 'Release') },
-         "Win2016 Ubuntu1804 clang-7 Debug Linux-Elf-build" :   { win2016LinuxElfBuild('18.04', 'clang-7', 'Debug') },
-         "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build" : { win2016LinuxElfBuild('18.04', 'clang-7', 'Release') },
-         "Win2016 Ubuntu1804 gcc Debug Linux-Elf-build" :       { win2016LinuxElfBuild('18.04', 'gcc', 'Debug') },
-         "Win2016 Debug Cross Compile" :                        { win2016CrossCompile('Debug') },
-         "Win2016 Release Cross Compile" :                      { win2016CrossCompile('Release') },
-         "Win2016 Debug Cross Compile with DCAP libs" :         { win2016CrossCompile('Debug', 'ON') },
-         "Win2016 Release Cross Compile with DCAP libs" :       { win2016CrossCompile('Release', 'ON') },
-         "Host verification Debug" :                            { ACCHostVerificationTest('18.04', 'Debug') },
-         "Host verification Release" :                          { ACCHostVerificationTest('18.04', 'Release') }
+try{
+    oe.emailJobStatus('STARTED')
+    
+    parallel "Check Developer Experience Ubuntu 16.04" :            { checkDevFlows('16.04') },
+            "Check Developer Experience Ubuntu 18.04" :            { checkDevFlows('18.04') },
+            "Check CI" :                                           { checkCI() },
+            "ACC1604 clang-7 Debug" :                              { ACCTest('ACC-1604', 'clang-7', 'Debug') },
+            "ACC1604 clang-7 Release" :                            { ACCTest('ACC-1604', 'clang-7', 'Release') },
+            "ACC1604 gcc Debug" :                                  { ACCTest('ACC-1604', 'gcc', 'Debug') },
+            "ACC1604 gcc Release" :                                { ACCTest('ACC-1604', 'gcc', 'Release') },
+            "ACC1604 Container RelWithDebInfo" :                   { ACCContainerTest('ACC-1604', '16.04') },
+            "ACC1604 Package RelWithDebInfo" :                     { ACCPackageTest('ACC-1604', '16.04') },
+            "ACC1804 clang-7 Debug" :                              { ACCTest('ACC-1804', 'clang-7', 'Debug') },
+            "ACC1804 clang-7 Release" :                            { ACCTest('ACC-1804', 'clang-7', 'Release') },
+            "ACC1804 gcc Debug" :                                  { ACCTest('ACC-1804', 'gcc', 'Debug') },
+            "ACC1804 gcc Release" :                                { ACCTest('ACC-1804', 'gcc', 'Release') },
+            "ACC1804 Container RelWithDebInfo" :                   { ACCContainerTest('ACC-1804', '18.04') },
+            "ACC1804 Package RelWithDebInfo" :                     { ACCPackageTest('ACC-1804', '18.04') },
+            "ACC1804 GNU gcc SGX1FLC" :                            { ACCGNUTest() },
+            "AArch64 1604 GNU gcc Debug" :                         { AArch64GNUTest('16.04', 'Debug')},
+            "AArch64 1604 GNU gcc Release" :                       { AArch64GNUTest('16.04', 'Release')},
+            "AArch64 1804 GNU gcc Debug" :                         { AArch64GNUTest('18.04', 'Debug')},
+            "AArch64 1804 GNU gcc Release" :                       { AArch64GNUTest('18.04', 'Release')},
+            "Sim 1804 clang-7 SGX1 Debug" :                        { simulationTest('18.04', 'SGX1', 'Debug')},
+            "Sim 1804 clang-7 SGX1 Release" :                      { simulationTest('18.04', 'SGX1', 'Release')},
+            "Sim 1804 clang-7 SGX1-FLC Debug" :                    { simulationTest('18.04', 'SGX1FLC', 'Debug')},
+            "Sim 1804 clang-7 SGX1-FLC Release" :                  { simulationTest('18.04', 'SGX1FLC', 'Release')},
+            "Win2016 Ubuntu1604 clang-7 Debug Linux-Elf-build" :   { win2016LinuxElfBuild('16.04', 'clang-7', 'Debug') },
+            "Win2016 Ubuntu1604 clang-7 Release Linux-Elf-build" : { win2016LinuxElfBuild('16.04', 'clang-7', 'Release') },
+            "Win2016 Ubuntu1804 clang-7 Debug Linux-Elf-build" :   { win2016LinuxElfBuild('18.04', 'clang-7', 'Debug') },
+            "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build" : { win2016LinuxElfBuild('18.04', 'clang-7', 'Release') },
+            "Win2016 Ubuntu1804 gcc Debug Linux-Elf-build" :       { win2016LinuxElfBuild('18.04', 'gcc', 'Debug') },
+            "Win2016 Debug Cross Compile" :                        { win2016CrossCompile('Debug') },
+            "Win2016 Release Cross Compile" :                      { win2016CrossCompile('Release') },
+            "Win2016 Debug Cross Compile with DCAP libs" :         { win2016CrossCompile('Debug', 'ON') },
+            "Win2016 Release Cross Compile with DCAP libs" :       { win2016CrossCompile('Release', 'ON') },
+            "Host verification Debug" :                            { ACCHostVerificationTest('18.04', 'Debug') },
+            "Host verification Release" :                          { ACCHostVerificationTest('18.04', 'Release') }
+}catch(Exception e)
+{
+    println "Caught global pipeline exception :" + e
+    GLOBAL_ERROR = e
+    throw e   
+} finally {
+    currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"    
+    oe.emailJobStatus(currentBuild.result)
+}
+

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -357,7 +357,6 @@ properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
 
 try{
     oe.emailJobStatus('STARTED')
-
     parallel "Check Developer Experience Ubuntu 16.04" :            { checkDevFlows('16.04') },
             "Check Developer Experience Ubuntu 18.04" :            { checkDevFlows('18.04') },
             "Check CI" :                                           { checkCI() },
@@ -393,8 +392,7 @@ try{
             "Win2016 Release Cross Compile with DCAP libs" :       { win2016CrossCompile('Release', 'ON') },
             "Host verification Debug" :                            { ACCHostVerificationTest('18.04', 'Debug') },
             "Host verification Release" :                          { ACCHostVerificationTest('18.04', 'Release') }
-}catch(Exception e)
-{
+} catch(Exception e) {
     println "Caught global pipeline exception :" + e
     GLOBAL_ERROR = e
     throw e   

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,3 +1,6 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
 @Library("OpenEnclaveCommon") _
 oe = new jenkins.common.Openenclave()
 
@@ -354,7 +357,7 @@ properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
 
 try{
     oe.emailJobStatus('STARTED')
-    
+
     parallel "Check Developer Experience Ubuntu 16.04" :            { checkDevFlows('16.04') },
             "Check Developer Experience Ubuntu 18.04" :            { checkDevFlows('18.04') },
             "Check CI" :                                           { checkCI() },
@@ -399,4 +402,3 @@ try{
     currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"    
     oe.emailJobStatus(currentBuild.result)
 }
-

--- a/.jenkins/Packaging.Jenkinsfile
+++ b/.jenkins/Packaging.Jenkinsfile
@@ -54,7 +54,6 @@ def WindowsPackaging(String build_type) {
 
 try{
     oe.emailJobStatus('STARTED')
-
     parallel "1604 SGX1FLC Package Debug" :          { LinuxPackaging('1604', 'Debug') },
          "1604 SGX1FLC Package Release" :        { LinuxPackaging('1604', 'Release') },
          "1604 SGX1FLC Package RelWithDebInfo" : { LinuxPackaging('1604', 'RelWithDebInfo') },
@@ -63,8 +62,7 @@ try{
          "1804 SGX1FLC Package RelWithDebInfo" : { LinuxPackaging('1804', 'RelWithDebInfo') },
          "Windows Debug" :                       { WindowsPackaging('DEBUG') },
          "Windows Release" :                     { WindowsPackaging('RELEASE') }
-}catch(Exception e)
-{
+} catch(Exception e) {
     println "Caught global pipeline exception :" + e
     GLOBAL_ERROR = e
     throw e   

--- a/.jenkins/libcxx_tests.Jenkinsfile
+++ b/.jenkins/libcxx_tests.Jenkinsfile
@@ -1,3 +1,6 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
 import hudson.slaves.*
 import hudson.model.*
 
@@ -6,6 +9,7 @@ oe = new jenkins.common.Openenclave()
 
 GLOBAL_TIMEOUT_MINUTES = 240
 CTEST_TIMEOUT_SECONDS = 480
+GLOBAL_ERROR = null
 
 XENIAL_LABEL = "LIBCXX-${BUILD_NUMBER}-1604"
 BIONIC_LABEL = "LIBCXX-${BUILD_NUMBER}-1804"
@@ -108,6 +112,8 @@ def cleanup(){
 }
 
 try {
+    oe.emailJobStatus('STARTED')
+
     for (int i = 1 ; i <= AGENT_NUM ; i++ ) {
         parallel "Deploy Ubuntu 16.04 #${i}" :  { ACCDeployVM("${XENIAL_LABEL}-${i}".toLowerCase(), "xenial" , "eastus", XENIAL_RG, "${VHD_URL_XENIAL}") },
                  "Deploy Ubuntu 18.04 #${i}" :  { ACCDeployVM("${BIONIC_LABEL}-${i}".toLowerCase(), "bionic", "westeurope", BIONIC_RG, "${VHD_URL_BIONIC}") }
@@ -127,7 +133,13 @@ try {
              "libcxx ACC1804 gcc Debug" :              { ACClibcxxTest(BIONIC_LABEL, 'gcc', 'Debug') },
              "libcxx ACC1804 gcc Release" :            { ACClibcxxTest(BIONIC_LABEL, 'gcc', 'Release') },
              "libcxx ACC1804 gcc RelWithDebInfo" :     { ACClibcxxTest(BIONIC_LABEL, 'gcc', 'RelWithDebinfo') }
+}catch(Exception e){
+    println "Caught global pipeline exception :" + e
+    GLOBAL_ERROR = e
+    throw e   
 } finally {
     cleanup()
     unregisterJenkinsSlaves()
+    currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"    
+    oe.emailJobStatus(currentBuild.result)
 }

--- a/.jenkins/libcxx_tests.Jenkinsfile
+++ b/.jenkins/libcxx_tests.Jenkinsfile
@@ -113,7 +113,6 @@ def cleanup(){
 
 try {
     oe.emailJobStatus('STARTED')
-
     for (int i = 1 ; i <= AGENT_NUM ; i++ ) {
         parallel "Deploy Ubuntu 16.04 #${i}" :  { ACCDeployVM("${XENIAL_LABEL}-${i}".toLowerCase(), "xenial" , "eastus", XENIAL_RG, "${VHD_URL_XENIAL}") },
                  "Deploy Ubuntu 18.04 #${i}" :  { ACCDeployVM("${BIONIC_LABEL}-${i}".toLowerCase(), "bionic", "westeurope", BIONIC_RG, "${VHD_URL_BIONIC}") }

--- a/.jenkins/libcxx_tests.Jenkinsfile
+++ b/.jenkins/libcxx_tests.Jenkinsfile
@@ -133,7 +133,7 @@ try {
              "libcxx ACC1804 gcc Debug" :              { ACClibcxxTest(BIONIC_LABEL, 'gcc', 'Debug') },
              "libcxx ACC1804 gcc Release" :            { ACClibcxxTest(BIONIC_LABEL, 'gcc', 'Release') },
              "libcxx ACC1804 gcc RelWithDebInfo" :     { ACClibcxxTest(BIONIC_LABEL, 'gcc', 'RelWithDebinfo') }
-}catch(Exception e){
+} catch(Exception e) {
     println "Caught global pipeline exception :" + e
     GLOBAL_ERROR = e
     throw e   


### PR DESCRIPTION
I added a global scoped variable to indicate failure - since a successful job run in the scope of finally will return null for currentBuild.result.  

That variable being null (or not) is used to determine the job's success. The email code was committed to the openenclave-ci, and for now it's configuration is global to anyone that uses that SCM library. Right now the email settings will CC: the project's default recipient list - configured in Jenkins, and send on To: the individual requesting the job. This can be changed later to include culprits or additional developers. [Extended Email Recipients](https://jenkins.io/doc/pipeline/steps/email-ext/#emailextrecipients-extended-email-recipients)

I'll need to make another pass for the remaining jobs' jenkinsfiles to add this capability once we triage what is needed.  For now this will cover release branches, bors, and sandbox jobs. See below for screenshots for examples on email:

![image](https://user-images.githubusercontent.com/56414747/68763462-7f9f8880-05e6-11ea-868f-60ef22b30488.png)

![image](https://user-images.githubusercontent.com/56414747/68763472-8928f080-05e6-11ea-9001-46db1e33cf8c.png)

![image](https://user-images.githubusercontent.com/56414747/68763516-a067de00-05e6-11ea-8c5c-b13c100d52f1.png)



