### PR TITLE
Allow windows build to get the compiler information of pre-built test

### DIFF
--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -12,6 +12,23 @@ add_subdirectory(host)
 
 if (BUILD_ENCLAVES)
     add_subdirectory(enc)
+elseif (LINUX_BIN_DIR)
+    # Find the build information from pre-compiled tests. If found, `LINUX_CXX_COMPILER_ID`
+    # and `LINUX_CXX_COMPILER_VERSION` will hold the corresponding information.
+    list(APPEND CMAKE_MODULE_PATH "${LINUX_BIN_DIR}/libcxx/enc")
+    include(build_info OPTIONAL)
+endif()
+
+if (ADD_WINDOWS_ENCLAVE_TESTS)
+    if (NOT LINUX_CXX_COMPILER_ID OR NOT LINUX_CXX_COMPILER_VERSION)
+        message(FATAL_ERROR "Could not find the compiler information of linux tests!")
+    endif()
+    # Load target LINUX_CXX_COMPILER_ID and LINUX_CXX_COMPILER_VERSION values.
+    set(ENCLAVE_CXX_COMPILER_ID ${LINUX_CXX_COMPILER_ID})
+    set(ENCLAVE_CXX_COMPILER_VERSION ${LINUX_CXX_COMPILER_VERSION})
+else ()
+    set(ENCLAVE_CXX_COMPILER_ID ${CMAKE_CXX_COMPILER_ID})
+    set(ENCLAVE_CXX_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION})
 endif()
 
 foreach(testcase ${alltests})
@@ -20,7 +37,7 @@ foreach(testcase ${alltests})
 # the allocations are entirely optimized out by Clang in these tests and are excluded from Clang release builds -- Skip running these tests
     if ("${name}" MATCHES "cons_default_throws_bad_alloc.pass" OR "${name}" MATCHES "allocator_allocator.members_construct.pass")
         string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
-        if (CMAKE_CXX_COMPILER_ID MATCHES Clang AND BUILD_TYPE_UPPER MATCHES REL)
+        if (ENCLAVE_CXX_COMPILER_ID MATCHES Clang AND BUILD_TYPE_UPPER MATCHES REL)
             continue()
         endif()
     endif()
@@ -30,23 +47,23 @@ foreach(testcase ${alltests})
             OR "${name}" MATCHES "sequences_array_at.pass" 
             OR "${name}" MATCHES "libcxx_containers_unord_next_pow2.pass" 
             OR "${name}" MATCHES "std_utilities_template.bitset_bitset.members_count.pass")
-        if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
+        if (ENCLAVE_CXX_COMPILER_ID MATCHES GNU)
             continue()
         endif()
     endif()
 
 # the following test fails when built with clang, see #830 -- Skipping this test in clang
     if ("${name}" MATCHES "array_sized_delete_array_calls_unsized_delete_array.pass")
-        if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
+        if (ENCLAVE_CXX_COMPILER_ID MATCHES Clang)
             continue()
         endif()
     endif()
 
 # the following test fails on GCC version 7, see  #1523 -- Skipping this test in GCC 7.0 -> 7.5
     if ("${name}" MATCHES "std_utilities_function.objects_comparisons_constexpr_init.pass")
-        if(CMAKE_CXX_COMPILER_ID MATCHES GNU
-               AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7
-               AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.5)
+        if(ENCLAVE_CXX_COMPILER_ID MATCHES GNU
+            AND ENCLAVE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7
+            AND ENCLAVE_CXX_COMPILER_VERSION VERSION_LESS 7.5)
             continue()
         endif()
     endif()
@@ -54,7 +71,7 @@ foreach(testcase ${alltests})
 # the following test fails on GCC 7 or newer, see #1559 -- Skip this test on GCC 7.0 and above in non debug builds
     if ("${name}" MATCHES "std_containers_associative_map_map.access_at.pass")
         string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
-        if (CMAKE_CXX_COMPILER_ID MATCHES GNU AND BUILD_TYPE_UPPER MATCHES REL)
+        if (ENCLAVE_CXX_COMPILER_ID MATCHES GNU AND BUILD_TYPE_UPPER MATCHES REL)
             continue()
         endif()
     endif()

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -35,6 +35,11 @@ target_include_directories(libcxxtest-support PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}
         )
 
+# Log the build information.
+set(BUILD_INFO_FILE "${CMAKE_CURRENT_BINARY_DIR}/build_info.cmake")
+file(WRITE "${BUILD_INFO_FILE}" "set(LINUX_CXX_COMPILER_ID \"${CMAKE_CXX_COMPILER_ID}\")\n")
+file(APPEND "${BUILD_INFO_FILE}" "set(LINUX_CXX_COMPILER_VERSION \"${CMAKE_CXX_COMPILER_VERSION}\")\n")
+
 # helper function to create enclave binary
 function(add_libcxx_test_enc NAME CXXFILE)
     add_enclave(TARGET libcxxtest-${NAME}_enc UUID 486dcdcc-f0c6-4bdd-91e0-c7566794f899 CXX SOURCES
@@ -92,9 +97,9 @@ foreach(testcase ${alltests})
             OR "${name}" MATCHES "sequences_array_at.pass" 
             OR "${name}" MATCHES "libcxx_containers_unord_next_pow2.pass" 
             OR "${name}" MATCHES "std_utilities_template.bitset_bitset.members_count.pass")
-            if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
-                continue()
-            endif()
+        if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
+            continue()
+        endif()
     endif()
 
 # the following test fails when built with clang, see #830 -- Skipping this test in clang


### PR DESCRIPTION
This PR resolves #2432, which provides a cmake script that allows the windows build to obtain compiler info from the pre-built cmake directories (only if LINUX_BIN_DIR is set). The script introduces two cmake variables `ENCLAVE_TESTS_CXX_COMPILER_ID` and `ENCLAVE_TESTS_CXX_COMPILER_VERSION` that store the corresponding information. Additional information can be exposed in the similar approach if needed.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>