### PR TITLE
Fix some of the memory safety issues reported by scan-build

### DIFF
--- a/enclave/core/sgx/td.c
+++ b/enclave/core/sgx/td.c
@@ -90,7 +90,7 @@ void td_push_callsite(td_t* td, Callsite* callsite)
 
 void td_pop_callsite(td_t* td)
 {
-    if (!td->callsites)
+    if (!td || !td->callsites)
         oe_abort();
 
     if (td->depth == 1)

--- a/host/asym_keys.c
+++ b/host/asym_keys.c
@@ -132,7 +132,7 @@ done:
     if (arg.key_info)
     {
         oe_secure_zero_fill(arg.key_info, arg.key_info_size);
-        free(arg.key_buffer);
+        free(arg.key_info);
     }
 
     return result;

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -554,6 +554,9 @@ oe_result_t oe_sgx_build_enclave(
     uint64_t vaddr = 0;
     oe_sgx_enclave_properties_t props;
 
+    if (!enclave)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
     memset(&oeimage, 0, sizeof(oeimage));
 
     /* Clear and initialize enclave structure */

--- a/host/sgx/elf.c
+++ b/host/sgx/elf.c
@@ -321,7 +321,7 @@ done:
     if (is)
         fclose(is);
 
-    if (rc != 0)
+    if (rc != 0 && elf)
     {
         free(elf->data);
         memset(elf, 0, sizeof(elf64_t));

--- a/host/sgx/switchless.c
+++ b/host/sgx/switchless.c
@@ -149,6 +149,21 @@ oe_result_t oe_start_switchless_manager(
     result = OE_OK;
 
 done:
+    if (result != OE_OK)
+    {
+        if (manager)
+        {
+            free(manager);
+            enclave->switchless_manager = NULL;
+        }
+
+        if (contexts)
+            free(contexts);
+
+        if (threads)
+            free(threads);
+    }
+
     return result;
 }
 

--- a/syscall/devices/hostfs/hostfs.c
+++ b/syscall/devices/hostfs/hostfs.c
@@ -433,8 +433,10 @@ static int _hostfs_dup(oe_fd_t* desc, oe_fd_t** new_file_out)
     file_t* file = _cast_file(desc);
     file_t* new_file = NULL;
 
-    if (new_file_out)
-        *new_file_out = NULL;
+    if (!new_file_out)
+        OE_RAISE_ERRNO(OE_EINVAL);
+
+    *new_file_out = NULL;
 
     /* Check parameters. */
     if (!file)

--- a/syscall/fdtable.c
+++ b/syscall/fdtable.c
@@ -283,12 +283,14 @@ int oe_fdtable_reassign(int fd, oe_fd_t* new_desc, oe_fd_t** old_desc)
     int ret = -1;
     bool locked = false;
 
+    if (!new_desc || !old_desc)
+        OE_RAISE_ERRNO(OE_EINVAL);
+
 #if !defined(NDEBUG)
     _assert_fd(new_desc);
 #endif
 
-    if (old_desc)
-        *old_desc = NULL;
+    *old_desc = NULL;
 
     oe_spin_lock(&_lock);
     locked = true;

--- a/syscall/netdb.c
+++ b/syscall/netdb.c
@@ -69,6 +69,8 @@ int oe_getaddrinfo(
 
     if (res_out)
         *res_out = NULL;
+    else
+        OE_RAISE_ERRNO(OE_EINVAL);
 
     oe_spin_lock(&_lock);
     locked = true;


### PR DESCRIPTION
In exploring static analysis tools, I ran Clang's scan-build static analysis tool on the codebase. I took a first pass at fixing some of the low-hanging fruit.

Specifically I took a look at:
* Use-after-free
* Double-free
* Dereference of null ptr
* A couple memory leaks