### PR TITLE
Implement global module initialization functions for OE modules

### DIFF
--- a/docs/DesignDocs/openenclave_modules.md
+++ b/docs/DesignDocs/openenclave_modules.md
@@ -1,0 +1,110 @@
+# OpenEnclave Modules
+
+The Open Enclave SDK provides a core set of functionality for build enclave
+applications. Some of these features &2014; such as memory management and ecall/ocall
+marshalling &2014; are required to create an enclave. Other features such as
+libc functions, host filesystem, and network sockets can be optionally included
+inside the enclave by the enclave developer. These optional features are known
+as **Open Enclave Modules** and are static libraries that can be optionally
+linked into the enclave binary.
+
+## Currently supported modules
+
+Currently, Open Enclave only supports modules that are part of the OE SDK source tree.
+Today there are 5 optionally includable modules:
+
+* hostfs
+* libc
+* hostepoll
+* hostsock
+* hostresolver
+
+## Module initialization
+
+OE modules can each have an initialization function which will be called on
+first entry to the enclave. This ensures that a module are fully initialized
+prior to an application using it. There are two ways to demark initialization
+functions:
+
+1. `OE_MODULE_INIT Attribute`
+
+The `OE_MODULE_INIT` attribute can be applied to a function. This ensures that the
+function is called on enclave entry.
+
+```
+OE_MODULE_INIT
+void init_my_module(void)
+{
+    // Do stuff
+}
+```
+
+2. `OE_MODULE_INIT_PRIORITY` Attribute
+
+Optionally, modules can specify a priority for their initialization functions.
+Functions with a lower priority value will be called before functions with a
+higher priority value. This can be used if one module depends on another being
+initialized first.
+
+```
+// mod1.c
+OE_MODULE_INIT_PRIORITY(0)
+void mod1_init(void)
+{
+    // Initialize module 1
+}
+
+// mod2.c
+OE_MODULE_INIT_PRIORITY(1)
+void mod2_init(void)
+{
+    // Do stuff that depends on mod1. This function will
+    // always be called after mod1_init.
+}
+```
+
+### Linker disclaimer
+
+Because modules can be added and removed at compile-time without the core OE
+library knowing about them, initialization functions are not actually
+referenced by symbol. They are instead kept in their own section in the binary.
+To ensure a module's initialization function is included in the final enclave
+binary there are 3 options:
+
+1. Add the module initialization function in the same file as a symbol that is
+referenced in the enclave binary.
+
+```
+// mod_init.c
+
+int always_used_symbol = 1;
+
+OE_MODULE_INIT
+void mod_init(void)
+{
+    // Do initialization
+}
+
+// enclave_app.c
+int main_function()
+{
+    int val = always_used_symbol;
+    // Do stuff
+}
+```
+
+2. Pass a flag to tell the linker to always link the initialization function.
+
+```
+OE_MODULE_INIT
+void mod_init(void)
+{
+    // Do initialization
+}
+```
+
+Then during compilation `$CC -o enclave -lmymodule.a -W,l,-u mod_init`
+
+3. Use a custom GNU linker script and mark the `.init_array` option as KEEP.
+
+TODO: Link to documentation on GNU link scripts and KEEP directive.

--- a/include/openenclave/internal/defs.h
+++ b/include/openenclave/internal/defs.h
@@ -71,4 +71,12 @@
 /* OE_FIELD_SIZE */
 #define OE_FIELD_SIZE(TYPE, FIELD) (sizeof(((TYPE*)0)->FIELD))
 
+/* OE_MODULE_INIT */
+#ifdef __GNUC__
+#define OE_MODULE_INIT __attribute__((used, constructor))
+#define OE_MODULE_INIT_PRIORITY(__p) __attribute__((used, constructor(__p)))
+#else
+#error OE_MODULE_INIT not implemented
+#endif
+
 #endif /* _OE_INTERNAL_DEFS_H */

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -2,7 +2,8 @@
 # Licensed under the MIT License.
 
 # Build the C library, using local sources and sources from musl.
-set(MUSLSRC ${PROJECT_SOURCE_DIR}/3rdparty/musl/musl/src)
+set(MUSLROOT ${PROJECT_SOURCE_DIR}/3rdparty/musl)
+set(MUSLSRC ${MUSLROOT}/musl/src)
 
 if (OE_SGX)
     add_library(oelibasm OBJECT
@@ -64,6 +65,7 @@ add_library(oelibc STATIC
     getaddrinfo.c
     getnameinfo.c
     kill.c
+    libc.c
     libunwind_stubs.c
     link.c
     locale.c
@@ -195,7 +197,6 @@ add_library(oelibc STATIC
     ${MUSLSRC}/fenv/__flt_rounds.c
     ${MUSLSRC}/internal/floatscan.c
     ${MUSLSRC}/internal/intscan.c
-    ${MUSLSRC}/internal/libc.c
     ${MUSLSRC}/internal/shgetc.c
     ${MUSLSRC}/legacy/getpagesize.c
     ${MUSLSRC}/locale/bind_textdomain_codeset.c

--- a/libc/libc.c
+++ b/libc/libc.c
@@ -1,0 +1,39 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "libc.h"
+
+#include <openenclave/internal/defs.h>
+
+struct __libc __libc;
+
+size_t __hwcap;
+size_t __sysinfo;
+char *__progname = 0, *__progname_full = 0;
+
+weak_alias(__progname, program_invocation_short_name);
+weak_alias(__progname_full, program_invocation_name);
+
+// Modifications start here
+extern char** __environ;
+static size_t __auxv;
+
+/*
+ * Initialize Musl libc in a global constructor which will be called on enclave
+ * load. Ensure that the libc initialization is the first init function called
+ * by giving it a priority of 0.
+ *
+ * Module constructor functions must be in the same file as another symbol
+ * which is referenced from the main enclave bianry. This is why this function
+ * does not exist in its own file. Alternatively, the linker could be explicitly
+ * told to keep this symbol, by calling the linker with `-u oe_init_c`.
+ */
+OE_MODULE_INIT_PRIORITY(0)
+void oe_init_c(void)
+{
+    __environ = 0;
+    __auxv = 0;
+    libc.auxv = &__auxv;
+    libc.page_size = OE_PAGE_SIZE;
+    libc.secure = 1;
+}


### PR DESCRIPTION
Initial prototype for global module initialization functions to initialize OE modules.

OE modules are static libraries that provide discreet functionality (such as libc or a host filesystem) which are compiled as static libraries and linked into the enclave binary. Modules may have any number of initialization functions, which will be called on first enclave entry prior to global constructors.

Fixes #2425
Fixes: #565