### PR TITLE
DevelopmentGuide.md: Add guidance on disabling doxygen comments

### DIFF
--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -16,6 +16,9 @@ Coding Conventions
   headers. This is also encouraged, but not strictly required, for internal API
   headers as well.
 
+* **DO** disable doxygen documentation for elements that are not in the public
+  API as described [here](./refman/doxygen-howto.md#disable-doxygen).
+
 * **DON'T** use global variables where possible.
 
 * **DON'T** use abbreviations unless they are already well-known terms known by

--- a/docs/refman/doxygen-howto.md
+++ b/docs/refman/doxygen-howto.md
@@ -182,6 +182,7 @@ For example.
  */
 ```
 
+<a name="disable-doxygen"></a>
 ### Disabling Doxygen documentation from blocks of code
 
 To disable Doxygen documentation from blocks of code with `#defines` or


### PR DESCRIPTION
This PR adds the following line to **DevelopmentGuide.md**.

```
* **DO** disable doxygen documentation for elements that are not in the public
  API as described [here](./refman/doxygen-howto.md#disable-doxygen).
```