### PR TITLE
OE SGX: Add context parameter for ecalls.

### DIFF
--- a/enclave/core/sgx/asmdefs.h
+++ b/enclave/core/sgx/asmdefs.h
@@ -37,6 +37,8 @@
 #define td_oret_arg (td_oret_func + 8)
 #define td_callsites (td_oret_arg + 8)
 #define td_simulate (td_callsites + 8)
+#define td_host_ecall_context (td_simulate + 8)
+#define td_host_previous_ecall_context (td_host_ecall_context + 8)
 
 #define oe_exit_enclave __morestack
 #ifndef __ASSEMBLER__

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -8,6 +8,7 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/atomic.h>
 #include <openenclave/internal/calls.h>
+#include <openenclave/internal/ecall_context.h>
 #include <openenclave/internal/fault.h>
 #include <openenclave/internal/globals.h>
 #include <openenclave/internal/jump.h>
@@ -589,14 +590,13 @@ oe_result_t oe_call_host_function_by_table_id(
         OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Initialize the arguments */
-    args = switchless ? oe_arena_calloc(1, sizeof(*args))
-                      : oe_host_calloc(1, sizeof(*args));
+    args = oe_ecall_context_get_ocall_args();
 
     if (args == NULL)
     {
         /* Fail if the enclave is crashing. */
         OE_CHECK(__oe_enclave_status);
-        OE_RAISE(OE_OUT_OF_MEMORY);
+        OE_RAISE(OE_UNEXPECTED);
     }
 
     args->table_id = table_id;
@@ -644,10 +644,6 @@ oe_result_t oe_call_host_function_by_table_id(
     result = OE_OK;
 
 done:
-    if (!switchless)
-    {
-        oe_host_free(args);
-    }
 
     return result;
 }

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -40,7 +40,7 @@ oe_enter:
 .cfi_startproc
 
 .save_host_registers:
-    // Backup the current host rbp, rsp and context to previous.
+    // Backup the current host rbp, rsp, and context to previous.
     mov %fs:td_host_rbp, %r8
     mov %r8, %fs:td_host_previous_rbp
     mov %fs:td_host_rsp, %r8

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -20,6 +20,7 @@
 //     Registers from host caller of EENTER:
 //         RDI - ARG1
 //         RSI - ARG2
+//         RDX - HOST ECALL CONTEXT
 //
 //     This function performs the following tasks:
 //
@@ -39,23 +40,26 @@ oe_enter:
 .cfi_startproc
 
 .save_host_registers:
-    // Backup the current host rbp and rsp to previous.
+    // Backup the current host rbp, rsp and context to previous.
     mov %fs:td_host_rbp, %r8
     mov %r8, %fs:td_host_previous_rbp
     mov %fs:td_host_rsp, %r8
     mov %r8, %fs:td_host_previous_rsp
+    mov %fs:td_host_ecall_context, %r8
+    mov %r8, %fs:td_host_previous_ecall_context
 
     // Save host registers (restored on EEXIT)
     mov %rcx, %fs:td_host_rcx // host return address here
     mov %rsp, %fs:td_host_rsp
     mov %rbp, %fs:td_host_rbp
+    mov %rdx, %fs:td_host_ecall_context
 
 .determine_entry_type:
     // Check if this is exception dispatching request.
     // exception-dispatching-request-check
     cmp $0, %rax
     jne .exception_entry
-    
+
     // Stop speculative execution at fallthrough of conditional
     // exception-dispatching-request-check.
     lfence
@@ -223,7 +227,7 @@ oe_enter:
     jmp .clear_enclave_registers
 
 .clean_exit:
-    // Stop speculative execution at target of conditional jump 
+    // Stop speculative execution at target of conditional jump
     // after exit-type-check.
     lfence
 

--- a/enclave/core/sgx/exception.c
+++ b/enclave/core/sgx/exception.c
@@ -278,6 +278,7 @@ void oe_real_exception_dispatcher(oe_context_t* oe_context)
         // handling.
         td->host_rbp = td->host_previous_rbp;
         td->host_rsp = td->host_previous_rsp;
+        td->host_ecall_context = td->host_previous_ecall_context;
 
         oe_continue_execution(oe_exception_record.context);
 
@@ -290,6 +291,7 @@ void oe_real_exception_dispatcher(oe_context_t* oe_context)
     // Let the oe_abort to run on the stack where the exception happens.
     td->host_rbp = td->host_previous_rbp;
     td->host_rsp = td->host_previous_rsp;
+    td->host_ecall_context = td->host_previous_ecall_context;
     oe_exception_record.context->rip = (uint64_t)oe_abort;
     oe_continue_execution(oe_exception_record.context);
 
@@ -363,6 +365,7 @@ void oe_virtual_exception_dispatcher(
         // Restore the RBP & RSP as required by return from EENTER
         td->host_rbp = td->host_previous_rbp;
         td->host_rsp = td->host_previous_rsp;
+        td->host_ecall_context = td->host_previous_ecall_context;
 
         // Advance RIP to the next instruction for continuation
         ssa_gpr->rip += 2;

--- a/enclave/core/sgx/hostcalls.c
+++ b/enclave/core/sgx/hostcalls.c
@@ -3,18 +3,78 @@
 
 #include <openenclave/edger8r/enclave.h>
 #include <openenclave/enclave.h>
+#include <openenclave/internal/ecall_context.h>
+#include "td.h"
 
-// Function used by oeedger8r for allocating ocall buffers. This function can be
-// optimized by allocating a buffer for making ocalls and pass it in to the
-// ecall and making it available for use here.
+/**
+ * Validate and fetch this thread's ecall context.
+ */
+static oe_ecall_context_t* _get_ecall_context()
+{
+    td_t* td = oe_get_td();
+    oe_ecall_context_t* ecall_context = td->host_ecall_context;
+    return oe_is_outside_enclave(ecall_context, sizeof(*ecall_context))
+               ? ecall_context
+               : NULL;
+}
+
+/**
+ * Fetch the ocall_args field if an ecall context has been passed in.
+ */
+oe_call_host_function_args_t* oe_ecall_context_get_ocall_args()
+{
+    oe_ecall_context_t* ecall_context = _get_ecall_context();
+    return ecall_context ? &ecall_context->ocall_args : NULL;
+}
+
+/**
+ * Get the ecall context's buffer if it is of an equal or larger size than the
+ * given size.
+ */
+void* oe_ecall_context_get_ocall_buffer(uint64_t size)
+{
+    oe_ecall_context_t* ecall_context = _get_ecall_context();
+    if (ecall_context)
+    {
+        // Copy to volatile variables to prevent TOCTOU attacks.
+        uint8_t* volatile ocall_buffer = ecall_context->ocall_buffer;
+        volatile uint64_t ocall_buffer_size = ecall_context->ocall_buffer_size;
+        if (ocall_buffer_size >= size &&
+            oe_is_outside_enclave(ocall_buffer, ocall_buffer_size))
+            return (void*)ocall_buffer;
+    }
+    return NULL;
+}
+
+// Thread local variable to keep track of whether ecall context's buffer
+// was used for making the current ocall.
+static __thread bool _thread_ecall_context_buffer_used;
+
+// Function used by oeedger8r for allocating ocall buffers.
 void* oe_allocate_ocall_buffer(size_t size)
 {
+    // Fetch the ecall context's ocall buffer if it is equal to or larger than
+    // given size. Use it if available.
+    void* buffer = oe_ecall_context_get_ocall_buffer(size);
+    if (buffer)
+    {
+        _thread_ecall_context_buffer_used = true;
+        return buffer;
+    }
+
+    // Perform host allocation by making an ocall.
+    _thread_ecall_context_buffer_used = false;
     return oe_host_malloc(size);
 }
 
 // Function used by oeedger8r for freeing ocall buffers.
 void oe_free_ocall_buffer(void* buffer)
 {
+    // ecall context's buffer is managed by the host and does not have to be
+    // freed.
+    if (_thread_ecall_context_buffer_used)
+        return;
+
     oe_host_free(buffer);
 }
 

--- a/enclave/core/sgx/td.c
+++ b/enclave/core/sgx/td.c
@@ -31,6 +31,11 @@ OE_STATIC_ASSERT(OE_OFFSETOF(td_t, oret_func) == td_oret_func);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, oret_arg) == td_oret_arg);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, callsites) == td_callsites);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, simulate) == td_simulate);
+OE_STATIC_ASSERT(
+    OE_OFFSETOF(td_t, host_ecall_context) == td_host_ecall_context);
+OE_STATIC_ASSERT(
+    OE_OFFSETOF(td_t, host_previous_ecall_context) ==
+    td_host_previous_ecall_context);
 
 // Static asserts for consistency with
 // debugger/pythonExtension/gdb_sgx_plugin.py

