### PR TITLE
Add continuation hook mechanism to the oe vectored exception handler

### DIFF
--- a/enclave/core/sgx/exception.c
+++ b/enclave/core/sgx/exception.c
@@ -279,6 +279,9 @@ void oe_real_exception_dispatcher(oe_context_t* oe_context)
         td->host_rbp = td->host_previous_rbp;
         td->host_rsp = td->host_previous_rsp;
 
+        if (oe_exception_record.continuation_callback)
+            oe_exception_record.continuation_callback(&oe_exception_record);
+
         oe_continue_execution(oe_exception_record.context);
 
         // Code should never run to here.

--- a/include/openenclave/bits/exception.h
+++ b/include/openenclave/bits/exception.h
@@ -134,6 +134,20 @@ typedef struct _oe_context
 } oe_context_t;
 /**< typedef struct _oe_context oe_context_t*/
 
+// Forward declaration of _oe_exception_record_t for use by
+// oe_vectored_exception_handler_t
+struct _oe_exception_record;
+
+/**
+ * oe_vectored_exception_handler_t - Function pointer for a vectored exception
+ * handler in an enclave.
+ * @param exception_context The record of exception information to be handled by
+ * the function which includes any flags, the failure code, faulting address and
+ * calling context for the exception.
+ */
+typedef uint64_t (*oe_vectored_exception_handler_t)(
+    struct _oe_exception_record* exception_context);
+
 /**
  * Exception context structure with the exception code, flags, address and
  * calling context of the exception.
@@ -147,18 +161,13 @@ typedef struct _oe_exception_record
     uint64_t address; /**< Exception address */
 
     oe_context_t* context; /**< Exception context */
+
+    /*! Optional callback that will be called prior to continuing execution
+     *  but after the pre-exception register state has been restored.
+     *  This is intended to be set in the initial vectored exception handler. */
+    oe_vectored_exception_handler_t continuation_callback;
 } oe_exception_record_t;
 /**< typedef struct _oe_exception_record oe_exception_record_t*/
-
-/**
- * oe_vectored_exception_handler_t - Function pointer for a vectored exception
- * handler in an enclave.
- * @param exception_context The record of exception information to be handled by
- * the function which includes any flags, the failure code, faulting address and
- * calling context for the exception.
- */
-typedef uint64_t (*oe_vectored_exception_handler_t)(
-    oe_exception_record_t* exception_context);
 
 OE_EXTERNC_END
 

--- a/tests/VectorException/VectorException.edl
+++ b/tests/VectorException/VectorException.edl
@@ -4,10 +4,15 @@
 enclave {
     include "openenclave/internal/cpuid.h"
 
+    untrusted {
+        void host_set_exception_handled();
+    };
+
     trusted {
         public int enc_test_vector_exception();
         public void enc_test_cpuid_in_global_constructors();
         public int enc_test_sigill_handling(
             [out] uint32_t cpuid_table[8][4]);
+        public void enc_test_continuation_callback();
     };
 };

--- a/tests/VectorException/enc/CMakeLists.txt
+++ b/tests/VectorException/enc/CMakeLists.txt
@@ -10,7 +10,7 @@ add_custom_command(
 
 # TODO: Does this need CXX?
 add_enclave(TARGET VectorException_enc UUID aa2379e1-ec26-4499-a396-18e9ce2228a4 SOURCES
-    enc.c sigill_handling.c init.cpp VectorException_t.c)
+    enc.c sigill_handling.c continuation_callback.c init.cpp VectorException_t.c)
 
 target_include_directories(VectorException_enc PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/VectorException/enc/continuation_callback.c
+++ b/tests/VectorException/enc/continuation_callback.c
@@ -1,0 +1,45 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/calls.h>
+
+#include "VectorException_t.h"
+
+#define OE_UD2_OPCODE 0x0b0f
+
+void call_illegal_instruction()
+{
+    asm volatile("ud2;");
+}
+
+uint64_t continuation_callback(oe_exception_record_t* record)
+{
+    record->context->rip += 2;
+
+    // OCalls can be make in the continuation callback
+    host_set_exception_handled();
+
+    return 0;
+}
+
+uint64_t handler(oe_exception_record_t* record)
+{
+    if (record->code == OE_EXCEPTION_ILLEGAL_INSTRUCTION)
+    {
+        if (*((uint16_t*)record->context->rip) == OE_UD2_OPCODE)
+        {
+            record->continuation_callback = continuation_callback;
+            return OE_EXCEPTION_CONTINUE_EXECUTION;
+        }
+    }
+
+    return OE_EXCEPTION_CONTINUE_SEARCH;
+}
+
+void enc_test_continuation_callback()
+{
+    oe_add_vectored_exception_handler(true, handler);
+    call_illegal_instruction();
+    oe_remove_vectored_exception_handler(handler);
+}

--- a/tests/VectorException/host/host.c
+++ b/tests/VectorException/host/host.c
@@ -111,6 +111,18 @@ void test_sigill_handling(oe_enclave_t* enclave)
     }
 }
 
+static bool _exception_handled = false;
+void test_continuation_callback(oe_enclave_t* enclave)
+{
+    enc_test_continuation_callback(enclave);
+    OE_TEST(_exception_handled);
+}
+
+void host_set_exception_handled()
+{
+    _exception_handled = true;
+}
+
 int main(int argc, const char* argv[])
 {
     oe_result_t result;
@@ -143,6 +155,7 @@ int main(int argc, const char* argv[])
 
     test_vector_exception(enclave);
     test_sigill_handling(enclave);
+    test_continuation_callback(enclave);
 
     oe_terminate_enclave(enclave);
 


### PR DESCRIPTION
Currently the OE vectored exception handler is called before the execution context is restored to the pre-exception state. Add a way to inject a callback which is called after the execution context has been restored. This enables more complicated operations such as making OCalls.

@mikbras This is a modified version of your initial implementation that attempts to unify the exception handling mechanisms so that the use case for each is clear to the developer.