### PR TITLE
Optimization/Security: Reduce TCB via gc-sections.

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -210,6 +210,9 @@ if (OE_SGX)
         -nostdinc
         -fno-stack-protector
         -fvisibility=hidden
+        # Put each function or data in its own section.
+        # This allows aggressively eliminating unused code.
+        -ffunction-sections -fdata-sections
         # "The default without -fpic is 'initial-exec'; with -fpic the
         # default is 'global-dynamic'."
         # https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
@@ -258,7 +261,8 @@ if(OE_SGX)
         -nostdlib -nodefaultlibs -nostartfiles
         -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,-pie,--build-id
         -Wl,-z,noexecstack
-        -Wl,-z,now)
+        -Wl,-z,now
+        -Wl,-gc-sections)
 elseif(OE_TRUSTZONE)
     target_link_libraries(oecore INTERFACE
         -nostdlib -nodefaultlibs -nostartfiles

--- a/host/sgx/asmdefs.h
+++ b/host/sgx/asmdefs.h
@@ -80,10 +80,12 @@ typedef struct _oe_host_ocall_frame
 #endif
 
 #ifndef __ASSEMBLER__
+OE_EXPORT
 void oe_notify_ocall_start(oe_host_ocall_frame_t* frame_pointer, void* tcs);
 #endif
 
 #ifndef __ASSEMBLER__
+OE_EXPORT
 void oe_notify_ocall_end(oe_host_ocall_frame_t* frame_pointer, void* tcs);
 #endif
 

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -834,10 +834,13 @@ oe_result_t oe_switchless_call_enclave_function(
 /*
 ** These two functions are needed to notify the debugger. They should not be
 ** optimized out even though they don't do anything in here.
+** OE_EXPORT is used to retain these function irrespective of linker
+** optimizations.
 */
 
 OE_NO_OPTIMIZE_BEGIN
 
+OE_EXPORT
 OE_NEVER_INLINE void oe_notify_ocall_start(
     oe_host_ocall_frame_t* frame_pointer,
     void* tcs)
@@ -848,6 +851,7 @@ OE_NEVER_INLINE void oe_notify_ocall_start(
     return;
 }
 
+OE_EXPORT
 OE_NEVER_INLINE void oe_notify_ocall_end(
     oe_host_ocall_frame_t* frame_pointer,
     void* tcs)

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -27,7 +27,9 @@ set(ENCLAVE_CFLAGS_LIST
   -fPIE
   -ftls-model=local-exec
   -fvisibility=hidden
-  -fno-stack-protector)
+  -fno-stack-protector
+  -ffunction-sections
+  -fdata-sections)
 
 set(ENCLAVE_CFLAGS_CLANG_LIST ${ENCLAVE_CFLAGS_LIST} ${SPECTRE_MITIGATION_FLAGS})
 list(JOIN ENCLAVE_CFLAGS_CLANG_LIST " " ENCLAVE_CFLAGS_CLANG)
@@ -52,6 +54,7 @@ set(ENCLAVE_CLIBS_1
   -Wl,--build-id
   -Wl,-z,noexecstack
   -Wl,-z,now
+  -Wl,-gc-sections
   -L\${libdir}/openenclave/enclave
   -loeenclave
   -loecryptombed

--- a/tests/debugger/oegdb/enc/enc.c
+++ b/tests/debugger/oegdb/enc/enc.c
@@ -33,6 +33,9 @@ int enc_add(int a, int b)
     return c;
 }
 
+// The following function is intended to be called by the debugger.
+// It must be retained via OE_EXPORT.
+OE_EXPORT
 int square(int x)
 {
     printf("square called with %d\n", x);


### PR DESCRIPTION
Function and variables are put in their own sections (-ffunction-sections and -fdata-sections).
Linker is asked to garbage collect unused sections (-gc-sections).
Thus any function/variable that is not reachable from the enclave entry point is eliminated
from the enclave binary, reducing the footprint and tcb.

For example, release build of echo_enc previously took 970KB. Now it takes 650KB.