### PR TITLE
Mark server is ready when it fails to initialize in the tls_e2e test

### DIFF
--- a/tests/tls_e2e/tls_e2e.edl
+++ b/tests/tls_e2e/tls_e2e.edl
@@ -15,5 +15,6 @@ enclave {
     };
     untrusted {
         int server_is_ready();
+        int server_initialization_failed();
     };
 };


### PR DESCRIPTION
The tls_e2e test currently deadlocks if it fails to initialize the server because it never marks the tls server as ready. On server init failure, mark the server as ready so that the client continues execution.

Fixes #2414