### PR TITLE
Fix code formatting in Windows Getting Started doc

### DIFF
--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
@@ -17,11 +17,11 @@ A version of Windows OS with native support for SGX features:
 
 - Clone the Open Enclave SDK.
 
-      ```powershell
-      git clone https://github.com/openenclave/openenclave.git
-      ```
+```powershell
+git clone https://github.com/openenclave/openenclave.git
+```
 
-      This creates a source tree under the directory called openenclave.
+This creates a source tree under the directory called openenclave.
 
 ## Install project prerequisites
 


### PR DESCRIPTION
Code block is indented, which keeps the markdown from rendering the git clone as code. Instead the literal text (backticks included) is rendered.