### PR TITLE
Complete the struct initializer to fix #2080

### DIFF
--- a/include/openenclave/bits/sgx/sgxproperties.h
+++ b/include/openenclave/bits/sgx/sgxproperties.h
@@ -128,7 +128,7 @@ typedef struct _oe_sgx_enclave_properties
         },                                                                \
         .image_info =                                                     \
         {                                                                 \
-            0                                                             \
+            0, 0, 0, 0, 0, 0                                              \
         },                                                                \
         .sigstruct =                                                      \
         {                                                                 \


### PR DESCRIPTION
Complete the struct initializer to remove the warning, `-Wmissing-field-initializers`, which is mentioned in #2080. Scan-build does not give such warnings afterwards.