### PR TITLE
Fix Windows warnings exposed by /W1 accross the codebase

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -88,7 +88,10 @@ elseif (MSVC)
 
   # Explicitly set C/CXX flags rather than using the defaults. This uses the defaults
   # but removes /W3 from CMAKE_C(XX)_FLAGS. Using W3 and W1 together adds many warnings
-  # that W3 is being overwritten by W1
+  # that W3 is being overwritten by W1. W3 as a default flag is removed in cmake 3.15,
+  # so this behavior can be removed if/when cmake_minimum_required is raised to 3.15.
+  # ======= Default compiler flags for cmake version 3.12 can be found here: =======
+  # https://github.com/Kitware/CMake/blob/v3.12.0/Modules/Platform/Windows-MSVC.cmake
   set (CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS")
   set (CMAKE_C_FLAGS_DEBUG "/MDd /Zi /Ob0 /Od /RTC1")
   set (CMAKE_C_FLAGS_RELEASE "/MD /O2 /Ob2 /DNDEBUG")

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -16,6 +16,8 @@ if (NOT CMAKE_C_COMPILER_ID STREQUAL CMAKE_CXX_COMPILER_ID)
     "${CMAKE_C_COMPILER_ID} != ${CMAKE_CXX_COMPILER_ID}")
 endif ()
 
+set(CMAKE_C_STANDARD 11)
+
 # Set the default standard to C++14 for all targets.
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -72,7 +74,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
   # and that are easy to avoid. Treat at warnings-as-errors, which forces developers
   # to fix warnings as they arise, so they don't accumulate "to be fixed later".
   add_compile_options(-Wall -Werror -Wpointer-arith -Wconversion -Wextra -Wno-missing-field-initializers)
-
   add_compile_options(-fno-strict-aliasing)
 
   # Enables XSAVE intrinsics
@@ -84,11 +85,36 @@ elseif (MSVC)
   if (MSVC_VERSION VERSION_LESS 1910)
     message(FATAL_ERROR "Only Visual Studio 2017 and above supported!")
   endif ()
+
+  # Explicitly set C/CXX flags rather than using the defaults. This uses the defaults
+  # but removes /W3 from CMAKE_C(XX)_FLAGS. Using W3 and W1 together adds many warnings
+  # that W3 is being overwritten by W1
+  set (CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS")
+  set (CMAKE_C_FLAGS_DEBUG "/MDd /Zi /Ob0 /Od /RTC1")
+  set (CMAKE_C_FLAGS_RELEASE "/MD /O2 /Ob2 /DNDEBUG")
+
+  set (CMAKE_CXX_FLAGS "/DWIN32 /D_WINDOWS /GR /EHsc")
+  set (CMAKE_CXX_FLAGS_DEBUG "/DWIN32 /D_WINDOWS /MDd /Zi /Ob0 /Od /RTC1")
+  set (CMAKE_CXX_FLAGS_RELEASE "/MD /O2 /Ob2 /DNDEBUG")
+
+  # Can't use add_compile_options because it adds for all file types and ml64
+  # doesn't recognize /wd flags
+  # Turns off warnings for:
+  # * Unicode character cannot be represented by current code page
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4566")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4566")
+
+  # Add Flags we want to use for both C and CXX
+  add_compile_options(/WX)
+  add_compile_options(/W1)
+
+  # Ignore compiler warnings:
+  # * unicode character not supported
+
   if (CMAKE_MSVC_PARALLEL_ENABLE)
     add_compile_options(/MP)
     message(STATUS "Using parallel compiling (/MP)")
   endif()
-
 endif ()
 
 # Use ML64 as assembler on Windows

--- a/common/cert.c
+++ b/common/cert.c
@@ -97,7 +97,7 @@ done:
 
 oe_result_t oe_get_crl_distribution_points(
     const oe_cert_t* cert,
-    const char*** urls,
+    char*** urls,
     size_t* num_urls,
     uint8_t* buffer,
     size_t* buffer_size)
