### PR TITLE
[CI/CD] Fix NSIS setup

### DIFF
--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -644,13 +644,12 @@ function Install-AzureDCAPWindows {
 }
 
 function Install-NSIS {
-    $installDir = Join-Path $env:ProgramFiles "nsis"
+    $installDir = Join-Path ${env:ProgramFiles(x86)} "NSIS"
 
-    $installerArguments = @(
-        '-q', '--a', 'install', '--eula=accept', '--no-progress')
     Install-Tool -InstallerPath $PACKAGES["nsis"]["local_file"] `
                  -InstallDirectory $installDir `
-                 -ArgumentList "/S"
+                 -ArgumentList @("/S") `
+                 -EnvironmentPath @($installDir, "${installDir}\Bin")
 }
 
 try {


### PR DESCRIPTION
* Fix install directory path
* Remove redundant `$installerArguments` variable
* Make sure the PATH is correctly updated after installation by using the `-EnvironmentPath` parameter

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>