### PR TITLE
Update libc-test to the latest version

### DIFF
--- a/3rdparty/musl/README.md
+++ b/3rdparty/musl/README.md
@@ -1,12 +1,21 @@
-musl libc:
-==========
+# Musl libc and libc-test projects
 
-This directory contains **musl libc**, obtained from this URL.
+This directory contains the musl libc library and acompanying libc-test test
+suite.
 
-```
-https://www.musl-libc.org/releases/musl-1.1.19.tar.gz
-```
+See `./update.make` for specific information regarding the source and version
+of these projects.
+
+## musl libc:
+
+This directory contains **musl libc**
 
 Typing **make** installs the source tree under the build directory and
 applies patches to it. Nothing is built though, as building is performed
 from the **libc** directory.
+
+## libc-test:
+
+libc-test is a generic libc testing framework.
+
+Building for OE tests is performed from tests/libc/CMakeLists.txt.

--- a/3rdparty/musl/libc-test/Makefile
+++ b/3rdparty/musl/libc-test/Makefile
@@ -117,14 +117,14 @@ api/main.OBJS:=$(api.OBJS)
 $(api.OBJS):$(B)/common/options.h
 $(api.OBJS):CFLAGS+=-pedantic-errors -Werror -Wno-unused -D_XOPEN_SOURCE=700
 
-all:$(B)/REPORT
-run:$(B)/REPORT
+all run: $(B)/REPORT
+	grep FAIL $< || echo PASS
 clean:
 	rm -f $(OBJS) $(BINS) $(LIBS) $(B)/common/libtest.a $(B)/common/runtest.exe $(B)/common/options.h $(B)/*/*.err
 cleanall: clean
 	rm -f $(B)/REPORT $(B)/*/REPORT
 $(B)/REPORT:
-	cat $^ |tee $@
+	cat $^ >$@
 
 $(B)/%.o:: src/%.c
 	$(CC) $(CFLAGS) $($*.CFLAGS) -c -o $@ $< 2>$@.err || echo BUILDERROR $@; cat $@.err

--- a/3rdparty/musl/libc-test/src/common/mtest.h
+++ b/3rdparty/musl/libc-test/src/common/mtest.h
@@ -122,7 +122,8 @@ static int checkulp(float d, int r)
 	// TODO: we only care about >=1.5 ulp errors for now, should be 1.0
 	if (r == RN)
 		return fabsf(d) < 1.5;
-	return 1;
+	// accept larger error in non-nearest rounding mode
+	return fabsf(d) < 3.0;
 }
 
 static int checkcr(long double y, long double ywant, int r)

--- a/3rdparty/musl/libc-test/src/functional/ipc_msg.c
+++ b/3rdparty/musl/libc-test/src/functional/ipc_msg.c
@@ -61,12 +61,12 @@ static void snd()
 	EQ(qid_ds.msg_qnum, 0, "got %d, want %d");
 	EQ(qid_ds.msg_lspid, 0, "got %d, want %d");
 	EQ(qid_ds.msg_lrpid, 0, "got %d, want %d");
-	EQ((long)qid_ds.msg_stime, 0, "got %ld, want %d");
-	EQ((long)qid_ds.msg_rtime, 0, "got %ld, want %d");
+	EQ((long long)qid_ds.msg_stime, 0, "got %lld, want %d");
+	EQ((long long)qid_ds.msg_rtime, 0, "got %lld, want %d");
 	if (qid_ds.msg_ctime < t)
-		t_error("qid_ds.msg_ctime >= t failed: got %ld, want >= %ld\n", (long)qid_ds.msg_ctime, (long)t);
+		t_error("qid_ds.msg_ctime >= t failed: got %lld, want >= %lld\n", (long long)qid_ds.msg_ctime, (long long)t);
 	if (qid_ds.msg_ctime > t+5)
-		t_error("qid_ds.msg_ctime <= t+5 failed: got %ld, want <= %ld\n", (long)qid_ds.msg_ctime, (long)t+5);
+		t_error("qid_ds.msg_ctime <= t+5 failed: got %lld, want <= %lld\n", (long long)qid_ds.msg_ctime, (long long)t+5);
 	if (qid_ds.msg_qbytes <= 0)
 		t_error("qid_ds.msg_qbytes > 0 failed: got %d, want > 0\n", qid_ds.msg_qbytes, t);
 
@@ -76,9 +76,9 @@ static void snd()
 	EQ(qid_ds.msg_qnum, 1, "got %d, want %d");
 	EQ(qid_ds.msg_lspid, getpid(), "got %d, want %d");
 	if (qid_ds.msg_stime < t)
-		t_error("msg_stime is %ld want >= %ld\n", (long)qid_ds.msg_stime, (long)t);
+		t_error("msg_stime is %lld want >= %lld\n", (long long)qid_ds.msg_stime, (long long)t);
 	if (qid_ds.msg_stime > t+5)
-		t_error("msg_stime is %ld want <= %ld\n", (long)qid_ds.msg_stime, (long)t+5);
+		t_error("msg_stime is %lld want <= %lld\n", (long long)qid_ds.msg_stime, (long long)t+5);
 }
 
 static void rcv()

--- a/3rdparty/musl/libc-test/src/functional/ipc_sem.c
+++ b/3rdparty/musl/libc-test/src/functional/ipc_sem.c
@@ -62,11 +62,11 @@ static void inc()
 	EQ(semid_ds.sem_perm.gid, getegid(), "got %d, want %d");
 	EQ(semid_ds.sem_perm.mode & 0x1ff, 0666, "got %o, want %o");
 	EQ(semid_ds.sem_nsems, 1, "got %d, want %d");
-	EQ((long)semid_ds.sem_otime, 0, "got %ld, want %d");
+	EQ((long long)semid_ds.sem_otime, 0, "got %lld, want %d");
 	if (semid_ds.sem_ctime < t)
