### PR TITLE
Only allow oe_handle_init_switchless to be called once

### DIFF
--- a/common/result.c
+++ b/common/result.c
@@ -128,6 +128,8 @@ const char* oe_result_str(oe_result_t result)
             return "OE_THREAD_JOIN_ERROR";
         case OE_ALREADY_EXISTS:
             return "OE_ALREADY_EXISTS";
+        case OE_ALREADY_INITIALIZED:
+            return "OE_ALREADY_INITIALIZED";
         case __OE_RESULT_MAX:
             break;
     }
@@ -195,6 +197,7 @@ bool oe_is_valid_result(uint32_t result)
         case OE_THREAD_CREATE_ERROR:
         case OE_THREAD_JOIN_ERROR:
         case OE_ALREADY_EXISTS:
+        case OE_ALREADY_INITIALIZED:
         {
             return true;
         }

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -339,6 +339,11 @@ typedef enum _oe_result
      */
     OE_ALREADY_EXISTS,
 
+    /**
+     * The desired resource has already been initialized.
+     */
+    OE_ALREADY_INITIALIZED,
+
     __OE_RESULT_MAX = OE_ENUM_MAX,
 } oe_result_t;
 /**< typedef enum _oe_result oe_result_t*/


### PR DESCRIPTION
Raise an error if `oe_handle_init_switchless` is called again after initialization. Even though is only ever called by the internal implementation, adding this check can't hurt. Especially if we later change how/when initialization happens.

Fixes #2187