### PR TITLE
Fix oegdb on Ubuntu with German locale

### DIFF
--- a/debugger/pythonExtension/load_symbol_cmd.py
+++ b/debugger/pythonExtension/load_symbol_cmd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2011-2017 Intel Corporation. All rights reserved.
+# Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,6 +30,8 @@
 #
 #
 
+# -*- coding: iso-8859-15 -*-
+
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -54,7 +56,7 @@ def GetLoadSymbolCommand(EnclaveFile, Base):
         # their offsets and add the Proj base address.
         for line in FileList:
             list = line.split();
-            if(len(list) > 0):
+            if(len(list) > 1):
                 SegOffset = -1;
                 # The readelf will put a space after the open bracket for single
                 # digit section numbers.  This causes the line.split to create


### PR DESCRIPTION
oegdb could not get symbols from enclave file on Ubuntu with a German
locale. This commit updates load_symbol_cmd.py to the current master of
intel/linux-sgx related to intel/linux-sgx#405