@@ -163,7 +163,7 @@ oe_result_t oe_get_crl_distribution_points(
 
         /* Set the pointer to the urls[] array if enough space */
         if (buffer && urls_bytes <= *buffer_size)
-            *urls = (const char**)buffer;
+            *urls = (char**)buffer;
 
         /* Process all the CRL distribution points */
         {
@@ -187,7 +187,7 @@ oe_result_t oe_get_crl_distribution_points(
                 {
                     // The address could point beyond end of buffer, but that is
                     // fine since an OE_BUFFER_TOO_SMALL error is raised below.
-                    (*urls)[i] = (const char*)(buffer + offset);
+                    (*urls)[i] = ((char*)buffer + offset);
                 }
 
                 /* Append the URL */

--- a/common/datetime.c
+++ b/common/datetime.c
@@ -1,6 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#include <openenclave/bits/defs.h>
 #include <openenclave/internal/datetime.h>
 #include <openenclave/internal/raise.h>
 #include <time.h>

--- a/common/sgx/revocation.c
+++ b/common/sgx/revocation.c
@@ -191,7 +191,7 @@ static oe_result_t _get_crl_distribution_point(oe_cert_t* cert, char** url)
     oe_result_t result = OE_FAILURE;
     size_t buffer_size = 512;
     uint8_t* buffer = oe_malloc(buffer_size);
-    const char** urls = NULL;
+    char** urls = NULL;
     uint64_t num_urls = 0;
     size_t url_length = 0;
 

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -223,6 +223,7 @@ list(APPEND PLATFORM_HOST_ONLY_SRC
   ../common/safecrt.c
   hexdump.c
   dupenv.c
+  fopen.c
   tests.c
   result.c
   traceh.c)

--- a/host/asym_keys.c
+++ b/host/asym_keys.c
@@ -27,7 +27,7 @@ oe_result_t oe_get_public_key_by_policy(
     size_t* key_info_size)
 {
     oe_result_t result = OE_UNEXPECTED;
-    uint32_t retval;
+    oe_result_t retval;
     const size_t KEY_BUFFER_SIZE = DEFAULT_KEY_BUFFER_SIZE;
     const size_t KEY_INFO_SIZE = 1024;
     struct
@@ -85,7 +85,7 @@ oe_result_t oe_get_public_key_by_policy(
     }
 
     /* If the buffers were too small, try again with corrected sizes. */
-    if ((oe_result_t)retval == OE_BUFFER_TOO_SMALL)
+    if (retval == OE_BUFFER_TOO_SMALL)
     {
         if (!(arg.key_buffer = realloc(arg.key_buffer, arg.key_buffer_size)))
             OE_RAISE(OE_OUT_OF_MEMORY);
@@ -109,7 +109,7 @@ oe_result_t oe_get_public_key_by_policy(
         }
     }
 
-    OE_CHECK((oe_result_t)retval);
+    OE_CHECK(retval);
 
     *key_buffer = arg.key_buffer;
     *key_buffer_size = arg.key_buffer_size;
@@ -147,7 +147,7 @@ oe_result_t oe_get_public_key(
     size_t* key_buffer_size)
 {
     oe_result_t result = OE_UNEXPECTED;
-    uint32_t retval;
+    oe_result_t retval;
     const size_t KEY_BUFFER_SIZE = DEFAULT_KEY_BUFFER_SIZE;
     struct
     {
@@ -190,7 +190,7 @@ oe_result_t oe_get_public_key(
     }
 
     /* If the buffers were too small, try again with corrected sizes. */
-    if ((oe_result_t)retval == OE_BUFFER_TOO_SMALL)
+    if (retval == OE_BUFFER_TOO_SMALL)
     {
         if (!(arg.key_buffer = realloc(arg.key_buffer, arg.key_buffer_size)))
             OE_RAISE(OE_OUT_OF_MEMORY);
@@ -209,7 +209,7 @@ oe_result_t oe_get_public_key(
         }
     }
 
-    OE_CHECK((oe_result_t)retval);
+    OE_CHECK(retval);
 
     *key_buffer = arg.key_buffer;
     *key_buffer_size = arg.key_buffer_size;

--- a/host/crypto/bcrypt/cert.c
+++ b/host/crypto/bcrypt/cert.c
@@ -43,8 +43,8 @@ static const CERT_STRONG_SIGN_PARA _OE_DEFAULT_SIGN_PARAMS = {
 
 static const CERT_CHAIN_PARA _OE_DEFAULT_CERT_CHAIN_PARAMS = {
     .cbSize = sizeof(CERT_CHAIN_PARA),
-    .RequestedUsage = {{0}},
-    .RequestedIssuancePolicy = {{0}},
+    .RequestedUsage = {0},
+    .RequestedIssuancePolicy = {0},
     .dwUrlRetrievalTimeout = 0,
     .fCheckRevocationFreshnessTime = FALSE,
     .dwRevocationFreshnessTime = 0,
@@ -204,7 +204,10 @@ static oe_result_t _bcrypt_load_cert_store_pem(
             OE_RAISE(find_result);
 
         OE_CHECK(oe_bcrypt_pem_to_der(
-            pem_cert, pem_cert_size, &der_blob.pbData, &der_blob.cbData));
+            (const uint8_t*)pem_cert,
+            pem_cert_size,
+            &der_blob.pbData,
+            &der_blob.cbData));
         free(pem_cert);
         pem_cert = NULL;
 
@@ -361,7 +364,7 @@ static oe_result_t _bcrypt_check_revocation(
         /* For parity with OpenSSL implementation, we require that a CRL
          * is provided for each issuer in the chain. */
         DWORD error = GetLastError();
-        if (error == CRYPT_E_NOT_FOUND)
+        if (error == (DWORD)CRYPT_E_NOT_FOUND)
             OE_RAISE(OE_VERIFY_CRL_MISSING);
         else
             OE_RAISE_MSG(
@@ -784,7 +787,8 @@ oe_result_t oe_cert_chain_read_pem(
     OE_CHECK(_bcrypt_load_cert_store_pem(pem_data, pem_data_size, &cert_store));
 
     /* Count the number of unique certs in the resulting cert store */
-    while (cert_context = CertEnumCertificatesInStore(cert_store, cert_context))
+    while (
+        (cert_context = CertEnumCertificatesInStore(cert_store, cert_context)))
         cert_count++;
 
     if (cert_count == 0)
@@ -796,7 +800,8 @@ oe_result_t oe_cert_chain_read_pem(
      * cert until a cert chain is found that uses all certs in the store and
      * terminates in a self-signed (root) certificate.
      */
-    while (cert_context = CertEnumCertificatesInStore(cert_store, cert_context))
+    while (
+        (cert_context = CertEnumCertificatesInStore(cert_store, cert_context)))
     {
         oe_result_t find_result = _bcrypt_get_cert_chain(
             cert_context, cert_store, cert_count, &cert_chain);
@@ -922,7 +927,7 @@ oe_result_t oe_cert_verify(
     }
 
     /* Add CRLs to cert store */
-    for (int j = 0; j < num_crls; j++)
+    for (size_t j = 0; j < num_crls; j++)
     {
         PCCRL_CONTEXT crl_context;
         OE_CHECK(oe_crl_get_context(crls[j], &crl_context));
@@ -960,7 +965,7 @@ done:
 
 oe_result_t oe_get_crl_distribution_points(
     const oe_cert_t* cert,
-    const char*** urls,
+    char*** urls,
     size_t* num_urls,
     uint8_t* buffer,
     size_t* buffer_size)
@@ -1044,7 +1049,7 @@ oe_result_t oe_get_crl_distribution_points(
         /* Copy the URLs array and pack the URL strings into buffer */
         if (buffer)
         {
-            uint8_t* offset = buffer + found_urls_size;
+            char* offset = (char*)buffer + found_urls_size;
             size_t remaining_bytes = found_urls_total_length;
             char** urls_array = (char**)buffer;
             for (DWORD k = 0; k < found_urls_count; k++)
@@ -1084,7 +1089,6 @@ oe_result_t oe_cert_get_rsa_public_key(
     oe_rsa_public_key_t* public_key)
 {
     oe_result_t result = OE_UNEXPECTED;
-    NTSTATUS status = STATUS_UNSUCCESSFUL;
     BCRYPT_KEY_HANDLE key_handle = NULL;
     PWSTR key_alg_name = NULL;
     ULONG key_alg_name_size;
@@ -1134,7 +1138,6 @@ oe_result_t oe_cert_get_ec_public_key(
     oe_ec_public_key_t* public_key)
 {
     oe_result_t result = OE_UNEXPECTED;
-    NTSTATUS status = STATUS_UNSUCCESSFUL;
     BCRYPT_KEY_HANDLE key_handle = NULL;
     PWSTR key_alg_name = NULL;
     ULONG key_alg_name_size;

--- a/host/crypto/bcrypt/crl.c
+++ b/host/crypto/bcrypt/crl.c
@@ -9,6 +9,7 @@
 #include "../magic.h"
 #include "bcrypt.h"
 #include "crl.h"
+#include "util.h"
 
 typedef struct _crl
 {
@@ -81,8 +82,7 @@ oe_result_t oe_crl_read_der(
             "CertCreateCRLContext failed, err=%#x\n",
             GetLastError());
 
-    impl->magic = OE_CRL_MAGIC;
-    impl->crl = crl_context;
+    _crl_init(impl, crl_context);
     result = OE_OK;
 
 done:

--- a/host/crypto/bcrypt/ec.c
+++ b/host/crypto/bcrypt/ec.c
@@ -96,8 +96,8 @@ static oe_result_t _fixup_public_key_info_for_import(
          * offsets from the original */
         new_key_info = (PCERT_PUBLIC_KEY_INFO)new_key_info_buffer;
         new_key_info->Algorithm.pszObjId =
-            new_key_info_buffer +
-            (key_info->Algorithm.pszObjId - key_info_base);
+            (PSTR)new_key_info_buffer +
+            (key_info->Algorithm.pszObjId - (PSTR)key_info_base);
         new_key_info->Algorithm.Parameters.pbData =
             new_key_info_buffer +
             (key_info->Algorithm.Parameters.pbData - key_info_base);
@@ -157,6 +157,8 @@ static oe_result_t _bcrypt_import_ec_private_key(
     DWORD d_data_size,
     BCRYPT_KEY_HANDLE* private_key)
 {
+    OE_UNUSED(ec_key_magic);
+
     oe_result_t result = OE_UNEXPECTED;
     DWORD key_blob_size = 0;
     BYTE* key_blob = NULL;
@@ -544,6 +546,8 @@ oe_result_t oe_ec_private_key_sign(
     uint8_t* signature,
     size_t* signature_size)
 {
+    OE_UNUSED(hash_type);
+
     oe_result_t result = OE_UNEXPECTED;
     uint8_t* raw_signature = NULL;
     size_t raw_signature_size = 0;
@@ -638,6 +642,8 @@ oe_result_t oe_ec_public_key_verify(
     const uint8_t* signature,
     size_t signature_size)
 {
+    OE_UNUSED(hash_type);
+
     oe_result_t result = OE_UNEXPECTED;
     BYTE* x509_signature = NULL;
     DWORD x509_signature_size = 0;
@@ -1013,8 +1019,8 @@ oe_result_t oe_ecdsa_signature_write_der(
 
     /* Encode the ECDSA siganture */
     {
-        CERT_ECC_SIGNATURE ecc_sig = {
-            (DWORD)max_rs_size, r, (DWORD)max_rs_size, s};
+        CERT_ECC_SIGNATURE ecc_sig = {{(DWORD)max_rs_size, r},
+                                      {(DWORD)max_rs_size, s}};
         BOOL success = CryptEncodeObjectEx(
             X509_ASN_ENCODING,
             X509_ECC_SIGNATURE,

--- a/host/crypto/bcrypt/pem.h
+++ b/host/crypto/bcrypt/pem.h
@@ -18,6 +18,8 @@ typedef enum _oe_pem_header
     OE_PEM_HEADER_PRIVATE_KEY = 2,
     OE_PEM_HEADER_RSA_PRIVATE_KEY = 3,
     OE_PEM_HEADER_EC_PRIVATE_KEY = 4,
+    /* Caution: always add new PEM header values here */
+    OE_PEM_HEADER_MAX,
     __OE_PEM_HEADER_MAX = OE_ENUM_MAX,
 } oe_pem_header_t;
 

--- a/host/crypto/bcrypt/rsa.c
+++ b/host/crypto/bcrypt/rsa.c
@@ -429,7 +429,6 @@ oe_result_t oe_rsa_public_key_equal(
     bool* equal)
 {
     oe_result_t result = OE_UNEXPECTED;
-    NTSTATUS status = STATUS_UNSUCCESSFUL;
 
     /* key1 and key2 are both BCRYPT_RSAKEY_BLOB structures
      * which should be comparable as raw byte buffers.

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -345,8 +345,7 @@ static const char* oe_ocall_str(oe_func_t ocall)
 
     OE_STATIC_ASSERT(OE_OCALL_BASE + OE_COUNTOF(func_names) == OE_OCALL_MAX);
 
-    if (ocall >= OE_OCALL_BASE &&
-        ocall < (OE_OCALL_BASE + OE_COUNTOF(func_names)))
+    if (ocall >= OE_OCALL_BASE && ocall < OE_OCALL_MAX)
         return func_names[ocall - OE_OCALL_BASE];
     else
         return "UNKNOWN";
@@ -367,8 +366,7 @@ static const char* oe_ecall_str(oe_func_t ecall)
 
     OE_STATIC_ASSERT(OE_ECALL_BASE + OE_COUNTOF(func_names) == OE_ECALL_MAX);
 
-    if (ecall >= OE_ECALL_BASE &&
-        ecall < (OE_ECALL_BASE + OE_COUNTOF(func_names)))
+    if (ecall >= OE_ECALL_BASE && ecall < OE_ECALL_MAX)
         return func_names[ecall - OE_ECALL_BASE];
     else
         return "UNKNOWN";

--- a/host/sgx/cpuid.h
+++ b/host/sgx/cpuid.h
@@ -29,12 +29,12 @@ static inline void oe_get_cpuid(
 #elif defined(_MSC_VER)
     int registers[4] = {0};
 
-    __cpuidex(registers, __leaf, __subleaf);
+    __cpuidex(registers, (int)__leaf, (int)__subleaf);
 
-    *__eax = registers[0];
-    *__ebx = registers[1];
-    *__ecx = registers[2];
-    *__edx = registers[3];
+    *__eax = (unsigned int)registers[0];
+    *__ebx = (unsigned int)registers[1];
+    *__ecx = (unsigned int)registers[2];
+    *__edx = (unsigned int)registers[3];
 #endif
 }
 #endif /* _OE_CPUIDCOUNT_H */

--- a/host/sgx/elf.c
+++ b/host/sgx/elf.c
@@ -80,15 +80,13 @@ static bool _is_valid_elf64(const elf64_t* elf)
         return false;
 
     /* Ensure that multiplying header size and num entries won't overflow. */
-    static_assert(
+    OE_STATIC_ASSERT(
         sizeof(uint64_t) >=
-            sizeof(header->e_phentsize) + sizeof(header->e_phnum),
-        "e_phentsize or e_phnum is too large");
+        sizeof(header->e_phentsize) + sizeof(header->e_phnum));
 
-    static_assert(
+    OE_STATIC_ASSERT(
         sizeof(uint64_t) >=
-            sizeof(header->e_shentsize) + sizeof(header->e_shnum),
-        "e_shentsize or e_shnum is too large");
+        sizeof(header->e_shentsize) + sizeof(header->e_shnum));
 
     uint64_t size = (uint64_t)header->e_phentsize * header->e_phnum;
     uint64_t end;
@@ -284,7 +282,7 @@ int elf64_load(const char* path, elf64_t* elf)
     if (fd == -1 || _fstat64(fd, &statbuf) != 0)
         goto done;
 
-    if (!(statbuf.st_mode & _S_IFREG) != 0)
+    if ((statbuf.st_mode & _S_IFREG) == 0)
         goto done;
 #else
     fd = fileno(is);
@@ -1652,9 +1650,7 @@ int elf64_add_section(
         }
 
         /* Update the size of the .shstrtab section */
-        static_assert(
-            sizeof(namesize) == sizeof(uint64_t),
-            "sizeof(namesize) != sizeof(uint64_t)");
+        OE_STATIC_ASSERT(sizeof(namesize) == sizeof(uint64_t));
 
         if (oe_safe_add_u64(
                 shdr->sh_size, (uint64_t)namesize, &shdr->sh_size) != OE_OK)

--- a/host/sgx/loadpe.c
+++ b/host/sgx/loadpe.c
@@ -265,6 +265,7 @@ oe_result_t oe_load_pe_enclave_image(
     PIMAGE_SECTION_HEADER section_hdr;
     const IMAGE_DATA_DIRECTORY* idd;
     uint32_t i;
+    DWORD old_protection;
 
     memset(image, 0, sizeof(oe_enclave_image_t));
     image->type = OE_IMAGE_TYPE_PE;
@@ -308,7 +309,10 @@ oe_result_t oe_load_pe_enclave_image(
 
     /* change protection to r/w */
     if (!VirtualProtect(
-            image->image_base, image->image_size, PAGE_READWRITE, &i))
+            image->image_base,
+            image->image_size,
+            PAGE_READWRITE,
+            &old_protection))
     {
         OE_RAISE(OE_FAILURE);
     }

--- a/host/sgx/registers.c
+++ b/host/sgx/registers.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #elif defined(_WIN32)
 #include <Windows.h>
+#include <immintrin.h>
 #endif
 
 #include <assert.h>

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -27,7 +27,6 @@ static oe_result_t _get_local_report(
     size_t* report_buffer_size)
 {
     oe_result_t result = OE_UNEXPECTED;
-    uint32_t retval;
 
     // opt_params, if specified, must be a sgx_target_info_t. When opt_params is
     // NULL, opt_params_size must be zero.
@@ -48,14 +47,12 @@ static oe_result_t _get_local_report(
 
     OE_CHECK(oe_get_sgx_report_ecall(
         enclave,
-        &retval,
+        &result,
         opt_params,
         opt_params_size,
         (sgx_report_t*)report_buffer));
 
     *report_buffer_size = sizeof(sgx_report_t);
-
-    result = (oe_result_t)retval;
 
 done:
 
@@ -302,13 +299,12 @@ oe_result_t oe_verify_report(
     }
     else if (header->report_type == OE_REPORT_TYPE_SGX_LOCAL)
     {
-        uint32_t retval;
+        oe_result_t retval;
 
         if (enclave == NULL)
             OE_RAISE(OE_INVALID_PARAMETER);
 
         OE_CHECK(oe_verify_report_ecall(enclave, &retval, report, report_size));
-
         OE_CHECK(retval);
     }
     else

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -12,6 +12,7 @@
 #endif
 
 #include <assert.h>
+#include <openenclave/bits/defs.h>
 #include <openenclave/bits/safecrt.h>
 #include <openenclave/bits/safemath.h>
 #include <openenclave/internal/raise.h>
@@ -254,6 +255,7 @@ done:
     return result;
 
 #elif defined(_WIN32)
+    OE_UNUSED(fd);
 
     /* Allocate enclave memory for simulated mode only */
     void* result = NULL;
@@ -281,6 +283,8 @@ static oe_result_t _sgx_free_enclave_memory(
     size_t size,
     bool is_simulation)
 {
+    OE_UNUSED(size);
+
     if (!is_simulation)
     {
         uint32_t enclave_error = 0;

--- a/host/sgx/windows/sgxquoteproviderloader.c
+++ b/host/sgx/windows/sgxquoteproviderloader.c
@@ -8,7 +8,7 @@
 
 oe_sgx_quote_provider_t provider = {0};
 
-static void _unload_quote_provider()
+static void _unload_quote_provider(void)
 {
     OE_TRACE_INFO("_unload_quote_provider dcap_quoteprov.dll\n");
     if (provider.handle)

--- a/host/sgx/windows/switchless.c
+++ b/host/sgx/windows/switchless.c
@@ -13,7 +13,8 @@ void oe_host_worker_wait(oe_host_worker_context_t* context)
     int32_t oldval = 1;
     int32_t newval = 0;
 
-    if (_InterlockedCompareExchange(&context->event, newval, oldval) == 0)
+    if (_InterlockedCompareExchange((long*)&context->event, newval, oldval) ==
+        0)
     {
         // If the previous value was zero, then wait while value is zero.
         uint32_t zero = 0;
@@ -25,5 +26,5 @@ void oe_host_worker_wake(oe_host_worker_context_t* context)
 {
     // Set the event and wake up the worker.
     context->event = 1;
-    WakeByAddressSingle(&context->event);
+    WakeByAddressSingle((void*)&context->event);
 }

--- a/host/windows/hostthread.c
+++ b/host/windows/hostthread.c
@@ -57,6 +57,9 @@ static BOOL CALLBACK OnceHelper(
     _Inout_opt_ PVOID Parameter,
     _Out_opt_ PVOID* Context)
 {
+    OE_UNUSED(InitOnce);
+    OE_UNUSED(Context);
+
     ((void (*)(void))Parameter)();
     return TRUE;
 }

--- a/host/windows/syscall.c
+++ b/host/windows/syscall.c
@@ -332,6 +332,8 @@ oe_host_fd_t oe_syscall_open_ocall(
     int flags,
     oe_mode_t mode)
 {
+    OE_UNUSED(mode);
+
     oe_host_fd_t ret = -1;
 
     if (strcmp(pathname, "/dev/stdin") == 0)
@@ -380,12 +382,18 @@ done:
 
 ssize_t oe_syscall_read_ocall(oe_host_fd_t fd, void* buf, size_t count)
 {
-    return _read(fd, buf, count);
+    if ((count & UINT_MAX) != count)
+        _set_errno(OE_EINVAL);
+
+    return _read((int)fd, buf, (unsigned int)count);
 }
 
 ssize_t oe_syscall_write_ocall(oe_host_fd_t fd, const void* buf, size_t count)
 {
-    return _write(fd, buf, count);
+    if ((count & UINT_MAX) != count)
+        _set_errno(OE_EINVAL);
+
+    return _write((int)fd, buf, (unsigned int)count);
 }
 
 ssize_t oe_syscall_readv_ocall(
@@ -472,12 +480,16 @@ done:
 
 oe_off_t oe_syscall_lseek_ocall(oe_host_fd_t fd, oe_off_t offset, int whence)
 {
+    OE_UNUSED(fd);
+    OE_UNUSED(offset);
+    OE_UNUSED(whence);
+
     PANIC;
 }
 
 int oe_syscall_close_ocall(oe_host_fd_t fd)
 {
-    return _close(fd);
+    return _close((int)fd);
 }
 
 static oe_host_fd_t _dup_socket(oe_host_fd_t);
@@ -517,61 +529,92 @@ oe_host_fd_t oe_syscall_dup_ocall(oe_host_fd_t oldfd)
 
 uint64_t oe_syscall_opendir_ocall(const char* pathname)
 {
+    OE_UNUSED(pathname);
+
     PANIC;
 }
 
 int oe_syscall_readdir_ocall(uint64_t dirp, struct oe_dirent* entry)
 {
+    OE_UNUSED(dirp);
+    OE_UNUSED(entry);
+
     PANIC;
 }
 
 void oe_syscall_rewinddir_ocall(uint64_t dirp)
 {
+    OE_UNUSED(dirp);
+
     PANIC;
 }
 
 int oe_syscall_closedir_ocall(uint64_t dirp)
 {
+    OE_UNUSED(dirp);
+
     PANIC;
 }
 
 int oe_syscall_stat_ocall(const char* pathname, struct oe_stat* buf)
 {
+    OE_UNUSED(pathname);
+    OE_UNUSED(buf);
+
     PANIC;
 }
 
 int oe_syscall_access_ocall(const char* pathname, int mode)
 {
+    OE_UNUSED(pathname);
+    OE_UNUSED(mode);
+
     PANIC;
 }
 
 int oe_syscall_link_ocall(const char* oldpath, const char* newpath)
 {
+    OE_UNUSED(oldpath);
+    OE_UNUSED(newpath);
+
     PANIC;
 }
 
 int oe_syscall_unlink_ocall(const char* pathname)
 {
+    OE_UNUSED(pathname);
+
     PANIC;
 }
 
 int oe_syscall_rename_ocall(const char* oldpath, const char* newpath)
 {
+    OE_UNUSED(oldpath);
+    OE_UNUSED(newpath);
+
     PANIC;
 }
 
 int oe_syscall_truncate_ocall(const char* pathname, oe_off_t length)
 {
+    OE_UNUSED(pathname);
+    OE_UNUSED(length);
+
     PANIC;
 }
 
 int oe_syscall_mkdir_ocall(const char* pathname, oe_mode_t mode)
 {
+    OE_UNUSED(pathname);
+    OE_UNUSED(mode);
+
     PANIC;
 }
 
 int oe_syscall_rmdir_ocall(const char* pathname)
 {
+    OE_UNUSED(pathname);
+
     PANIC;
 }
 
@@ -651,12 +694,12 @@ static oe_host_fd_t _dup_socket(oe_host_fd_t oldfd)
 
 static int _wsa_startup()
 {
-    static bool wsa_init_done = FALSE;
+    static int64_t wsa_init_done = FALSE;
     WSADATA wsaData;
     int ret = 0;
 
     if (oe_atomic_compare_and_swap(
-            &wsa_init_done, (int64_t) false, (int64_t) true))
+            (volatile int64_t*)&wsa_init_done, (int64_t)0, (int64_t)1))
     {
         ret = WSAStartup(2, &wsaData);
         if (ret != 0)
@@ -693,6 +736,11 @@ int oe_syscall_socketpair_ocall(
     int protocol,
     oe_host_fd_t sv_out[2])
 {
+    OE_UNUSED(domain);
+    OE_UNUSED(type);
+    OE_UNUSED(protocol);
+    OE_UNUSED(sv_out);
+
     PANIC;
 }
 
@@ -773,6 +821,18 @@ ssize_t oe_syscall_recvmsg_ocall(
     size_t* msg_controllen_out,
     int flags)
 {
+    OE_UNUSED(sockfd);
+    OE_UNUSED(msg_name);
+    OE_UNUSED(msg_namelen);
+    OE_UNUSED(msg_namelen_out);
+    OE_UNUSED(msg_iov_buf);
+    OE_UNUSED(msg_iovlen);
+    OE_UNUSED(msg_iov_buf_size);
+    OE_UNUSED(msg_control);
+    OE_UNUSED(msg_controllen);
+    OE_UNUSED(msg_controllen_out);
+    OE_UNUSED(flags);
+
     PANIC;
 }
 
@@ -787,6 +847,16 @@ ssize_t oe_syscall_sendmsg_ocall(
     size_t msg_controllen,
     int flags)
 {
+    OE_UNUSED(sockfd);
+    OE_UNUSED(msg_name);
+    OE_UNUSED(msg_namelen);
+    OE_UNUSED(msg_iov_buf);
+    OE_UNUSED(msg_iovlen);
+    OE_UNUSED(msg_iov_buf_size);
+    OE_UNUSED(msg_control);
+    OE_UNUSED(msg_controllen);
+    OE_UNUSED(flags);
+
     PANIC;
 }
 
@@ -826,7 +896,7 @@ ssize_t oe_syscall_recvfrom_ocall(
         (int)len,
         flags,
         (struct sockaddr*)src_addr,
-        addrlen_in);
+        (int*)&addrlen_in);
     if (ret == SOCKET_ERROR)
     {
         _set_errno(_winsockerr_to_errno(WSAGetLastError()));
@@ -890,6 +960,11 @@ ssize_t oe_syscall_recvv_ocall(
     int iovcnt,
     size_t iov_buf_size)
 {
+    OE_UNUSED(fd);
+    OE_UNUSED(iov_buf);
+    OE_UNUSED(iovcnt);
+    OE_UNUSED(iov_buf_size);
+
     PANIC;
 }
 
@@ -899,6 +974,11 @@ ssize_t oe_syscall_sendv_ocall(
     int iovcnt,
     size_t iov_buf_size)
 {
+    OE_UNUSED(fd);
+    OE_UNUSED(iov_buf);
+    OE_UNUSED(iovcnt);
+    OE_UNUSED(iov_buf_size);
+
     PANIC;
 }
 
@@ -973,6 +1053,11 @@ int oe_syscall_ioctl_ocall(
     uint64_t argsize,
     void* argout)
 {
+    OE_UNUSED(fd);
+    OE_UNUSED(arg);
+    OE_UNUSED(argsize);
+    OE_UNUSED(argout);
+
     errno = 0;
 
     // We don't support any ioctls right now as we will have to translate the
@@ -1047,6 +1132,11 @@ int oe_syscall_getsockname_ocall(
     oe_socklen_t addrlen_in,
     oe_socklen_t* addrlen_out)
 {
+    OE_UNUSED(sockfd);
+    OE_UNUSED(addr);
+    OE_UNUSED(addrlen_in);
+    OE_UNUSED(addrlen_out);
+
     PANIC;
 }
 
@@ -1056,11 +1146,18 @@ int oe_syscall_getpeername_ocall(
     oe_socklen_t addrlen_in,
     oe_socklen_t* addrlen_out)
 {
+    OE_UNUSED(sockfd);
+    OE_UNUSED(addr);
+    OE_UNUSED(addrlen_in);
+    OE_UNUSED(addrlen_out);
+
     PANIC;
 }
 
 int oe_syscall_shutdown_sockets_device_ocall(oe_host_fd_t sockfd)
 {
+    OE_UNUSED(sockfd);
+
     PANIC;
 }
 
@@ -1074,6 +1171,9 @@ int oe_syscall_shutdown_sockets_device_ocall(oe_host_fd_t sockfd)
 
 int oe_syscall_kill_ocall(int pid, int signum)
 {
+    OE_UNUSED(pid);
+    OE_UNUSED(signum);
+
     PANIC;
 }
 
@@ -1205,6 +1305,14 @@ int oe_syscall_getnameinfo_ocall(
     oe_socklen_t servlen,
     int flags)
 {
+    OE_UNUSED(sa);
+    OE_UNUSED(salen);
+    OE_UNUSED(host);
+    OE_UNUSED(hostlen);
+    OE_UNUSED(serv);
+    OE_UNUSED(servlen);
+    OE_UNUSED(flags);
+
     PANIC;
 }
 
@@ -1218,6 +1326,8 @@ int oe_syscall_getnameinfo_ocall(
 
 oe_host_fd_t oe_syscall_epoll_create1_ocall(int flags)
 {
+    OE_UNUSED(flags);
+
     PANIC;
 }
 
@@ -1227,6 +1337,11 @@ int oe_syscall_epoll_wait_ocall(
     unsigned int maxevents,
     int timeout)
 {
+    OE_UNUSED(epfd);
+    OE_UNUSED(events);
+    OE_UNUSED(maxevents);
+    OE_UNUSED(timeout);
+
     PANIC;
 }
 
@@ -1241,11 +1356,18 @@ int oe_syscall_epoll_ctl_ocall(
     int64_t fd,
     struct oe_epoll_event* event)
 {
+    OE_UNUSED(epfd);
+    OE_UNUSED(op);
+    OE_UNUSED(fd);
+    OE_UNUSED(event);
+
     PANIC;
 }
 
 int oe_syscall_epoll_close_ocall(oe_host_fd_t epfd)
 {
+    OE_UNUSED(epfd);
+
     PANIC;
 }
 
@@ -1262,6 +1384,10 @@ int oe_syscall_poll_ocall(
     oe_nfds_t nfds,
     int timeout)
 {
+    OE_UNUSED(host_fds);
+    OE_UNUSED(nfds);
+    OE_UNUSED(timeout);
+
     PANIC;
 }
 
@@ -1310,11 +1436,16 @@ unsigned int oe_syscall_getegid_ocall(void)
 
 int oe_syscall_getpgid_ocall(int pid)
 {
+    OE_UNUSED(pid);
+
     PANIC;
 }
 
 int oe_syscall_getgroups_ocall(size_t size, unsigned int* list)
 {
+    OE_UNUSED(size);
+    OE_UNUSED(list);
+
     PANIC;
 }
 

--- a/include/openenclave/internal/atomic.h
+++ b/include/openenclave/internal/atomic.h
@@ -14,8 +14,14 @@
 #pragma intrinsic(_InterlockedCompareExchangePointer)
 __int64 _InterlockedIncrement64(__int64* lpAddend);
 __int64 _InterlockedDecrement64(__int64* lpAddend);
-__int64 _InterlockedCompareExchange64(__int64* Dest, __int64 val, __int64 old);
-void* _InterlockedCompareExchangePointer(void** Dest, void* newptr, void* old);
+__int64 _InterlockedCompareExchange64(
+    __int64 volatile* Dest,
+    __int64 val,
+    __int64 old);
+void* _InterlockedCompareExchangePointer(
+    void* volatile* Dest,
+    void* newptr,
+    void* old);
 #endif
 
 /* Atomically increment **x** and return its new value */

--- a/include/openenclave/internal/crypto/cert.h
+++ b/include/openenclave/internal/crypto/cert.h
@@ -340,7 +340,7 @@ oe_result_t oe_cert_find_extension(
  */
 oe_result_t oe_get_crl_distribution_points(
     const oe_cert_t* cert,
-    const char*** urls,
+    char*** urls,
     size_t* num_urls,
     uint8_t* buffer,
     size_t* buffer_size);

--- a/scripts/clangw
+++ b/scripts/clangw
@@ -42,6 +42,16 @@ function call_clang {
         [ "$a" == "/FS" ]           && continue
         [ "$a" == "/showIncludes" ] && continue
         [ "$a" == "/JMC" ]          && continue
+        [ "$a" == "/W1" ]           && continue
+        [ "$a" == "/W2" ]           && continue
+        [ "$a" == "/W3" ]           && continue
+        [ "$a" == "/W4" ]           && continue
+        [ "$a" == "/WX" ]           && continue
+
+        # Ignore warnings for specific error codes
+        if [[ "$a" =~ /[wW][dD][0-9]* ]]; then
+            continue
+        fi
 
         # Map the following arguments
         [ "$a" == "/DNDEBUG" ]   && args+="-DNDEBUG "   && continue

--- a/tests/bigmalloc/host/host.c
+++ b/tests/bigmalloc/host/host.c
@@ -1,6 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#include <inttypes.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/tests.h>
 #include "bigmalloc_u.h"
@@ -52,7 +53,8 @@ int main(int argc, const char* argv[])
         {
             fprintf(
                 stderr,
-                "%s: warning: insufficient memory to load enclave: %lu\n",
+                "%s: warning: insufficient memory to load enclave: %" PRIu64
+                "\n",
                 argv[0],
                 free_memory);
 

--- a/tests/crypto/ec_tests.c
+++ b/tests/crypto/ec_tests.c
@@ -878,7 +878,7 @@ static void _test_crl_distribution_points(void)
 {
     oe_result_t r;
     oe_cert_t cert;
-    const char** urls = NULL;
+    char** urls = NULL;
     size_t num_urls;
     size_t buffer_size = 0;
 

--- a/tests/oeedger8r/host/teststring.cpp
+++ b/tests/oeedger8r/host/teststring.cpp
@@ -276,7 +276,6 @@ void test_string_edl_ecalls(oe_enclave_t* enclave)
     }
     // Test wstrings without null terminators.
     {
-        OE_UNUSED(ecall_wstring_no_null_terminator_modified);
         // wchar_t is not a portable type. Hence the test is performed
         // only on Linux.
 #ifdef __linux__
@@ -384,7 +383,7 @@ void test_wstring_edl_ecalls(oe_enclave_t* enclave)
     if (!g_enabled[TYPE_WCHAR_T])
         return;
 
-    swprintf(str, 50, L"%S", str_value);
+    swprintf(str, 50, L"%lS", str_value);
 
     // wchar_t*
     OE_TEST(ecall_wstring_fun1(enclave, str) == OE_OK);
@@ -399,7 +398,7 @@ void test_wstring_edl_ecalls(oe_enclave_t* enclave)
     OE_TEST(wcscmp(str, L"Goodbye\n") == 0);
 
     // Restore value.
-    swprintf(str, 50, L"%S", str_value);
+    swprintf(str, 50, L"%lS", str_value);
 
     // wchar_t* user check.
     OE_TEST(ecall_wstring_fun5(enclave, str) == OE_OK);

--- a/tests/switchless/host/host.c
+++ b/tests/switchless/host/host.c
@@ -1,6 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#include <inttypes.h>
 #include <limits.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/atomic.h>
@@ -36,9 +37,9 @@ double get_relative_time_in_microseconds()
 static double frequency;
 double get_relative_time_in_microseconds()
 {
-    double current_time;
+    LARGE_INTEGER current_time;
     QueryPerformanceCounter(&current_time);
-    return current_time / frequency;
+    return current_time.QuadPart / frequency;
 }
 
 #endif
@@ -119,12 +120,12 @@ int main(int argc, const char* argv[])
 
     if (argc >= 3)
     {
-        sscanf(argv[2], "%lu", &num_host_threads);
+        sscanf(argv[2], "%" SCNu64, &num_host_threads);
     }
 
     if (argc == 4)
     {
-        sscanf(argv[3], "%lu", &num_enclave_threads);
+        sscanf(argv[3], "%" SCNu64, &num_enclave_threads);
     }
 
 #if defined(__WIN32)
@@ -162,7 +163,7 @@ int main(int argc, const char* argv[])
         {
             oe_put_err("thread_create(host): ret=%u", ret);
         }
-        printf("Launched enclave producer thread %ld\n", i);
+        printf("Launched enclave producer thread %" PRIu64 "\n", i);
     }
     printf("Using main enclave thread\n");
     double switchless_microseconds = make_repeated_switchless_ocalls(enclave);

--- a/tests/syscall/socket/host/host.c
+++ b/tests/syscall/socket/host/host.c
@@ -9,6 +9,7 @@
 #include "../../platform/linux.h"
 #endif
 
+#include <inttypes.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/tests.h>
 #include <openenclave/internal/types.h>
@@ -134,7 +135,7 @@ char* host_client(in_port_t port)
         if ((n = sock_recv(sockfd, recvBuff, sizeof(recvBuff), 0)) > 0)
         {
             recvBuff[n] = '\0';
-            printf("host finished reading: %ld bytes...\n", n);
+            printf("host finished reading: %" PRIu64 " bytes...\n", n);
             break;
         }
         else

--- a/tests/tools/oecert/host/host.cpp
+++ b/tests/tools/oecert/host/host.cpp
@@ -487,8 +487,8 @@ int main(int argc, const char* argv[])
     result = oe_terminate_enclave(enclave);
 exit:
 #else
-#pragma message \
-    "OE_LINK_SGX_DCAP_QL is not set to ON.  This tool requires DCAP libraries."
+#pragma message( \
+    "OE_LINK_SGX_DCAP_QL is not set to ON.  This tool requires DCAP libraries.")
     OE_UNUSED(argc);
     OE_UNUSED(argv);
 #endif

--- a/tests/tools/oecertdump/host/host.cpp
+++ b/tests/tools/oecertdump/host/host.cpp
@@ -318,8 +318,8 @@ exit:
     }
 
 #else
-#pragma message \
-    "OE_LINK_SGX_DCAP_QL is not set to ON.  This tool requires DCAP libraries."
+#pragma message( \
+    "OE_LINK_SGX_DCAP_QL is not set to ON.  This tool requires DCAP libraries.")
     OE_UNUSED(argc);
     OE_UNUSED(argv);
     printf("oecertdump requires DCAP libraries.\n");

--- a/tools/oesgx/oesgx.c
+++ b/tools/oesgx/oesgx.c
@@ -152,7 +152,8 @@ int main(int argc, const char* argv[])
         epc_size =
             ((regs.ecx & 0x0fffff000) |
              ((uint64_t)(regs.edx & 0x0fffff) << 32));
-        printf("EPC size on the platform: %lu\n", epc_size);
+        printf(
+            "EPC size on the platform: %llu\n", (unsigned long long)epc_size);
     }
     return 0;
 }

--- a/tools/oesign/oedump.c
+++ b/tools/oesign/oedump.c
@@ -1,6 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#include <inttypes.h>
 #include <openenclave/bits/defs.h>
 #include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/elf.h>
@@ -179,7 +180,7 @@ void dump_enclave_properties(const oe_sgx_enclave_properties_t* props)
     bool debug = props->config.attributes & OE_SGX_FLAGS_DEBUG;
     printf("debug=%u\n", debug);
 
-    printf("xfrm=%lx\n", props->config.xfrm);
+    printf("xfrm=%" PRIx64 "\n", props->config.xfrm);
 
     printf(
         "num_heap_pages=%llu\n",


### PR DESCRIPTION
Also enables /W1 and /WX to ensure new W1 violations are not added. The
end goal is to enable /W3 /WX for all Windows builds.