### PR TITLE
Exposed backtrace via GNU functions (execinfo.h)

### DIFF
--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -58,6 +58,9 @@ ExternalProject_Add(musl_includes
     COMMAND ${CMAKE_COMMAND} -E copy
       ${PATCHES_DIR}/setjmp.h
       ${MUSL_DIR}/include/setjmp.h
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${PATCHES_DIR}/execinfo.h
+      ${MUSL_DIR}/include/execinfo.h
   CONFIGURE_COMMAND
     ${CMAKE_COMMAND} -E chdir ${MUSL_DIR}
     ${OE_BASH} -x ./configure

--- a/3rdparty/musl/patches/execinfo.h
+++ b/3rdparty/musl/patches/execinfo.h
@@ -1,0 +1,23 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_MUSL_PATCHES_EXECINFO_H
+#define _OE_MUSL_PATCHES_EXECINFO_H
+
+#include <openenclave/bits/defs.h>
+
+OE_EXTERNC_BEGIN
+
+// See https://www.gnu.org/software/libc/manual/html_node/Backtraces.html
+// for a description of the GNU backtrace functions.
+
+int backtrace(void** buffer, int size);
+
+char** backtrace_symbols(void* const* buffer, int size);
+
+// This is not implemented yet.
+// void backtrace_symbols_fd(void *const *buffer, int size, int fd);
+
+OE_EXTERNC_END
+
+#endif /* _OE_MUSL_PATCHES_EXECINFO_H */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]
 ------------
 
+### Added
+
+- Support for backtracing in debug and release builds.
+    - Implementations for GNU functions `backtrace` and `backtrace_symbols` (defined in execinfo.h)
+    - Enclaves are built using `-fno-omit-frame-pointer` for accurate backtraces.
+
 ### Changed
 
 - Open Enclave SDK is now officially an incubation project as part of the Linux

--- a/docs/LibcSupport.md
+++ b/docs/LibcSupport.md
@@ -6,6 +6,7 @@ assert.h | Yes | - |
 complex.h | Partial | **Unsupported functions:** cacos(), cacosh(), cacoshl(), cacosl(), casin(), casinh(), casinhl(), casinl(), csqrt(), csqrtl(), cpow(), cpowf(), cpowl() |
 ctype.h | Partial | Only basic support for C/POSIX locale. |
 errno.h | Yes | - |
+execinfo.h | Partial | **Supported functions:** backtrace(), backtrace_symbols(). <br> Enclaves must be compiled with `-fno-omit-frame-pointer` for accurate backtraces. |
 fenv.h | Yes | - |
 float.h | Yes | - |
 inttypes.h | Partial | **Unsupported functions:** imaxabs(), imaxdiv() |

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -212,6 +212,8 @@ if (OE_SGX)
         -nostdinc
         -fstack-protector-strong
         -fvisibility=hidden
+        # Preserve frame-pointer in Release mode to enable oe_backtrace.
+        -fno-omit-frame-pointer
         # Put each function or data in its own section.
         # This allows aggressively eliminating unused code.
         -ffunction-sections -fdata-sections

--- a/enclave/core/sgx/backtrace.c
+++ b/enclave/core/sgx/backtrace.c
@@ -8,6 +8,7 @@
 #include <openenclave/internal/backtrace.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/globals.h>
+#include <openenclave/internal/malloc.h>
 #include <openenclave/internal/print.h>
 #include <openenclave/internal/raise.h>
 #include "sgx_t.h"
@@ -26,7 +27,7 @@ const void* _check_address(const void* ptr)
     return ptr;
 }
 
-/* Safe implementation of oe_backtrace.
+/* Safe implementation of backtrace.
  *
  * The original implementation used the ___builtin_return_address intrinsic.
  * The intrinsic however is unsafe and can crash if any function in the
@@ -36,21 +37,10 @@ const void* _check_address(const void* ptr)
  * This new implementation below safely walks up the call-stack, ensuring that
  * each potential-frame is not null and lies within the enclave.
  */
