### PR TITLE
Make sure the latest versions of dependencies is present

### DIFF
--- a/scripts/ansible/roles/linux/az-dcap-client/tasks/stable-install.yml
+++ b/scripts/ansible/roles/linux/az-dcap-client/tasks/stable-install.yml
@@ -12,5 +12,5 @@
 - name: Install the official Azure-DCAP-Client APT package
   apt:
     name: az-dcap-client
-    state: present
+    state: latest
     update_cache: yes

--- a/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
+++ b/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
@@ -5,7 +5,7 @@
 - name: Install apt-transport-https APT package
   apt:
     name: apt-transport-https
-    state: present
+    state: latest
 
 - name: Add APT repository key
   apt_key:

--- a/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
@@ -16,7 +16,7 @@
 - name: Install Docker prerequisite packages
   apt:
     name: "{{ ci_apt_packages }}"
-    state: present
+    state: latest
     update_cache: yes
     install_recommends: no
 

--- a/scripts/ansible/roles/linux/docker/tasks/stable-install.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/stable-install.yml
@@ -32,7 +32,7 @@
 - name: Docker | Install Docker-CE
   apt:
     name: "{{ apt_packages }}"
-    state: present
+    state: latest
     update_cache: yes
   retries: 10
   delay: 10

--- a/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
@@ -14,7 +14,7 @@
   apt:
     name:
       - "dkms"
-    state: present
+    state: latest
     update_cache: yes
     install_recommends: no
 

--- a/scripts/ansible/roles/linux/intel/tasks/sgx-packages.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/sgx-packages.yml
@@ -23,21 +23,21 @@
 - name: Install the Intel libsgx package dependencies
   apt:
     name: "{{ intel_sgx_package_dependencies }}"
-    state: present
+    state: latest
     update_cache: yes
     install_recommends: no
 
 - name: Install the Intel libsgx packages
   apt:
     name: "{{ intel_sgx_packages }}"
-    state: present
+    state: latest
     update_cache: yes
     install_recommends: no
 
 - name: Install the Intel DCAP packages
   apt:
     name: "{{ intel_dcap_packages }}"
-    state: present
+    state: latest
     update_cache: yes
     install_recommends: no
   when: flc_enabled|bool

--- a/scripts/ansible/roles/linux/jenkins/tasks/slave-setup.yml
+++ b/scripts/ansible/roles/linux/jenkins/tasks/slave-setup.yml
@@ -21,7 +21,7 @@
 - name: Jenkins | Install Java JRE needed by Jenkins
   apt:
     name: openjdk-8-jre
-    state: present
+    state: latest
     update_cache: yes
   retries: 10
   delay: 10

--- a/scripts/ansible/roles/linux/openenclave/tasks/environment-setup-cross-arm.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/environment-setup-cross-arm.yml
@@ -29,6 +29,6 @@
 - name: Install the additional Open Enclave prerequisites APT packages for ARM development
   apt:
     name: "{{ apt_arm_packages }}"
-    state: present
+    state: latest
     update_cache: yes
     install_recommends: no

--- a/scripts/ansible/roles/linux/openenclave/tasks/environment-setup.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/environment-setup.yml
@@ -26,7 +26,7 @@
 - name: Install all the Open Enclave prerequisites APT packages for development
   apt:
     name: "{{ apt_packages }}"
-    state: present
+    state: latest
     update_cache: yes
     install_recommends: no
 

--- a/scripts/ansible/roles/linux/openenclave/tasks/stable-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/stable-install.yml
@@ -15,5 +15,5 @@
 - name: Install the official Open Enclave APT package
   apt:
     name: open-enclave
-    state: present
+    state: latest
     update_cache: yes


### PR DESCRIPTION
fix #2311 

"latest" isn't perfect, but is definitely better than "present". It probably would make sense to pin the Intel deps, assuming they don't clean up old versions. For Ubuntu deps, it's impossible to do that, since they regularly purge old versions (See #1746).

Signed-off-by: Amaury Chamayou amchamay@microsoft.com