### PR TITLE
Fix oe_accept not returning peer addr

### DIFF
--- a/syscall/devices/hostsock/hostsock.c
+++ b/syscall/devices/hostsock/hostsock.c
@@ -273,10 +273,10 @@ static oe_fd_t* _hostsock_accept(
         new_sock->host_fd = retval;
 
         // copy peer addr to out buffer
-        if (addrlen && *addrlen <= addrlen_in)
+        if (addrlen)
         {
             oe_assert(addr);
-            if (oe_memcpy_s(addr, addrlen_in, &buf, *addrlen) != OE_OK)
+            if (oe_memcpy_s(addr, addrlen_in, &buf.addr, *addrlen) != OE_OK)
                 OE_RAISE_ERRNO(OE_EINVAL);
         }
     }

--- a/syscall/devices/hostsock/hostsock.c
+++ b/syscall/devices/hostsock/hostsock.c
@@ -271,6 +271,14 @@ static oe_fd_t* _hostsock_accept(
             OE_RAISE_ERRNO_MSG(oe_errno, "retval=%d", retval);
 
         new_sock->host_fd = retval;
+
+        // copy peer addr to out buffer
+        if (addrlen && *addrlen <= addrlen_in)
+        {
+            oe_assert(addr);
+            if (oe_memcpy_s(addr, addrlen_in, &buf, *addrlen) != OE_OK)
+                OE_RAISE_ERRNO(OE_EINVAL);
+        }
     }
 
     ret = &new_sock->base;

--- a/tests/syscall/socket/enc/enc.c
+++ b/tests/syscall/socket/enc/enc.c
@@ -146,10 +146,10 @@ int ecall_run_server()
         printf("enc: accepting\n");
 
         struct oe_sockaddr_in peer_addr = {0};
-        oe_socklen_t peer_addr_len = sizeof peer_addr;
+        oe_socklen_t peer_addr_len = sizeof(peer_addr);
         connfd = oe_accept(
             listenfd, (struct oe_sockaddr*)&peer_addr, &peer_addr_len);
-        OE_TEST(peer_addr_len == sizeof peer_addr);
+        OE_TEST(peer_addr_len == sizeof(peer_addr));
         OE_TEST(peer_addr.sin_family == OE_AF_INET);
         OE_TEST(oe_ntohs(peer_addr.sin_port) >= 1024);
         OE_TEST(oe_ntohl(peer_addr.sin_addr.s_addr) == OE_INADDR_LOOPBACK);

--- a/tests/syscall/socket/enc/enc.c
+++ b/tests/syscall/socket/enc/enc.c
@@ -144,7 +144,16 @@ int ecall_run_server()
     {
         oe_sleep_msec(1);
         printf("enc: accepting\n");
-        connfd = oe_accept(listenfd, (struct oe_sockaddr*)NULL, NULL);
+
+        struct oe_sockaddr_in peer_addr = {0};
+        oe_socklen_t peer_addr_len = sizeof peer_addr;
+        connfd = oe_accept(
+            listenfd, (struct oe_sockaddr*)&peer_addr, &peer_addr_len);
+        OE_TEST(peer_addr_len == sizeof peer_addr);
+        OE_TEST(peer_addr.sin_family == OE_AF_INET);
+        OE_TEST(oe_ntohs(peer_addr.sin_port) >= 1024);
+        OE_TEST(oe_ntohl(peer_addr.sin_addr.s_addr) == OE_INADDR_LOOPBACK);
+
         if (connfd >= 0)
         {
             printf("enc: accepted fd = %d\n", connfd);


### PR DESCRIPTION
The posix accept() function takes a pointer to a sockaddr struct that it fills with the address of the peer socket. The oe_accept() function passes a buffer to the host call to receive the peer address, but on return the result is not used. This PR adds the code to copy the result to the user provided buffer so that oe_accept() behaves likes accept().