### PR TITLE
Nsis

### DIFF
--- a/scripts/ansible/oe-windows-acc-setup.yml
+++ b/scripts/ansible/oe-windows-acc-setup.yml
@@ -30,6 +30,8 @@
         devcon_package_hash: "A38E409617FC89D0BA1224C31E42AF4344013FEA046D2248E4B9E03F67D5908A"
         az_dcap_client_url:  "https://oejenkins.blob.core.windows.net/oejenkins/azure.dcap.windows.0.0.2.nupkg"
         az_dcap_client_hash: "E319A6C2D136FE5EDB8799305F6151B71F4CE4E67D96CA74538D0AD5D2D793F1"
+        nsis_url:            "https://oejenkins.blob.core.windows.net/oejenkins/nsis-3.05-setup.exe"
+        nsis_hash:           "1A3CC9401667547B9B9327A177B13485F7C59C2303D4B6183E7BC9E6C8D6BFDB"
 
     - name: OE setup | Run the install-windows-prereqs.ps1 script (this may take a while)
       script: ../install-windows-prereqs.ps1
@@ -58,6 +60,8 @@
         -DevconHash          "{{ devcon_package_hash }}"
         -AzureDCAPNupkgURL   "{{ az_dcap_client_url }}"
         -AzureDCAPNupkgHash  "{{ az_dcap_client_hash }}"
+        -NSISURL             "{{ nsis_url }}"
+        -NSISHash            "{{ nsis_hash }}"
 
     - name: OE setup | Reboot the node
       win_reboot:

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -32,6 +32,8 @@ Param(
     [string]$AzureDCAPNupkgHash = '79C698B61CADA32F56F26647B96BBB1C00B7409A6646597C7CC2908A57677256',
     [string]$Python3ZipURL = 'https://www.python.org/ftp/python/3.7.4/python-3.7.4-embed-amd64.zip',
     [string]$Python3ZipHash = 'FB65E5CD595AD01049F73B47BC0EE23FD03F0CBADC56CB318990CEE83B37761B',
+    [string]$NSISURL = 'https://oejenkins.blob.core.windows.net/oejenkins/nsis-3.05-setup.exe',
+    [string]$NSISHash = '4E1DB5A7400E348B1B46A4A11B6D9557FD84368E4AD3D4BC4C1BE636C89638AA',
     [Parameter(mandatory=$true)][string]$InstallPath,
     [Parameter(mandatory=$true)][ValidateSet("SGX1FLC", "SGX1", "SGX1FLC-NoDriver")][string]$LaunchConfiguration,
     [Parameter(mandatory=$true)][ValidateSet("None", "Azure")][string]$DCAPClientType
@@ -112,6 +114,11 @@ $PACKAGES = @{
         "url" = $Python3ZipURL
         "hash" = $Python3ZipHash
         "local_file" = Join-Path $PACKAGES_DIRECTORY "Python3.zip"
+    }
+    "nsis" = @{
+        "url" = $NSISURL
+        "hash" = $NSISHash
+        "local_file" = Join-Path $PACKAGES_DIRECTORY "nsis-3.05-setup.exe"
     }
 }
 
@@ -571,6 +578,16 @@ function Install-DCAP-Dependencies {
         }
     }
 
+    function Install-NSIS {
+    $installDir = Join-Path $env:ProgramFiles "nsis"
+
+    $installerArguments = @(
+        '-q', '--a', 'install', '--eula=accept', '--no-progress')
+    Install-Tool -InstallerPath $PACKAGES["nsis"]["local_file"] `
+                 -InstallDirectory $installDir `
+                 -ArgumentList "/S"
+    }
+
     $TEMP_NUGET_DIR = "$PACKAGES_DIRECTORY\Azure_DCAP_Client_nupkg"
     New-Directory -Path $OE_NUGET_DIR -RemoveExisting
     New-Directory -Path $TEMP_NUGET_DIR -RemoveExisting
@@ -647,6 +664,7 @@ try {
     Install-LLVM
     Install-Git
     Install-Shellcheck
+    Install-NSIS
 
     if ($LaunchConfiguration -ne "SGX1FLC-NoDriver")
     {

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -33,7 +33,7 @@ Param(
     [string]$Python3ZipURL = 'https://www.python.org/ftp/python/3.7.4/python-3.7.4-embed-amd64.zip',
     [string]$Python3ZipHash = 'FB65E5CD595AD01049F73B47BC0EE23FD03F0CBADC56CB318990CEE83B37761B',
     [string]$NSISURL = 'https://oejenkins.blob.core.windows.net/oejenkins/nsis-3.05-setup.exe',
-    [string]$NSISHash = '4E1DB5A7400E348B1B46A4A11B6D9557FD84368E4AD3D4BC4C1BE636C89638AA',
+    [string]$NSISHash = '1A3CC9401667547B9B9327A177B13485F7C59C2303D4B6183E7BC9E6C8D6BFDB',
     [Parameter(mandatory=$true)][string]$InstallPath,
     [Parameter(mandatory=$true)][ValidateSet("SGX1FLC", "SGX1", "SGX1FLC-NoDriver")][string]$LaunchConfiguration,
     [Parameter(mandatory=$true)][ValidateSet("None", "Azure")][string]$DCAPClientType
@@ -578,16 +578,6 @@ function Install-DCAP-Dependencies {
         }
     }
 
-    function Install-NSIS {
-    $installDir = Join-Path $env:ProgramFiles "nsis"
-
-    $installerArguments = @(
-        '-q', '--a', 'install', '--eula=accept', '--no-progress')
-    Install-Tool -InstallerPath $PACKAGES["nsis"]["local_file"] `
-                 -InstallDirectory $installDir `
-                 -ArgumentList "/S"
-    }
-
     $TEMP_NUGET_DIR = "$PACKAGES_DIRECTORY\Azure_DCAP_Client_nupkg"
     New-Directory -Path $OE_NUGET_DIR -RemoveExisting
     New-Directory -Path $TEMP_NUGET_DIR -RemoveExisting
@@ -651,6 +641,16 @@ function Install-AzureDCAPWindows {
     pushd "$OE_NUGET_DIR\Azure.DCAP.Windows\script"
     & ".\InstallAzureDCAP.ps1" $targetPath
     popd
+}
+
+function Install-NSIS {
+    $installDir = Join-Path $env:ProgramFiles "nsis"
+
+    $installerArguments = @(
+        '-q', '--a', 'install', '--eula=accept', '--no-progress')
+    Install-Tool -InstallerPath $PACKAGES["nsis"]["local_file"] `
+                 -InstallDirectory $installDir `
+                 -ArgumentList "/S"
 }
 
 try {


### PR DESCRIPTION
We encountered an issue within the CI/CD infrastructure while testing packages. The `makensis` binary tool is needed by `cpack.exe` to rectify this issue and prevent a repetition of this.