-		t_error("semid_ds.sem_ctime >= t failed: got %ld, want >= %ld\n", (long)semid_ds.sem_ctime, (long)t);
+		t_error("semid_ds.sem_ctime >= t failed: got %lld, want >= %lld\n", (long long)semid_ds.sem_ctime, (long long)t);
 	if (semid_ds.sem_ctime > t+5)
-		t_error("semid_ds.sem_ctime <= t+5 failed: got %ld, want <= %ld\n", (long)semid_ds.sem_ctime, (long)t+5);
+		t_error("semid_ds.sem_ctime <= t+5 failed: got %lld, want <= %lld\n", (long long)semid_ds.sem_ctime, (long long)t+5);
 
 	/* test sem_op > 0 */
 	sops.sem_num = 0;

--- a/3rdparty/musl/libc-test/src/functional/ipc_shm.c
+++ b/3rdparty/musl/libc-test/src/functional/ipc_shm.c
@@ -59,12 +59,12 @@ static void set()
 	EQ(shmid_ds.shm_lpid, 0, "got %d, want %d");
 	EQ(shmid_ds.shm_cpid, getpid(), "got %d, want %d");
 	EQ((int)shmid_ds.shm_nattch, 0, "got %d, want %d");
-	EQ((long)shmid_ds.shm_atime, 0, "got %ld, want %d");
-	EQ((long)shmid_ds.shm_dtime, 0, "got %ld, want %d");
+	EQ((long long)shmid_ds.shm_atime, 0, "got %lld, want %d");
+	EQ((long long)shmid_ds.shm_dtime, 0, "got %lld, want %d");
 	if (shmid_ds.shm_ctime < t)
-		t_error("shmid_ds.shm_ctime >= t failed: got %ld, want >= %ld\n", (long)shmid_ds.shm_ctime, (long)t);
+		t_error("shmid_ds.shm_ctime >= t failed: got %lld, want >= %lld\n", (long long)shmid_ds.shm_ctime, (long long)t);
 	if (shmid_ds.shm_ctime > t+5)
-		t_error("shmid_ds.shm_ctime <= t+5 failed: got %ld, want <= %ld\n", (long)shmid_ds.shm_ctime, (long)t+5);
+		t_error("shmid_ds.shm_ctime <= t+5 failed: got %lld, want <= %lld\n", (long long)shmid_ds.shm_ctime, (long long)t+5);
 
 	/* test attach */
 	if ((p=shmat(shmid, 0, 0)) == 0)
@@ -73,9 +73,9 @@ static void set()
 	EQ((int)shmid_ds.shm_nattch, 1, "got %d, want %d");
 	EQ(shmid_ds.shm_lpid, getpid(), "got %d, want %d");
 	if (shmid_ds.shm_atime < t)
-		t_error("shm_atime is %ld want >= %ld\n", (long)shmid_ds.shm_atime, (long)t);
+		t_error("shm_atime is %lld want >= %lld\n", (long long)shmid_ds.shm_atime, (long long)t);
 	if (shmid_ds.shm_atime > t+5)
-		t_error("shm_atime is %ld want <= %ld\n", (long)shmid_ds.shm_atime, (long)t+5);
+		t_error("shm_atime is %lld want <= %lld\n", (long long)shmid_ds.shm_atime, (long long)t+5);
 	strcpy(p, "test data");
 	T(shmdt(p));
 }

