### PR TITLE
Link all host code with noexecstack

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -452,12 +452,13 @@ add_library(oehostapp INTERFACE)
 target_link_libraries(oehostapp INTERFACE oehost)
 
 if (UNIX)
+  target_link_libraries(oehost INTERFACE
+      -Wl,-z,noexecstack)
   target_link_libraries(oehostapp INTERFACE
-      -rdynamic
-      -Wl,-z,noexecstack)
+      -rdynamic)
   target_link_libraries(oehostverify INTERFACE
-      -rdynamic
-      -Wl,-z,noexecstack)
+      -Wl,-z,noexecstack
+      -rdynamic)
 endif ()
 
 # Install targets


### PR DESCRIPTION
Compile all host code on linux with noexecstack to ensure the stack is not executable.

Not only is this good security practice as the Linux kernel invokes READ_IMPLIES_EXEC on mmap and mprotect for processes with executable stacks, which means read requests will be treated as read/execute requests. The SGX driver however ignores the READ_IMPLIES_EXEC flag when hooking mmap/mprotect calls which can causes spurious failures when attempting to mmap/mprotect enclave pages.