--- a/host/sgx/enter.c
+++ b/host/sgx/enter.c
@@ -76,13 +76,13 @@ static __thread uint8_t _thread_ocall_buffer[16 * 1024];
  * oe_enter Executes the ENCLU instruction and transfers control to the enclave.
  *
  * The ENCLU instruction has the following contract:
- * EENTER(RBX=TCS, RCX=AEP, RDI=ARG1, RSI=ARG2, RDX=ECALL_CONTEXT) contract
+ * EENTER(RBX=TCS, RCX=AEP, RDX=ECALL_CONTEXT, RDI=ARG1, RSI=ARG2) contract
  * Input:
- *       RBX=TCS, RCX=AEP, RDI=ARG1, RSI=ARG2, EDX=ECALL_CONTEXT
+ *       RBX=TCS, RCX=AEP, RDX=ECALL_CONTEXT, RDI=ARG1, RSI=ARG2
  *       RBP=Current host stack rbp,
  *       RSP=Current host stack sp.
  *       All other registers are NOT used/ignored.
- *  Output:
+ * Output:
  *       RDI=ARG1OUT, RSI=ARG2OUT,
  *       RBP, RBP are preserved.
  *       All other Registers are clobbered.

--- a/host/sgx/enter.c
+++ b/host/sgx/enter.c
@@ -70,7 +70,7 @@
  * Thread specific OCALL buffers. Large enough for most ocalls.
  * Note: Currently, quotes are about 10KB.
  */