--- a/3rdparty/musl/libc-test/src/functional/pthread_mutex_pi.c
+++ b/3rdparty/musl/libc-test/src/functional/pthread_mutex_pi.c
@@ -1,0 +1,168 @@
+/* testing pthread mutex behaviour with various attributes */
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include "test.h"
+
+#define T(f) if ((r=(f))) t_error(#f " failed: %s\n", strerror(r))
+#define E(f) if (f) t_error(#f " failed: %s\n", strerror(errno))
+
+static void *relock(void *arg)
+{
+	void **a = arg;
+	int r;
+
+	T(pthread_mutex_lock(a[0]));
+	E(sem_post(a[1]));
+	*(int*)a[2] = pthread_mutex_lock(a[0]);
+	E(sem_post(a[1]));
+
+	T(pthread_mutex_unlock(a[0]));
+	if (*(int*)a[2] == 0)
+		T(pthread_mutex_unlock(a[0]));
+	return 0;
+}
+
+static int test_relock(int mtype)
+{
+	struct timespec ts;
+	pthread_t t;
+	pthread_mutex_t m;
+	pthread_mutexattr_t ma;
+	sem_t s;
+	int i;
+	int r;
+	void *p;
+	void *a[] = {&m,&s,&i};
+
+	T(pthread_mutexattr_init(&ma));
+	T(pthread_mutexattr_settype(&ma, mtype));
+	T(pthread_mutexattr_setprotocol(&ma, PTHREAD_PRIO_INHERIT));
+	T(pthread_mutex_init(a[0], &ma));
+	T(pthread_mutexattr_destroy(&ma));
+	E(sem_init(a[1], 0, 0));
+	T(pthread_create(&t, 0, relock, a));
+	E(sem_wait(a[1]));
+	E(clock_gettime(CLOCK_REALTIME, &ts));
+	ts.tv_nsec += 100*1000*1000;
+	if (ts.tv_nsec >= 1000*1000*1000) {
+		ts.tv_nsec -= 1000*1000*1000;
+		ts.tv_sec += 1;
+	}
+	r = sem_timedwait(a[1],&ts);
+	if (r == -1) {
+		if (errno != ETIMEDOUT)
+			t_error("sem_timedwait failed with unexpected error: %s\n", strerror(errno));
+		/* leave the deadlocked relock thread running */
+		return -1;
+	}
+	T(pthread_join(t, &p));
+	T(pthread_mutex_destroy(a[0]));
+	E(sem_destroy(a[1]));
+	return i;
+}
+
+static void *unlock(void *arg)
+{
+	void **a = arg;
+
+	*(int*)a[1] = pthread_mutex_unlock(a[0]);
+	return 0;
+}
+
+static int test_unlock(int mtype)
+{
+	pthread_t t;
+	pthread_mutex_t m;
+	pthread_mutexattr_t ma;
+	int i;
+	int r;
+	void *p;
+	void *a[] = {&m,&i};
+
+	T(pthread_mutexattr_init(&ma));
+	T(pthread_mutexattr_settype(&ma, mtype));
+	T(pthread_mutexattr_setprotocol(&ma, PTHREAD_PRIO_INHERIT));
+	T(pthread_mutex_init(a[0], &ma));
+	T(pthread_mutexattr_destroy(&ma));
+	T(pthread_create(&t, 0, unlock, a));
+	T(pthread_join(t, &p));
+	T(pthread_mutex_destroy(a[0]));
+	return i;
+}
+
+static int test_unlock_other(int mtype)
+{
+	pthread_t t;
+	pthread_mutex_t m;
+	pthread_mutexattr_t ma;
+	int i;
+	int r;
+	void *p;
+	void *a[] = {&m,&i};
+
+	T(pthread_mutexattr_init(&ma));
+	T(pthread_mutexattr_settype(&ma, mtype));
+	T(pthread_mutexattr_setprotocol(&ma, PTHREAD_PRIO_INHERIT));
+	T(pthread_mutex_init(a[0], &ma));
+	T(pthread_mutexattr_destroy(&ma));
+	T(pthread_mutex_lock(a[0]));
+	T(pthread_create(&t, 0, unlock, a));
+	T(pthread_join(t, &p));
+	T(pthread_mutex_unlock(a[0]));
+	T(pthread_mutex_destroy(a[0]));
+	return i;
+}
+
+static void test_mutexattr()
+{
+	pthread_mutex_t m;
+	pthread_mutexattr_t a;
+	int r;
+	int i;
+
+	T(pthread_mutexattr_init(&a));
+	T(pthread_mutexattr_gettype(&a, &i));
+	if (i != PTHREAD_MUTEX_DEFAULT)
+		t_error("default mutex type is %d, wanted PTHREAD_MUTEX_DEFAULT (%d)\n", i, PTHREAD_MUTEX_DEFAULT);
+	T(pthread_mutexattr_settype(&a, PTHREAD_MUTEX_ERRORCHECK));
+	T(pthread_mutexattr_gettype(&a, &i));
+	if (i != PTHREAD_MUTEX_ERRORCHECK)
+		t_error("setting error check mutex type failed failed: got %d, wanted %d\n", i, PTHREAD_MUTEX_ERRORCHECK);
+	T(pthread_mutexattr_destroy(&a));
+}
+
+int main(void)
+{
+	int i;
+
+	test_mutexattr();
+
+	i = test_relock(PTHREAD_MUTEX_NORMAL);
+	if (i != -1)
+		t_error("PTHREAD_MUTEX_NORMAL relock did not deadlock, got %s\n", strerror(i));
+	i = test_relock(PTHREAD_MUTEX_ERRORCHECK);
+	if (i != EDEADLK)
+		t_error("PTHREAD_MUTEX_ERRORCHECK relock did not return EDEADLK, got %s\n", i==-1?"deadlock":strerror(i));
+	i = test_relock(PTHREAD_MUTEX_RECURSIVE);
+	if (i != 0)
+		t_error("PTHREAD_MUTEX_RECURSIVE relock did not succed, got %s\n", i==-1?"deadlock":strerror(i));
+
+	i = test_unlock(PTHREAD_MUTEX_ERRORCHECK);
+	if (i != EPERM)
+		t_error("PTHREAD_MUTEX_ERRORCHECK unlock did not return EPERM, got %s\n", strerror(i));
+	i = test_unlock(PTHREAD_MUTEX_RECURSIVE);
+	if (i != EPERM)
+		t_error("PTHREAD_MUTEX_RECURSIVE unlock did not return EPERM, got %s\n", strerror(i));
+
+	i = test_unlock_other(PTHREAD_MUTEX_ERRORCHECK);
+	if (i != EPERM)
+		t_error("PTHREAD_MUTEX_ERRORCHECK unlock did not return EPERM, got %s\n", strerror(i));
+	i = test_unlock_other(PTHREAD_MUTEX_RECURSIVE);
+	if (i != EPERM)
+		t_error("PTHREAD_MUTEX_RECURSIVE unlock did not return EPERM, got %s\n", strerror(i));
+
+	return t_status;
+}

--- a/3rdparty/musl/libc-test/src/functional/tls_local_exec.c
+++ b/3rdparty/musl/libc-test/src/functional/tls_local_exec.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <string.h>
 #include <pthread.h>
 #include "test.h"
 
@@ -8,6 +9,7 @@ static __thread char d4096 __attribute__ ((aligned(4096))) = 33;
 static __thread char z1 = 0;
 static __thread char z64 __attribute__ ((aligned(64))) = 0;
 static __thread char z4096 __attribute__ ((aligned(4096))) = 0;
+static __thread const char *s1 = "s1";
 
 static int tnum;
 
@@ -39,6 +41,8 @@ static void *check(void *arg)
 
 	CHECK(ptrmod(&z64, 64) == 0, " address is %p, want 64 byte alignment", &z64);
 	CHECK(ptrmod(&z4096, 4096) == 0, " address is %p, want 4096 byte alignment", &z4096);
+
+	CHECK(!strcmp(s1, "s1"), " want s1 got %s", s1);
 	return 0;
 }
 