-int oe_backtrace(void** buffer, int size)
+OE_NEVER_INLINE
+int oe_backtrace_impl(void** start_frame, void** buffer, int size)
 {
-    OE_UNUSED(buffer);
-    OE_UNUSED(size);
-#ifdef OE_USE_DEBUG_MALLOC
-    // Fetch the frame-pointer of the current function.
-    // The current function oe_backtrace is not expected to be inlined.
-    // The rbp register contains the frame-pointer upon entry to the function.
-    void** frame = NULL;
-    asm volatile("movq %%rbp, %0"
-                 : "=r"(frame)
-                 : /* no inputs */
-                 : /* no clobbers */
-    );
-
+    void** frame = start_frame;
     // Upon entry to a function, rsp + 0 contains the return address.
     // Generally, the first thing that a function does upong entry is
     //     push %rbp
@@ -83,17 +73,20 @@ int oe_backtrace(void** buffer, int size)
     }
 
     return n;
-#else
-    return 0;
-#endif
 }
 
-char** oe_backtrace_symbols(void* const* buffer, int size)
+int oe_backtrace(void** buffer, int size)
 {
-    /* Backtrace must use the internal allocator to bypass debug-malloc. */
-    extern void* dlmalloc(size_t size);
-    extern void dlfree(void* ptr);
-    extern void* dlrealloc(void* ptr, size_t size);
+    return oe_backtrace_impl(__builtin_frame_address(0), buffer, size);
+}
+
+char** oe_backtrace_symbols_impl(
+    void* const* buffer,
+    int size,
+    void* (*malloc_fcn)(size_t),
+    void* (*realloc_fcn)(void*, size_t),
+    void (*free_fcn)(void*))
+{
     char** ret = NULL;
     void* symbols_buffer = NULL;
     const size_t SYMBOLS_BUFFER_SIZE = 4096;
@@ -105,7 +98,7 @@ char** oe_backtrace_symbols(void* const* buffer, int size)
     if (!buffer || size < 0)
         goto done;
 
-    if (!(symbols_buffer = dlmalloc(symbols_buffer_size)))
+    if (!(symbols_buffer = malloc_fcn(symbols_buffer_size)))
         goto done;
 
     /* First call might return OE_BUFFER_TOO_SMALL. */
@@ -125,8 +118,8 @@ char** oe_backtrace_symbols(void* const* buffer, int size)
     if ((oe_result_t)retval == OE_BUFFER_TOO_SMALL)
     {
         symbols_buffer_size = symbols_buffer_size_out;
-
-        if (!(symbols_buffer = dlrealloc(symbols_buffer, symbols_buffer_size)))
+        if (!(symbols_buffer =
+                  realloc_fcn(symbols_buffer, symbols_buffer_size)))
             goto done;
 
         if (oe_backtrace_symbols_ocall(
@@ -158,8 +151,8 @@ char** oe_backtrace_symbols(void* const* buffer, int size)
             symbols_buffer_size_out,
             &argv,
             (size_t)size,
-            dlmalloc,
-            dlfree) != OE_OK)
+            malloc_fcn,
+            free_fcn) != OE_OK)
     {
         goto done;
     }
@@ -170,12 +163,21 @@ char** oe_backtrace_symbols(void* const* buffer, int size)
 done:
 
     if (symbols_buffer)
-        dlfree(symbols_buffer);
+        free_fcn(symbols_buffer);
 
     if (argv)
-        dlfree(argv);
+        free_fcn(argv);
 
     return ret;
+}
+
+char** oe_backtrace_symbols(void* const* buffer, int size)
+{
+    /* Backtrace must use the internal allocator to bypass debug-malloc. */
+    extern void* dlmalloc(size_t size);
+    extern void* dlrealloc(void* ptr, size_t size);
+    extern void dlfree(void* ptr);
+    return oe_backtrace_symbols_impl(buffer, size, dlmalloc, dlrealloc, dlfree);
 }
 
 void oe_backtrace_symbols_free(char** ptr)

--- a/enclave/core/sgx/backtrace.c
+++ b/enclave/core/sgx/backtrace.c
@@ -75,6 +75,15 @@ int oe_backtrace_impl(void** start_frame, void** buffer, int size)
     return n;
 }
 
