### PR TITLE
Add @advanced doxygen tag support

### DIFF
--- a/docs/refman/CMakeLists.txt
+++ b/docs/refman/CMakeLists.txt
@@ -19,13 +19,11 @@ if (ENABLE_REFMAN)
 
   # Allow @experimental to be used in headers to mark an API as experimental and add it to a list of
   # experimental APIs.
-  set(DOXYGEN_ALIASES
-    "experimental = \\xrefitem experimental \\\"This feature is marked as experimental\\\" \\\"Experimental List\\\""
-    "experimental{1} = \\xrefitem experimental \\\"Experimental\\\" \\\"Experimental List\\\" \\1")
-
-  # Allow @advanced to be used in headers to mark an API as advanced and add it to a list of
+  # Also allow @advanced to be used in headers to mark an API as advanced and add it to a list of
   # advanced APIs.
   set(DOXYGEN_ALIASES
+    "experimental = \\xrefitem experimental \\\"This feature is marked as experimental\\\" \\\"Experimental List\\\""
+    "experimental{1} = \\xrefitem experimental \\\"Experimental\\\" \\\"Experimental List\\\" \\1"
     "advanced = \\xrefitem advanced \\\"This feature is marked as advanced and is not intended for use by apps\\\" \\\"Advanced List\\\"")
 
   # NOTE: These were set to their non-default values in the existing

--- a/docs/refman/CMakeLists.txt
+++ b/docs/refman/CMakeLists.txt
@@ -23,6 +23,11 @@ if (ENABLE_REFMAN)
     "experimental = \\xrefitem experimental \\\"This feature is marked as experimental\\\" \\\"Experimental List\\\""
     "experimental{1} = \\xrefitem experimental \\\"Experimental\\\" \\\"Experimental List\\\" \\1")
 
+  # Allow @advanced to be used in headers to mark an API as advanced and add it to a list of
+  # advanced APIs.
+  set(DOXYGEN_ALIASES
+    "advanced = \\xrefitem advanced \\\"This feature is marked as advanced and is not intended for use by apps\\\" \\\"Advanced List\\\"")
+
   # NOTE: These were set to their non-default values in the existing
   # configuration file, so that configuration has been copied here.
   # However, they may or may not be desired.


### PR DESCRIPTION
Similar to the support for @experimental added in PR #2364,
this PR adds support for @advanced in doxygen to help address
issue #2547.

This change causes a separate "advanced.html" page to be created that has
a list of all advanced APIs. Tagging an API with @advanced then causes
the following notice to show up on that API's own page, with the notice
hotlinked to the advanced.html page:

```
This feature is marked as advanced and is not intended for use by apps:
```

Signed-off-by: Dave Thaler <dthaler@microsoft.com>