--- a/3rdparty/musl/libc-test/src/functional/utime.c
+++ b/3rdparty/musl/libc-test/src/functional/utime.c
@@ -1,0 +1,73 @@
+#include <sys/stat.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "test.h"
+
+#define TEST(c, ...) ((c) ? 1 : (t_error(#c" failed: " __VA_ARGS__),0))
+#define TESTVAL(v,op,x) TEST(v op x, "%jd\n", (intmax_t)(v))
+
+int main(void)
+{
+	struct stat st;
+	FILE *f;
+	int fd;
+	time_t t;
+
+	TEST(utimensat(AT_FDCWD, "/dev/null/invalid", ((struct timespec[2]){{.tv_nsec=UTIME_OMIT},{.tv_nsec=UTIME_OMIT}}), 0)==0 || errno==ENOTDIR,
+		"%s\n", strerror(errno));
+	TEST(futimens(-1, ((struct timespec[2]){{.tv_nsec=UTIME_OMIT},{.tv_nsec=UTIME_OMIT}}))==0 || errno==EBADF,
+		"%s\n", strerror(errno));
+
+	if (!TEST(f = tmpfile())) return t_status;
+	fd = fileno(f);
+
+	TEST(futimens(fd, (struct timespec[2]){0}) == 0, "\n");
+	TEST(fstat(fd, &st) == 0, "\n");
+	TESTVAL(st.st_atim.tv_sec,==,0);
+	TESTVAL(st.st_atim.tv_nsec,==,0);
+	TESTVAL(st.st_mtim.tv_sec,==,0);
+	TESTVAL(st.st_mtim.tv_nsec,==,0);
+
+	TEST(futimens(fd, ((struct timespec[2]){{.tv_sec=1,.tv_nsec=UTIME_OMIT},{.tv_sec=1,.tv_nsec=UTIME_OMIT}})) == 0, "\n");
+	TEST(fstat(fd, &st) == 0, "\n");
+	TESTVAL(st.st_atim.tv_sec,==,0);
+	TESTVAL(st.st_atim.tv_nsec,==,0);
+	TESTVAL(st.st_mtim.tv_sec,==,0);
+	TESTVAL(st.st_mtim.tv_nsec,==,0);
+
+	t = time(0);
+
+	TEST(futimens(fd, ((struct timespec[2]){{.tv_nsec=UTIME_NOW},{.tv_nsec=UTIME_OMIT}})) == 0, "\n");
+	TEST(fstat(fd, &st) == 0, "\n");
+	TESTVAL(st.st_atim.tv_sec,>=,t);
+	TESTVAL(st.st_mtim.tv_sec,==,0);
+	TESTVAL(st.st_mtim.tv_nsec,==,0);
+	
+	TEST(futimens(fd, (struct timespec[2]){0}) == 0, "\n");
+	TEST(futimens(fd, ((struct timespec[2]){{.tv_nsec=UTIME_OMIT},{.tv_nsec=UTIME_NOW}})) == 0, "\n");
+	TEST(fstat(fd, &st) == 0, "\n");
+	TESTVAL(st.st_atim.tv_sec,==,0);
+	TESTVAL(st.st_mtim.tv_sec,>=,t);
+
+	TEST(futimens(fd, ((struct timespec[2]){{.tv_nsec=UTIME_NOW},{.tv_nsec=UTIME_OMIT}})) == 0, "\n");
+	TEST(fstat(fd, &st) == 0, "\n");
+	TESTVAL(st.st_atim.tv_sec,>=,t);
+	TESTVAL(st.st_mtim.tv_sec,>=,t);
+
+	if (TEST((time_t)(1LL<<32) == (1LL<<32), "implementation has Y2038 EOL\n")) {
+		if (TEST(futimens(fd, ((struct timespec[2]){{.tv_sec=1LL<<32},{.tv_sec=1LL<<32}})) == 0, "%s\n", strerror(errno))) {
+			TEST(fstat(fd, &st) == 0, "\n");
+			TESTVAL(st.st_atim.tv_sec, ==, 1LL<<32);
+			TESTVAL(st.st_mtim.tv_sec, ==, 1LL<<32);
+		}
+	}
+
+	fclose(f);
+
+	return t_status;
+}

