### PR TITLE
Port tls_e2e test host from pthread to std::thread

### DIFF
--- a/tests/tls_e2e/host/host.cpp
+++ b/tests/tls_e2e/host/host.cpp
@@ -155,8 +155,6 @@ void run_server(void* arg)
 
     OE_TRACE_INFO("Leaving server thread...\n");
     fflush(stdout);
-done:
-    return NULL;
 }
 
 void run_client(void* arg)
@@ -222,8 +220,6 @@ void run_client(void* arg)
     }
 
     fflush(stdout);
-done:
-    return NULL;
 }
 
 int run_test_with_config(tls_test_configs_t* test_configs)
@@ -235,9 +231,8 @@ int run_test_with_config(tls_test_configs_t* test_configs)
 
     {
         // Release lock on scope exit
-        std::unique_lock<std::mutex> l(g_server_mutex);
-        while (!g_server_condition)
-            g_server_cond.wait(l);
+        std::unique_lock<std::mutex> server_lock(g_server_mutex);
+        g_server_cond.wait(server_lock, []{ return g_server_cond; });
     }
 
     fflush(stdout);
@@ -324,7 +319,6 @@ done:
 int main(int argc, const char* argv[])
 {
 #ifdef OE_LINK_SGX_DCAP_QL
-
     oe_result_t result = OE_FAILURE;
     uint32_t flags = OE_ENCLAVE_FLAG_DEBUG;
     int ret = 0;

--- a/tests/tls_e2e/host/host.cpp
+++ b/tests/tls_e2e/host/host.cpp
@@ -154,6 +154,9 @@ void run_server(void* arg)
     }
 
     OE_TRACE_INFO("Leaving server thread...\n");
+
+// Label needed for OE_CHECK* macros
+done:
     fflush(stdout);
 }
 
@@ -219,6 +222,8 @@ void run_client(void* arg)
         g_client_thread_exit_code = 0;
     }
 
+// Label needed for OE_CHECK* macros
+done:
     fflush(stdout);
 }
 
@@ -232,7 +237,7 @@ int run_test_with_config(tls_test_configs_t* test_configs)
     {
         // Release lock on scope exit
         std::unique_lock<std::mutex> server_lock(g_server_mutex);
-        g_server_cond.wait(server_lock, []{ return g_server_cond; });
+        g_server_cond.wait(server_lock, [] { return g_server_condition; });
     }
 
     fflush(stdout);

--- a/tests/tls_e2e/host/host.cpp
+++ b/tests/tls_e2e/host/host.cpp
@@ -6,12 +6,16 @@
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/tests.h>
-#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "tls_e2e_u.h"
+
+#include <condition_variable>
+#include <exception>
+#include <mutex>
+#include <thread>
 
 #define SERVER_PORT "12345"
 #define SERVER_IP "127.0.0.1"
@@ -60,20 +64,22 @@ typedef enum test_config_type
 
 oe_enclave_t* g_server_enclave = NULL;
 oe_enclave_t* g_client_enclave = NULL;
+
 int g_server_thread_exit_code = 0;
 int g_client_thread_exit_code = 0;
-pthread_mutex_t server_mutex;
-pthread_cond_t server_cond;
 bool g_server_condition = false;
-pthread_t server_thread_id;
+
+std::mutex server_mutex;
+std::condition_variable server_cond;
+std::thread server_thread;
 
 int server_is_ready()
 {
     OE_TRACE_INFO("TLS server_is_ready!\n");
-    pthread_mutex_lock(&server_mutex);
+    server_mutex.lock();
     g_server_condition = true;
-    pthread_cond_signal(&server_cond);
-    pthread_mutex_unlock(&server_mutex);
+    server_cond.notify_all();
+    server_mutex.unlock();
     return 1;
 }
 
@@ -118,7 +124,7 @@ done:
     return result;
 }
 
-void* server_thread(void* arg)
+void* run_server(void* arg)
 {
     oe_result_t result = OE_FAILURE;
     tls_thread_context_config_t* config = &(((tls_test_configs_t*)arg)->server);
@@ -149,19 +155,17 @@ void* server_thread(void* arg)
 
     OE_TRACE_INFO("Leaving server thread...\n");
     fflush(stdout);
-    pthread_exit((void*)&g_server_thread_exit_code);
 done:
     return NULL;
 }
 
