### PR TITLE
[Docs] Update documentation for RHEL 8

### DIFF
--- a/docs/GettingStartedDocs/Contributors/SGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/SGX1FLCGettingStarted.md
@@ -30,14 +30,16 @@ sudo scripts/ansible/install-ansible.sh
 If you are running in an Azure Confidential Compute (ACC) VM and would like to use the attestation features, you should also run the following command from the root of the source tree:
 
 ```bash
-sudo ansible-playbook scripts/ansible/oe-contributors-acc-setup.yml
+ansible-playbook scripts/ansible/oe-contributors-acc-setup.yml
 ```
 
 If you are not running in an ACC VM, you should instead run:
 
 ```bash
-sudo ansible-playbook scripts/ansible/oe-contributors-setup.yml
+ansible-playbook scripts/ansible/oe-contributors-setup.yml
 ```
+
+NOTE: The Ansible playbook commands from above will try and execute tasks with `sudo` rights. Make sure that the user running the playbooks has `sudo` rights, and if it uses a `sudo` password add the following extra parameter `--ask-become-pass`.
 
 ## Build
 

--- a/docs/GettingStartedDocs/Contributors/SGX1GettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/SGX1GettingStarted.md
@@ -3,11 +3,13 @@
 ## Platform requirements
 
 - Ubuntu 16.04-LTS 64-bits
+- Ubuntu 18.04-LTS 64-bits
+- Red Hat Enterprise Linux 8 64-bits
 - SGX1 capable system. Most likely this will be an Intel SkyLake or Intel KabyLake system
 
 ## Clone Open Enclave SDK repo from GitHub
 
-Use the following command to download the source code.
+Use the following command to download the source code (make sure `git` is installed before doing this):
 
 ```bash
 git clone https://github.com/openenclave/openenclave.git
@@ -29,8 +31,10 @@ sudo scripts/ansible/install-ansible.sh
 Run the following command from the root of the source tree:
 
 ```bash
-sudo ansible-playbook scripts/ansible/oe-contributors-setup-sgx1.yml
+ansible-playbook scripts/ansible/oe-contributors-setup-sgx1.yml
 ```
+
+NOTE: The Ansible playbook command from above will try and execute tasks with `sudo` rights. Make sure that the user running the playbook has `sudo` rights, and if it uses a `sudo` password add the following extra parameter `--ask-become-pass`.
 
 ## Build
 

--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -59,4 +59,5 @@ ansible-playbook jenkins-setup.yml
 
 * Ubuntu 16.04
 * Ubuntu 18.04
+* Red Hat Enterprise Linux 8
 * Windows Server 2016 (ACC VM)

--- a/scripts/ansible/install-ansible.sh
+++ b/scripts/ansible/install-ansible.sh
@@ -7,6 +7,14 @@ set -o errexit
 
 DIR=$(dirname "$0")
 
-apt-get update
-apt-get install libssl-dev libffi-dev python3-pip -y
+if which yum > /dev/null; then
+    yum install git python3-pip -y
+elif which apt-get > /dev/null; then
+    apt-get update
+    apt-get install libssl-dev libffi-dev python3-pip -y
+else
+    echo "ERROR: Only these package managers are supported: yum, apt-get"
+    exit 1
+fi
+
 pip3 install -U -r "$DIR/requirements.txt"

--- a/scripts/ansible/remove-ansible.sh
+++ b/scripts/ansible/remove-ansible.sh
@@ -7,6 +7,14 @@ set -o errexit
 
 DIR=$(dirname "$0")
 
-apt-get update
-apt-get install python3-pip -y
+if which yum > /dev/null; then
+    yum install python3-pip -y
+elif which apt-get > /dev/null; then
+    apt-get update
+    apt-get install python3-pip -y
+else
+    echo "ERROR: Only these package managers are supported: yum, apt-get"
+    exit 1
+fi
+
 pip3 uninstall -r "$DIR/requirements.txt" -y


### PR DESCRIPTION
* Make sure that `install-ansible.sh` and `remove-ansible.sh` scripts work on `yum` based operating systems
* Adapt GettingStartedDocs/Contributors for RHEL 8:
  * Add RHEL 8 to the supported platforms
  * When running the Ansible playbooks `sudo` is not required since the playbooks use `become: yes` flag