### PR TITLE
Add instructions for how to exclude files/directories from scan-build

### DIFF
--- a/docs/GettingStartedDocs/Contributors/RunningStaticAnalysis.md
+++ b/docs/GettingStartedDocs/Contributors/RunningStaticAnalysis.md
@@ -40,3 +40,29 @@
     ```
 
     Running `scan-view /tmp/scan-build-2019-12-12-102130-18694-1` will open results in a web browser.
+
+## Interpreting warnings
+
+Ideally, all warnings would be legitimate and CI/CD could reject PRs which introduce scan-build errors.
+Unfortunately there are currently many scan-build errors in the OE codebase, and many of them are in
+external code.
+
+Specifically, errors reported from the 3rdparty directory should be ignored. Any other warnings are considered
+bugs and should be fixed.
+
+## Excluding directories
+
+Clang 8 adds the ability to exclude specific directories from static analysis.
+
+```{bash}
+$ scan-build-8 cmake .. -G Ninja -DHAS_QUOTE_PROVIDER=OFF
+$ scan-build-8 --exclude 3rdparty/ ninja
+```
+
+Additionally, scan-build can be run with a mismatched version of clang. For example,
+scan-build-8 can use clang-7 as a compiler:
+
+```
+$ scan-build-8 --use-analyzer=/usr/bin/clang-7 cmake .. -G Ninja -DHAS_QUOTE_PROVIDER=OFF
+$ scan-build-8 --use-analyzer=/usr/bin/clang-7 --exclude 3rdparty/ ninja
+```


### PR DESCRIPTION
Update scan-build instructions to explain how warnings should be treated and to show how to exclude paths/files with newer versions of scan-build.

End goal is to run scan-build in CI/CD, ignoring the 3rdparty directory. Even though clang-7 is still the recommended compiler for OE, people can use newer versions of scan-build to make sifting through these bugs a little easier.