### PR TITLE
Updated README.md to contain a link to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ documentation:
 - [Governance Model](docs/Governance.md)
 - [Build SDK and run tests](docs/GettingStartedDocs/Contributors/building_oe_sdk.md)
 
+API Documentation
+-----------------
+
+The Doxygen generated documentation corresponding to the APIs currently supported by the master branch is [here](https://openenclave.github.io/openenclave/api/index.html).
+API Documentation for older releases of the SDK can be found on the Open Enclave SDK [website](https://openenclave.io/sdk).
+
 Licensing
 =========
 


### PR DESCRIPTION
Add a link to API docs in README.md. Fixes #2214 
Signed-off-by: Radhikaj <radhikaj@microsoft.com>