+/**
+ * oe_backtrace itself must not appear in the backtrace. It ought to behave as
+ * if it was inlined. To keep the implementation private, the function is
+ * defined here (which rules out the ability to use compiler's inline keywords)
+ * and its frame address is passed to oe_backtrace_impl. oe_backtrace_impl walks
+ * the callstack starting at caller of the given frame. This ensures that
+ * oe_backtrace is omitted from the backtrace. This scheme also works whether
+ * the compiler emits a call or jmp instruction to call oe_backtrace_impl.
+ */
 int oe_backtrace(void** buffer, int size)
 {
     return oe_backtrace_impl(__builtin_frame_address(0), buffer, size);

--- a/include/openenclave/internal/backtrace.h
+++ b/include/openenclave/internal/backtrace.h
@@ -14,6 +14,26 @@ OE_EXTERNC_BEGIN
 #define OE_BACKTRACE_MAX 32
 
 /**
+ * This function is intended to be called by GNU **backtrace** and
+ * **oe_backtrace** functions.
+ */
+int oe_backtrace_impl(void** start_frame, void** buffer, int size);
+
+/**
+ * This function implements GNU **backtrace_symbols** and
+ * **oe_backtrace** functions. The debug_malloc feature gathers backtraces when
+ * memory is allocated. debug-malloc itself must not be used to allocate symbol
+ * buffer in this case. This internal function debug-malloc to use the lower
+ * level dlmalloc functions for creating backtrace symbols.
+ */
+char** oe_backtrace_symbols_impl(
+    void* const* buffer,
+    int size,
+    void* (*malloc_fcn)(size_t),
+    void* (*realloc_fcn)(void*, size_t),
+    void (*free_fcn)(void*));
+
+/**
  * This function behaves like the GNU **backtrace** function. See the
  * **backtrace** manpage for more information.
  */

--- a/include/openenclave/internal/backtrace.h
+++ b/include/openenclave/internal/backtrace.h
@@ -14,17 +14,17 @@ OE_EXTERNC_BEGIN
 #define OE_BACKTRACE_MAX 32
 
 /**
- * This function is intended to be called by GNU **backtrace** and
- * **oe_backtrace** functions.
+ * This function is intended to be called by GNU **backtrace** (oelibc) and
+ * **oe_backtrace** (oecore) functions.
  */
 int oe_backtrace_impl(void** start_frame, void** buffer, int size);
 
 /**
- * This function implements GNU **backtrace_symbols** and
- * **oe_backtrace** functions. The debug_malloc feature gathers backtraces when
- * memory is allocated. debug-malloc itself must not be used to allocate symbol
- * buffer in this case. This internal function debug-malloc to use the lower
- * level dlmalloc functions for creating backtrace symbols.
+ * This function implements GNU **backtrace_symbols** (oelibc) and
+ * **oe_backtrace** (oecore) functions. The debug_malloc feature gathers
+ * backtraces when memory is allocated. debug-malloc itself must not be used to
+ * allocate symbol buffer in this case. This internal function debug-malloc to
+ * use the lower level dlmalloc functions for creating backtrace symbols.
  */
 char** oe_backtrace_symbols_impl(
     void* const* buffer,

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -56,6 +56,7 @@ endif()
 
 add_library(oelibc STATIC
     atexit.c
+    backtrace.c
     dladdr.c
     errno.c
     epoll.c

--- a/libc/backtrace.c
+++ b/libc/backtrace.c
@@ -1,0 +1,17 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <execinfo.h>
+#include <openenclave/enclave.h>
+#include <openenclave/internal/backtrace.h>
+#include <stdlib.h>
+
+int backtrace(void** buffer, int size)
+{
+    return oe_backtrace_impl(__builtin_frame_address(0), buffer, size);
+}
+
+char** backtrace_symbols(void* const* buffer, int size)
+{
+    return oe_backtrace_symbols_impl(buffer, size, malloc, realloc, free);
+}

--- a/libc/backtrace.c
+++ b/libc/backtrace.c
@@ -6,6 +6,15 @@
 #include <openenclave/internal/backtrace.h>
 #include <stdlib.h>
 
+/**
+ * backtrace itself must not appear in the backtrace. It ought to behave as
+ * if it was inlined. To keep the implementation private, the function is
+ * defined here (which rules out the ability to use compiler's inline keywords)
+ * and its frame address is passed to oe_backtrace_impl. oe_backtrace_impl walks
+ * the callstack starting at caller of the given frame. This ensures that
+ * oe_backtrace is omitted from the backtrace. This scheme also works whether
+ * the compiler emits a call or jmp instruction to call oe_backtrace_impl.
+ */
 int backtrace(void** buffer, int size)
 {
     return oe_backtrace_impl(__builtin_frame_address(0), buffer, size);

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -28,6 +28,7 @@ set(ENCLAVE_CFLAGS_LIST
   -ftls-model=local-exec
   -fvisibility=hidden
   -fstack-protector-strong
+  -fno-omit-frame-pointer
   -ffunction-sections
   -fdata-sections)
 

--- a/tests/backtrace/enc/CMakeLists.txt
+++ b/tests/backtrace/enc/CMakeLists.txt
@@ -6,9 +6,7 @@ oeedl_file(../backtrace.edl enclave gen)
 
 add_enclave(TARGET backtrace_enc UUID c21d0c84-a32b-430a-ad9a-7bf8b47eff0c CXX SOURCES enc.cpp ${gen})
 
-if(USE_DEBUG_MALLOC)
-    target_compile_definitions(backtrace_enc PRIVATE OE_USE_DEBUG_MALLOC)
-endif()
+target_link_libraries(backtrace_enc oelibc)
 
 target_include_directories(backtrace_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                            ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/backtrace/enc/enc.cpp
+++ b/tests/backtrace/enc/enc.cpp
@@ -127,6 +127,8 @@ extern "C" bool test(size_t num_syms, const char** syms)
     OE_TEST(_syms != NULL);
 
     _print_backtrace(b.buffer, (size_t)b.size, num_syms, syms);
+    free(_syms);
+
     return true;
 }
 
@@ -144,6 +146,8 @@ extern "C" bool test_unwind(size_t num_syms, const char** syms)
         OE_TEST(_syms != NULL);
 
         _print_backtrace(b.buffer, (size_t)b.size, num_syms, syms);
+
+        free(_syms);
         return true;
     }
     return false;

--- a/tests/backtrace/enc/enc.cpp
+++ b/tests/backtrace/enc/enc.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#include <execinfo.h>
 #include <openenclave/edger8r/enclave.h>
 #include <openenclave/enclave.h>
-#include <openenclave/internal/backtrace.h>
 #include <openenclave/internal/print.h>
 #include <openenclave/internal/tests.h>
 #include <string.h>
@@ -19,7 +19,7 @@ struct Backtrace
 
 extern "C" OE_NEVER_INLINE void GetBacktrace(Backtrace* b)
 {
-    b->size = oe_backtrace(b->buffer, OE_COUNTOF(b->buffer));
+    b->size = backtrace(b->buffer, OE_COUNTOF(b->buffer));
 
     /* Check for truncation */
     OE_TEST(b->size < (int)OE_COUNTOF(b->buffer));
@@ -32,7 +32,7 @@ extern "C" OE_NEVER_INLINE void func4(size_t num_syms, const char** syms)
     OE_UNUSED(num_syms);
     OE_UNUSED(syms);
 
-    b.size = oe_backtrace(b.buffer, OE_COUNTOF(b.buffer));
+    b.size = backtrace(b.buffer, OE_COUNTOF(b.buffer));
 
     /* Check for truncation */
     OE_TEST(b.size < (int)OE_COUNTOF(b.buffer));
@@ -55,32 +55,61 @@ extern "C" OE_NEVER_INLINE void func1(size_t num_syms, const char** syms)
     func2(num_syms, syms);
 }
 
-/* Backtrace does not work in non-debug builds */
-#ifdef OE_USE_DEBUG_MALLOC
 static void _print_backtrace(
     void* const* buffer,
     size_t size,
     size_t num_expected_symbols,
     const char* expected_symbols[])
 {
-    char** symbols = oe_backtrace_symbols(buffer, static_cast<int>(size));
+    char** symbols = backtrace_symbols(buffer, static_cast<int>(size));
     OE_TEST(symbols != NULL);
 
     oe_host_printf("=== backtrace:\n");
 
-    for (size_t i = 0; i < size; i++)
-        oe_host_printf("%s(): (%p)\n", symbols[i], buffer[i]);
+    OE_TEST(size <= num_expected_symbols);
+    {
+        // Optimizations may cause certain frames to be omitted (due to inlining
+        // or tail-call etc). We need to assert that the backtrace is an ordered
+        // subset of expected backtrace.
+        size_t num_skipped = 0;
+        size_t idx = 0;
 
-    OE_TEST(size == num_expected_symbols);
+        // Iterate through the expected symbols
+        for (size_t i = 0; i < num_expected_symbols; i++)
+        {
+            if (strcmp(expected_symbols[i], symbols[idx]) == 0)
+            {
+                // Expected and actual symbols match.
+                // Move past the current frame.
+                oe_host_printf("%s(): (%p)\n", symbols[idx], buffer[idx]);
+                ++idx;
+            }
+            else
+            {
+                // Mismatch. Mark this expected frame as skipped.
+                // But do not move past the current frame.
+                oe_host_printf(
+                    "Skipped expected frame %s\n", expected_symbols[i]);
+                ++num_skipped;
+            }
+        }
 
-    for (size_t i = 0; i < size; i++)
-        OE_TEST(strcmp(expected_symbols[i], symbols[i]) == 0);
+        oe_host_printf("\nSkipped %d frames\n", (int)num_skipped);
+
+        // All the gathered frames must be consumed.
+        OE_TEST(idx == size);
+
+#ifndef NDEBUG
+        // In debug mode, expected and actual backtraces must exactly match.
+        // In release mode, some frames may be skipped.
+        OE_TEST(num_skipped == 0);
+#endif
+    }
 
     oe_host_printf("\n");
 
-    oe_backtrace_symbols_free(symbols);
+    free(symbols);
 }
-#endif
 
 extern "C" bool test(size_t num_syms, const char** syms)
 {
@@ -92,16 +121,12 @@ extern "C" bool test(size_t num_syms, const char** syms)
     OE_UNUSED(num_syms);
     OE_UNUSED(syms);
 
-/* Backtrace does not work in non-debug builds */
-#ifdef OE_USE_DEBUG_MALLOC
     OE_TEST(b.size > 0);
 
-    char** _syms = oe_backtrace_symbols(b.buffer, b.size);
+    char** _syms = backtrace_symbols(b.buffer, b.size);
     OE_TEST(_syms != NULL);
 
     _print_backtrace(b.buffer, (size_t)b.size, num_syms, syms);
-#endif
-
     return true;
 }
 
@@ -115,13 +140,10 @@ extern "C" bool test_unwind(size_t num_syms, const char** syms)
     }
     catch (Backtrace& b)
     {
-/* backtrace does not work in non-debug builds */
-#ifdef OE_USE_DEBUG_MALLOC
-        char** _syms = oe_backtrace_symbols(b.buffer, b.size);
+        char** _syms = backtrace_symbols(b.buffer, b.size);
         OE_TEST(_syms != NULL);
 
         _print_backtrace(b.buffer, (size_t)b.size, num_syms, syms);
-#endif
         return true;
     }
     return false;


### PR DESCRIPTION
Compile with -fno-omit-frame-pointer. This allows using rbp
to walk up the stack.

Backtrace functionality is exposed via the GNU functions instead of
oe_ prefixed funtions.

A tricky aspect of the implementation is that backtraces are used
by debug malloc (which is available only in debug builds).
When debug malloc uses backtraces, it must not use (debug) malloc
to allocate memory; instead it must use the lower level dlmalloc.
This is enabled by passing memory management functions to
oe_back_trace_symbols_impl.

To avoid duplication of the backtrace gathering logic, the implementation
is moved into oe_backtrace_impl. It is expected to be called from
oe_backtrace and from backtrace. It removed the frame of the caller
in the gathered backtrace.

Fixes #2421
Fixes #961

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>