### PR TITLE
Set oe_abort(), _handle_exit() and oe_exit_enclave() as noreturn functions

### DIFF
--- a/enclave/core/optee/gp.c
+++ b/enclave/core/optee/gp.c
@@ -384,6 +384,13 @@ void oe_abort(void)
 {
     /* No return */
     TEE_Panic(TEE_ERROR_GENERIC);
+
+    /**
+     * TEE_Panic() does not return, but it is not properly annotated.
+     * Ensure the compiler does not return from this function.
+     */
+    while (1)
+        ;
 }
 
 TEE_Result TA_CreateEntryPoint(void)

--- a/enclave/core/sgx/asmdefs.h
+++ b/enclave/core/sgx/asmdefs.h
@@ -44,7 +44,7 @@
  * It should not be confused with oe_exit(), which maps to the standard-C
  * exit() function defined in <openenclave/corelibc/stdlib.h>.
  */
-void oe_exit_enclave(uint64_t arg1, uint64_t arg2);
+void oe_exit_enclave(uint64_t arg1, uint64_t arg2) OE_NO_RETURN;
 #endif
 
 #ifndef __ASSEMBLER__

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -312,6 +312,8 @@ done:
 **
 **==============================================================================
 */
+static void _handle_exit(oe_code_t code, uint16_t func, uint64_t arg)
+    OE_NO_RETURN;
 
 static void _handle_exit(oe_code_t code, uint16_t func, uint64_t arg)
 {
@@ -917,5 +919,4 @@ void oe_abort(void)
 
     // Return to the latest ECALL.
     _handle_exit(OE_CODE_ERET, 0, __oe_enclave_status);
-    return;
 }

--- a/include/openenclave/bits/defs.h
+++ b/include/openenclave/bits/defs.h
@@ -13,6 +13,13 @@
 #define OE_API_VERSION 2
 #endif
 
+/* OE_NO_RETURN */
+#if defined(__GNUC__)
+#define OE_NO_RETURN __attribute__((__noreturn__))
+#else
+#define OE_NO_RETURN
+#endif
+
 /* OE_PRINTF_FORMAT */
 #if defined(__GNUC__) && (__GNUC__ >= 4)
 #define OE_PRINTF_FORMAT(N, M) __attribute__((format(printf, N, M)))

--- a/include/openenclave/corelibc/bits/defs.h
+++ b/include/openenclave/corelibc/bits/defs.h
@@ -6,12 +6,6 @@
 
 #include <openenclave/bits/defs.h>
 
-#ifdef __GNUC__
-#define OE_NO_RETURN __attribute__((__noreturn__))
-#else
-#define OE_NO_RETURN
-#endif
-
 #if __STDC_VERSION__ >= 199901L
 #define OE_RESTRICT restrict
 #elif !defined(__GNUC__) || defined(__cplusplus)

--- a/include/openenclave/enclave.h
+++ b/include/openenclave/enclave.h
@@ -205,7 +205,7 @@ char* oe_host_strndup(const char* str, size_t n);
  * Mark the enclave as aborting. This blocks future enclave entry calls. The
  * enclave continues to execute until all threads exit the enclave.
  */
-void oe_abort(void);
+void oe_abort(void) OE_NO_RETURN;
 
 /**
  * @cond IGNORE


### PR DESCRIPTION
Set oe_abort(), handle_exit() and oe_exit_enclave() as noreturn functions in order to stop scan-build from generating warnings associated with oe_abort() (see issue #2464 for details). Now the number of bugs has become 140 and all bugs are found in third-party files.