### PR TITLE
Fix gdb load symbols script to find .text section

### DIFF
--- a/debugger/pythonExtension/load_symbol_cmd.py
+++ b/debugger/pythonExtension/load_symbol_cmd.py
@@ -71,7 +71,7 @@ def GetLoadSymbolCommand(EnclaveFile, Base):
                         # If it is the .text section, put it in a special place in the array
                         # because the 'add-symbol-file' command treats it differently.
                         #print "%#08x" % (int(list[SegOffset+3], 16))
-                        if(list[SegOffset+1].find(".text") != -1):
+                        if(list[SegOffset+1] == ".text"):
                             Out[99][0] = "-s";
                             Out[99][1] = list[SegOffset+1];
                             Out[99][2] = str(int(list[SegOffset+3], 16) + int(Base, 10));


### PR DESCRIPTION
The gdb plugin looks for the .text section by just checking if the section contains .text. This means the plugin will treat any section which contains .text as the text section.

Change the script to look for a section which exactly matches with .text

Fixes #2056