### PR TITLE
Fix broken link

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -314,5 +314,5 @@ an issue to discuss the idea.
 Code of Conduct
 ---------------
 
-This project follows a [Code of Conduct](docs/CodeOfConduct.md) adapted from the
+This project follows a [Code of Conduct](CodeOfConduct.md) adapted from the
 [Contributor Covenant v1.4](https://www.contributor-covenant.org).


### PR DESCRIPTION
Problem was due to docs/docs appearing in the path instead of just docs,
because the path is already relative to the docs directory.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>