### PR TITLE
change required approvers from 1 to 2

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [ "continuous-integration/jenkins/branch" ]
 pr_status = [ "DCO" ]
-required_approvals = 1
+required_approvals = 2
 block_labels = [ "do not merge" ]
 delete_merged_branches = true
 timeout_sec = 7200 # two hours


### PR DESCRIPTION
Change the required reviewers from 1 to 2.

We should be requiring 2 approvers given cross-collaboration efforts.