### PR TITLE
Implement nanosleep ocall in edl

### DIFF
--- a/common/syscall.edl
+++ b/common/syscall.edl
@@ -21,6 +21,7 @@
 
 enclave {
 
+    include "openenclave/corelibc/time.h"
     include "openenclave/internal/syscall/netdb.h"
     include "openenclave/internal/syscall/sys/epoll.h"
     include "openenclave/internal/syscall/sys/poll.h"
@@ -407,5 +408,9 @@ enclave {
             [out, count=size] unsigned int* list)
             propagate_errno;
 
+        int oe_syscall_nanosleep_ocall(
+            [in] struct oe_timespec* req,
+            [in, out] struct oe_timespec* rem)
+            propagate_errno;
     };
 };

--- a/enclave/core/time.c
+++ b/enclave/core/time.c
@@ -6,20 +6,6 @@
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/time.h>
 
-int oe_sleep_msec(uint64_t milliseconds)
-{
-    int ret = -1;
-
-    if (oe_ocall(OE_OCALL_SLEEP, milliseconds, NULL) != OE_OK)
-        goto done;
-
-    ret = 0;
-
-done:
-
-    return ret;
-}
-
 uint64_t oe_get_time(void)
 {
     uint64_t ret = (uint64_t)-1;

--- a/host/linux/syscall.c
+++ b/host/linux/syscall.c
@@ -1378,3 +1378,18 @@ int oe_syscall_uname_ocall(struct oe_utsname* buf)
 done:
     return ret;
 }
+
+/*
+**==============================================================================
+**
+** sleep():
+**
+**==============================================================================
+*/
+
+int oe_syscall_nanosleep_ocall(struct oe_timespec* req, struct oe_timespec* rem)
+{
+    errno = 0;
+
+    return nanosleep((struct timespec*)req, (struct timespec*)rem);
+}

--- a/host/linux/time.c
+++ b/host/linux/time.c
@@ -21,27 +21,6 @@ static uint64_t _time()
            ((uint64_t)ts.tv_nsec / _MSEC_TO_NSEC);
 }
 
