### PR TITLE
Fix oe_random for size > 1024

### DIFF
--- a/tests/crypto/random_tests.c
+++ b/tests/crypto/random_tests.c
@@ -13,38 +13,48 @@
 #include "tests.h"
 
 #define SEQ_COUNT 64
-#define SEQ_LENGTH 19
 
-void TestRandom(void)
+static void _test_random(size_t seq_length)
 {
-    printf("=== begin %s()\n", __FUNCTION__);
+    printf("=== begin %s(%zu)\n", __FUNCTION__, seq_length);
 
-    uint8_t buf[SEQ_COUNT][SEQ_LENGTH];
+    uint8_t buf[SEQ_COUNT][seq_length];
     memset(buf, 0, sizeof(buf));
 
     for (size_t i = 0; i < SEQ_COUNT; i++)
     {
         /* Generate a random sequence */
         OE_TEST(
-            oe_random_internal(buf[i], SEQ_LENGTH * sizeof(uint8_t)) == OE_OK);
+            oe_random_internal(buf[i], seq_length * sizeof(uint8_t)) == OE_OK);
 
         /* Be sure buffer is not filled with same character */
         {
             size_t m;
             uint8_t c = buf[i][0];
 
-            for (m = 1; m < SEQ_LENGTH && buf[i][m] == c; m++)
+            for (m = 1; m < seq_length && buf[i][m] == c; m++)
                 ;
 
-            OE_TEST(m != SEQ_LENGTH);
+            OE_TEST(m != seq_length);
         }
 
         /* Check whether duplicate of one of the previous calls */
         for (size_t j = 0; j < i; j++)
         {
-            OE_TEST(memcmp(buf[j], buf[i], SEQ_LENGTH * sizeof(uint8_t)) != 0);
+            OE_TEST(memcmp(buf[j], buf[i], seq_length * sizeof(uint8_t)) != 0);
         }
     }
 
     printf("=== passed %s()\n", __FUNCTION__);
+}
+
+void TestRandom(void)
+{
+    _test_random(19);
+    _test_random(1023);
+    _test_random(1024);
+    _test_random(1025);
+    _test_random(2047);
+    _test_random(2048);
+    _test_random(2049);
 }

--- a/tests/crypto/random_tests.c
+++ b/tests/crypto/random_tests.c
@@ -5,6 +5,7 @@
 #include <openenclave/enclave.h>
 #endif
 
+#include <openenclave/internal/defs.h>
 #include <openenclave/internal/random.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
@@ -13,12 +14,13 @@
 #include "tests.h"
 
 #define SEQ_COUNT 64
+#define SEQ_LENGTH_MAX 2049
 
 static void _test_random(size_t seq_length)
 {
     printf("=== begin %s(%zu)\n", __FUNCTION__, seq_length);
 
-    uint8_t buf[SEQ_COUNT][seq_length];
+    uint8_t buf[SEQ_COUNT][SEQ_LENGTH_MAX];
     memset(buf, 0, sizeof(buf));
 
     for (size_t i = 0; i < SEQ_COUNT; i++)
@@ -57,4 +59,5 @@ void TestRandom(void)
     _test_random(2047);
     _test_random(2048);
     _test_random(2049);
+    OE_STATIC_ASSERT(SEQ_LENGTH_MAX == 2049);
 }


### PR DESCRIPTION
mbedtls_ctr_drbg_random() does not accept arbitrary large output sizes
and must be called repeatedly to fill large buffers.