### PR TITLE
[Ansible] Use the cached node Windows MSI installer

### DIFF
--- a/scripts/ansible/oe-windows-acc-setup.yml
+++ b/scripts/ansible/oe-windows-acc-setup.yml
@@ -18,7 +18,7 @@
         seven_zip_hash:      "F00E1588ED54DDF633D8652EB89D0A8F95BD80CCCFC3EED362D81927BEC05AA5"
         vs_buildtools:       "https://oejenkins.blob.core.windows.net/oejenkins/vs_buildtools_2017.exe"
         vs_buildtools_hash:  "6F49872B04A0EAEDF5ED96AB25F7697062D81A419D45D9970E41784F31165BF2"
-        node_url:            "https://nodejs.org/dist/v10.16.3/node-v10.16.3-x64.msi"
+        node_url:            "https://oejenkins.blob.core.windows.net/oejenkins/node-v10.16.3-x64.msi"
         node_hash:           "f68b75eea46232adb8fd38126c977dc244166d29e7c6cd2df930b460c38590a9"
         clang7_url:          "https://oejenkins.blob.core.windows.net/oejenkins/LLVM-7.0.1-win64.exe"
         clang7_hash:         "672E4C420D6543A8A9F8EC5F1E5F283D88AC2155EF4C57232A399160A02BFF57"


### PR DESCRIPTION
The MSI installer has been already cached before this change.

Closes https://github.com/openenclave/openenclave/issues/2243

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>