### PR TITLE
Enable /W2 to treat W2 warnings as errors for Windows builds

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -76,6 +76,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
   add_compile_options(-Wall -Werror -Wpointer-arith -Wconversion -Wextra -Wno-missing-field-initializers)
   add_compile_options(-fno-strict-aliasing)
 
+  # Allow checks which always evaluate to true or false due to type limits.
+  # This is required as some macros operate on types of varying sizes.
+  add_compile_options(-Wno-type-limits)
+
   # Enables XSAVE intrinsics
   if (OE_SGX)
       add_compile_options(-mxsave)
@@ -104,12 +108,13 @@ elseif (MSVC)
   # doesn't recognize /wd flags
   # Turns off warnings for:
   # * Unicode character cannot be represented by current code page
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4566")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4566")
+  # * Flexible array members. These are standard in C99 so we will allow them.
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4566 /wd4200")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4566 /wd4200")
 
   # Add Flags we want to use for both C and CXX
   add_compile_options(/WX)
-  add_compile_options(/W1)
+  add_compile_options(/W2)
 
   # Ignore compiler warnings:
   # * unicode character not supported

--- a/include/openenclave/edger8r/common.h
+++ b/include/openenclave/edger8r/common.h
@@ -66,14 +66,24 @@ done:
     return result;
 }
 
-#define OE_ADD_SIZE(total, size)                \
-    do                                          \
-    {                                           \
-        if (oe_add_size(&total, size) != OE_OK) \
-        {                                       \
-            _result = OE_INTEGER_OVERFLOW;      \
-            goto done;                          \
-        }                                       \
+#define OE_ADD_SIZE(total, size)                                 \
+    do                                                           \
+    {                                                            \
+        if (sizeof(total) > sizeof(size_t) && total > SIZE_MAX)  \
+        {                                                        \
+            _result = OE_INVALID_PARAMETER;                      \
+            goto done;                                           \
+        }                                                        \
+        if (sizeof(size) > sizeof(size_t) && size > SIZE_MAX)    \
+        {                                                        \
+            _result = OE_INVALID_PARAMETER;                      \
+            goto done;                                           \
+        }                                                        \
+        if (oe_add_size((size_t*)&total, (size_t)size) != OE_OK) \
+        {                                                        \
+            _result = OE_INTEGER_OVERFLOW;                       \
+            goto done;                                           \
+        }                                                        \
     } while (0)
 
 /**

--- a/tools/oeedger8r/src/Sources.ml
+++ b/tools/oeedger8r/src/Sources.ml
@@ -81,7 +81,9 @@ let _get_param_size (ptype, decl, argstruct) =
     and count = attr_value_to_string argstruct p.ps_count in
     match (size, count) with
     | Some s, None -> s
-    | None, Some c -> sprintf "(%s * sizeof(%s))" c type_expr
+    (* TODO: Check that c actually fits in size_t. Also check for overflow,
+     * similar to oe_add_size *)
+    | None, Some c -> sprintf "((size_t)%s * sizeof(%s))" c type_expr
     (* TODO: Check that this is an even multiple of the size of type. *)
     | Some s, Some c -> sprintf "(%s * %s)" s c
     | None, None ->


### PR DESCRIPTION
Change windows builds to treat W1 and W2 warnings as errors, rather than just W1. Additionally, fix errors which arise from enabling this flag.

Warning for use of Flexible Array Members is ignored, although we should consider alternatives as these are a concerning in terms of memory safety.