### PR TITLE
Remove path resolution for source in mounting external hostfs

### DIFF
--- a/syscall/devices/hostfs/hostfs.c
+++ b/syscall/devices/hostfs/hostfs.c
@@ -221,6 +221,15 @@ static int _hostfs_mount(
     if ((flags & OE_MS_RDONLY))
         fs->mount.flags = flags;
 
+    /* ---------------------------------------------------------------------
+     * Only support absolute paths. Hostfs is treated as an external
+     * filesystem. As such, it does not make sense to resolve relative paths
+     * using the enclave's current working directory.
+     * ---------------------------------------------------------------------
+     */
+    if (source && source[0] != '/')
+        OE_RAISE_ERRNO(OE_EINVAL);
+
     /* Save the source parameter (will be needed to form host paths). */
     oe_strlcpy(fs->mount.source, source, sizeof(fs->mount.source));
 

--- a/syscall/mount.c
+++ b/syscall/mount.c
@@ -151,7 +151,7 @@ int oe_mount(
         target = target_path.buf;
     }
 
-    /* Note: Normialization of source path is left to the external device
+    /* Note: Normalization of source path is left to the external device
      * as it may not be a path internal to the enclave.
      */
 

--- a/syscall/mount.c
+++ b/syscall/mount.c
@@ -166,7 +166,12 @@ int oe_mount(
         struct oe_stat buf;
         int retval = -1;
 
-        if ((retval = oe_stat(target, &buf)) != 0)
+        /**
+         * oe_stat tries to do a mount resolution, but the directory is not yet
+         * mounted. As a result, we must call the filesystem's stat
+         * implementation directly.
+         */
+        if ((retval = device->ops.fs.stat(device, target, &buf)) != 0)
             OE_RAISE_ERRNO(oe_errno);
 
         if (!OE_S_ISDIR(buf.st_mode))

--- a/syscall/mount.c
+++ b/syscall/mount.c
@@ -137,7 +137,6 @@ int oe_mount(
     oe_device_t* device = NULL;
     oe_device_t* new_device = NULL;
     bool locked = false;
-    oe_syscall_path_t source_path;
     oe_syscall_path_t target_path;
     mount_point_t mount_point = {0};
 
@@ -152,14 +151,9 @@ int oe_mount(
         target = target_path.buf;
     }
 
-    /* Normalize the source path if any. */
-    if (source)
-    {
-        if (!oe_realpath(source, &source_path))
-            OE_RAISE_ERRNO(OE_EINVAL);
-
-        source = source_path.buf;
-    }
+    /* Note: Normialization of source path is left to the external device
+     * as it may not be a path internal to the enclave.
+     */
 
     /* Resolve the device for the given filesystemtype. */
     device = oe_device_table_find(filesystemtype, OE_DEVICE_TYPE_FILE_SYSTEM);

--- a/tests/syscall/fs/enc/enc.cpp
+++ b/tests/syscall/fs/enc/enc.cpp
@@ -637,7 +637,7 @@ void test_fs(const char* src_dir, const char* tmp_dir)
         OE_TEST(
             oe_mount("/", "/", OE_DEVICE_NAME_HOST_FILE_SYSTEM, 0, NULL) == 0);
         const int flags = OE_O_CREAT | OE_O_TRUNC | OE_O_WRONLY;
-        OE_TEST(oe_open(path, flags, MODE) == 0);
+        OE_TEST(oe_open(path, flags, MODE) != -1);
         OE_TEST(oe_umount("/") == 0);
 
         // Open file in tmp dir using a relative path
@@ -645,9 +645,15 @@ void test_fs(const char* src_dir, const char* tmp_dir)
             oe_mount(
                 tmp_dir, tmp_dir, OE_DEVICE_NAME_HOST_FILE_SYSTEM, 0, NULL) ==
             0);
-        OE_TEST(oe_chdir(tmp_dir));
-        OE_TEST(oe_open("./testfile", OE_O_RDONLY, MODE) == 0);
+        OE_TEST(oe_chdir(tmp_dir) == 0);
+        OE_TEST(oe_open("./testfile", OE_O_RDONLY, MODE) != -1);
         OE_TEST(oe_umount(tmp_dir) == 0);
+
+        // Change workdir back for other tests.
+        OE_TEST(
+            oe_mount("/", "/", OE_DEVICE_NAME_HOST_FILE_SYSTEM, 0, NULL) == 0);
+        OE_TEST(oe_chdir("/") == 0);
+        OE_TEST(oe_umount("/") == 0);
     }
 
     /* Test writing to a read-only mounted file system. */

--- a/tests/syscall/fs/enc/enc.cpp
+++ b/tests/syscall/fs/enc/enc.cpp
@@ -631,13 +631,15 @@ void test_fs(const char* src_dir, const char* tmp_dir)
     /* Test reading from enclave relative path */
     {
         char path[OE_PATH_MAX];
+        int fd;
         mkpath(path, tmp_dir, "testfile");
 
         // Create file in tmp dir
         OE_TEST(
             oe_mount("/", "/", OE_DEVICE_NAME_HOST_FILE_SYSTEM, 0, NULL) == 0);
         const int flags = OE_O_CREAT | OE_O_TRUNC | OE_O_WRONLY;
-        OE_TEST(oe_open(path, flags, MODE) != -1);
+        OE_TEST((fd = oe_open(path, flags, MODE)) != -1);
+        OE_TEST(close(fd) != -1);
         OE_TEST(oe_umount("/") == 0);
 
         // Open file in tmp dir using a relative path
@@ -646,7 +648,8 @@ void test_fs(const char* src_dir, const char* tmp_dir)
                 tmp_dir, tmp_dir, OE_DEVICE_NAME_HOST_FILE_SYSTEM, 0, NULL) ==
             0);
         OE_TEST(oe_chdir(tmp_dir) == 0);
-        OE_TEST(oe_open("./testfile", OE_O_RDONLY, MODE) != -1);
+        OE_TEST((fd = oe_open("./testfile", OE_O_RDONLY, MODE)) != -1);
+        OE_TEST(close(fd) != -1);
         OE_TEST(oe_umount(tmp_dir) == 0);
 
         // Change workdir back for other tests.

--- a/tests/syscall/hostfs/enc/enc.c
+++ b/tests/syscall/hostfs/enc/enc.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <assert.h>
+#include <openenclave/corelibc/errno.h>
 #include <openenclave/enclave.h>
 #include <setjmp.h>
 #include <stdio.h>
@@ -15,6 +16,19 @@ void test_hostfs(const char* tmp_dir)
     if (oe_load_module_host_file_system() != OE_OK)
     {
         fprintf(stderr, "oe_load_module_host_file_system() failed\n");
+        exit(1);
+    }
+
+    /* Mount with a relative source should fail */
+    if (mount(".", "/", OE_HOST_FILE_SYSTEM, 0, NULL) == 0)
+    {
+        fprintf(stderr, "mount() with relative path should not succeed\n");
+        exit(1);
+    }
+    else if (oe_errno != OE_EINVAL)
+    {
+        fprintf(
+            stderr, "mount() with relative path should fail with OE_EINVAL\n");
         exit(1);
     }
 


### PR DESCRIPTION
The enclave's internal current working directory has no inherent relation to the external hostfs device. As such, resolving a relative source path using the internal cwd provides odd behavior.

To simplify mounting of hostfs, we will only allow absolute source paths.