### PR TITLE
Make use of sealed_data_size in data-sealing samples to fix issue #2220

### DIFF
--- a/samples/data-sealing/common/dispatcher.cpp
+++ b/samples/data-sealing/common/dispatcher.cpp
@@ -179,10 +179,17 @@ int ecall_dispatcher::unseal_data(
     size_t seal_key_size = 0;
     uint8_t* key_info = NULL;
     size_t key_info_size = 0;
-    (void)sealed_data_size;
 
     unsigned char* data_buf = NULL;
     int ret = 0;
+
+    // ensure that sealed_data_size is IV_SIZE
+    if (sealed_data_size != IV_SIZE)
+    {
+        TRACE_ENCLAVE("sealed_data_size is not equal to IV_SIZE");
+        ret = ERROR_SEALED_DATA_FAIL;
+        goto exit;
+    }
 
     key_info = sealed_data->encrypted_data + sealed_data->encrypted_data_len;
     key_info_size = sealed_data->key_info_size;
@@ -202,7 +209,7 @@ int ecall_dispatcher::unseal_data(
     }
 
     // read initialization vector values
-    memcpy(iv, m_sealed_data->iv, IV_SIZE);
+    memcpy(iv, m_sealed_data->iv, sealed_data_size);
 
     // We need to cast these variables down to unsigned int.
     // Check if that will cut off any significant bits.
@@ -244,7 +251,7 @@ int ecall_dispatcher::unseal_data(
 
     // Unseal data: decrypt data with the seal key
     // re-initialization vector values
-    memcpy(iv, m_sealed_data->iv, IV_SIZE);
+    memcpy(iv, m_sealed_data->iv, sealed_data_size);
 
     data_buf =
         (unsigned char*)oe_host_malloc(m_sealed_data->encrypted_data_len);

--- a/samples/data-sealing/common/shared.h
+++ b/samples/data-sealing/common/shared.h
@@ -20,6 +20,7 @@
 #define ERROR_SIGN_SEALED_DATA_FAIL 4
 #define ERROR_CIPHER_ERROR 5
 #define ERROR_UNSEALED_DATA_FAIL 6
+#define ERROR_SEALED_DATA_FAIL 7
 
 typedef struct _sealed_data_t
 {


### PR DESCRIPTION
This is related to issues #2220 and #2431. After discussion with @anakrish and @radhikaj, since sealed_data_size is always equal to IV_SIZE in the unseal_data function, we should use sealed_data_size instead of voiding it at the beginning. Therefore, I have added an if-statement to ensure sealed_data_size is IV_SIZE, and use it throughout the rest of the function.