-static void _sleep(uint64_t milliseconds)
-{
-    struct timespec ts;
-    const struct timespec* req = &ts;
-    struct timespec rem = {0, 0};
-
-    ts.tv_sec = (time_t)(milliseconds / _SEC_TO_MSEC);
-    ts.tv_nsec = (long)((milliseconds % _SEC_TO_MSEC) * _MSEC_TO_NSEC);
-
-    while (nanosleep(req, &rem) != 0 && errno == EINTR)
-    {
-        req = &rem;
-    }
-}
-
-void oe_handle_sleep(uint64_t arg_in)
-{
-    const uint64_t milliseconds = arg_in;
-    _sleep(milliseconds);
-}
-
 void oe_handle_get_time(uint64_t arg_in, uint64_t* arg_out)
 {
     OE_UNUSED(arg_in);

--- a/host/ocalls.h
+++ b/host/ocalls.h
@@ -9,7 +9,6 @@
 void HandleMalloc(uint64_t arg_in, uint64_t* arg_out);
 void HandleFree(uint64_t arg);
 
-void oe_handle_sleep(uint64_t arg_in);
 void oe_handle_get_time(uint64_t arg_in, uint64_t* arg_out);
 
 void oe_handle_wake_host_worker(uint64_t arg_in);

--- a/host/optee/linux/enclave.c
+++ b/host/optee/linux/enclave.c
@@ -211,10 +211,6 @@ static TEEC_Result _handle_generic_rpc(
         case OE_OCALL_THREAD_WAKE:
             return TEEC_ERROR_NOT_SUPPORTED;
 
-        case OE_OCALL_SLEEP:
-            oe_handle_sleep(*(uint64_t*)input_buffer);
-            break;
-
         case OE_OCALL_GET_TIME:
             oe_handle_get_time(
                 *(uint64_t*)input_buffer, (uint64_t*)output_buffer);

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -315,7 +315,6 @@ static const char* oe_ocall_str(oe_func_t ocall)
         "THREAD_WAIT",
         "MALLOC",
         "FREE",
-        "SLEEP",
         "GET_TIME"
     };
     // clang-format on
@@ -401,10 +400,6 @@ static oe_result_t _handle_ocall(
 
         case OE_OCALL_THREAD_WAKE:
             HandleThreadWake(enclave, arg_in);
-            break;
-
-        case OE_OCALL_SLEEP:
-            oe_handle_sleep(arg_in);
             break;
 
         case OE_OCALL_GET_TIME:

--- a/host/windows/syscall.c
+++ b/host/windows/syscall.c
@@ -1532,8 +1532,8 @@ int oe_syscall_nanosleep_ocall(struct oe_timespec* req, struct oe_timespec* rem)
 
     Sleep((DWORD)milliseconds);
 
-    // Windows sleep will always sleep is not interruptable by hardware
-    // exception handling. Just wait the whole time and zero rem.
+    // Windows sleep is not interruptable by hardware exception handling. Just
+    // wait the whole time and zero rem.
     if (rem)
         memset(rem, 0, sizeof(*rem));
 

--- a/host/windows/syscall.c
+++ b/host/windows/syscall.c
@@ -1502,3 +1502,38 @@ int oe_syscall_uname_ocall(struct oe_utsname* buf)
 done:
     return ret;
 }
+
+/*
+**==============================================================================
+**
+** nanosleep():
+**
+**==============================================================================
+*/
+
+int oe_syscall_nanosleep_ocall(struct oe_timespec* req, struct oe_timespec* rem)
+{
+    uint64_t milliseconds = 0;
+
+    if (!req)
+    {
+        _set_errno(OE_EINVAL);
+        return -1;
+    }
+
+    milliseconds += req->tv_sec * 1000UL;
+    milliseconds += req->tv_nsec / 1000000UL;
+
+    for (uint64_t i = 0; i < div; i++)
+        Sleep(UINT_MAX);
+
+    Sleep((DWORD)mod);
+
+    // Windows sleep will always sleep is not interruptable by hardware
+    // exception handling. Just wait the whole time and zero rem.
+    if (rem)
+        memset(rem, 0, sizeof(*rem));
+
+    _set_errno(0);
+    return 0;
+}

--- a/host/windows/syscall.c
+++ b/host/windows/syscall.c
@@ -1524,10 +1524,13 @@ int oe_syscall_nanosleep_ocall(struct oe_timespec* req, struct oe_timespec* rem)
     milliseconds += req->tv_sec * 1000UL;
     milliseconds += req->tv_nsec / 1000000UL;
 
-    for (uint64_t i = 0; i < div; i++)
+    while (milliseconds > UINT_MAX)
+    {
         Sleep(UINT_MAX);
+        milliseconds -= UINT_MAX;
+    }
 
-    Sleep((DWORD)mod);
+    Sleep((DWORD)milliseconds);
 
     // Windows sleep will always sleep is not interruptable by hardware
     // exception handling. Just wait the whole time and zero rem.

--- a/host/windows/time.c
+++ b/host/windows/time.c
@@ -46,18 +46,6 @@ static uint64_t _time()
     return (x.QuadPart / TICKS_PER_MILLISECOND);
 }
 
