### PR TITLE
Add validation for packaging

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -209,20 +209,7 @@ def win2016CrossCompile(String build_type, String has_quote_provider = 'OFF') {
     stage("Windows ${build_type} with SGX ${has_quote_provider}") {
         node(node_label) {
             timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                dir("build/X64-${build_type}") {
-
-                  /* We need to copy nuget into the expected location
-                  https://github.com/openenclave/openenclave/blob/a982b46cf440def8fb66e94f2622a4f81e2b350b/host/CMakeLists.txt#L188-L197 */
-
-                  bat """
-                      vcvars64.bat x64 && \
-                      cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=${has_quote_provider} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
-                      ninja.exe && \
-                      ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT_SECONDS}
-                      """
-                }
+                oe.WinCompilePackageTest("build/X64-${build_type}", build_type, has_quote_provider, CTEST_TIMEOUT_SECONDS)
             }
         }
     }

--- a/.jenkins/Packaging.Jenkinsfile
+++ b/.jenkins/Packaging.Jenkinsfile
@@ -33,18 +33,7 @@ def WindowsPackaging(String build_type) {
     stage('Windows SGX1FLC ${build_type}') {
         node('SGXFLC-Windows-DCAP') {
             timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                dir('build') {
-                    bat """
-                        vcvars64.bat x64 && \
-                        cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=ON -DNUGET_PACKAGE_PATH=C:/oe_prereqs -DCPACK_GENERATOR=NuGet -Wdev && \
-                        ninja.exe && \
-                        ctest.exe -V -C RELEASE --timeout ${CTEST_TIMEOUT_SECONDS} && \
-                        cpack.exe -D CPACK_NUGET_COMPONENT_INSTALL=ON -DCPACK_COMPONENTS_ALL=OEHOSTVERIFY && \
-                        cpack.exe
-                        """
-                }
+                oe.WinCompilePackageTest("build", build_type, "ON", CTEST_TIMEOUT_SECONDS)
                 azureUpload(storageCredentialId: 'oe_jenkins_storage_account', filesPath: 'build/*.nupkg', storageType: 'blobstorage', virtualPath: "master/${BUILD_NUMBER}/windows/${build_type}/SGX1FLC/", containerName: 'oejenkins')
                 azureUpload(storageCredentialId: 'oe_jenkins_storage_account', filesPath: 'build/*.nupkg', storageType: 'blobstorage', virtualPath: "master/latest/windows/${build_type}/SGX1FLC/", containerName: 'oejenkins')
             }


### PR DESCRIPTION
The pipeline of openenclave generates NuGet packages on Windows platforms. However, those packages created were not tested before being publicized. Lacking of NuGet package validation has lead to `v0.8.0` being faulty, such that we had to publish a `v0.8.1` as a remediation. This PR is intended to fix this loophole by adding validate steps on top of the NuGet packages that were being created.