### PR TITLE
Ignore ~/.gdbinit when running oegdb tests

### DIFF
--- a/tests/debugger/oegdb/CMakeLists.txt
+++ b/tests/debugger/oegdb/CMakeLists.txt
@@ -8,6 +8,7 @@ add_test(
     NAME oegdb-test
     COMMAND
         ${OE_BINDIR}/oegdb --batch
+        -nh # Do not use user's gdbinit
         --command=${CMAKE_CURRENT_SOURCE_DIR}/commands.gdb
         --return-child-result # This fails the test in case of any error.
         -arg host/oe_gdb_test_host enc/oe_gdb_test_enc
@@ -17,6 +18,7 @@ add_test(
     NAME oegdb-test-simulation-mode
     COMMAND
         ${OE_BINDIR}/oegdb --batch
+        -nh # Do not use user's gdbinit
         --command=${CMAKE_CURRENT_SOURCE_DIR}/commands.gdb
         --return-child-result # This fails the test in case of any error.
         -arg host/oe_gdb_test_host enc/oe_gdb_test_enc --simulation-mode


### PR DESCRIPTION
The oegdb tests fail when using some popular gdbinit plugins such as gdb-dashboard. Because this test does some python scripting in gdb, simply disable running with the user's .gdbinit file.