### PR TITLE
Refactor edl wrapper files

### DIFF
--- a/enclave/core/sgx/sgx_t_wrapper.c
+++ b/enclave/core/sgx/sgx_t_wrapper.c
@@ -5,9 +5,6 @@
 
 #include <openenclave/enclave.h>
 
-#include <openenclave/corelibc/stdio.h>
-#include <openenclave/corelibc/string.h>
-#include <openenclave/edger8r/enclave.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/thread.h>
 

--- a/enclave/core/tee_t_wrapper.c
+++ b/enclave/core/tee_t_wrapper.c
@@ -1,13 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#define OE_NEED_STDC_NAMES
-
 #include <openenclave/enclave.h>
-
-#include <openenclave/corelibc/stdio.h>
-#include <openenclave/corelibc/string.h>
-#include <openenclave/edger8r/enclave.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/thread.h>
 

--- a/host/sgx/sgx_u_wrapper.c
+++ b/host/sgx/sgx_u_wrapper.c
@@ -3,7 +3,6 @@
 
 #include <openenclave/host.h>
 
-#include <openenclave/edger8r/host.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>
 

--- a/host/syscall_u_wrapper.c
+++ b/host/syscall_u_wrapper.c
@@ -3,7 +3,6 @@
 
 #include <openenclave/host.h>
 
-#include <openenclave/edger8r/host.h>
 #include <openenclave/internal/calls.h>
 #include "hostthread.h"
 

--- a/host/tee_u_wrapper.c
+++ b/host/tee_u_wrapper.c
@@ -3,7 +3,6 @@
 
 #include <openenclave/host.h>
 
-#include <openenclave/edger8r/host.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>
 

--- a/include/openenclave/edger8r/common.h
+++ b/include/openenclave/edger8r/common.h
@@ -66,24 +66,24 @@ done:
     return result;
 }
 
-#define OE_ADD_SIZE(total, size)                                 \
-    do                                                           \
-    {                                                            \
-        if (sizeof(total) > sizeof(size_t) && total > SIZE_MAX)  \
-        {                                                        \
-            _result = OE_INVALID_PARAMETER;                      \
-            goto done;                                           \
-        }                                                        \
-        if (sizeof(size) > sizeof(size_t) && size > SIZE_MAX)    \
-        {                                                        \
-            _result = OE_INVALID_PARAMETER;                      \
-            goto done;                                           \
-        }                                                        \
-        if (oe_add_size((size_t*)&total, (size_t)size) != OE_OK) \
-        {                                                        \
-            _result = OE_INTEGER_OVERFLOW;                       \
-            goto done;                                           \
-        }                                                        \
+#define OE_ADD_SIZE(total, size)                                   \
+    do                                                             \
+    {                                                              \
+        if (sizeof(total) > sizeof(size_t) && total > OE_SIZE_MAX) \
+        {                                                          \
+            _result = OE_INVALID_PARAMETER;                        \
+            goto done;                                             \
+        }                                                          \
+        if (sizeof(size) > sizeof(size_t) && size > OE_SIZE_MAX)   \
+        {                                                          \
+            _result = OE_INVALID_PARAMETER;                        \
+            goto done;                                             \
+        }                                                          \
+        if (oe_add_size((size_t*)&total, (size_t)size) != OE_OK)   \
+        {                                                          \
+            _result = OE_INTEGER_OVERFLOW;                         \
+            goto done;                                             \
+        }                                                          \
     } while (0)
 
 /**

--- a/syscall/syscall_t_wrapper.c
+++ b/syscall/syscall_t_wrapper.c
@@ -6,8 +6,6 @@
 #include <openenclave/enclave.h>
 
 #include <openenclave/corelibc/stdio.h>
-#include <openenclave/corelibc/string.h>
-#include <openenclave/edger8r/enclave.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/thread.h>
 

--- a/tools/oeedger8r/src/Sources.ml
+++ b/tools/oeedger8r/src/Sources.ml
@@ -763,6 +763,8 @@ let generate_trusted (ec : enclave_content) (ep : Intel.Util.edger8r_params) =
   [
     sprintf "#include \"%s_t.h\"" ec.file_shortnm;
     "";
+    "#define OE_NEED_STDC_NAMES";
+    "";
     "#include <openenclave/edger8r/enclave.h>";
     "";
     "#include <stdlib.h>";


### PR DESCRIPTION
All internal edl files have wrappers in order to register ecall and ocall tables since out of the box edl only supports compiling a single edl file per enclave application.

Refactor to rely less on these wrappers with the goal of eventually removing these wrappers entirely.

These wrappers cannot be removed until we publish the edl files with the SDK and require enclave developers to import them into their own EDL.