### PR TITLE
Support the deep copy of out-only parameters

### DIFF
--- a/include/openenclave/edger8r/common.h
+++ b/include/openenclave/edger8r/common.h
@@ -99,7 +99,7 @@ done:
  * buffer. Make sure that the buffer has enough space.
  */
 #define OE_SET_OUT_POINTER(argname, argsize, argtype)                        \
-    if (pargs_in->argname)                                                   \
+    do                                                                       \
     {                                                                        \
         pargs_in->argname = (argtype)(output_buffer + output_buffer_offset); \
         OE_ADD_SIZE(output_buffer_offset, (size_t)(argsize));                \
@@ -108,7 +108,7 @@ done:
             _result = OE_BUFFER_TOO_SMALL;                                   \
             goto done;                                                       \
         }                                                                    \
-    }
+    } while (0)
 
 /**
  * Compute and set the pointer value for the given parameter within the output

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -111,9 +111,16 @@ enclave {
     // Test that it is only copied in, not out.
     public void deepcopy_in([in, count=1] CountStruct* s);
 
+    // Deep copy of one `CountStruct` with an embedded array in and out
+    // should take place.
+    public void deepcopy_inout_count([in, out, count=1] CountStruct* s);
+
     // Deep copy of one `CountStruct` with an embedded array out
     // should take place.
-    public void deepcopy_out_count([in, out, count=1] CountStruct* s);
+    public void deepcopy_out_count([out, count=1] CountStruct* s);
+
+    // Test for recursive copying for out structure.
+    public void deepcopy_nested_out([out, count=1] NestedStruct* n);
 
     // Test a real-world scenario.
     public void deepcopy_iovec([in, out, count=n] IOVEC* iov, size_t n);

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -204,16 +204,35 @@ void deepcopy_in(CountStruct* s)
         s->ptr[i] = i;
 }
 
-void deepcopy_out_count(CountStruct* s)
+void deepcopy_inout_count(CountStruct* s)
 {
-    OE_TEST(s->count == 0);
-    OE_TEST(s->size == 0);
+    OE_TEST(s->count == 5);
+    OE_TEST(s->size == 6);
     for (size_t i = 0; i < 3; ++i)
-        OE_TEST(s->ptr[i] == 0);
+        OE_TEST(s->ptr[i] == 7);
     s->count = 7;
     s->size = 64;
     for (size_t i = 0; i < 3; ++i)
         s->ptr[i] = data[i];
+}
+
+void deepcopy_out_count(CountStruct* s)
+{
+    s->count = 7;
+    s->size = 64;
+    for (size_t i = 0; i < 3; ++i)
+        s->ptr[i] = data[i];
+}
+
+void deepcopy_nested_out(NestedStruct* n)
+{
+    OE_TEST(oe_is_within_enclave(n, sizeof(NestedStruct)));
+    OE_TEST(oe_is_within_enclave(n->array_of_int, 4 * sizeof(int)));
+    for (int i = 0; i < 4; ++i)
+        n->array_of_int[i] = i;
+    OE_TEST(oe_is_within_enclave(n->array_of_struct, 3 * sizeof(CountStruct)));
+    for (size_t i = 0; i < 3; ++i)
+        deepcopy_out_count(&(n->array_of_struct[i]));
 }
 
 void deepcopy_iovec(IOVEC* iov, size_t n)

--- a/tools/oeedger8r/src/Sources.ml
+++ b/tools/oeedger8r/src/Sources.ml
@@ -178,7 +178,10 @@ let rec get_ptr_setter get_deepcopy args count setter (ptype, decl) =
         (* NOTE: This makes the embedded check in the `OE_` macro superfluous. *)
         [
           sprintf "if (pargs_in->%s)"
-            (String.concat " && pargs_in->" (List.rev (arg :: args)));
+            (if args = [] then arg
+            else ((String.concat " && pargs_in->" (List.rev(args))) ^
+              ((if setter = "SET_OUT" then " && !" else " && ") ^
+              "pargs_in->" ^ arg)))
         ];
         [ sprintf "    OE_%s_POINTER(%s, %s, %s);" setter arg size tystr ];
         (let param_count = get_param_count (ptype, decl, argstruct) in


### PR DESCRIPTION
This PR revolves #2412, which supports out only parameters with deep copy. Previously, the oeedger8r recursively generates checks for the existence of each pointer in the annotated parameter's data structure. This works for the cases of in and in/out as the content of the structure is copied to the enclave while this is not the case for the out-only parameter.

See the following example:
```
struct { 
   size_t size; 
   int *buf; 
} foo; 
```
Enclave checks: 
```
if (parags_in->s) 
    OE_SET_OUT_POINTER(s, 1 * sizeof(foo), foo*); 
If (parags_in->s && parags_in->s->buf) 
    OE_SET_OUT_POINTER(s->buf, 1 * sizeof(int), int*); 
```
-> This check fails because the `buf` is not initialized, preventing the setup of the data structure.

The patches modified the oeedger8r to ensure that for the case of out-only parameter, any nested pointer should be NULL and its parent should not before setting up the data structure.

Example:
```
if (parags_in->s) 
    OE_SET_OUT_POINTER(s, 1 * sizeof(foo), foo*); 
If (parags_in->s && !parags_in->s->buf) 
    OE_SET_OUT_POINTER(s->buf, 1 * sizeof(int), int*); 
```

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>