### PR TITLE
Fix nanosleep() for req == rem

### DIFF
--- a/libc/syscalls.c
+++ b/libc/syscalls.c
@@ -107,20 +107,20 @@ static long _syscall_nanosleep(long n, long x1, long x2)
 
     OE_UNUSED(n);
 
+    if (req)
+    {
+        /* Convert timespec to milliseconds */
+        milliseconds += req->tv_sec * 1000UL;
+        milliseconds += req->tv_nsec / 1000000UL;
+
+        /* Perform OCALL */
+        ret = oe_sleep_msec(milliseconds);
+    }
+
+    /* Clear remaining time. Do this after reading from req because it may be
+     * that req == rem. */
     if (rem)
         memset(rem, 0, sizeof(*rem));
-
-    if (!req)
-        goto done;
-
-    /* Convert timespec to milliseconds */
-    milliseconds += req->tv_sec * 1000UL;
-    milliseconds += req->tv_nsec / 1000000UL;
-
-    /* Perform OCALL */
-    ret = oe_sleep_msec(milliseconds);
-
-done:
 
     return ret;
 }

--- a/tests/stdc/enc/enc.cpp
+++ b/tests/stdc/enc/enc.cpp
@@ -174,6 +174,7 @@ static void _test_time_functions(void)
     const uint64_t SEC_TO_USEC = 1000000UL;
     const uint64_t JAN_1_2018 = 1514786400UL * SEC_TO_USEC;
     const uint64_t JAN_1_2050 = 2524629600UL * SEC_TO_USEC;
+    const uint64_t SLEEP_SECS = 3;
     uint64_t now;
 
     /* Test time(): this test will fail if run after Jan 1, 2050 */
@@ -209,8 +210,6 @@ static void _test_time_functions(void)
 
     /* Test nanosleep() */
     {
-        const uint64_t SLEEP_SECS = 3;
-
         uint64_t before = oe_get_time();
 
         /* Sleep for SLEEP_SECS seconds */
@@ -219,6 +218,33 @@ static void _test_time_functions(void)
             timespec rem;
             OE_TEST(nanosleep(&req, &rem) == 0);
         }
+
+        uint64_t after = oe_get_time();
+
+        OE_TEST(after > before);
+    }
+
+    /* Test nanosleep() with req==rem */
+    {
+        uint64_t before = oe_get_time();
+
+        /* Sleep for SLEEP_SECS seconds */
+        {
+            timespec ts = {SLEEP_SECS, 0};
+            OE_TEST(nanosleep(&ts, &ts) == 0);
+        }
+
+        uint64_t after = oe_get_time();
+
+        OE_TEST(after > before);
+    }
+
+    /* Test sleep() */
+    {
+        uint64_t before = oe_get_time();
+
+        /* Sleep for SLEEP_SECS seconds */
+        OE_TEST(sleep(SLEEP_SECS) == 0);
 
         uint64_t after = oe_get_time();
 

--- a/tests/stdc/enc/enc.cpp
+++ b/tests/stdc/enc/enc.cpp
@@ -174,7 +174,7 @@ static void _test_time_functions(void)
     const uint64_t SEC_TO_USEC = 1000000UL;
     const uint64_t JAN_1_2018 = 1514786400UL * SEC_TO_USEC;
     const uint64_t JAN_1_2050 = 2524629600UL * SEC_TO_USEC;
-    const uint64_t SLEEP_SECS = 3;
+    const uint64_t SLEEP_SECS = 1;
     uint64_t now;
 
     /* Test time(): this test will fail if run after Jan 1, 2050 */


### PR DESCRIPTION
Calling nanosleep(&ts, &ts) resulted in a sleep of 0 because ts was
overwritten before milliseconds were calculated. Also fixes sleep() and
this_thread::sleep_for() which use nanosleep this way.

With this change the following libcxx tests fail:
165 - tests/libcxxtest-std_thread_thread.mutex_thread.lock_thread.lock.shared_thread.lock.shared.cons_mutex.pass (Child aborted)
166 - tests/libcxxtest-std_thread_thread.mutex_thread.lock_thread.lock.shared_thread.lock.shared.locking_lock.pass (Child aborted)
170 - tests/libcxxtest-read.mutex_thread.mutex.requirements_thread.sharedtimedmutex.requirements_thread.sharedtimedmutex.class_lock_shared.pass (Child aborted)

https://github.com/openenclave/openenclave/blob/8911dfdb304bacfcfcd37d1d92a52b3ac039a4c3/3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/lock_shared.pass.cpp#L38-L80

This is because these tests assert that the mutex operations are fast enough (l. 57). Previously, the sleep in line 77 did not sleep so that the condition was easily satisfied.

These tests still work if the tolerance is increased, e.g., like in line 46. How should I deal with them? Fix them (although it is 3rdparty)? Move to broken? Move to unsupported?