### PR TITLE
Publish return code defines for vectored exception handling

### DIFF
--- a/include/openenclave/bits/exception.h
+++ b/include/openenclave/bits/exception.h
@@ -16,6 +16,14 @@
 
 OE_EXTERNC_BEGIN
 
+/** Return value used by an enclave vectored exception handler to indicate
+ *  to the dispatcher that it should continue searching for the next handler. */
+#define OE_EXCEPTION_CONTINUE_SEARCH 0x0
+
+/** Return value used by an enclave vectored exception handler to indicate
+ *  to the dispatcher that it should stop searching and continue execution. */
+#define OE_EXCEPTION_CONTINUE_EXECUTION 0xFFFFFFFF
+
 /**
  * Divider exception code, used by vectored exception handler.
  */

--- a/include/openenclave/internal/calls.h
+++ b/include/openenclave/internal/calls.h
@@ -95,9 +95,6 @@ typedef enum _oe_func
 
 OE_STATIC_ASSERT(sizeof(oe_func_t) == sizeof(unsigned int));
 
-#define OE_EXCEPTION_CONTINUE_SEARCH 0x0
-#define OE_EXCEPTION_CONTINUE_EXECUTION 0xFFFFFFFF
-
 /*
 **==============================================================================
 **


### PR DESCRIPTION
The vectored exception handling feature is published as a public API but the return code defines OE_EXCEPTION_CONTINUE_SEARCH and OE_EXCEPTION_CONTINUE_EXECUTION are in internal headers. Move these to enclave.h where oe_add_vectored_exception_handler resides.