### PR TITLE
Support clang-9 and clang-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,9 @@ endif ()
 # Set compiler search order to prefer Clang
 # This has to be done before `project`
 # http://cmake.3232098.n2.nabble.com/Prefer-clang-over-gcc-td7597742.html
-set(CMAKE_C_COMPILER_NAMES clang-7 cc)
-set(CMAKE_CXX_COMPILER_NAMES clang++-7 c++)
+# Look for latest supported versions before defaulting to system clang.
+set(CMAKE_C_COMPILER_NAMES clang-9 clang-8 clang-7 clang cc)
+set(CMAKE_CXX_COMPILER_NAMES clang++-9 clang++-8 clang++-7 clang++ c++)
 
 project("Open Enclave SDK" LANGUAGES C CXX ${OE_ASM}
   HOMEPAGE_URL "https://github.com/openenclave/openenclave")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,13 @@ endif ()
 # This has to be done before `project`
 # http://cmake.3232098.n2.nabble.com/Prefer-clang-over-gcc-td7597742.html
 # Look for latest supported versions before defaulting to system clang.
-set(CMAKE_C_COMPILER_NAMES clang-9 clang-8 clang-7 clang cc)
-set(CMAKE_CXX_COMPILER_NAMES clang++-9 clang++-8 clang++-7 clang++ c++)
+if (UNIX)
+  set(CMAKE_C_COMPILER_NAMES clang-9 clang-8 clang-7 clang cc)
+  set(CMAKE_CXX_COMPILER_NAMES clang++-9 clang++-8 clang++-7 clang++ c++)
+elseif(WIN32)
+  # For host side we use MSVC. For building enclaves, we use wrapper scripts
+  # that invoke installed version of clang.
+endif()
 
 project("Open Enclave SDK" LANGUAGES C CXX ${OE_ASM}
   HOMEPAGE_URL "https://github.com/openenclave/openenclave")

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -4,8 +4,8 @@
 # Check Clang version.
 if (CMAKE_C_COMPILER_ID MATCHES Clang)
   if (CMAKE_C_COMPILER_VERSION VERSION_LESS 7 OR
-      CMAKE_C_COMPILER_VERSION VERSION_GREATER 7.99)
-    message(WARNING "Open Enclave officially supports Clang 7 only, "
+      CMAKE_C_COMPILER_VERSION VERSION_GREATER 9.99)
+    message(WARNING "Open Enclave officially supports Clang 7, Clang 8 and Clang 9 only, "
       "but your Clang version (${CMAKE_C_COMPILER_VERSION}) "
       "is older or newer than that. Build problems may occur.")
   endif ()

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
@@ -44,6 +44,11 @@ sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-
 > package which is necessary for performing remote attestation in Azure. A general
 > implementation for using Intel DCAP outside the Azure environment is coming soon.
 
