### PR TITLE
Fix SGX prereq installation instructions for Windows 10

### DIFF
--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
@@ -38,6 +38,13 @@ Run the following from PowerShell to deploy all the prerequisites for building O
 ./scripts/install-windows-prereqs.ps1
 ```
 
+On Windows 10, the Intel PSW is delivered via Windows Update. Running the
+executable installer will fail on Windows 10 machines. To skip PSW installation:
+
+```powershell
+./scripts/install-windows-prereqs.ps1 -LaunchConfiguration SGX1FLC-NoDriver
+```
+
 To install the prerequisites along with the Azure DCAP Client, use the below
 command. The Azure DCAP Client is necessary to perform attestation on an Azure
 Confidential Computing VM. This command assumes that you would like the

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
@@ -41,6 +41,13 @@ would like to install the packages to `C:/oe_prereqs`.
 ./scripts/install-windows-prereqs.ps1 -InstallPath C:/oe_prereqs -LaunchConfiguration SGX1 -DCAPClientType None
 ```
 
+On Windows 10, the Intel PSW is delivered via Windows Update. Running the
+executable installer will fail on Windows 10 machines. To skip PSW installation:
+
+```powershell
+./scripts/install-windows-prereqs.ps1 -InstallPath C:/oe_prereqs -LaunchConfiguration SGX1-NoDriver -DCAPClientType None
+```
+
 If you prefer to manually install prerequisites, please refer to this
 [document](WindowsManualInstallPrereqs.md).
 

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -33,7 +33,7 @@ Param(
     [string]$Python3ZipURL = 'https://www.python.org/ftp/python/3.7.4/python-3.7.4-embed-amd64.zip',
     [string]$Python3ZipHash = 'FB65E5CD595AD01049F73B47BC0EE23FD03F0CBADC56CB318990CEE83B37761B',
     [Parameter(mandatory=$true)][string]$InstallPath,
-    [Parameter(mandatory=$true)][ValidateSet("SGX1FLC", "SGX1", "SGX1FLC-NoDriver")][string]$LaunchConfiguration,
+    [Parameter(mandatory=$true)][ValidateSet("SGX1FLC", "SGX1", "SGX1FLC-NoDriver", "SGX1-NoDriver")][string]$LaunchConfiguration,
     [Parameter(mandatory=$true)][ValidateSet("None", "Azure")][string]$DCAPClientType
 )
 
@@ -648,7 +648,7 @@ try {
     Install-Git
     Install-Shellcheck
 
-    if ($LaunchConfiguration -ne "SGX1FLC-NoDriver")
+    if (($LaunchConfiguration -ne "SGX1FLC-NoDriver") -and ($LaunchConfiguration -ne "SGX1-NoDriver"))
     {
         Install-PSW
     }


### PR DESCRIPTION
On Windows 10, the SGX PSW is installed by Windows update. Fix the installation instructions to skip PSW installation for Windows 10 and add a LaunchConfigutation option to the installer script for SGX1-NoDriver without FLC.

Fixes #2449