--- a/3rdparty/musl/libc-test/src/math/acosh.c
+++ b/3rdparty/musl/libc-test/src/math/acosh.c
@@ -34,11 +34,12 @@ int main(void)
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
-			// only report at most one <2ulp error
-			if (fabsf(d) < 2 && err) continue;
+			if (fabsf(d) < 2.0f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s acosh(%a) want %a got %a ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/asinh.c
+++ b/3rdparty/musl/libc-test/src/math/asinh.c
@@ -34,11 +34,12 @@ int main(void)
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
-			// only report at most one <2ulp error
-			if (fabsf(d) < 2 && err) continue;
+			if (fabsf(d) < 2.0f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s asinh(%a) want %a got %a ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/ceil.c
+++ b/3rdparty/musl/libc-test/src/math/ceil.c
@@ -27,7 +27,7 @@ int main(void)
 		y = ceil(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s ceil(%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/ceilf.c
+++ b/3rdparty/musl/libc-test/src/math/ceilf.c
@@ -27,7 +27,7 @@ int main(void)
 		y = ceilf(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s ceilf(%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/ceill.c
+++ b/3rdparty/musl/libc-test/src/math/ceill.c
@@ -33,7 +33,7 @@ int main(void)
 		y = ceill(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s ceill(%La)=%La, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/cos.c
+++ b/3rdparty/musl/libc-test/src/math/cos.c
@@ -36,9 +36,12 @@ int main(void)
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (p->r != RN)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s cos(%a) want %a got %a ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/erf.c
+++ b/3rdparty/musl/libc-test/src/math/erf.c
@@ -34,9 +34,12 @@ int main(void)
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (fabs(d) < 4.0f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s erf(%a) want %a got %a ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/erfc.c
+++ b/3rdparty/musl/libc-test/src/math/erfc.c
@@ -34,9 +34,12 @@ int main(void)
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (fabs(d) < 4.0f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s erfc(%a) want %a got %a ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/exp2.c
+++ b/3rdparty/musl/libc-test/src/math/exp2.c
@@ -27,10 +27,13 @@ int main(void)
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
 		if (!checkexcept(e, p->e, p->r)) {
+			if (fabs(y) < 0x1p-1022 && (e|INEXACT) == (INEXACT|UNDERFLOW))
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: bad fp exception: %s exp2(%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));
-			err++;
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {

--- a/3rdparty/musl/libc-test/src/math/expm1l.c
+++ b/3rdparty/musl/libc-test/src/math/expm1l.c
@@ -41,9 +41,12 @@ int main(void)
 		}
 		d = ulperrl(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (fabsf(d) < 2.5f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s expm1l(%La) want %La got %La ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/floor.c
+++ b/3rdparty/musl/libc-test/src/math/floor.c
@@ -27,7 +27,7 @@ int main(void)
 		y = floor(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s floor(%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/floorf.c
+++ b/3rdparty/musl/libc-test/src/math/floorf.c
@@ -27,7 +27,7 @@ int main(void)
 		y = floorf(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s floorf(%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/floorl.c
+++ b/3rdparty/musl/libc-test/src/math/floorl.c
@@ -33,7 +33,7 @@ int main(void)
 		y = floorl(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s floorl(%La)=%La, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/j0.c
+++ b/3rdparty/musl/libc-test/src/math/j0.c
@@ -14,7 +14,7 @@ int main(void)
 	#pragma STDC FENV_ACCESS ON
 	double y;
 	float d;
-	int e, i, err = 0;
+	int e, i, bad, err = 0;
 	struct d_d *p;
 
 	for (i = 0; i < sizeof t/sizeof *t; i++) {
@@ -35,12 +35,12 @@ int main(void)
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
-//			printf("%s:%d: %s j0(%a) want %a got %a ulperr %.3f = %a + %a\n",
-//				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
-			// TODO: avoid spamming the output
-			printf(__FILE__ ": known to be broken near zeros\n");
-			break;
+			if (fabsf(d) < 0x1p52f)
+				printf("X ");
+			else
+				err++;
+			printf("%s:%d: %s j0(%a) want %a got %a ulperr %.3f = %a + %a\n",
+				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/j0f.c
+++ b/3rdparty/musl/libc-test/src/math/j0f.c
@@ -36,12 +36,12 @@ int main(void)
 		}
 		d = ulperrf(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
-//			printf("%s:%d: %s j0f(%a) want %a got %a ulperr %.3f = %a + %a\n",
-//				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
-			// TODO: avoid spamming the output
-			printf(__FILE__ ": known to be broken near zeros\n");
-			break;
+			if (fabsf(d) < 0x1p23f)
+				printf("X ");
+			else
+				err++;
+			printf("%s:%d: %s j0f(%a) want %a got %a ulperr %.3f = %a + %a\n",
+				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/jn.c
+++ b/3rdparty/musl/libc-test/src/math/jn.c
@@ -34,9 +34,12 @@ int main(void)
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (fabsf(d) < 3.0f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s jn(%lld, %a) want %a got %a, ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->i, p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/jnf.c
+++ b/3rdparty/musl/libc-test/src/math/jnf.c
@@ -35,9 +35,12 @@ int main(void)
 		}
 		d = ulperrf(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (fabsf(d) < 3.0f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s jnf(%lld, %a) want %a got %a, ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->i, p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/lgamma.c
+++ b/3rdparty/musl/libc-test/src/math/lgamma.c
@@ -15,7 +15,7 @@ int main(void)
 	int yi;
 	double y;
 	float d;
-	int e, i, err = 0;
+	int e, i, bad, err = 0;
 	struct d_di *p;
 
 	for (i = 0; i < sizeof t/sizeof *t; i++) {
@@ -36,10 +36,14 @@ int main(void)
 			err++;
 		}
 		d = ulperr(y, p->y, p->dy);
-		if (!checkulp(d, p->r) || (!isnan(p->x) && p->x!=-inf && !(p->e&DIVBYZERO) && yi != p->i)) {
+		bad = !isnan(p->x) && p->x!=-inf && !(p->e&DIVBYZERO) && yi != p->i;
+		if (bad || !checkulp(d, p->r)) {
+			if (!bad && fabsf(d) < 11.0f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s lgamma(%a) want %a,%lld got %a,%d ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, p->i, y, yi, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/lgamma_r.c
+++ b/3rdparty/musl/libc-test/src/math/lgamma_r.c
@@ -17,7 +17,7 @@ int main(void)
 	int yi;
 	double y;
 	float d;
-	int e, i, err = 0;
+	int e, i, bad, err = 0;
 	struct d_di *p;
 
 	for (i = 0; i < sizeof t/sizeof *t; i++) {
@@ -37,10 +37,14 @@ int main(void)
 			err++;
 		}
 		d = ulperr(y, p->y, p->dy);
-		if (!checkulp(d, p->r) || (!isnan(p->x) && p->x!=-inf && !(p->e&DIVBYZERO) && yi != p->i)) {
+		bad = !isnan(p->x) && p->x!=-inf && !(p->e&DIVBYZERO) && yi != p->i;
+		if (bad || !checkulp(d, p->r)) {
+			if (!bad && fabsf(d) < 11.0f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s lgamma_r(%a) want %a,%lld got %a,%d ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, p->i, y, yi, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/lgammaf.c
+++ b/3rdparty/musl/libc-test/src/math/lgammaf.c
@@ -17,7 +17,7 @@ int main(void)
 	int yi;
 	double y;
 	float d;
-	int e, i, err = 0;
+	int e, i, bad, err = 0;
 	struct f_fi *p;
 
 	for (i = 0; i < sizeof t/sizeof *t; i++) {
@@ -38,10 +38,14 @@ int main(void)
 			err++;
 		}
 		d = ulperrf(y, p->y, p->dy);
-		if (!checkulp(d, p->r) || (!isnan(p->x) && p->x!=-inf && !(p->e&DIVBYZERO) && yi != p->i)) {
+		bad = !isnan(p->x) && p->x!=-inf && !(p->e&DIVBYZERO) && yi != p->i;
+		if (bad || !checkulp(d, p->r)) {
+			if (!bad && fabsf(d) < 2.0f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s lgammaf(%a) want %a,%lld got %a,%d ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, p->i, y, yi, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/lgammaf_r.c
+++ b/3rdparty/musl/libc-test/src/math/lgammaf_r.c
@@ -17,7 +17,7 @@ int main(void)
 	int yi;
 	double y;
 	float d;
-	int e, i, err = 0;
+	int e, i, bad, err = 0;
 	struct f_fi *p;
 
 	for (i = 0; i < sizeof t/sizeof *t; i++) {
@@ -37,10 +37,14 @@ int main(void)
 			err++;
 		}
 		d = ulperrf(y, p->y, p->dy);
-		if (!checkulp(d, p->r) || (!isnan(p->x) && p->x!=-inf && !(p->e&DIVBYZERO) && yi != p->i)) {
+		bad = !isnan(p->x) && p->x!=-inf && !(p->e&DIVBYZERO) && yi != p->i;
+		if (bad || !checkulp(d, p->r)) {
+			if (!bad && fabsf(d) < 2.0f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s lgammaf_r(%a) want %a,%lld got %a,%d ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, p->i, y, yi, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/llround.c
+++ b/3rdparty/musl/libc-test/src/math/llround.c
@@ -25,7 +25,7 @@ int main(void)
 		yi = llround(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexcept(e, p->e, p->r)) {
+		if (!checkexcept(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s llround(%a)=%lld, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->i, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/llroundf.c
+++ b/3rdparty/musl/libc-test/src/math/llroundf.c
@@ -25,7 +25,7 @@ int main(void)
 		yi = llroundf(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexcept(e, p->e, p->r)) {
+		if (!checkexcept(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s llroundf(%a)=%lld, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->i, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/llroundl.c
+++ b/3rdparty/musl/libc-test/src/math/llroundl.c
@@ -31,7 +31,7 @@ int main(void)
 		yi = llroundl(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexcept(e, p->e, p->r)) {
+		if (!checkexcept(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s llroundl(%La)=%lld, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->i, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/lround.c
+++ b/3rdparty/musl/libc-test/src/math/lround.c
@@ -25,7 +25,7 @@ int main(void)
 		yi = lround(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexcept(e, p->e, p->r)) {
+		if (!checkexcept(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s lround(%a)=%lld, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->i, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/lroundf.c
+++ b/3rdparty/musl/libc-test/src/math/lroundf.c
@@ -25,7 +25,7 @@ int main(void)
 		yi = lroundf(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexcept(e, p->e, p->r)) {
+		if (!checkexcept(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s lroundf(%a)=%lld, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->i, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/lroundl.c
+++ b/3rdparty/musl/libc-test/src/math/lroundl.c
@@ -31,7 +31,7 @@ int main(void)
 		yi = lroundl(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexcept(e, p->e, p->r)) {
+		if (!checkexcept(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s lroundl(%La)=%lld, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->i, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/pow.c
+++ b/3rdparty/musl/libc-test/src/math/pow.c
@@ -29,10 +29,13 @@ int main(void)
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
 		if (!checkexcept(e, p->e, p->r)) {
+			if (fabs(y) < 0x1p-1022 && (e|INEXACT) == (INEXACT|UNDERFLOW))
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: bad fp exception: %s pow(%a,%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->x2, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));
-			err++;
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {

--- a/3rdparty/musl/libc-test/src/math/powf.c
+++ b/3rdparty/musl/libc-test/src/math/powf.c
@@ -28,10 +28,13 @@ int main(void)
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
 		if (!checkexcept(e, p->e, p->r)) {
+			if (fabsf(y) < 0x1p-126f && (e|INEXACT) == (INEXACT|UNDERFLOW))
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: bad fp exception: %s powf(%a,%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->x2, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));
-			err++;
 		}
 		d = ulperrf(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {

--- a/3rdparty/musl/libc-test/src/math/round.c
+++ b/3rdparty/musl/libc-test/src/math/round.c
@@ -26,7 +26,7 @@ int main(void)
 		y = round(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s round(%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/roundf.c
+++ b/3rdparty/musl/libc-test/src/math/roundf.c
@@ -26,7 +26,7 @@ int main(void)
 		y = roundf(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s roundf(%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/roundl.c
+++ b/3rdparty/musl/libc-test/src/math/roundl.c
@@ -32,7 +32,7 @@ int main(void)
 		y = roundl(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s roundl(%La)=%La, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/sin.c
+++ b/3rdparty/musl/libc-test/src/math/sin.c
@@ -36,9 +36,12 @@ int main(void)
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (p->r != RN)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s sin(%a) want %a got %a ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/sinh.c
+++ b/3rdparty/musl/libc-test/src/math/sinh.c
@@ -36,9 +36,12 @@ int main(void)
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (fabsf(d) < 2.0f || p->r != RN)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s sinh(%a) want %a got %a ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/sinhf.c
+++ b/3rdparty/musl/libc-test/src/math/sinhf.c
@@ -35,9 +35,12 @@ int main(void)
 		}
 		d = ulperrf(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (p->r != RN)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s sinhf(%a) want %a got %a ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/sinhl.c
+++ b/3rdparty/musl/libc-test/src/math/sinhl.c
@@ -42,9 +42,12 @@ int main(void)
 		}
 		d = ulperrl(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (fabsf(d) < 5.0f || p->r != RN)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s sinhl(%La) want %La got %La ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/tan.c
+++ b/3rdparty/musl/libc-test/src/math/tan.c
@@ -36,9 +36,12 @@ int main(void)
 		}
 		d = ulperr(y, p->y, p->dy);
 		if (!checkulp(d, p->r)) {
+			if (p->r != RN)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s tan(%a) want %a got %a ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/tgamma.c
+++ b/3rdparty/musl/libc-test/src/math/tgamma.c
@@ -33,11 +33,13 @@ int main(void)
 			err++;
 		}
 		d = ulperr(y, p->y, p->dy);
-		// TODO: 2 ulp errors allowed
-		if (p->r==RN && fabs(d)>2) {
+		if (!checkulp(d, p->r)) {
+			if (fabsf(d) < 5.5f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s tgamma(%a) want %a got %a ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/trunc.c
+++ b/3rdparty/musl/libc-test/src/math/trunc.c
@@ -26,7 +26,7 @@ int main(void)
 		y = trunc(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s trunc(%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/truncf.c
+++ b/3rdparty/musl/libc-test/src/math/truncf.c
@@ -26,7 +26,7 @@ int main(void)
 		y = truncf(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s truncf(%a)=%a, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/truncl.c
+++ b/3rdparty/musl/libc-test/src/math/truncl.c
@@ -32,7 +32,7 @@ int main(void)
 		y = truncl(p->x);
 		e = fetestexcept(INEXACT|INVALID|DIVBYZERO|UNDERFLOW|OVERFLOW);
 
-		if (!checkexceptall(e, p->e, p->r)) {
+		if (!checkexceptall(e, p->e, p->r) && (e|INEXACT) != p->e) {
 			printf("%s:%d: bad fp exception: %s truncl(%La)=%La, want %s",
 				p->file, p->line, rstr(p->r), p->x, p->y, estr(p->e));
 			printf(" got %s\n", estr(e));

--- a/3rdparty/musl/libc-test/src/math/y0.c
+++ b/3rdparty/musl/libc-test/src/math/y0.c
@@ -14,7 +14,7 @@ int main(void)
 	#pragma STDC FENV_ACCESS ON
 	double y;
 	float d;
-	int e, i, err = 0;
+	int e, i, bad, err = 0;
 	struct d_d *p;
 
 	for (i = 0; i < sizeof t/sizeof *t; i++) {
@@ -34,13 +34,14 @@ int main(void)
 			err++;
 		}
 		d = ulperr(y, p->y, p->dy);
-		if ((!(p->x < 0) && !checkulp(d, p->r)) || (p->x < 0 && !isnan(y) && y != -inf)) {
-//			printf("%s:%d: %s y0(%a) want %a got %a ulperr %.3f = %a + %a\n",
-//				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
-			// TODO: avoid spamming the output
-			printf(__FILE__ ": known to be broken near zeros\n");
-			break;
+		bad = p->x < 0 && !isnan(y) && y != -inf;
+		if (bad || (!(p->x < 0) && !checkulp(d, p->r))) {
+			if (!bad && fabsf(d) < 0x1p52f)
+				printf("X ");
+			else
+				err++;
+			printf("%s:%d: %s y0(%a) want %a got %a ulperr %.3f = %a + %a\n",
+				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/y0f.c
+++ b/3rdparty/musl/libc-test/src/math/y0f.c
@@ -15,7 +15,7 @@ int main(void)
 	#pragma STDC FENV_ACCESS ON
 	float y;
 	float d;
-	int e, i, err = 0;
+	int e, i, bad, err = 0;
 	struct f_f *p;
 
 	for (i = 0; i < sizeof t/sizeof *t; i++) {
@@ -35,13 +35,14 @@ int main(void)
 			err++;
 		}
 		d = ulperrf(y, p->y, p->dy);
-		if ((!(p->x < 0) && !checkulp(d, p->r)) || (p->x < 0 && !isnan(y) && y != -inf)) {
-//			printf("%s:%d: %s y0f(%a) want %a got %a ulperr %.3f = %a + %a\n",
-//				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
-			// TODO: avoid spamming the output
-			printf(__FILE__ ": known to be broken near zeros\n");
-			break;
+		bad = p->x < 0 && !isnan(y) && y != -inf;
+		if (bad || (!(p->x < 0) && !checkulp(d, p->r))) {
+			if (!bad && fabsf(d) < 0x1p23f)
+				printf("X ");
+			else
+				err++;
+			printf("%s:%d: %s y0f(%a) want %a got %a ulperr %.3f = %a + %a\n",
+				p->file, p->line, rstr(p->r), p->x, p->y, y, d, d-p->dy, p->dy);
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/math/ynf.c
+++ b/3rdparty/musl/libc-test/src/math/ynf.c
@@ -14,7 +14,7 @@ int main(void)
 	#pragma STDC FENV_ACCESS ON
 	double y;
 	float d;
-	int e, i, err = 0;
+	int e, i, bad, err = 0;
 	struct fi_f *p;
 
 	for (i = 0; i < sizeof t/sizeof *t; i++) {
@@ -34,10 +34,14 @@ int main(void)
 			err++;
 		}
 		d = ulperrf(y, p->y, p->dy);
-		if ((!(p->x < 0) && !checkulp(d, p->r)) || (p->x < 0 && !isnan(y) && y != -inf)) {
+		bad = p->x < 0 && !isnan(y) && y != -inf;
+		if (bad || (!(p->x < 0) && !checkulp(d, p->r))) {
+			if (!bad && fabsf(d) < 2.5f)
+				printf("X ");
+			else
+				err++;
 			printf("%s:%d: %s ynf(%lld, %a) want %a got %a, ulperr %.3f = %a + %a\n",
 				p->file, p->line, rstr(p->r), p->i, p->x, p->y, y, d, d-p->dy, p->dy);
-			err++;
 		}
 	}
 	return !!err;

--- a/3rdparty/musl/libc-test/src/musl/pleval.mk
+++ b/3rdparty/musl/libc-test/src/musl/pleval.mk
@@ -1,0 +1,5 @@
+# suppress warnings, with gcc -Wno-parentheses -Wno-bool-compare is needed
+$(N).CFLAGS := -w
+# do not build and run the dynamic link tests (__pleval is no longer public)
+$(B)/$(N).err:
+	touch $@

--- a/3rdparty/musl/libc-test/src/regression/lseek-large.c
+++ b/3rdparty/musl/libc-test/src/regression/lseek-large.c
@@ -1,0 +1,27 @@
+// lseek should work with >2G offset
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include "test.h"
+
+#define A(c) ((c) || (t_error(#c " failed: %s\n", strerror(errno)), 0))
+
+int main(void)
+{
+	off_t a[] = {0x7fffffff, 0x80000000, 0x80000001, 0xffffffff, 0x100000001, 0x1ffffffff, 0 };
+	off_t r;
+	FILE *f;
+	int fd;
+	int i;
+
+	A((f = tmpfile()) != 0);
+	A((fd = fileno(f)) != -1);
+	for (i = 0; a[i]; i++) {
+		r = lseek(fd, a[i], SEEK_SET);
+		if (r != a[i])
+			t_error("lseek(fd, 0x%llx, SEEK_SET) got 0x%llx\n", (long long)a[i], (long long)r);
+	}
+	return t_status;
+}

--- a/3rdparty/musl/libc-test/src/regression/sscanf-eof.c
+++ b/3rdparty/musl/libc-test/src/regression/sscanf-eof.c
@@ -1,0 +1,18 @@
+// introduced by d6c855caa88ddb1ab6e24e23a14b1e7baf4ba9c7 2018-09-15
+// sscanf may crash on short input
+#include <stdio.h>
+#include "test.h"
+
+int main(void)
+{
+	const char *s = "0";
+	const char *fmt = "%f%c";
+	float f = 1.0f;
+	char c = 'x';
+	int r = sscanf(s, fmt, &f, &c);
+	if (r != 1)
+		t_error("sscanf(\"%s\", \"%s\",..) returned %d, wanted 1\n", s, fmt, r);
+	if (f != 0.0f || c != 'x')
+		t_error("sscanf(\"%s\", \"%s\",..) assigned f=%f c='%c', wanted i=0 c='x'\n", s, fmt, f, c);
+	return t_status;
+}

--- a/3rdparty/musl/libc-test/src/regression/syscall-sign-extend.c
+++ b/3rdparty/musl/libc-test/src/regression/syscall-sign-extend.c
@@ -1,44 +1,26 @@
 // commit 5f95f965e933c5b155db75520ac27c92ddbcf400 2014-03-18
 // syscall should not sign extend pointers on x32
 #define _GNU_SOURCE
-#include <string.h>
 #include <errno.h>
-#include <unistd.h>
-#include <time.h>
+#include <fcntl.h>
+#include <string.h>
 #include <sys/syscall.h>
+#include <unistd.h>
 #include "test.h"
 
-#define T(f) ((f) && (t_error(#f " failed: %s\n", strerror(errno)), 0))
-
-static unsigned long long tsdiff(struct timespec ts2, struct timespec ts)
-{
-	if (ts2.tv_nsec < ts.tv_nsec) {
-		ts2.tv_nsec += 1000000000;
-		ts2.tv_sec--;
-	}
-	if (ts2.tv_sec < ts.tv_sec) {
-		t_error("non-monotonic SYS_clock_gettime vs clock_gettime: %llu ns\n",
-			(ts.tv_sec - ts2.tv_sec)*1000000000ULL + ts.tv_nsec - ts2.tv_nsec);
-		return 0;
-	}
-	return (ts2.tv_sec - ts.tv_sec)*1000000000ULL + (ts2.tv_nsec - ts.tv_nsec);
-}
+#define T(f) (!(f) && (t_error(#f " failed: %s\n", strerror(errno)), 0))
 
 int main(void)
 {
-	struct timespec ts, ts2;
-	unsigned long long diff;
+	char buf[1] = {1};
+	int fd;
+	int r;
 
 	// test syscall with pointer
-	T(syscall(SYS_clock_gettime, CLOCK_REALTIME, &ts));
-
-	// check if timespec is filled correctly
-	T(clock_gettime(CLOCK_REALTIME, &ts2));
-	// adjust because linux vdso is non-monotonic wrt the syscall..
-	ts.tv_nsec += 2;
-	diff = tsdiff(ts2, ts);
-	if (diff > 5 * 1000000000ULL)
-		t_error("large diff between clock_gettime calls: %llu ns\n", diff);
+	T((fd = open("/dev/zero", O_RDONLY)) >= 0);
+	T((r = syscall(SYS_read, fd, buf, 1)) == 1);
+	if (buf[0] != 0)
+		t_error("read %d instead of 0\n", buf[0]);
 
 	return t_status;
 }

--- a/3rdparty/musl/update.make
+++ b/3rdparty/musl/update.make
@@ -21,7 +21,8 @@ update-musl:
 
 update-libc-test:
 	rm -rf libc-test
-	git clone git://nsz.repo.hu:45100/repo/libc-test
+	git clone git://repo.or.cz/libc-test
+	git -C libc-test checkout a51df71b050f3f9dfdc0a7d90978b57277b582ec
 	rm -rf libc-test/.git
 	rm libc-test/.gitignore
 


### PR DESCRIPTION
Update libc-test to revision a51df71b050f3f9dfdc0a7d90978b57277b582ec. This revision contains many fixes for math tests which previously failed.

I will update the tests we run and the `LibcSupport.md` document in a separate PR to make it easier to review.