### PR TITLE
Add -fstack-protector-strong to the CFLAG for pkgconfig.

### DIFF
--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -27,7 +27,7 @@ set(ENCLAVE_CFLAGS_LIST
   -fPIE
   -ftls-model=local-exec
   -fvisibility=hidden
-  -fno-stack-protector
+  -fstack-protector-strong
   -ffunction-sections
   -fdata-sections)
 


### PR DESCRIPTION
For SDK's end users, this option is already turned on for enclave through cmake configuration /opt/openenclave/lib/openenclave/cmake/openenclave-targets.cmake. This change will make -fstack-protector-strong as a default option in case end users use pkgconfig to setup the environment.

Signed-off-by: Alvin Chen <alvin@chen.asia>