### PR TITLE
Fix document typo on windows build

### DIFF
--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
@@ -81,7 +81,7 @@ To build debug enclaves:
 cd openenclave
 mkdir build/x64-Debug
 cd build/x64-Debug
-cmake -G ninja -DNUGET_PACKAGE_PATH=C:/oe_prereqs -DCMAKE_INSTALL_PREFIX=install ../..
+cmake -G Ninja -DNUGET_PACKAGE_PATH=C:/oe_prereqs -DCMAKE_INSTALL_PREFIX=install ../..
 ninja
 ```
 
@@ -97,7 +97,7 @@ Similarly, to build release enclaves, specify the flag
 cd C:/openenclave
 mkdir build/x64-Release
 cd build/x64-Release
-cmake -G ninja -DCMAKE_BUILD_TYPE=Release -DNUGET_PACKAGE_PATH=C:/oe_prereqs -DCMAKE_INSTALL_PREFIX=install ../..
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DNUGET_PACKAGE_PATH=C:/oe_prereqs -DCMAKE_INSTALL_PREFIX=install ../..
 ninja
 ```
 


### PR DESCRIPTION
This PR fixes #2392, which is another typo in the document that has not been fixed in #2387.