-static uint8_t __thread _thread_ocall_buffer[16 * 1024];
+static __thread uint8_t _thread_ocall_buffer[16 * 1024];
 
 /**
  * oe_enter Executes the ENCLU instruction and transfers control to the enclave.

--- a/include/openenclave/internal/ecall_context.h
+++ b/include/openenclave/internal/ecall_context.h
@@ -1,0 +1,39 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+#ifndef _OE_INTERNAL_ECALL_CONTEXT_H
+#define _OE_INTERNAL_ECALL_CONTEXT_H
+
+#include <openenclave/bits/defs.h>
+#include <openenclave/bits/result.h>
+#include <openenclave/bits/types.h>
+#include <openenclave/internal/calls.h>
+
+OE_EXTERNC_BEGIN
+
+typedef struct _oe_ecall_context
+{
+    // For debug enclaves, registers values for ocall stack stitching.
+    uint64_t eexit_rbp;
+    uint64_t eexit_rsp;
+    uint64_t eexit_rip;
+
+    // Storage for making ocall
+    oe_call_host_function_args_t ocall_args;
+    uint64_t ocall_buffer_size;
+    uint8_t* ocall_buffer;
+} oe_ecall_context_t;
+
+/**
+ * Fetch the ocall_args field if an ecall context has been passed in.
+ */
+oe_call_host_function_args_t* oe_ecall_context_get_ocall_args();
+
+/**
+ * Get the ecall context's buffer if it is of an equal or larger size than the
+ * given size.
+ */
+void* oe_ecall_context_get_ocall_buffer(uint64_t size);
+
+OE_EXTERNC_END
+
+#endif /* _OE_INTERNAL_ECALL_CONTEXT_H */

