### PR TITLE
Added a verify report case when the endorsement file is not NULL

### DIFF
--- a/include/openenclave/bits/properties.h
+++ b/include/openenclave/bits/properties.h
@@ -71,6 +71,10 @@ typedef struct _oe_enclave_properties_header
 #endif
 
 /**
+ * @cond DEV
+ */
+
+/**
  * This function sets the minimum value of issue dates of CRL and TCB info
  * accepted by the enclave. CRL and TCB info issued before this date
  * are rejected for attestation.
@@ -86,6 +90,9 @@ oe_result_t __oe_sgx_set_minimum_crl_tcb_issue_date(
     uint32_t minutes,
     uint32_t seconds);
 
+/**
+ * @endcond
+ */
 OE_EXTERNC_END
 
 #endif /* _OE_BITS_PROPERTIES_H */

--- a/tests/host_verify/host/host.cpp
+++ b/tests/host_verify/host/host.cpp
@@ -198,6 +198,29 @@ static int _verify_report(
         _read_binary_file(
             endorsements_filename, &endorsements_data, &endorsements_file_size);
 
+        result = oe_verify_remote_report(
+            report_data,
+            report_file_size,
+            endorsements_data,
+            endorsements_file_size,
+            NULL);
+        if (pass)
+            OE_TEST(result == OE_OK);
+        else
+        {
+            // Note: The failure result code is different between linux vs
+            // windows.
+            //
+            OE_TEST(result != OE_OK);
+            OE_TRACE_INFO(
+                "Report %s verification failed as expected. The generated "
+                "endorsement file is %s. Failure %d(%s)\n",
+                report_filename,
+                endorsements_filename,
+                result,
+                oe_result_str(result));
+        }
+
         result = oe_verify_sgx_quote(
             report_data,
             report_file_size,


### PR DESCRIPTION
Change 1: Added a verify report case when the endorsement file is not NULL. This was missing in the host_verify test.
Change 2: Removing __oe_sgx_set_minimum_crl_tcb_issue_date() from the public document since its a private API. Addressing Issue #2359.