### PR TITLE
Provide more specific error message when Platform TCB is not up-to-date

### DIFF
--- a/common/sgx/revocation.c
+++ b/common/sgx/revocation.c
@@ -410,7 +410,7 @@ oe_result_t oe_validate_revocation_list(
             sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_TCB_INFO].size,
             &platform_tcb_level,
             &parsed_tcb_info),
-        "Failed to parse TCB info. %s",
+        "Failed to parse TCB info or Platform TCB is not up-to-date. %s",
         oe_result_str(result));
 
     OE_CHECK_MSG(


### PR DESCRIPTION
In current implementation, the function oe_parse_tcb_info_json can return results OE_JSON_INFO_PARSE_ERROR or OE_TCB_LEVEL_INVALID. But the error message is always "Failed to parse TCB info". When oe_parse_tcb_info_json returns OE_TCB_LEVEL_INVALID, the log will be "Failed to parse TCB info. OE_TCB_LEVEL_INVALID (oe_result_t=OE_TCB_LEVEL_INVALID) " which is misleading . Developers who will the log might think the issue is because of some errors related to parsing while the actual reason is the Platform TCB is not up-to-date.