### PR TITLE
Optimize switchless ocall scheduling

### DIFF
--- a/host/sgx/switchless.c
+++ b/host/sgx/switchless.c
@@ -29,10 +29,16 @@ static void* _switchless_ocall_worker(void* arg)
         volatile oe_call_host_function_args_t* local_call_arg = NULL;
         if ((local_call_arg = context->call_arg) != NULL)
         {
-            context->call_arg = NULL;
-
+            // Handle the switchless call, but do not clear the slot yet. Since
+            // the slot is not empty, any new incoming switchless call request
+            // will be scheduled in another available work thread and get
+            // handled immediately.
             oe_handle_call_host_function(
                 (uint64_t)local_call_arg, context->enclave);
+
+            // After handling the switchless call, mark this worker thread
+            // as free by clearing the slot.
+            context->call_arg = NULL;
 
             // Reset spin count for next message.
             context->total_spin_count += context->spin_count;

--- a/tests/switchless/enc/enc.c
+++ b/tests/switchless/enc/enc.c
@@ -76,9 +76,9 @@ int enc_echo_regular(const char* in, char out[STRING_LEN], int repeats)
 }
 
 OE_SET_ENCLAVE_SGX(
-    1,    /* ProductID */
-    1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    64,   /* HeapPageCount */
-    64,   /* StackPageCount */
-    16);  /* TCSCount */
+    1,        /* ProductID */
+    1,        /* SecurityVersion */
+    true,     /* AllowDebug */
+    64,       /* HeapPageCount */
+    64,       /* StackPageCount */
+    NUM_TCS); /* TCSCount */

--- a/tests/switchless/host/host.c
+++ b/tests/switchless/host/host.c
@@ -135,6 +135,14 @@ int main(int argc, const char* argv[])
     if (argc == 4)
     {
         sscanf(argv[3], "%" SCNu64, &num_enclave_threads);
+        if (num_enclave_threads > NUM_TCS)
+        {
+            fprintf(
+                stderr,
+                "Number of enclave threads must be less than %d\n",
+                (int)NUM_TCS);
+            return 1;
+        }
     }
 
 #if defined(__WIN32)
@@ -162,7 +170,7 @@ int main(int argc, const char* argv[])
 
     // Measure switchless ocall performance.
     uint64_t num_extra_enc_threads = num_enclave_threads - 1;
-    thread_info_t tinfo[32];
+    thread_info_t tinfo[NUM_TCS];
     for (uint64_t i = 0; i < num_extra_enc_threads; ++i)
     {
         int ret = 0;

--- a/tests/switchless/switchless.edl
+++ b/tests/switchless/switchless.edl
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 enclave {
+    enum num_tcs_t {
+        NUM_TCS = 32
+    };
+
     trusted {
         public int enc_echo_switchless(
             [string, in] const char* in,


### PR DESCRIPTION
Switchless worker thread used to clear its slot before handling the
switchless ocall. This caused another switchless ocall to be scheduled
on the worker thread, even before it could complete the current ocall.

In order to optimize scheduling, the work thread now first handles the
switchless ocall and then clears its slot. This causes the thread to
be considered "busy" till the ocall is handled. While the thread is
"busy", switchless ocalls are scheduled in other available worker threads.

Test cleanup:
tests/switchless has been tweaked to measure and display the speed up
factor of fastest and slowest enclave threads making switchless calls.
Previously, only the fastest time as displayed.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>