### PR TITLE
Avoid data race with variable _capacity

### DIFF
--- a/enclave/core/arena.c
+++ b/enclave/core/arena.c
@@ -39,11 +39,14 @@ void* oe_arena_malloc(size_t size)
     // Create the anera if it hasn't been created.
     if (_arena.buffer == NULL)
     {
-        void* buffer = oe_allocate_arena(_capacity);
+        _arena.capacity = __atomic_load_n(&_capacity, __ATOMIC_SEQ_CST);
+        void* buffer = oe_allocate_arena(_arena.capacity);
         if (buffer == NULL)
+        {
+            _arena.capacity = 0;
             return NULL;
+        }
         _arena.buffer = (uint8_t*)buffer;
-        _arena.capacity = _capacity;
         _arena.used = 0;
     }
 

--- a/enclave/core/arena.c
+++ b/enclave/core/arena.c
@@ -26,7 +26,7 @@ bool oe_configure_arena_capacity(size_t cap)
     {
         return false;
     }
-    _capacity = cap;
+    __atomic_store_n(&_capacity, cap, __ATOMIC_SEQ_CST);
     return true;
 }
 


### PR DESCRIPTION
This fix copies the shared variable `_capacity` into a thread-local area atomically, and then operates on the thread-local copy thereafter. This ensures function `oe_arena_malloc` sees a consistent capacity value throughout its execution in the face of other threads modifying `_capacity`.