### PR TITLE
Add Jordan to CGC in Committers.md

### DIFF
--- a/docs/Committers.md
+++ b/docs/Committers.md
@@ -35,6 +35,7 @@ Committee Members
 | Andrew Schwartzmeyer | Microsoft   | andschwa@microsoft.com        | andschwa       |
 | Dave Thaler          | Microsoft   | dthaler@microsoft.com         | dthaler        |
 | John Kordich         | Independent | jkordich@gmail.com            | johnkord       |
+| Jordan Hand          | Microsoft   | jorhand@microsoft.com         | jhand2         |
 | Mike Brasher         | Microsoft   | mikbras@microsoft.com         | mikbras        |
 | Radhika Jandhyala    | Microsoft   | radhikaj@microsoft.com        | radhikaj       |
 | Simon Leet           | Microsoft   | simon.leet@microsoft.com      | CodeMonkeyLeet |


### PR DESCRIPTION
Per [2/11/2020 CGC meeting](https://hackmd.io/TOJhJXswQ5yfObq1T659ug#February-11-2020), add Jordan to the CGC list in docs/Committers.md.

Signed-off-by: Simon Leet <simon.leet@microsoft.com>