### PR TITLE
Workaround for debugger dependency of SDK symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,8 @@ release notes for the set of issues addressed.
 - Ability to debug ELF enclaves on Windows using Windbg/CDB
     - [Visual Studio Code CDB Extension](https://aka.ms/CDBVSCode)
     - [WinDbg Preview](https://aka.ms/WinDbgPreview)
-    - The new oedebugrt.dll binary needs to be copied to the app folder to enable this.
+    - The new oedebugrt.dll and accompanying oedebugrt.pdb need to be copied to the
+      app folder to enable this.
 - Preview support for 64-bit ARM TrustZone-capable boards with OP-TEE OS
   - See the [documentation](docs/GettingStartedDocs/OP-TEE/Introduction.md)
     for the list of supported platforms, features, and known issues.

--- a/cmake/copy_oedebugrt_target.cmake
+++ b/cmake/copy_oedebugrt_target.cmake
@@ -18,12 +18,19 @@ function(copy_oedebugrt_target TARGET_NAME)
     get_property(OEDEBUGRTLOCATION TARGET openenclave::oedebugrt PROPERTY LOCATION)
     # Add copy actions for the dependencies
     add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/oedebugrt.dll ${CMAKE_CURRENT_BINARY_DIR}/oedebugrt.pdb
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/oedebugrt.dll
         DEPENDS ${OEDEBUGRTLOCATION}
         COMMAND ${CMAKE_COMMAND} -E copy ${OEDEBUGRTLOCATION} ${CMAKE_CURRENT_BINARY_DIR})
 
+    get_filename_component(OEDEBUGRTFOLDER "${OEDEBUGRTLOCATION}" DIRECTORY)
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/oedebugrt.pdb
+        DEPENDS ${OEDEBUGRTFOLDER}/oedebugrt.pdb
+        COMMAND ${CMAKE_COMMAND} -E copy ${OEDEBUGRTFOLDER}/oedebugrt.pdb ${CMAKE_CURRENT_BINARY_DIR})
 
     # Always create the requested target, which may have an empty dependency list
-    add_custom_target(${TARGET_NAME} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/oedebugrt.dll)
+    add_custom_target(${TARGET_NAME} DEPENDS 
+      ${CMAKE_CURRENT_BINARY_DIR}/oedebugrt.dll
+      ${CMAKE_CURRENT_BINARY_DIR}/oedebugrt.pdb)
 
 endfunction( copy_oedebugrt_target )

--- a/cmake/copy_oedebugrt_target.cmake
+++ b/cmake/copy_oedebugrt_target.cmake
@@ -18,7 +18,7 @@ function(copy_oedebugrt_target TARGET_NAME)
     get_property(OEDEBUGRTLOCATION TARGET openenclave::oedebugrt PROPERTY LOCATION)
     # Add copy actions for the dependencies
     add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/oedebugrt.dll
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/oedebugrt.dll ${CMAKE_CURRENT_BINARY_DIR}/oedebugrt.pdb
         DEPENDS ${OEDEBUGRTLOCATION}
         COMMAND ${CMAKE_COMMAND} -E copy ${OEDEBUGRTLOCATION} ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/debugger/debugrt/host/CMakeLists.txt
+++ b/debugger/debugrt/host/CMakeLists.txt
@@ -16,6 +16,15 @@ else()
   target_compile_definitions(oedebugrt PRIVATE
     OE_BUILDING_DEBUGRT_SHARED_LIBRARY)
   
+  # oedebugrt must itself have debug symbols for WinDbg to support OE
+  # debugging. Therefore oedebugrt must be compiled with /Zi and oedebugrt.pdb
+  # must be installed alongside oedebugrt.dll.
+  # Note: VS Debugger does not have this requirement. This WinDbg requirement
+  # is temporary.
+  set_target_properties(oedebugrt PROPERTIES
+    COMPILE_FLAGS "/Zi" # Compile with debug information
+    LINK_FLAGS "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF") # Create pdb
+  install(FILES $<TARGET_PDB_FILE:oedebugrt> DESTINATION ${CMAKE_INSTALL_BINDIR})
   install(TARGETS oedebugrt EXPORT openenclave-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -214,6 +214,17 @@ if (OE_SGX AND WIN32)
   # oedebugrt is accessed via a bridge on Win32 and need not be linked.
   list(APPEND PLATFORM_SDK_ONLY_SRC
     sgx/windows/debugrtbridge.c)
+
+  # __oe_dispatch_ocall function must have debug symbols for debuggers to
+  # stitch the ocall stack. Use /Z7 flag to embed the debugging information
+  # in the object file. When a host application is built, the linker will
+  # extract this debugging information and put it in the pdb for the host
+  # application. Using /Z7 avoids having to distribut oehost.pdb.
+  # Note: This is a temporary fix and debuggers will not have this requirement
+  # when ocall stack stitching is also done via the debugger contract.
+  set_source_files_properties(
+    sgx/calls.c
+    PROPERTIES COMPILE_FLAGS "/Z7")
 endif()
 
 # Common host verification files that work on any OS/architecture.


### PR DESCRIPTION
Currently, the Windows debuggers have the following *temporary* requirements.
In the next iterations, these requirments will be removed.

- WinDbg requires debug symbols oeedebugrt.dll. Therefore it must be built with
  debugging information (/Zi compiler flag, /debug linker flag). Additionally,
  oedebugrt.pdb must be distributed.
 - Visual Studio debugger requires debug symbol information for for __oe_dispatch_ocall
  function. Therefore this the file which contains this function (host/sgx/calls.c) is
  compiled with /Z7 flags which causes the object file to contain debug information.
  The object file becomes part of oehost.lib and when an enclave applicaiton is created,
  the linker extracts the debug information from this object file and puts it in the
  application's pdb.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>