-void oe_handle_sleep(uint64_t arg_in)
-{
-    const uint64_t milliseconds = arg_in;
-    const uint64_t div = milliseconds / (uint64_t)UINT_MAX;
-    const uint64_t mod = milliseconds % (uint64_t)UINT_MAX;
-
-    for (uint64_t i = 0; i < div; i++)
-        Sleep(UINT_MAX);
-
-    Sleep((DWORD)mod);
-}
-
 void oe_handle_get_time(uint64_t arg_in, uint64_t* arg_out)
 {
     OE_UNUSED(arg_in);

--- a/include/openenclave/internal/calls.h
+++ b/include/openenclave/internal/calls.h
@@ -83,7 +83,6 @@ typedef enum _oe_func
     OE_OCALL_THREAD_WAIT,
     OE_OCALL_MALLOC,
     OE_OCALL_FREE,
-    OE_OCALL_SLEEP,
     OE_OCALL_GET_TIME,
     /* Caution: always add new OCALL function numbers here */
     OE_OCALL_MAX, /* This value is never used */

--- a/include/openenclave/internal/syscall/unistd.h
+++ b/include/openenclave/internal/syscall/unistd.h
@@ -8,6 +8,7 @@
 #include <openenclave/bits/types.h>
 #include <openenclave/corelibc/bits/types.h>
 #include <openenclave/corelibc/stdarg.h>
+#include <openenclave/corelibc/time.h>
 #include <openenclave/internal/syscall/unistd.h>
 
 OE_EXTERNC_BEGIN
@@ -72,6 +73,8 @@ int oe_gethostname(char* name, size_t len);
 int oe_getdomainname(char* name, size_t len);
 
 unsigned int oe_sleep(unsigned int seconds);
+
+int oe_nanosleep(struct oe_timespec* req, struct oe_timespec* rem);
 
 int oe_dup(int fd);
 

--- a/include/openenclave/internal/time.h
+++ b/include/openenclave/internal/time.h
@@ -11,19 +11,6 @@ OE_EXTERNC_BEGIN
 /*
 **==============================================================================
 **
-** oe_sleep_msec()
-**
-**     Sleep for milliseconds. Return 0 on success and -1 if thread
-**     interrupted.
-**
-**==============================================================================
-*/
-
-int oe_sleep_msec(uint64_t milliseconds);
-
-/*
-**==============================================================================
-**
 ** oe_get_time()
 **
 **     Return milliseconds elapsed since the Epoch or (uint64_t)-1 on error.

--- a/libc/syscalls.c
+++ b/libc/syscalls.c
@@ -98,33 +98,6 @@ done:
     return ret;
 }
 
-static long _syscall_nanosleep(long n, long x1, long x2)
-{
-    const struct timespec* req = (struct timespec*)x1;
-    struct timespec* rem = (struct timespec*)x2;
-    size_t ret = -1;
-    uint64_t milliseconds = 0;
-
-    OE_UNUSED(n);
-
-    if (rem)
-        memset(rem, 0, sizeof(*rem));
-
-    if (!req)
-        goto done;
-
-    /* Convert timespec to milliseconds */
-    milliseconds += req->tv_sec * 1000UL;
-    milliseconds += req->tv_nsec / 1000000UL;
-
-    /* Perform OCALL */
-    ret = oe_sleep_msec(milliseconds);
-
-done:
-
-    return ret;
-}
-
 static void _stat_to_oe_stat(struct stat* stat, struct oe_stat* oe_stat)
 {
     oe_stat->st_dev = stat->st_dev;
@@ -238,8 +211,6 @@ long __syscall(long n, long x1, long x2, long x3, long x4, long x5, long x6)
     /* Handle syscall internally if possible. */
     switch (n)
     {
-        case SYS_nanosleep:
-            return _syscall_nanosleep(n, x1, x2);
         case SYS_gettimeofday:
             return _syscall_gettimeofday(n, x1, x2);
         case SYS_clock_gettime:

--- a/syscall/syscall.c
+++ b/syscall/syscall.c
@@ -809,6 +809,13 @@ static long _syscall(
             goto done;
         }
 #endif
+        case OE_SYS_nanosleep:
+        {
+            struct oe_timespec* req = (struct oe_timespec*)arg1;
+            struct oe_timespec* rem = (struct oe_timespec*)arg2;
+            ret = (long)oe_nanosleep(req, rem);
+            goto done;
+        }
         default:
         {
             oe_errno = OE_ENOSYS;

--- a/syscall/unistd.c
+++ b/syscall/unistd.c
@@ -138,12 +138,11 @@ done:
     return ret;
 }
 
-unsigned int oe_sleep(unsigned int seconds)
+int oe_nanosleep(struct oe_timespec* req, struct oe_timespec* rem)
 {
-    const uint64_t ONE_SECOND = 1000;
-    const uint64_t msec = seconds * ONE_SECOND;
-
-    return (oe_sleep_msec(msec) == 0) ? 0 : seconds;
+    int ret = 0;
+    oe_syscall_nanosleep_ocall(&ret, req, rem);
+    return ret;
 }
 
 oe_pid_t oe_getpid(void)

--- a/tests/libcxx/tests.broken
+++ b/tests/libcxx/tests.broken
@@ -14,4 +14,5 @@
 # The following three tests fails on ACC Windows VM.
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.locking/lock.pass.cpp
+../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.locking/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/lock_shared.pass.cpp

--- a/tests/libcxx/tests.supported
+++ b/tests/libcxx/tests.supported
@@ -4024,7 +4024,6 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_adopt_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_defer_lock.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.locking/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.locking/try_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.locking/try_lock_for.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.locking/unlock.pass.cpp

--- a/tests/libcxx/tests.supported.default
+++ b/tests/libcxx/tests.supported.default
@@ -27,7 +27,6 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.guard/adopt_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.guard/mutex.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.locking/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.recursive/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.once/thread.once.callonce/call_once.pass.cpp

--- a/tests/libcxx/tests.unsupported
+++ b/tests/libcxx/tests.unsupported
@@ -485,6 +485,7 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_duration.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_time_point.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_try_to_lock.pass.cpp
+../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.locking/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.locking/try_lock_until.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.class/try_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.recursive/try_lock.pass.cpp

--- a/tests/syscall/platform/linux.h
+++ b/tests/syscall/platform/linux.h
@@ -82,17 +82,12 @@ OE_INLINE int get_error(void)
 
 OE_INLINE void sleep_msec(uint32_t msec)
 {
-#if defined(OE_BUILD_ENCLAVE)
-    extern int oe_sleep_msec(uint64_t milliseconds);
-    oe_sleep_msec(msec);
-#else
     struct timespec ts;
 
     ts.tv_sec = (uint64_t)msec / 1000;
     ts.tv_nsec = ((int64_t)msec % 1000) * 1000000;
 
     nanosleep(&ts, NULL);
-#endif
 }
 
 typedef struct _thread

--- a/tests/syscall/socket/enc/enc.c
+++ b/tests/syscall/socket/enc/enc.c
@@ -142,7 +142,6 @@ int ecall_run_server()
 
     while (1)
     {
-        oe_sleep_msec(1);
         printf("enc: accepting\n");
 
         struct oe_sockaddr_in peer_addr = {0};
@@ -171,7 +170,6 @@ int ecall_run_server()
                 {
                     printf("write test data n = %ld errno = %d\n", n, oe_errno);
                 }
-                oe_sleep_msec(3);
             } while (1);
 
             break;

--- a/tests/syscall/socketpair/enc/enc.c
+++ b/tests/syscall/socketpair/enc/enc.c
@@ -82,7 +82,7 @@ int run_enclave_client(char* recv_buff, ssize_t* recv_buff_len)
         {
             printf("Read error, retry\n");
             numtries++;
-            oe_sleep_msec(3000);
+            sleep(3);
         }
     } while (numtries < 10);
 
@@ -119,7 +119,7 @@ int run_enclave_server()
         {
             printf("write test data n = %ld errno = %d\n", n, oe_errno);
         }
-        oe_sleep_msec(1000);
+        sleep(1);
     } while (!done);
 
     // Shutdown the writing


### PR DESCRIPTION
**Disclaimer**: oeedger8r ocalls are much slower than hand-written ocalls. For this reason, nanosleep takes longer than before. This led to some libcxx test failures, which is why the tolerance is increased with `-DTEST_HAS_SANITIZERS`. We should consider holding this PR until the performance of this ocall can be improved.

Currently sleep and nanosleep are implemented as special-case ocalls and
not in EDL. Implement them in EDL.

Additionally, fix nanosleep to be properly implemented for resuming after
being interrupted for signal handling.

Note that in musl libc sleep is just implemented with nanosleep which is why the sleep ocall was removed entirely.

Fixes #2405