### PR TITLE
Modify the loader to page-align all source addresses

### DIFF
--- a/host/sgx/elf.c
+++ b/host/sgx/elf.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include "../fopen.h"
+#include "../memalign.h"
 #include "../strings.h"
 
 #define GOTO(LABEL)                                            \
@@ -1923,7 +1924,7 @@ oe_result_t elf64_load_relocations(
     {
         *size_out = oe_round_up_to_page_size(size);
 
-        if (!(*data_out = malloc(*size_out)))
+        if (!(*data_out = oe_memalign(OE_PAGE_SIZE, *size_out)))
         {
             *size_out = 0;
             goto done;

--- a/host/sgx/loadelf.c
+++ b/host/sgx/loadelf.c
@@ -37,7 +37,7 @@ static oe_result_t _free_elf_image(oe_enclave_image_t* image)
 
     if (image->u.elf.segments)
     {
-        free(image->u.elf.segments);
+        oe_memalign_free(image->u.elf.segments);
     }
 
     memset(image, 0, sizeof(*image));
@@ -235,8 +235,12 @@ static oe_result_t _load_elf_image(const char* path, oe_enclave_image_t* image)
     }
 
     /* allocate segments */
-    image->u.elf.segments = (oe_elf_segment_t*)calloc(
-        image->u.elf.num_segments, sizeof(oe_elf_segment_t));
+    image->u.elf.segments = (oe_elf_segment_t*)oe_memalign(
+        OE_PAGE_SIZE, image->u.elf.num_segments * sizeof(oe_elf_segment_t));
+    memset(
+        image->u.elf.segments,
+        0,
+        image->u.elf.num_segments * sizeof(oe_elf_segment_t));
     if (!image->u.elf.segments)
     {
         OE_RAISE(OE_OUT_OF_MEMORY);
@@ -360,7 +364,7 @@ static oe_result_t _load_elf_image(const char* path, oe_enclave_image_t* image)
         sizeof(oe_elf_segment_t),
         _compare_segments);
 
-    /* validate segments are valid */
+    /* check that segments are valid */
     for (i = 0; i < image->u.elf.num_segments - 1; i++)
     {
         const oe_elf_segment_t* seg = &image->u.elf.segments[i];
@@ -415,7 +419,7 @@ static oe_result_t _unload(oe_enclave_image_t* image)
 {
     if (image->u.elf.reloc_data)
     {
-        free(image->u.elf.reloc_data);
+        oe_memalign_free(image->u.elf.reloc_data);
     }
 
     return _free_elf_image(image);

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -605,8 +605,8 @@ oe_result_t oe_sgx_load_enclave_data(
     if (context->state != OE_SGX_LOAD_STATE_ENCLAVE_CREATED)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    /* ADDR must be page aligned */
-    if (addr % OE_PAGE_SIZE)
+    /* addr and src must both be page aligned */
+    if (addr % OE_PAGE_SIZE || src % OE_PAGE_SIZE)
         OE_RAISE(OE_INVALID_PARAMETER);
 
 #if defined(OE_TRACE_MEASURE)

--- a/tests/thread_local/host/host.cpp
+++ b/tests/thread_local/host/host.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <limits.h>
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/elf.h>
 #include <openenclave/internal/error.h>
@@ -75,7 +76,7 @@ int main(int argc, const char* argv[])
 // for the exported scenario as well. Therefore we don't perform the
 // assertion.
 #endif
-        free(relocs);
+        oe_memalign_free(relocs);
     }
 
     const uint32_t flags = oe_get_create_flags();


### PR DESCRIPTION
New revisions of the upstream Linux kernel SGX driver require all source and target addresses to be page-aligned for page loads into the enclave. Allocate the buffer for relocation pages on a page-aligned address to fulfill this requirement for source addresses.

This was tested with v26 of the currently-being-upstreamed driver.