--- a/include/openenclave/internal/ecall_context.h
+++ b/include/openenclave/internal/ecall_context.h
@@ -12,11 +12,6 @@ OE_EXTERNC_BEGIN
 
 typedef struct _oe_ecall_context
 {
-    // For debug enclaves, registers values for ocall stack stitching.
-    uint64_t eexit_rbp;
-    uint64_t eexit_rsp;
-    uint64_t eexit_rip;
-
     // Storage for making ocall
     oe_call_host_function_args_t ocall_args;
     uint64_t ocall_buffer_size;

--- a/include/openenclave/internal/sgxtypes.h
+++ b/include/openenclave/internal/sgxtypes.h
@@ -572,7 +572,7 @@ oe_thread_data_t* oe_get_thread_data(void);
 
 #define OE_THREAD_LOCAL_SPACE (OE_PAGE_SIZE)
 
-#define OE_THREAD_SPECIFIC_DATA_SIZE (3840)
+#define OE_THREAD_SPECIFIC_DATA_SIZE (3824)
 
 typedef struct _callsite Callsite;
 
@@ -612,6 +612,10 @@ typedef struct _td
 
     /* Simulation mode is active if non-zero */
     uint64_t simulate;
+
+    /* Host ecall context pointers */
+    struct _oe_ecall_context* host_ecall_context;
+    struct _oe_ecall_context* host_previous_ecall_context;
 
     /* Reserved for thread specific data. */
     uint8_t thread_specific_data[OE_THREAD_SPECIFIC_DATA_SIZE];

--- a/include/openenclave/internal/sgxtypes.h
+++ b/include/openenclave/internal/sgxtypes.h
@@ -572,6 +572,14 @@ oe_thread_data_t* oe_get_thread_data(void);
 
 #define OE_THREAD_LOCAL_SPACE (OE_PAGE_SIZE)
 
+/**
+ * thread_specific_data is the last field in td_t. It takes up any remainaing
+ * space after the declarations of the previous fields.
+ * Its size is equal to
+ *     sizeof(td_t) - OE_OFFSETOF(td_t, thread_specific_data)
+ * Due to the inability to use OE_OFFSETOF on a struct while defining its
+ * members, this value is computed and hard-coded.
+ */
 #define OE_THREAD_SPECIFIC_DATA_SIZE (3824)
 
 typedef struct _callsite Callsite;
@@ -623,6 +631,9 @@ typedef struct _td
 OE_PACK_END
 
 OE_CHECK_SIZE(sizeof(td_t), 4096);
+OE_STATIC_ASSERT(
+    OE_THREAD_SPECIFIC_DATA_SIZE ==
+    sizeof(td_t) - OE_OFFSETOF(td_t, thread_specific_data));
 
 /* Get the thread data object for the current thread */
 td_t* oe_get_td(void);


### PR DESCRIPTION
The host passes in an instance of oe_ecall_context_t to the enclave
when making an ecall. This context can hold information that the enclave
can leverage to efficiently implement different functionality.

- Fast ocalls.
  Currently making an EDL generated ocall involves 4 core ocalls in addition
  to the core ocall to call the host implementation of the ocall.
  The 4 additional ocalls are needed to allocate/free the oe_call_host_function_args_t
  structure as well as to allocate/free the serialized ocall arguments.

  oe_ecall_context_t avoids all these additional ocalls to allocate/free memory.
  The context stores the oe_call_host_function_args_t as well has pointer to a host
  memory buffer for marshaling the serialized ocall inputs and outputs.
  The host memory buffer is allocated in thread local storage and can be large enough
  to accommodate most common ocalls.

- OCall stack stitching
  The context provides a place to store the enclave's exit frame (rbp, rsp, rip).
  A debug enclave can store its exit frame in the context prior to making the eexit
  for the ocall. Host side SDK can then use the exit frame information to stitch
  the ocall stack in place as well as pass it along to oedebugrt.
  This change is part of the debugger contract and will be done in another PR.

This PR addresses #2046. An additional argument (context) is added to the ecall and this in turn allows passing parameters efficiently to ocalls.