### PR TITLE
Add warnings for full EDL serialization

### DIFF
--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -54,7 +54,7 @@ enclave {
 
   trusted {
     // Since `s` is passed by value, `s.ptr` is not deep copied.
-    public void deepcopy_value(ShallowStruct s, [user_check] uint64_t* ptr);
+    public void deepcopy_value(struct ShallowStruct s, [user_check] uint64_t* ptr);
 
     // Although `s` is passed by pointer, because `s.ptr` does not
     // have any attribute, it is still not deep copied.

--- a/tools/oeedger8r/src/Common.ml
+++ b/tools/oeedger8r/src/Common.ml
@@ -49,6 +49,8 @@ let flatten_map f l = List.flatten (List.map f l)
 
 let flatten_map2 f l m = List.flatten (List.map2 f l m)
 
+let is_ptr (p, _) = match p with PTPtr _ -> true | PTVal _ -> false
+
 let is_in_ptr = function
   | PTVal _ -> false
   | PTPtr (_, a) -> a.pa_chkptr && a.pa_direction = PtrIn

--- a/tools/oeedger8r/src/Common.mli
+++ b/tools/oeedger8r/src/Common.mli
@@ -13,6 +13,8 @@ val flatten_map : ('a -> 'b list) -> 'a list -> 'b list
 
 val flatten_map2 : ('a -> 'b -> 'c list) -> 'a list -> 'b list -> 'c list
 
+val is_ptr : Intel.Ast.parameter_type * 'a -> bool
+
 val is_in_ptr : Intel.Ast.parameter_type -> bool
 
 val is_out_ptr : Intel.Ast.parameter_type -> bool

--- a/tools/oeedger8r/src/Emitter.ml
+++ b/tools/oeedger8r/src/Emitter.ml
@@ -69,6 +69,12 @@ let warn_foreign_structs (fd : func_decl) =
         (get_tystr t)
   | None -> ()
 
+let warn_ptr_return_value (fd : func_decl) =
+  match fd.rtype with
+  | Ptr _ ->
+      printf "Warning: Function '%s' has a pointer return value.\n" fd.fname
+  | _ -> ()
+
 let warn_signed_size_or_count_types (fd : func_decl) =
   let print_signedness_warning p =
     printf
@@ -180,7 +186,8 @@ let write_enclave_code (ec : enclave_content) (ep : Intel.Util.edger8r_params) =
       warn_non_portable_types f;
       warn_signed_size_or_count_types f;
       warn_size_and_count_params f;
-      warn_foreign_structs f)
+      warn_foreign_structs f;
+      warn_ptr_return_value f)
     funcs;
   (* End EDL validation. *)
   (* NOTE: The below code encapsulates all our file I/O. *)

--- a/tools/oeedger8r/src/Sources.ml
+++ b/tools/oeedger8r/src/Sources.ml
@@ -19,7 +19,7 @@ let get_struct_by_name (cts : composite_type list) (name : string) =
     members of the [Struct] which should be deep-copied, otherwise we
     return an empty list.
 
-    NOTE: This is a higher-order function that is mean to have its
+    NOTE: This is a higher-order function that is meant to have its
     first two arguments partially applied, and then used repeatedly. *)
 let get_deepcopy_function (enabled : bool) (cts : composite_type list)
     (a : atype) =


### PR DESCRIPTION
This adds the three warnings requested in the Full EDL Serialization proposal, accepted in #2176.

It does not complete the addition of the togglable CLI flags, although that should be done at a later date (it would be a great introduction to developing the edger8r).

This is WIP for now as I want some tests, and I want to validate the logic with @mikbras.

Also, I seem to have uncovered a bug in the parser where a user-defined type `struct Foo` is recognized as a `Foreign` type if it is referenced via the C++ syntax `Foo` instead of `struct Foo`.