### PR TITLE
Fix opendir() does not return NULL on error

### DIFF
--- a/syscall/devices/hostfs/hostfs.c
+++ b/syscall/devices/hostfs/hostfs.c
@@ -871,13 +871,13 @@ static oe_fd_t* _hostfs_opendir(oe_device_t* device, const char* name)
     if (oe_syscall_opendir_ocall(&retval, host_name) != OE_OK)
         OE_RAISE_ERRNO(OE_EINVAL);
 
-    if (retval != 0)
-    {
-        dir->base.type = OE_FD_TYPE_FILE;
-        dir->magic = DIR_MAGIC;
-        dir->base.ops.file = _get_file_ops();
-        dir->host_dir = retval;
-    }
+    if (!retval)
+        OE_RAISE_ERRNO(oe_errno);
+
+    dir->base.type = OE_FD_TYPE_FILE;
+    dir->magic = DIR_MAGIC;
+    dir->base.ops.file = _get_file_ops();
+    dir->host_dir = retval;
 
     ret = &dir->base;
     dir = NULL;

--- a/tests/syscall/fs/enc/enc.cpp
+++ b/tests/syscall/fs/enc/enc.cpp
@@ -327,6 +327,17 @@ static void test_unlink_file(FILE_SYSTEM& fs, const char* tmp_dir)
 }
 
 template <class FILE_SYSTEM>
+static void test_invalid_path(FILE_SYSTEM& fs)
+{
+    const char* const path = "doesnotexist";
+    printf("--- %s()\n", __FUNCTION__);
+    OE_TEST(fs.open(path, O_RDONLY, 0) == FILE_SYSTEM::invalid_file_handle);
+    OE_TEST(fs.opendir(path) == FILE_SYSTEM::invalid_dir_handle);
+    OE_TEST(fs.rmdir(path) == -1);
+    OE_TEST(fs.truncate(path, 0) == -1);
+}
+
+template <class FILE_SYSTEM>
 void test_all(FILE_SYSTEM& fs, const char* tmp_dir)
 {
     cleanup(fs, tmp_dir);
@@ -338,6 +349,7 @@ void test_all(FILE_SYSTEM& fs, const char* tmp_dir)
     test_readdir(fs, tmp_dir);
     test_truncate_file(fs, tmp_dir);
     test_unlink_file(fs, tmp_dir);
+    test_invalid_path(fs);
     cleanup(fs, tmp_dir);
 }
 

--- a/tests/syscall/fs/enc/file_system.h
+++ b/tests/syscall/fs/enc/file_system.h
@@ -30,6 +30,9 @@ class oe_fd_file_system
     typedef struct oe_stat stat_type;
     typedef struct oe_dirent dirent_type;
 
+    static constexpr file_handle invalid_file_handle = -1;
+    static constexpr dir_handle invalid_dir_handle = nullptr;
+
     oe_fd_file_system(void)
     {
     }
@@ -158,6 +161,9 @@ class fd_file_system
     typedef struct oe_stat stat_type;
     typedef struct dirent dirent_type;
 
+    static constexpr file_handle invalid_file_handle = -1;
+    static constexpr dir_handle invalid_dir_handle = nullptr;
+
     fd_file_system(void)
     {
     }
@@ -285,6 +291,9 @@ class stream_file_system
     typedef DIR* dir_handle;
     typedef struct stat stat_type;
     typedef struct dirent dirent_type;
+
+    static constexpr file_handle invalid_file_handle = nullptr;
+    static constexpr dir_handle invalid_dir_handle = nullptr;
 
     stream_file_system(void)
     {


### PR DESCRIPTION
oe_opendir() always returned a valid pointer even if the host call
returned NULL.