### PR TITLE
Rename __cxa_atexit in oecore to oe_cxa_atexit

### DIFF
--- a/enclave/core/atexit.c
+++ b/enclave/core/atexit.c
@@ -56,7 +56,7 @@ static oe_atexit_entry_t* _new_atexit_entry(void (*func)(void*), void* arg)
 /*
 **==============================================================================
 **
-** __cxa_atexit()
+** oe_cxa_atexit()
 **
 **     Installs a function to be invoked upon exit (enclave termination).
 **
@@ -66,7 +66,7 @@ static oe_atexit_entry_t* _new_atexit_entry(void (*func)(void*), void* arg)
 **==============================================================================
 */
 
-int __cxa_atexit(void (*func)(void*), void* arg, void* dso_handle)
+int oe_cxa_atexit(void (*func)(void*), void* arg, void* dso_handle)
 {
     oe_atexit_entry_t* entry;
     OE_UNUSED(dso_handle);
@@ -105,7 +105,7 @@ int oe_atexit(void (*function)(void))
      * is pushed on the stack but then ignored by function(), which expects
      * no arguments.
      */
-    return __cxa_atexit((Function)function, NULL, NULL);
+    return oe_cxa_atexit((Function)function, NULL, NULL);
 }
 
 /*

--- a/enclave/core/atexit.h
+++ b/enclave/core/atexit.h
@@ -12,7 +12,7 @@ int oe_atexit(void (*function)(void));
 
 void oe_call_atexit_functions(void);
 
-int __cxa_atexit(void (*func)(void*), void* arg, void* dso_handle);
+int oe_cxa_atexit(void (*func)(void*), void* arg, void* dso_handle);
 
 OE_EXTERNC_END
 

--- a/enclave/core/init_fini.c
+++ b/enclave/core/init_fini.c
@@ -45,11 +45,11 @@
 **     being constructed, the compiler generates a function that:
 **
 **         (1) Invokes the constructor
-**         (2) Invokes __cxa_atexit() passing it the destructor
+**         (2) Invokes oe_cxa_atexit() passing it the destructor
 **
 **     Note that the FINI_ARRAY (used by oe_call_fini_functions) does not
 **     contain any finalization functions for calling destructors. Instead
-**     the __cxa_atexit() implementation must save the destructor functions
+**     the oe_cxa_atexit() implementation must save the destructor functions
 **     and invoke them on enclave termination.
 **
 **==============================================================================
@@ -99,7 +99,7 @@ void oe_call_init_functions(void)
 **         (1) C functions tagged with __attribute__(destructor)
 **
 **     Note that global C++ destructors are not referenced by the FINI_ARRAY.
-**     Destructors are passed to __cxa_atexit() by invoking functions in the
+**     Destructors are passed to oe_cxa_atexit() by invoking functions in the
 **     INIT_ARRAY (see oe_call_init_functions() for more information).
 **
 **     oe_call_fini_functions() invokes all functions in this array from finish

--- a/enclave/core/optee/gp.c
+++ b/enclave/core/optee/gp.c
@@ -501,7 +501,7 @@ void TA_CloseSessionEntryPoint(void* sess_ctx)
 
 void TA_DestroyEntryPoint(void)
 {
-    /* Call functions installed by __cxa_atexit() and oe_atexit() */
+    /* Call functions installed by oe_cxa_atexit() and oe_atexit() */
     oe_call_atexit_functions();
 
     /* Call all finalization functions */

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -408,7 +408,7 @@ static void _handle_ecall(
         }
         case OE_ECALL_DESTRUCTOR:
         {
-            /* Call functions installed by __cxa_atexit() and oe_atexit() */
+            /* Call functions installed by oe_cxa_atexit() and oe_atexit() */
             oe_call_atexit_functions();
 
             /* Call all finalization functions */

--- a/libc/atexit.c
+++ b/libc/atexit.c
@@ -16,3 +16,10 @@
 #undef OE_NEED_STDC_NAMES
 #undef __UNDEF_OE_NEED_STDC_NAMES
 #endif
+
+extern int oe_cxa_atexit(void (*func)(void*), void* arg, void* dso_handle);
+
+int __cxa_atexit(void (*func)(void*), void* arg, void* dso_handle)
+{
+    return oe_cxa_atexit(func, arg, dso_handle);
+}


### PR DESCRIPTION
Symbols in oecore should not conflict with symbols defined in libc to allow alternate libc implementations to be used without issue.

Retain oe_cxa_atexit implementation so that it can be used by oecore. Modify oelibc to simply call oe_cxa_atexit from __cxa_atexit.