### PR TITLE
Allow versions of clang-format other than 7, simply emit a warning

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,5 +24,7 @@ ObjCSpaceBeforeProtocolList: false
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyReturnTypeOnItsOwnLine: 300
 PointerAlignment: Left
+SpacesInContainerLiterals: false
+SpacesInSquareBrackets: false
 TabWidth: 4
 ...

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -140,8 +140,7 @@ check_version()
         # Because clang-format is not invariant across versions, this
         # is an explicit equivalence check.
         if [[ ${v1[$i]} -ne ${v2[$i]} ]]; then
-            echo "format-code requires clang-format version $1, installed version is $2"
-            exit 1
+            echo "Warning: format-code prefers clang-format version $1, installed version is $2"
         fi
     done
 }


### PR DESCRIPTION
Allow `format-code` to run with versions of `clang-format` other than 7, even though the formatting rules could potentially be different in our remote builds. Emit a warning explaining that the caller should use `clang-format-7` if possible.

I am adding this change to make it possible (but not officially supported) to develop for OE on different Linux distros. For example, Fedora 31 only has packages for clang 8 and 9, not 7.

While clang 7 is the only officially supported version for OE development, 8 and 9 do work so I am attempting to lower the bar for entry for non-Ubuntu development.