### PR TITLE
Fix attested_tls sample build dependencies

### DIFF
--- a/samples/attested_tls/client/enc/CMakeLists.txt
+++ b/samples/attested_tls/client/enc/CMakeLists.txt
@@ -18,7 +18,9 @@ add_executable(tls_client_enc
 	       cert_verifier.cpp
 	       identity_verifier.cpp
 	       ../../common/utility.cpp
-	       ${CMAKE_CURRENT_BINARY_DIR}/tls_client_t.c)
+         ${CMAKE_CURRENT_BINARY_DIR}/tls_client_t.c)
+
+add_dependencies(tls_client_enc tls_server_sign_enc)
 
 if (WIN32)
   maybe_build_using_clangw(tls_client_enc)

--- a/samples/attested_tls/non_enc_client/CMakeLists.txt
+++ b/samples/attested_tls/non_enc_client/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(tls_non_enc_client
 	       verify_callback.cpp
 	       verify_signer_openssl.cpp)
 
+add_dependencies(tls_non_enc_client tls_server_sign_enc)
+
 target_include_directories(tls_non_enc_client PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}

--- a/samples/attested_tls/server/enc/CMakeLists.txt
+++ b/samples/attested_tls/server/enc/CMakeLists.txt
@@ -12,6 +12,7 @@ add_custom_command(OUTPUT tls_server_enc.signed tls_server_enc_mrenclave.h
   COMMAND openenclave::oesign sign -e $<TARGET_FILE:tls_server_enc> -c ${CMAKE_SOURCE_DIR}/server/enc/enc.conf -k ${CMAKE_SOURCE_DIR}/server/enc/private.pem
   COMMAND openenclave::oesign dump -e tls_server_enc.signed  > temp.dmp
   COMMAND bash ${CMAKE_SOURCE_DIR}/scripts/gen_mrenclave_header.sh ${CMAKE_SOURCE_DIR}/common/tls_server_enc_mrenclave.h temp.dmp
+  COMMAND ${CMAKE_COMMAND} -E sleep 1
   COMMAND ${CMAKE_COMMAND} -E remove temp.dmp)
 
 add_executable(tls_server_enc


### PR DESCRIPTION
Fixes build failure in #2367 by properly expressing build dependencies. More details in the issue.