-void* client_thread(void* arg)
+void* run_client(void* arg)
 {
     oe_result_t result = OE_FAILURE;
     tls_thread_context_config_t* client_config =
         &(((tls_test_configs_t*)arg)->client);
     tls_thread_context_config_t* server_config =
         &(((tls_test_configs_t*)arg)->server);
-    void* retval = NULL;
 
     OE_TRACE_INFO("Client thread: call launch_tls_client()\n");
     result = launch_tls_client(
@@ -186,10 +190,10 @@ void* client_thread(void* arg)
 
     OE_TRACE_INFO("Waiting for the server thread to terminate...\n");
     // block client thread until the server thread is done
-    pthread_join(server_thread_id, (void**)&retval);
+    server_thread.join();
 
     // enforce server return value
-    OE_TRACE_INFO("server returns retval = [%d]\n", *(int*)retval);
+    OE_TRACE_INFO("server returns retval = [%d]\n", g_server_thread_exit_code);
 
     if (server_config->args.fail_cert_verify_callback ||
         server_config->args.fail_enclave_identity_verifier_callback ||
@@ -197,7 +201,7 @@ void* client_thread(void* arg)
     {
         // since this test ignores SIGPIPE, ther client thread will terminiate
         // with 0
-        OE_TEST(*(int*)(retval) == 0);
+        OE_TEST(g_server_thread_exit_code == 0);
     }
 
     // In the no-fault-injection test case, the client thread should return
@@ -216,7 +220,7 @@ void* client_thread(void* arg)
         // g_client_thread_exit_code could be any values in negative test cases
         g_client_thread_exit_code = 0;
     }
-    pthread_exit((void*)&g_client_thread_exit_code);
+
     fflush(stdout);
 done:
     return NULL;
@@ -224,44 +228,24 @@ done:
 
 int run_test_with_config(tls_test_configs_t* test_configs)
 {
-    pthread_attr_t server_tattr;
-    pthread_attr_t client_tattr;
-    pthread_t client_thread_id;
-    int ret = 0;
-    void* retval = NULL;
-
     // create server thread
-    ret = pthread_attr_init(&server_tattr);
-    if (ret)
-        oe_put_err("pthread_attr_init(server): ret=%u", ret);
-
-    ret = pthread_create(
-        &server_thread_id, NULL, server_thread, (void*)test_configs);
-    if (ret)
-        oe_put_err("pthread_create(server): ret=%u", ret);
+    server_thread = std::thread(run_server, (void*)test_configs);
 
     OE_TRACE_INFO("wait until TLS server is ready to accept client request\n");
-    pthread_mutex_lock(&server_mutex);
+    std::unique_lock<std::mutex> l(server_mutex);
     while (!g_server_condition)
-        pthread_cond_wait(&server_cond, &server_mutex);
-    pthread_mutex_unlock(&server_mutex);
+        server_cond.wait(l);
 
     fflush(stdout);
 
     // create client thread
-    ret = pthread_attr_init(&client_tattr);
-    if (ret)
-        oe_put_err("pthread_attr_init(client): ret=%u", ret);
+    std::thread client_thread(run_client, (void*)test_configs);
+    client_thread.join();
+    OE_TRACE_INFO(
+        "Client thread terminated with ret =%d... \n",
+        g_client_thread_exit_code);
 
-    ret = pthread_create(
-        &client_thread_id, NULL, client_thread, (void*)test_configs);
-    if (ret)
-        oe_put_err("pthread_create(client): ret=%u", ret);
-
-    pthread_join(client_thread_id, &retval);
-    ret = *(int*)retval;
-    OE_TRACE_INFO("Client thread terminated with ret =%d... \n", ret);
-    return ret;
+    return g_client_thread_exit_code;
 }
 
 int run_scenarios_tests()
@@ -336,6 +320,7 @@ done:
 int main(int argc, const char* argv[])
 {
 #ifdef OE_LINK_SGX_DCAP_QL
+
     oe_result_t result = OE_FAILURE;
     uint32_t flags = OE_ENCLAVE_FLAG_DEBUG;
     int ret = 0;


### PR DESCRIPTION
Port the tls_e2e test host side to use std::thread instead of pthread. This will allow the test to run on Windows, which does not officially support pthread.

Note that this change alone will not get the test running on Windows, but it is necessary groundwork.