### PR TITLE
Convert `oe_handle_init_switchless` into an EDL defined function

### DIFF
--- a/common/tee.edl
+++ b/common/tee.edl
@@ -43,6 +43,10 @@ enclave
             [out, size=key_info_size] void* key_info,
             size_t key_info_size,
             [out] size_t* key_info_size_out);
+
+        public oe_result_t oe_handle_init_switchless(
+            [user_check] void* host_worker_contexts,
+            size_t num_host_workers);
     };
 
     untrusted

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -66,6 +66,7 @@ if (OE_SGX)
         sgx/report.c
         sgx/sched_yield.c
         sgx/spinlock.c
+        sgx/switchlesscalls.c
         sgx/td.c
         sgx/td_basic.c
         sgx/thread.c
@@ -107,6 +108,7 @@ elseif (OE_TRUSTZONE)
         optee/sched_yield.c
         optee/spinlock.c
         optee/stubs.c
+        optee/switchlesscalls.c
         optee/thread.c
         optee/tracee.c)
 endif()
@@ -148,7 +150,6 @@ add_library(oecore STATIC
     string.c
     strtok_r.c
     strtoul.c
-    switchlesscalls.c
     tee_t_wrapper.c
     time.c
     tracee.c

--- a/enclave/core/optee/gp.c
+++ b/enclave/core/optee/gp.c
@@ -476,12 +476,6 @@ TEE_Result TA_InvokeCommandEntryPoint(
             result = TEE_ERROR_BAD_STATE;
             break;
         }
-        case OE_ECALL_INIT_CONTEXT_SWITCHLESS:
-        {
-            /* TODO: initialize switchless calls */
-            result = TEE_ERROR_NOT_IMPLEMENTED;
-            break;
-        }
         default:
         {
             /* No function found with the number */

--- a/enclave/core/optee/switchlesscalls.c
+++ b/enclave/core/optee/switchlesscalls.c
@@ -1,0 +1,47 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+// TODO: Switchless calls for op-tee
+
+#include "../switchlesscalls.h"
+#include <openenclave/edger8r/enclave.h>
+#include <openenclave/enclave.h>
+
+bool oe_is_switchless_initialized()
+{
+    return false;
+}
+
+oe_result_t oe_handle_init_switchless(
+    void* host_worker_contexts,
+    size_t num_host_workers)
+{
+    OE_UNUSED(host_worker_contexts);
+    OE_UNUSED(num_host_workers);
+    return OE_UNSUPPORTED;
+}
+
+oe_result_t oe_post_switchless_ocall(oe_call_host_function_args_t* args)
+{
+    OE_UNUSED(args);
+    return OE_UNSUPPORTED;
+}
+
+oe_result_t oe_switchless_call_host_function(
+    size_t function_id,
+    const void* input_buffer,
+    size_t input_buffer_size,
+    void* output_buffer,
+    size_t output_buffer_size,
+    size_t* output_bytes_written)
+{
+    return oe_call_host_function_by_table_id(
+        OE_UINT64_MAX,
+        function_id,
+        input_buffer,
+        input_buffer_size,
+        output_buffer,
+        output_buffer_size,
+        output_bytes_written,
+        true /* switchless */);
+}

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -433,11 +433,6 @@ static void _handle_ecall(
             arg_out = _handle_init_enclave(arg_in);
             break;
         }
-        case OE_ECALL_INIT_CONTEXT_SWITCHLESS:
-        {
-            arg_out = oe_handle_init_switchless(arg_in);
-            break;
-        }
         default:
         {
             /* No function found with the number */

--- a/enclave/core/switchlesscalls.h
+++ b/enclave/core/switchlesscalls.h
@@ -8,8 +8,6 @@
 
 bool oe_is_switchless_initialized();
 
-oe_result_t oe_handle_init_switchless(uint64_t arg_in);
-
 oe_result_t oe_post_switchless_ocall(oe_call_host_function_args_t* args);
 
 #endif // _OE_SWITCHLESSCALLS_H

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -338,7 +338,6 @@ static const char* oe_ecall_str(oe_func_t ecall)
         "INIT_ENCLAVE",
         "CALL_ENCLAVE_FUNCTION",
         "VIRTUAL_EXCEPTION_HANDLER",
-        "INIT_CONTEXT_SWITCHLESS",
     };
     // clang-format on
 

--- a/host/sgx/switchless.c
+++ b/host/sgx/switchless.c
@@ -10,6 +10,7 @@
 #include "../hostthread.h"
 #include "../ocalls.h"
 #include "enclave.h"
+#include "tee_u.h"
 
 /**
  * Number of iterations an ocall worker thread would spin before going to sleep
@@ -85,7 +86,6 @@ oe_result_t oe_start_switchless_manager(
     size_t num_host_workers)
 {
     oe_result_t result = OE_UNEXPECTED;
-    uint64_t result_out = 0;
     oe_switchless_call_manager_t* manager = NULL;
     oe_host_worker_context_t* contexts = NULL;
     oe_thread_t* threads = NULL;
@@ -139,12 +139,12 @@ oe_result_t oe_start_switchless_manager(
     enclave->switchless_manager = manager;
 
     // Inform the enclave about the switchless manager through an ECALL
-    OE_CHECK(oe_ecall(
+    OE_CHECK(oe_handle_init_switchless(
         enclave,
-        OE_ECALL_INIT_CONTEXT_SWITCHLESS,
-        (uint64_t)manager,
-        &result_out));
-    OE_CHECK((oe_result_t)result_out);
+        &result,
+        (void*)manager->host_worker_contexts,
+        num_host_workers));
+    OE_CHECK(result);
 
     result = OE_OK;
 

--- a/include/openenclave/internal/calls.h
+++ b/include/openenclave/internal/calls.h
@@ -75,7 +75,6 @@ typedef enum _oe_func
     OE_ECALL_INIT_ENCLAVE,
     OE_ECALL_CALL_ENCLAVE_FUNCTION,
     OE_ECALL_VIRTUAL_EXCEPTION_HANDLER,
-    OE_ECALL_INIT_CONTEXT_SWITCHLESS,
     /* Caution: always add new ECALL function numbers here */
     OE_ECALL_MAX,
 


### PR DESCRIPTION
This PR addresses #2174, converting the hand-written ecall of `oe_handle_init_switchless` into EDL-based one.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>