### PR TITLE
Added libsgx-launch package to ansible

### DIFF
--- a/scripts/ansible/roles/linux/intel/tasks/redhat/sgx-packages-install.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/redhat/sgx-packages-install.yml
@@ -43,6 +43,11 @@
     name: "{{ intel_sgx_packages }}"
     state: latest
 
+- name: Install Intel SGX launch package
+  yum:
+    name: "{{ intel_sgx_launch_package }}"
+    state: latest
+
 - name: Cleanup installation
   file:
     path: "/tmp/sgx_rpm_local_repo.tgz"

--- a/scripts/ansible/roles/linux/intel/tasks/ubuntu/sgx-packages-install.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/ubuntu/sgx-packages-install.yml
@@ -30,3 +30,11 @@
     update_cache: yes
     install_recommends: no
   when: flc_enabled|bool
+
+- name: Install the Intel enclave launch package
+  apt:
+    name: "{{ intel_sgx_launch_package }}"
+    state: latest
+    update_cache: yes
+    install_recommends: no
+  when: not flc_enabled|bool

--- a/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
@@ -2,6 +2,10 @@
 # Licensed under the MIT License.
 
 ---
+intel_sgx_launch_package:
+  - "libsgx-launch"
+  - "libsgx-aesm-launch-plugin"
+
 intel_sgx_packages:
   - "sgx-aesm-service"
   - "libsgx-enclave-common"

--- a/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
@@ -6,6 +6,7 @@ intel_sgx_packages:
   - "sgx-aesm-service"
   - "libsgx-enclave-common"
   - "libsgx-enclave-common-devel"
+  - "libsgx-launch"
   - "libsgx-urts"
   - "libsgx-ae-pce"
   - "libsgx-ae-qe3"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
@@ -14,7 +14,6 @@ intel_sgx_packages:
   - "libsgx-ae-pce"
   - "libsgx-ae-qe3"
 
-
 intel_dcap_packages:
   - "libsgx-dcap-ql"
   - "libsgx-dcap-ql-dev"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
@@ -2,6 +2,10 @@
 # Licensed under the MIT License.
 
 ---
+intel_sgx_launch_package:
+  - "libsgx-launch"
+  - "libsgx-aesm-launch-plugin"
+
 intel_sgx_packages:
   - "libsgx-enclave-common"
   - "libsgx-enclave-common-dev"
@@ -9,6 +13,7 @@ intel_sgx_packages:
   - "libsgx-ae-qve"
   - "libsgx-ae-pce"
   - "libsgx-ae-qe3"
+
 
 intel_dcap_packages:
   - "libsgx-dcap-ql"


### PR DESCRIPTION
Fixes #2599 

Adds the libsgx-launch and libsgx-aesm-launch-plugin to the ansible setup in order to allow non-dcap enclave launch. This reflects a change in the intel driver/package arrangement.