### PR TITLE
Updated Linux Debug using VS Code doc

### DIFF
--- a/docs/GettingStartedDocs/Linux_vscode.md
+++ b/docs/GettingStartedDocs/Linux_vscode.md
@@ -115,7 +115,7 @@ Open enc.c and put a breakpoint and continue execution.
 
 ![Enclave Breakpoint](images/VSCodeLinuxEnclaveBreakpoint.png)
 
-To step through open enclave code you may need to change the source file mapping to point to the OE SDK source. Add the following to the project launch json under configurations:
+To step through open enclave code you may need to change the source file mapping to point to the OE SDK source. Add the following to the project launch json under configurations and update with the correct path to the openenclave source:
 
 ```json
 "sourceFileMap": {

--- a/docs/GettingStartedDocs/Linux_vscode.md
+++ b/docs/GettingStartedDocs/Linux_vscode.md
@@ -115,4 +115,12 @@ Open enc.c and put a breakpoint and continue execution.
 
 ![Enclave Breakpoint](images/VSCodeLinuxEnclaveBreakpoint.png)
 
+To step through open enclave code you may need to change the source file mapping to point to the OE SDK source. Add the following to the project launch json under configurations:
+
+```json
+"sourceFileMap": {
+   "/home/jenkins/work_dir/workspace/OpenEnclave-v0.7.x_packages": "/home/username/path2code/openenclave/",
+},
+```
+
 To use `oegdb` at the command line, one can select the "Debug Console" tab near the terminal pane. Then the standard gdb commands can be used, as long as they are prefixed with `-exec` first, like `-exec bt`. Please read documentation for `gdb` for further information on how to use `oegdb`: [https://sourceware.org/gdb/current/onlinedocs/gdb/](https://sourceware.org/gdb/current/onlinedocs/gdb/)


### PR DESCRIPTION
Based on existing tutorial in doc, debugger wouldn't correctly locate oesdk. Added info for configuration setting to map to the oe source code when stepping through applications. 