+If you wish to use clang-8 or clang-9, also install them
+```bash
+sudo apt -y install clang-8 clang-9
+```
+
 If you wish to use the Ninja build system rather than make, also install
 ```bash
 sudo apt -y install ninja-build

--- a/docs/GettingStartedDocs/install_oe_sdk-Windows.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Windows.md
@@ -41,9 +41,11 @@ C:\Program Files\Git\mingw64\bin\openssl.exe
 
 ### Clang
 
-Download [Clang/LLVM for Windows 64-bit](http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe).
+Download [Clang/LLVM 7 for Windows 64-bit](http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe).
 Install Clang 7.0.1 and add the LLVM folder (typically C:\Program Files\LLVM\bin)
 to PATH. Open Enclave SDK uses clang to build the enclave binaries.
+
+OE SDK supports versions of Clang/LLVM 7 or above. They can be downloaded from [LLVM Download Page](http://releases.llvm.org/download.html)
 
 Open up a command prompt and ensure that clang is added to PATH.
 

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -78,7 +78,14 @@ if (OE_SGX)
 
     # Functions in td_basic.c will change the status of td and may trigger
     # stack check fail, thus it is necessary to turn off stack check.
-    set_source_files_properties(sgx/td_basic.c PROPERTIES
+    # Functions in calls (e.g __oe_handle_main, _handle_ecalls) are called
+    # before stack protector is setup up for the enclave thread. Therefore
+    # stack check must also be turned off for calls.c.
+    # Also refer to MUSL files included below.
+    set_source_files_properties(
+        sgx/td_basic.c
+        sgx/calls.c
+	PROPERTIES
         COMPILE_FLAGS -fno-stack-protector)
 
     # OS specific sources for SGX.
@@ -154,13 +161,27 @@ add_library(oecore STATIC
     tracee.c
     ${PLATFORM_SRC})
 
+
+# The compiler can generate calls to memset and memcpy before stack checking has
+# been set up for an enclave thread. Therefore these functions must not be
+# compiled with stack protection.
+# When compiling memset and memcpy, prevent the compiler from generating using
+# builtin functions (__builtin_memcpy, __builtin_memset) to implement these
+# functions. Builtin functions call their ISO C equivalents and therefore using
+# builtins may generate recursive calls (memset -> __builtin__memset -> memset).
+# Also suppress type conversion warnings introduced by 3rdparty code.
+set_source_files_properties(
+  ${MUSL_SRC_DIR}/string/memcpy.c
+  ${MUSL_SRC_DIR}/string/memset.c
+  PROPERTIES
+  COMPILE_FLAGS
+  "-fno-stack-protector -Wno-conversion -fno-builtin-memcpy -fno-builtin-memset")
+
 # Suppress type conversion warnings introduced by 3rdparty code
 set_source_files_properties(${MUSL_SRC_DIR}/prng/rand.c ROPERTIES
     COMPILE_FLAGS -Wno-conversion)
 set_source_files_properties(${MUSL_SRC_DIR}/string/memmove.c PROPERTIES
     COMPILE_FLAGS -Wno-sign-conversion)
-set_source_files_properties(${MUSL_SRC_DIR}/string/memset.c PROPERTIES
-    COMPILE_FLAGS -Wno-conversion)
 set_source_files_properties(__secs_to_tm.c PROPERTIES
     COMPILE_FLAGS -Wno-conversion)
 

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -79,7 +79,7 @@ if (OE_SGX)
     # Functions in td_basic.c will change the status of td and may trigger
     # stack check fail, thus it is necessary to turn off stack check.
     # Functions in calls (e.g __oe_handle_main, _handle_ecalls) are called
-    # before stack protector is setup up for the enclave thread. Therefore
+    # before stack protector is set up for the enclave thread. Therefore
     # stack check must also be turned off for calls.c.
     # Also refer to MUSL files included below.
     set_source_files_properties(

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -666,7 +666,6 @@ add_library(oelibc STATIC
     ${MUSLSRC}/string/memmem.c
     ${MUSLSRC}/string/mempcpy.c
     ${MUSLSRC}/string/memrchr.c
-    #${MUSLSRC}/string/memset.c
     ${MUSLSRC}/string/rindex.c
     ${MUSLSRC}/string/stpcpy.c
     ${MUSLSRC}/string/stpncpy.c

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -663,13 +663,10 @@ add_library(oelibc STATIC
     ${MUSLSRC}/string/index.c
     ${MUSLSRC}/string/memccpy.c
     ${MUSLSRC}/string/memchr.c
-    ${MUSLSRC}/string/memcmp.c
-    ${MUSLSRC}/string/memcpy.c
     ${MUSLSRC}/string/memmem.c
-    ${MUSLSRC}/string/memmove.c
     ${MUSLSRC}/string/mempcpy.c
     ${MUSLSRC}/string/memrchr.c
-    ${MUSLSRC}/string/memset.c
+    #${MUSLSRC}/string/memset.c
     ${MUSLSRC}/string/rindex.c
     ${MUSLSRC}/string/stpcpy.c
     ${MUSLSRC}/string/stpncpy.c
@@ -786,10 +783,10 @@ maybe_build_using_clangw(oelibc)
 # NOTE: This is the minimum required for musl sources.
 set_property(TARGET oelibc PROPERTY C_STANDARD 99)
 
-target_compile_options(oelibc PRIVATE
-    -fno-builtin-memcpy
-    -fno-builtin-memset
-    -ffreestanding)
+# A freestanding environment is one in which no standard library exists and
+# program start up may not necessarily be at main. C library itself must be
+# built in a freestanding environment.
+target_compile_options(oelibc PRIVATE -ffreestanding)
 
 if (OE_SGX)
     target_compile_options(oelibc PRIVATE -mrdrnd)


### PR DESCRIPTION
clang-8 and clang-9 have added improvements to x86-speculative-load-hardening.
Visual Studio's clang support now bundles clang-8.

clang-8 can be supported without any changes to master.

clang-9 generates stack checking for functions in sgx/calls.c as well as memset/memcpy.
Th former functions are called before stack checking is setup for an enclave thread,
whereas the latter are called during the setup/cleanup of stack checking.
Therefore, these files must be compiled without stack protectors.

Additional fixes:
- memset, memcpy and other C files were being compiled in oecore with different flags
and then in oelibc with different flags. Now they are compiled in oelibc with correct
flags
- Whole of oelibc was being compiled with no builtin memset or memcpy. Only those two
functions are now being compiled in that manner. This allows the compiler to use
the builtins as needed when compiling oelibc.

Fixes #1688

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>