### PR TITLE
libmbedcrypto.a is missing symbols.

### DIFF
--- a/3rdparty/mbedtls/CMakeLists.txt
+++ b/3rdparty/mbedtls/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(mbedcrypto_static STATIC
   mbedtls/library/aes.c
   mbedtls/library/aesni.c
   mbedtls/library/arc4.c
+  mbedtls/library/aria.c
   mbedtls/library/asn1parse.c
   mbedtls/library/asn1write.c
   mbedtls/library/base64.c
@@ -70,6 +71,8 @@ add_library(mbedcrypto_static STATIC
   mbedtls/library/blowfish.c
   mbedtls/library/camellia.c
   mbedtls/library/ccm.c
+  mbedtls/library/chacha20.c
+  mbedtls/library/chachapoly.c
   mbedtls/library/cipher.c
   mbedtls/library/cipher_wrap.c
   mbedtls/library/cmac.c
@@ -86,6 +89,7 @@ add_library(mbedcrypto_static STATIC
   mbedtls/library/error.c
   mbedtls/library/gcm.c
   mbedtls/library/havege.c
+  mbedtls/library/hkdf.c
   mbedtls/library/hmac_drbg.c
   mbedtls/library/md.c
   mbedtls/library/md2.c
@@ -93,6 +97,7 @@ add_library(mbedcrypto_static STATIC
   mbedtls/library/md5.c
   mbedtls/library/md_wrap.c
   mbedtls/library/memory_buffer_alloc.c
+  mbedtls/library/nist_kw.c
   mbedtls/library/oid.c
   mbedtls/library/padlock.c
   mbedtls/library/pem.c
@@ -104,6 +109,7 @@ add_library(mbedcrypto_static STATIC
   mbedtls/library/pkwrite.c
   mbedtls/library/platform.c
   mbedtls/library/platform_util.c
+  mbedtls/library/poly1305.c
   mbedtls/library/ripemd160.c
   mbedtls/library/rsa.c
   mbedtls/library/rsa_internal.c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased][Unreleased_log]
 ------------
+### Fixed
+- Fix #2607 so that libmbedcrypto now includes mbedtls_hkdf().
 
 [v0.8.1][v0.8.1_log] - 2020-02-07
 ---------------------


### PR DESCRIPTION
Updated cmake to include missing source files when compiling libmbedcrypto.a

Fix #2607