### PR TITLE
Enable tests for previously unsupported math functions

### DIFF
--- a/docs/LibcSupport.md
+++ b/docs/LibcSupport.md
@@ -14,7 +14,7 @@ iso646.h | Yes | - |
 limits.h | Yes | - |
 locale.h | Partial | Only basic support for C/POSIX locale |
 malloc.h | Partial | - |
-math.h | Partial | **Unsupported functions:** acosh(), asinh(), fmal(), lgamma(), lgammaf(), sinh(), sinhl(), tgamma() |
+math.h | Partial | **Unsupported functions:** fmal(), tgamma() |
 setjmp.h | Yes | - |
 signal.h | No | - |
 stdalign.h | No | - |
@@ -27,7 +27,7 @@ stdio.h | Partial | All I/O functions implicitly call out to untrusted host. <br
 stdlib.h | Partial | **Unsupported functions:** div(), ldiv(), lldiv() |
 stdnoreturn.h | No | - |
 string.h | Partial | Only basic support for C/POSIX locale. |
-tgmath.h | Partial | **Unsupported functions:** acosh(), asinh(), fmal(), lgamma(), lgamma_r(), scalbn(), scalbnf(), scalbnl(), sinh(), sinhl(), tgamma() |
+tgmath.h | Partial | **Unsupported functions:** fmal(), scalbn(), scalbnf(), scalbnl(), tgamma() |
 pthread.h | Partial | Synchronization primitives are not secure across calls to host. Threads are still scheduled by the untrusted host process and an enclave cannot rely on threads making forward progress. <br> **Supported functions:** <br> _- General:_ pthread_self(), pthread_equal(), pthread_once() <br> _- Spinlock:_ pthread_spin_init(), pthread_spin_lock(), pthread_spin_unlock(), pthread_spin_destroy() <br> _- Mutex:_ pthread_mutexattr_init(), pthread_mutexattr_settype(), pthread_mutexattr_destroy(), pthread_mutex_init(), pthread_mutex_lock(), pthread_mutex_trylock(), pthread_mutex_unlock(), pthread_mutex_destroy() <br> _- RW Lock:_ pthread_rwlock_init(), pthread_rwlock_rdlock(), pthread_rwlock_wrlock(), pthread_rwlock_unlock(), pthread_rwlock_destroy() <br> _- Cond:_ pthread_cond_init(), pthread_cond_wait(), pthread_cond_timedwait(), pthread_cond_signal(), pthread_cond_broadcast(), pthread_cond_destroy() <br> _- Thread local storage:_ pthread_key_create(), pthread_key_delete(), pthread_setspecific(), pthread_getspecific() |
 threads.h | No | - |
 time.h | Partial | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. <br> **Supported functions:** time(), gettimeofday(), clock_gettime(), nanosleep(). _Please note that clock_gettime() only supports CLOCK_REALTIME_ |

--- a/tests/libc/tests.cmake
+++ b/tests/libc/tests.cmake
@@ -48,11 +48,13 @@ set(LIBC_TESTS
     3rdparty/musl/libc-test/src/functional/wcstol.c
     3rdparty/musl/libc-test/src/math/acos.c
     3rdparty/musl/libc-test/src/math/acosf.c
+    3rdparty/musl/libc-test/src/math/acosh.c
     3rdparty/musl/libc-test/src/math/acoshf.c
     3rdparty/musl/libc-test/src/math/acoshl.c
     3rdparty/musl/libc-test/src/math/acosl.c
     3rdparty/musl/libc-test/src/math/asin.c
     3rdparty/musl/libc-test/src/math/asinf.c
+    3rdparty/musl/libc-test/src/math/asinh.c
     3rdparty/musl/libc-test/src/math/asinhf.c
     3rdparty/musl/libc-test/src/math/asinhl.c
     3rdparty/musl/libc-test/src/math/asinl.c
@@ -121,12 +123,18 @@ set(LIBC_TESTS
     3rdparty/musl/libc-test/src/math/hypotf.c
     3rdparty/musl/libc-test/src/math/hypotl.c
     3rdparty/musl/libc-test/src/math/isless.c
+    3rdparty/musl/libc-test/src/math/j0.c
     3rdparty/musl/libc-test/src/math/j0f.c
     3rdparty/musl/libc-test/src/math/j1.c
     3rdparty/musl/libc-test/src/math/j1f.c
+    3rdparty/musl/libc-test/src/math/jn.c
     3rdparty/musl/libc-test/src/math/ldexp.c
     3rdparty/musl/libc-test/src/math/ldexpf.c
     3rdparty/musl/libc-test/src/math/ldexpl.c
+    3rdparty/musl/libc-test/src/math/lgamma.c
+    3rdparty/musl/libc-test/src/math/lgamma_r.c
+    3rdparty/musl/libc-test/src/math/lgammaf.c
+    3rdparty/musl/libc-test/src/math/lgammaf_r.c
     3rdparty/musl/libc-test/src/math/lgammal.c
     3rdparty/musl/libc-test/src/math/lgammal_r.c
     3rdparty/musl/libc-test/src/math/llrint.c
@@ -191,7 +199,9 @@ set(LIBC_TESTS
     3rdparty/musl/libc-test/src/math/sincosf.c
     3rdparty/musl/libc-test/src/math/sincosl.c
     3rdparty/musl/libc-test/src/math/sinf.c
+    3rdparty/musl/libc-test/src/math/sinh.c
     3rdparty/musl/libc-test/src/math/sinhf.c
+    3rdparty/musl/libc-test/src/math/sinhl.c
     3rdparty/musl/libc-test/src/math/sinl.c
     3rdparty/musl/libc-test/src/math/sqrt.c
     3rdparty/musl/libc-test/src/math/sqrtf.c
@@ -314,18 +324,8 @@ if (FALSE)
         3rdparty/musl/libc-test/src/functional/tls_init_dlopen.c
         3rdparty/musl/libc-test/src/functional/tls_local_exec.c
         3rdparty/musl/libc-test/src/functional/vfork.c  # uses fork, execv
-        3rdparty/musl/libc-test/src/math/acosh.c
-        3rdparty/musl/libc-test/src/math/asinh.c
         3rdparty/musl/libc-test/src/math/fmal.c
-        3rdparty/musl/libc-test/src/math/j0.c
-        3rdparty/musl/libc-test/src/math/jn.c
         3rdparty/musl/libc-test/src/math/jnf.c
-        3rdparty/musl/libc-test/src/math/lgamma.c
-        3rdparty/musl/libc-test/src/math/lgammaf.c
-        3rdparty/musl/libc-test/src/math/lgammaf_r.c
-        3rdparty/musl/libc-test/src/math/lgamma_r.c
-        3rdparty/musl/libc-test/src/math/sinh.c
-        3rdparty/musl/libc-test/src/math/sinhl.c
         3rdparty/musl/libc-test/src/math/tgamma.c
         3rdparty/musl/libc-test/src/math/y0.c
         3rdparty/musl/libc-test/src/math/y0f.c


### PR DESCRIPTION
Many libc math tests which failed under the older version of libc-test now succeed. Enable the tests that pass and remove them from the list of unsupported functions in docs/LibcSupport.md.