### PR TITLE
OP-TEE Build Fixes

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -99,6 +99,6 @@ if (OE_TRUSTZONE)
     install(TARGETS teec EXPORT openenclave-targets)
 
     install(FILES ${BINARY_DIR}/libteec/libteec.a
-      DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/optee/libteec/libteec.a)
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/optee/libteec)
   endif ()
 endif ()

--- a/3rdparty/optee/libutee/CMakeLists.txt
+++ b/3rdparty/optee/libutee/CMakeLists.txt
@@ -6,8 +6,7 @@ add_library(oeuteeasm
 set_property(TARGET oeuteeasm PROPERTY C_STANDARD 99)
 target_compile_options(oeuteeasm PRIVATE
   ${OE_TZ_TA_S_FLAGS}
-  $<BUILD_INTERFACE:-include ${OE_TZ_TA_DEV_KIT_CONF}>
-  $<INSTALL_INTERFACE:-include openenclave/3rdparty/optee/conf.h>)
+  -include ${OE_TZ_TA_DEV_KIT_CONF})
 target_include_directories(oeuteeasm PRIVATE
   ${OE_TZ_LIBUTEE_INC}
   ${OE_TZ_LIBUTILS_EXT_INC})

--- a/3rdparty/optee/libutee/CMakeLists.txt
+++ b/3rdparty/optee/libutee/CMakeLists.txt
@@ -6,7 +6,8 @@ add_library(oeuteeasm
 set_property(TARGET oeuteeasm PROPERTY C_STANDARD 99)
 target_compile_options(oeuteeasm PRIVATE
   ${OE_TZ_TA_S_FLAGS}
-  -include ${OE_TZ_TA_DEV_KIT_CONF})
+  $<BUILD_INTERFACE:-include ${OE_TZ_TA_DEV_KIT_CONF}>
+  $<INSTALL_INTERFACE:-include openenclave/3rdparty/optee/conf.h>)
 target_include_directories(oeuteeasm PRIVATE
   ${OE_TZ_LIBUTEE_INC}
   ${OE_TZ_LIBUTILS_EXT_INC})
@@ -32,7 +33,8 @@ add_library(oeutee
   ${OE_TZ_LIBUTILS_EXT_SRC}/consttime_memcmp.c)
 set_property(TARGET oeutee PROPERTY C_STANDARD 99)
 target_compile_options(oeutee PUBLIC
-  -include ${OE_TZ_TA_DEV_KIT_CONF})
+  $<BUILD_INTERFACE:-include ${OE_TZ_TA_DEV_KIT_CONF}>
+  $<INSTALL_INTERFACE:-include openenclave/3rdparty/optee/conf.h>)
 target_include_directories(oeutee PRIVATE
   ${OE_TZ_LIBUTEE_SRC}
   ${OE_TZ_LIBUTEE_INC}
@@ -88,7 +90,7 @@ add_dependencies(oelibutee_includes oelibutee_includes_copy)
 target_include_directories(oelibutee_includes
   INTERFACE
   $<BUILD_INTERFACE:${OEUTEE_DIR}>
-  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/optee/liboeutee>)
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/optee/liboeutee>)
 
 add_library(oelibutee INTERFACE)
 
@@ -100,7 +102,10 @@ target_link_libraries(oelibutee INTERFACE
 install(TARGETS oelibutee oelibutee_includes EXPORT openenclave-targets)
 
 install(DIRECTORY ${OEUTEE_DIR}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/optee/liboeutee)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/optee)
+
+install(FILES ${OE_TZ_TA_DEV_KIT_CONF}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/optee)
 
 install(TARGETS oeutee oeuteeasm EXPORT openenclave-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/cmake/add_enclave.cmake
+++ b/cmake/add_enclave.cmake
@@ -228,8 +228,8 @@ macro(add_enclave_optee)
   # Set linker options.
   # NOTE: This has to be at the end, apparently:
   #       https://gitlab.kitware.com/cmake/cmake/issues/17210
-  set(CMAKE_EXE_LINKER_FLAGS "-T ${TA_LINKER_SCRIPT} -L${LIBGCC_PATH}")
+  set(CMAKE_EXE_LINKER_FLAGS "-T ${TA_LINKER_SCRIPT} -L${LIBGCC_PATH} --entry=_start")
   if(ENCLAVE_CXX)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --eh-frame-hdr --entry=_start")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --eh-frame-hdr")
   endif()
 endmacro()

--- a/include/openenclave/bits/optee/opteeproperties.h
+++ b/include/openenclave/bits/optee/opteeproperties.h
@@ -12,7 +12,6 @@
 #define _OE_BITS_OPTEE_OPTEEPROPERTIES_H
 
 #include <openenclave/bits/defs.h>
-#include <openenclave/corelibc/bits/defs.h>
 
 OE_EXTERNC_BEGIN
 


### PR DESCRIPTION
Up to this point, no-one has attempted to build a DEB package from a build of the SDK targeting OP-TEE on ARM TrustZone. Seeing as I am working to enable the VS Code extension for Open Enclave to work against the `master` branch, using the CMake configuration files that the packaging process generates became desirable. This way, using CMake, one can target Intel SGX and both OP-TEE / ARM TrustZone platforms without needing to make any code changes anywhere.

This PR fixes a few mistakes in the files that configure the build for OP-TEE on ARM TrustZone. More specifically, it ensures that the resulting binary outputs and CMake configuration files are coherent.