### PR TITLE
Update oe_prereqs folder install path to reflect recent changes

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -191,7 +191,7 @@ def win2016LinuxElfBuild(String version, String compiler, String build_type) {
                 dir('build') {
                   bat """
                       vcvars64.bat x64 && \
-                      cmake.exe ${WORKSPACE} -G Ninja -DADD_WINDOWS_ENCLAVE_TESTS=ON -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=ON -DCMAKE_BUILD_TYPE=${build_type} -DLINUX_BIN_DIR=${WORKSPACE}\\linuxbin\\tests -DNUGET_PACKAGE_PATH=C:/openenclave/prereqs/nuget -Wdev && \
+                      cmake.exe ${WORKSPACE} -G Ninja -DADD_WINDOWS_ENCLAVE_TESTS=ON -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=ON -DCMAKE_BUILD_TYPE=${build_type} -DLINUX_BIN_DIR=${WORKSPACE}\\linuxbin\\tests -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
                       ninja -v && \
                       ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT_SECONDS}
                       """
@@ -218,7 +218,7 @@ def win2016CrossCompile(String build_type, String has_quote_provider = 'OFF') {
 
                   bat """
                       vcvars64.bat x64 && \
-                      cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=${has_quote_provider} -DNUGET_PACKAGE_PATH=C:/openenclave/prereqs/nuget -Wdev && \
+                      cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=${has_quote_provider} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
                       ninja.exe && \
                       ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT_SECONDS}
                       """
@@ -307,7 +307,7 @@ def ACCHostVerificationTest(String version, String build_type) {
                     dir('build') {
                         bat """
                             vcvars64.bat x64 && \
-                            cmake.exe ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=OFF -DCMAKE_BUILD_TYPE=${build_type} -DNUGET_PACKAGE_PATH=C:/openenclave/prereqs/nuget -Wdev && \
+                            cmake.exe ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=OFF -DCMAKE_BUILD_TYPE=${build_type} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
                             ninja -v && \
                             ctest.exe -V -C ${build_type} -R host_verify --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                             """
@@ -363,8 +363,8 @@ try{
 } catch(Exception e) {
     println "Caught global pipeline exception :" + e
     GLOBAL_ERROR = e
-    throw e   
+    throw e
 } finally {
-    currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"    
+    currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"
     oe.emailJobStatus(currentBuild.result)
 }

--- a/.jenkins/Packaging.Jenkinsfile
+++ b/.jenkins/Packaging.Jenkinsfile
@@ -38,7 +38,7 @@ def WindowsPackaging(String build_type) {
                 dir('build') {
                     bat """
                         vcvars64.bat x64 && \
-                        cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=ON -DNUGET_PACKAGE_PATH=C:/openenclave/prereqs/nuget -DCPACK_GENERATOR=NuGet -Wdev && \
+                        cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=ON -DNUGET_PACKAGE_PATH=C:/oe_prereqs -DCPACK_GENERATOR=NuGet -Wdev && \
                         ninja.exe && \
                         ctest.exe -V -C RELEASE --timeout ${CTEST_TIMEOUT_SECONDS} && \
                         cpack && \
@@ -65,8 +65,8 @@ try{
 } catch(Exception e) {
     println "Caught global pipeline exception :" + e
     GLOBAL_ERROR = e
-    throw e   
+    throw e
 } finally {
-    currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"    
+    currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"
     oe.emailJobStatus(currentBuild.result)
 }

--- a/.jenkins/custom_label.Jenkinsfile
+++ b/.jenkins/custom_label.Jenkinsfile
@@ -55,7 +55,7 @@ def win2016CrossCompile(String build_type, String has_quote_provider = 'OFF') {
 
                   bat """
                       vcvars64.bat x64 && \
-                      cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=${has_quote_provider} -DNUGET_PACKAGE_PATH=C:/openenclave/prereqs/nuget -Wdev && \
+                      cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=${has_quote_provider} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
                       ninja.exe && \
                       ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT_SECONDS}
                       """
@@ -91,11 +91,10 @@ def win2016LinuxElfBuild(String version, String compiler, String build_type) {
                 checkout scm
                 unstash "linux-${compiler}-${build_type}-${version}-${BUILD_NUMBER}"
                 bat 'move build linuxbin'
-                powershell 'Copy-Item -Recurse C:\\openenclave\\prereqs\\nuget ${env:WORKSPACE}\\prereqs'
                 dir('build') {
                   bat """
                       vcvars64.bat x64 && \
-                      cmake.exe ${WORKSPACE} -G Ninja -DADD_WINDOWS_ENCLAVE_TESTS=ON -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=ON -DCMAKE_BUILD_TYPE=${build_type} -DLINUX_BIN_DIR=${WORKSPACE}\\linuxbin\\tests -Wdev && \
+                      cmake.exe ${WORKSPACE} -G Ninja -DADD_WINDOWS_ENCLAVE_TESTS=ON -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=ON -DCMAKE_BUILD_TYPE=${build_type} -DLINUX_BIN_DIR=${WORKSPACE}\\linuxbin\\tests -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
                       ninja -v && \
                       ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT_SECONDS}
                       """

--- a/scripts/ansible/oe-windows-acc-setup.yml
+++ b/scripts/ansible/oe-windows-acc-setup.yml
@@ -33,7 +33,7 @@
 
     - name: OE setup | Run the install-windows-prereqs.ps1 script (this may take a while)
       script: ../install-windows-prereqs.ps1
-        -InstallPath         "C:\openenclave"
+        -InstallPath         "C:\oe_prereqs"
         -LaunchConfiguration "{{ 'SGX1FLC' if dcap_testing_node is defined and dcap_testing_node == 'true' else 'SGX1' }}"
         -DCAPClientType      "{{ 'Azure' }}"
         -IntelPSWURL         "{{ intel_psw_url }}"

--- a/scripts/ansible/roles/windows/az-dcap-client/vars/windows.yml
+++ b/scripts/ansible/roles/windows/az-dcap-client/vars/windows.yml
@@ -11,9 +11,9 @@ lc_driver:
   reg_value: 1
 
 validation_directories:
-  - "C:\\openenclave\\prereqs\\nuget\\DCAP_Components"
-  - "C:\\openenclave\\prereqs\\nuget\\EnclaveCommonAPI"
+  - "C:\\oe_prereqs\\DCAP_Components"
+  - "C:\\oe_prereqs\\EnclaveCommonAPI"
 
 validation_binaries:
-  - "C:\\openenclave\\prereqs\\nuget\\DCAP_Components\\build\\lib\\native\\Libraries\\sgx_dcap_ql.lib"
-  - "C:\\openenclave\\prereqs\\nuget\\EnclaveCommonAPI\\lib\\native\\x64-Release\\sgx_enclave_common.lib"
+  - "C:\\oe_prereqs\\DCAP_Components\\build\\lib\\native\\Libraries\\sgx_dcap_ql.lib"
+  - "C:\\oe_prereqs\\EnclaveCommonAPI\\lib\\native\\x64-Release\\sgx_enclave_common.lib"

--- a/scripts/ansible/roles/windows/openenclave/vars/windows.yml
+++ b/scripts/ansible/roles/windows/openenclave/vars/windows.yml
@@ -15,6 +15,7 @@ validation_directories:
   - "C:\\Program Files\\shellcheck"
   - "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC\\Auxiliary\\Build"
   - "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\Common7\\Tools"
+  - "C:\\oe_prereqs\\node_modules\\esy"
 
 validation_files:
   - "C:\\Program Files\\LLVM\\lib\\libclang.lib"
@@ -28,3 +29,4 @@ validation_binaries:
   - "C:\\Program Files\\shellcheck\\shellcheck.exe"
   - "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC\\Tools\\MSVC\\14.16.27023\\bin\\Hostx64\\x64\\cl.exe"
   - "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC\\Tools\\MSVC\\14.16.27023\\bin\\Hostx64\\x64\\link.exe"
+  - "C:\\oe_prereqs\\esy"

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -424,10 +424,10 @@ function Install-Node {
                  -ArgumentList @("/quiet", "/passive") `
                  -EnvironmentPath @($installDir)
 
-    Add-ToSystemPath -Path "${env:APPDATA}\npm"
+    Add-ToSystemPath -Path "${InstallPath}"
 
     Start-ExecuteWithRetry -ScriptBlock {
-        npm install -g esy@0.5.8
+        npm install --prefix "${InstallPath}" -g esy@0.5.8
     } -RetryMessage "Failed to install esy. Retrying"
 }
 
@@ -646,7 +646,6 @@ try {
     Install-OpenSSL
     Install-LLVM
     Install-Git
-    Install-Node
     Install-Shellcheck
 
     if ($LaunchConfiguration -ne "SGX1FLC-NoDriver")
@@ -665,6 +664,8 @@ try {
     }
 
     Install-DCAP-Dependencies
+    # Install-Node has to be executed after Install-DCAP-Dependencies because it removes existing $InstallPath directory
+    Install-Node
     Install-VCRuntime
 
     Write-Output 'Please reboot your computer for the configuration to complete.'


### PR DESCRIPTION
Update oe_prereqs InstallPath to reflect recent changes in our Documentation
Moved NuGet packets from C:\openenclave\prereqs\nuget. to C:\oe_prereqs

Npm installs esy by default in $env:APPDATA of current user.  This causes issue when our VHD's are built with a different user than the one being used to run the builds.

Move installation of esy to C:\oe_prereqs folder