### PR TITLE
Add test to make an OCall in the enclave Vectored Exception Handler

### DIFF
--- a/tests/VectorException/VectorException.edl
+++ b/tests/VectorException/VectorException.edl
@@ -4,8 +4,13 @@
 enclave {
     include "openenclave/internal/cpuid.h"
 
+    untrusted {
+        void host_set_was_ocall_called();
+    };
+
     trusted {
         public int enc_test_vector_exception();
+        public int enc_test_ocall_in_handler();
         public void enc_test_cpuid_in_global_constructors();
         public int enc_test_sigill_handling(
             [out] uint32_t cpuid_table[8][4]);

--- a/tests/VectorException/host/host.c
+++ b/tests/VectorException/host/host.c
@@ -12,6 +12,12 @@
 
 #define SKIP_RETURN_CODE 2
 
+static bool _was_ocall_called = false;
+void host_set_was_ocall_called()
+{
+    _was_ocall_called = true;
+}
+
 void test_vector_exception(oe_enclave_t* enclave)
 {
     int ret = -1;
@@ -28,6 +34,20 @@ void test_vector_exception(oe_enclave_t* enclave)
     }
 
     OE_TEST(ret == 0);
+}
+
+void test_ocall_in_handler(oe_enclave_t* enclave)
+{
+    int ret = -1;
+    oe_result_t result = enc_test_ocall_in_handler(enclave, &ret);
+
+    if (result != OE_OK)
+    {
+        oe_put_err("enc_test_ocall_in_handler() failed: result=%u", result);
+    }
+
+    OE_TEST(ret == 0);
+    OE_TEST(_was_ocall_called == true);
 }
 
 void test_sigill_handling(oe_enclave_t* enclave)


### PR DESCRIPTION
Add a test function to tests/VectorException to test the ability to make an OCall in the exception handler.