### PR TITLE
Fix clang-format version parser

### DIFF
--- a/scripts/format-code
+++ b/scripts/format-code
@@ -170,7 +170,7 @@ check_clang-format()
 
     local required_cfver='7.0.1'
     # shellcheck disable=SC2155
-    local cfver=$(${cf} --version | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')
+    local cfver=$(${cf} --version | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
     check_version "${required_cfver}" "${cfver}"
 }
 


### PR DESCRIPTION
If version is listed twice in `clang-format --version` (as it is in the fedora version of the package), this check will fail. Instead, just take the first occurrence of the version number.

Prior to this change on fedora 29:
```
$ clang-format --version
clang-format version 7.0.1 (Fedora 7.0.1-6.fc29)
```

`cfver` contains `7.0.1 7.0.1`