### PR TITLE
Add @experimental annotation support to doxygen

### DIFF
--- a/docs/refman/CMakeLists.txt
+++ b/docs/refman/CMakeLists.txt
@@ -17,6 +17,12 @@ if (ENABLE_REFMAN)
   # have to specify it because we have another directory to strip.
   set(DOXYGEN_STRIP_FROM_PATH "${PROJECT_SOURCE_DIR}/include/openenclave/;${PROJECT_SOURCE_DIR}/docs/refman")
 
+  # Allow @experimental to be used in headers to mark an API as experimental and add it to a list of
+  # experimental APIs.
+  set(DOXYGEN_ALIASES
+    "experimental = \\xrefitem experimental \\\"This feature is marked as experimental\\\" \\\"Experimental List\\\""
+    "experimental{1} = \\xrefitem experimental \\\"Experimental\\\" \\\"Experimental List\\\" \\1")
+
   # NOTE: These were set to their non-default values in the existing
   # configuration file, so that configuration has been copied here.
   # However, they may or may not be desired.


### PR DESCRIPTION
Addresses issue #2216

This uses the custom tags mechanism explained in the stackoverflow thread: https://stackoverflow.com/questions/537043/custom-tags-with-doxygen
Example use of @experimental in another GitHub project: blynkkk/blynk-library@579545d

Together, these cause a separate "experimental.html" page to be created that has a list of all experimental APIs.  Tagging an API with @experimental then causes the notice to show up on that API's own page, and the notice is hotlinked to the experimental.html page. 

@experimental
causes the following to show up (linked to the Experimental List page):

> This feature is marked as experimental:

@experimental FooBar
casues the following to show up (linked to the Experimental List page):

> This feature is marked as experimental:
>> FooBar

So you use no argument if the entire API is experimental.
You use an argument if some particular subset or variation is experimental.

See http://www.doxygen.nl/manual/custcmd.html#custcmd_complex and http://www.doxygen.nl/manual/commands.html#cmdxrefitem for more info.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>