### PR TITLE
OE SGX: Move switchless infrastructure to EDL

### DIFF
--- a/common/sgx/switchless.edl
+++ b/common/sgx/switchless.edl
@@ -19,8 +19,8 @@ enclave
     trusted
     {
         public oe_result_t oe_init_context_switchless_ecall(
-	    [user_check] struct _host_worker_context* host_worker_contexts,
-	    uint64_t num_host_workers);
+            [user_check] struct _host_worker_context* host_worker_contexts,
+            uint64_t num_host_workers);
 
     };
 
@@ -28,6 +28,6 @@ enclave
     {
         // Wake up a host switchless ocall worker thread.
         void oe_wake_switchless_worker_ocall(
-	    [user_check] struct _host_worker_context* context);
+            [user_check] struct _host_worker_context* context);
     };
 };

--- a/common/sgx/switchless.edl
+++ b/common/sgx/switchless.edl
@@ -1,0 +1,33 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/*
+**==============================================================================
+**
+** switchless.edl:
+**
+**     This file declares internal ECALLs/OCALLs used by switchless calling
+**     infrastructure.
+**
+**==============================================================================
+*/
+
+enclave
+{
+    include "openenclave/bits/types.h"
+
+    trusted
+    {
+        public oe_result_t oe_init_context_switchless_ecall(
+	    [user_check] struct _host_worker_context* host_worker_contexts,
+	    uint64_t num_host_workers);
+
+    };
+
+    untrusted
+    {
+        // Wake up a host switchless ocall worker thread.
+        void oe_wake_switchless_worker_ocall(
+	    [user_check] struct _host_worker_context* context);
+    };
+};

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -188,9 +188,9 @@ set_source_files_properties(__secs_to_tm.c PROPERTIES
 
 maybe_build_using_clangw(oecore)
 
-add_dependencies(oecore tee_trusted_edl switchless_trusted_edl)
+add_dependencies(oecore tee_trusted_edl)
 if(OE_SGX)
-    add_dependencies(oecore sgx_trusted_edl)
+    add_dependencies(oecore sgx_trusted_edl switchless_trusted_edl)
 endif()
 target_include_directories(oecore PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -22,6 +22,24 @@ add_custom_target(tee_trusted_edl
 
 ##==============================================================================
 ##
+## These rules generate the edge routines for the internal ECALLs/OCALLs used
+## by switchless calls.
+##
+##==============================================================================
+if (OE_SGX)
+    set(SWITCHLESS_EDL_FILE ${EDL_DIR}/sgx/switchless.edl)
+
+    add_custom_command(
+        OUTPUT switchless_t.h switchless_t.c switchless_args.h
+        DEPENDS ${SWITCHLESS_EDL_FILE} edger8r
+        COMMAND edger8r --search-path ${EDL_DIR} --trusted ${SWITCHLESS_EDL_FILE})
+
+    add_custom_target(switchless_trusted_edl
+        DEPENDS switchless_t.h switchless_t.c switchless_args.h)
+endif()
+
+##==============================================================================
+##
 ## These rules generate the edge routines for the internal SGX-specific
 ## ECALLs/OCALLs used by liboehost/liboecore.
 ##
@@ -54,28 +72,30 @@ if (OE_SGX)
         sgx/backtrace.c
         sgx/calls.c
         sgx/cpuid.c
+        sgx/enter.S
         sgx/entropy.c
         sgx/exception.c
+        sgx/exit.S
+        sgx/getkey.S
         sgx/globals.c
         sgx/hostcalls.c
         sgx/init.c
-        sgx/sgx_t_wrapper.c
         sgx/keys.c
+        sgx/longjmp.S
         sgx/memory.c
         sgx/properties.c
         sgx/random_internal.c
         sgx/report.c
         sgx/sched_yield.c
+        sgx/setjmp.S
+        sgx/sgx_t_wrapper.c
         sgx/spinlock.c
+        sgx/switchless_t_wrapper.c
+        sgx/switchlesscalls.c
         sgx/td.c
         sgx/td_basic.c
         sgx/thread.c
-        sgx/tracee.c
-        sgx/enter.S
-        sgx/exit.S
-        sgx/getkey.S
-        sgx/longjmp.S
-        sgx/setjmp.S)
+        sgx/tracee.c)
 
     # Functions in td_basic.c will change the status of td and may trigger
     # stack check fail, thus it is necessary to turn off stack check.
@@ -151,7 +171,6 @@ add_library(oecore STATIC
     string.c
     strtok_r.c
     strtoul.c
-    switchlesscalls.c
     tee_t_wrapper.c
     time.c
     tracee.c
@@ -169,7 +188,7 @@ set_source_files_properties(__secs_to_tm.c PROPERTIES
 
 maybe_build_using_clangw(oecore)
 
-add_dependencies(oecore tee_trusted_edl)
+add_dependencies(oecore tee_trusted_edl switchless_trusted_edl)
 if(OE_SGX)
     add_dependencies(oecore sgx_trusted_edl)
 endif()

--- a/enclave/core/optee/gp.c
+++ b/enclave/core/optee/gp.c
@@ -476,12 +476,6 @@ TEE_Result TA_InvokeCommandEntryPoint(
             result = TEE_ERROR_BAD_STATE;
             break;
         }
-        case OE_ECALL_INIT_CONTEXT_SWITCHLESS:
-        {
-            /* TODO: initialize switchless calls */
-            result = TEE_ERROR_NOT_IMPLEMENTED;
-            break;
-        }
         default:
         {
             /* No function found with the number */

--- a/enclave/core/sgx/sgx_t_wrapper.c
+++ b/enclave/core/sgx/sgx_t_wrapper.c
@@ -38,6 +38,8 @@ static oe_result_t _call_host_function(
         false /* non-switchless */);
 }
 
+/* Include the oeedger8r generated C file. The macros defined above customize
+ * the generated code for internal use. */
 #include "sgx_t.c"
 
 /* Registers the sgx ECALL function table. */

--- a/enclave/core/sgx/switchless_t_wrapper.c
+++ b/enclave/core/sgx/switchless_t_wrapper.c
@@ -38,6 +38,8 @@ static oe_result_t _call_host_function(
         false /* non-switchless */);
 }
 
+/* Include the oeedger8r generated C file. The macros defined above customize
+ * the generated code for internal use. */
 #include "switchless_t.c"
 
 /* Registers the switchless ECALL function table. */

--- a/enclave/core/sgx/switchless_t_wrapper.c
+++ b/enclave/core/sgx/switchless_t_wrapper.c
@@ -1,0 +1,51 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#define OE_NEED_STDC_NAMES
+
+#include <openenclave/enclave.h>
+
+#include <openenclave/corelibc/stdio.h>
+#include <openenclave/corelibc/string.h>
+#include <openenclave/edger8r/enclave.h>
+#include <openenclave/internal/calls.h>
+#include <openenclave/internal/thread.h>
+
+/* Rename the global ecalls table. */
+#define __oe_ecalls_table __oe_switchless_ecalls_table
+#define __oe_ecalls_table_size __oe_switchless_ecalls_table_size
+
+/* Override oe_call_host_function() calls with _call_host_function(). */
+#define oe_call_host_function _call_host_function
+
+/* Use this function below instead of oe_call_host_function(). */
+static oe_result_t _call_host_function(
+    size_t function_id,
+    const void* input_buffer,
+    size_t input_buffer_size,
+    void* output_buffer,
+    size_t output_buffer_size,
+    size_t* output_bytes_written)
+{
+    return oe_call_host_function_by_table_id(
+        OE_SWITCHLESS_OCALL_FUNCTION_TABLE_ID,
+        function_id,
+        input_buffer,
+        input_buffer_size,
+        output_buffer,
+        output_buffer_size,
+        output_bytes_written,
+        false /* non-switchless */);
+}
+
+#include "switchless_t.c"
+
+/* Registers the switchless ECALL function table. */
+oe_result_t oe_register_switchless_ecall_function_table(void)
+{
+    const uint64_t table_id = OE_SWITCHLESS_ECALL_FUNCTION_TABLE_ID;
+    const oe_ecall_func_t* ecalls = __oe_switchless_ecalls_table;
+    const size_t num_ecalls = __oe_switchless_ecalls_table_size;
+
+    return oe_register_ecall_function_table(table_id, ecalls, num_ecalls);
+}

--- a/enclave/core/sgx/switchlesscalls.c
+++ b/enclave/core/sgx/switchlesscalls.c
@@ -55,7 +55,6 @@ oe_result_t oe_init_context_switchless_ecall(
 {
     oe_result_t result = OE_UNEXPECTED;
     uint64_t contexts_size = 0;
-    uint64_t threads_size = 0;
 
     if (!oe_atomic_compare_and_swap(
             (volatile int64_t*)&_switchless_init_in_progress,
@@ -71,7 +70,6 @@ oe_result_t oe_init_context_switchless_ecall(
     }
 
     contexts_size = sizeof(oe_host_worker_context_t) * num_host_workers;
-    threads_size = sizeof(oe_thread_t) * num_host_workers;
 
     // Ensure the contexts are outside of enclave
     if (!oe_is_outside_enclave(host_worker_contexts, contexts_size) ||

--- a/enclave/core/sgx/switchlesscalls.c
+++ b/enclave/core/sgx/switchlesscalls.c
@@ -7,6 +7,7 @@
 #include <openenclave/internal/atomic.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/utils.h>
+#include "switchless_t.h"
 
 // The number of host thread workers. Initialized by host through ECALL
 static size_t _host_worker_count = 0;
@@ -41,21 +42,20 @@ bool oe_is_switchless_initialized()
 /*
 **==============================================================================
 **
-** oe_handle_init_switchless()
+** oe_init_context_switchless_ecall()
 **
-** Handle the OE_ECALL_INIT_CONTEXT_SWITCHLESS from host.
+** Initialize switchless calls infrastructure. This function call be called only
+** once.
 **
 **==============================================================================
 */
-oe_result_t oe_handle_init_switchless(uint64_t arg_in)
+oe_result_t oe_init_context_switchless_ecall(
+    oe_host_worker_context_t* host_worker_contexts,
+    uint64_t num_host_workers)
 {
     oe_result_t result = OE_UNEXPECTED;
-    oe_switchless_call_manager_t* manager = NULL;
-    oe_switchless_call_manager_t safe_manager;
-    size_t contexts_size, threads_size;
-
-    if (arg_in == 0)
-        OE_RAISE(OE_INVALID_PARAMETER);
+    uint64_t contexts_size = 0;
+    uint64_t threads_size = 0;
 
     if (!oe_atomic_compare_and_swap(
             (volatile int64_t*)&_switchless_init_in_progress,
@@ -70,20 +70,12 @@ oe_result_t oe_handle_init_switchless(uint64_t arg_in)
         OE_RAISE(OE_ALREADY_INITIALIZED);
     }
 
-    manager = (oe_switchless_call_manager_t*)arg_in;
-    safe_manager = *manager;
+    contexts_size = sizeof(oe_host_worker_context_t) * num_host_workers;
+    threads_size = sizeof(oe_thread_t) * num_host_workers;
 
-    contexts_size =
-        sizeof(oe_host_worker_context_t) * safe_manager.num_host_workers;
-    threads_size = sizeof(oe_thread_t) * safe_manager.num_host_workers;
-
-    // Ensure the switchless manager and its arrays are outside of enclave
-    if (!oe_is_outside_enclave(manager, sizeof(oe_switchless_call_manager_t)) ||
-        !oe_is_outside_enclave(
-            safe_manager.host_worker_contexts, contexts_size) ||
-        !oe_is_outside_enclave(
-            safe_manager.host_worker_threads, threads_size) ||
-        safe_manager.num_host_workers == 0)
+    // Ensure the contexts are outside of enclave
+    if (!oe_is_outside_enclave(host_worker_contexts, contexts_size) ||
+        num_host_workers == 0)
     {
         OE_RAISE(OE_INVALID_PARAMETER);
     }
@@ -91,9 +83,9 @@ oe_result_t oe_handle_init_switchless(uint64_t arg_in)
     /* lfence after checks. */
     oe_lfence();
 
-    // Copy the worker context array pointer and its size to avoid TOCTOU
-    _host_worker_count = safe_manager.num_host_workers;
-    _host_worker_contexts = safe_manager.host_worker_contexts;
+    // Stash host worker information in enclave memory.
+    _host_worker_count = num_host_workers;
+    _host_worker_contexts = host_worker_contexts;
 
     __atomic_store_n(&_is_switchless_initialized, true, __ATOMIC_SEQ_CST);
 
@@ -170,10 +162,8 @@ oe_result_t oe_post_switchless_ocall(oe_call_host_function_args_t* args)
                     // The pevious value of the event was 0 which means that the
                     // worker was previously sleeping.
                     // Wake it via an ocall.
-                    oe_ocall(
-                        OE_OCALL_WAKE_HOST_WORKER,
-                        (uint64_t)&_host_worker_contexts[tries],
-                        NULL);
+                    oe_wake_switchless_worker_ocall(
+                        &_host_worker_contexts[tries]);
                 }
 
                 return OE_OK;

--- a/enclave/core/sgx/switchlesscalls.c
+++ b/enclave/core/sgx/switchlesscalls.c
@@ -134,7 +134,7 @@ oe_result_t oe_post_switchless_ocall(oe_call_host_function_args_t* args)
                 // call. Determine if it needs to be woken up or not.
                 //
                 // If event is 0, it means that it has gone to sleep. Wake it by
-                // making an ocall (OE_OCALL_WAKE_HOST_WORKER).
+                // making an ocall (oe_wake_switchless_worker_ocall).
                 // Note: it is important to use an atomic cas operation to set
                 // the value to 1 before making the ocall. Setting the value to
                 // 1 prevents the host worker from simulataneously going to

--- a/enclave/core/sgx/switchlesscalls.h
+++ b/enclave/core/sgx/switchlesscalls.h
@@ -8,8 +8,6 @@
 
 bool oe_is_switchless_initialized();
 
-oe_result_t oe_handle_init_switchless(uint64_t arg_in);
-
 oe_result_t oe_post_switchless_ocall(oe_call_host_function_args_t* args);
 
 #endif // _OE_SWITCHLESSCALLS_H

--- a/enclave/core/tee_t_wrapper.c
+++ b/enclave/core/tee_t_wrapper.c
@@ -38,6 +38,8 @@ static oe_result_t _call_host_function(
         false /* non-switchless */);
 }
 
+/* Include the oeedger8r generated C file. The macros defined above customize
+ * the generated code for internal use. */
 #include "tee_t.c"
 
 /* Registers the tee ECALL function table. */

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -22,6 +22,24 @@ add_custom_target(tee_untrusted_edl
 
 ##==============================================================================
 ##
+## These rules generate the edge routines for the internal ECALLs/OCALLs used
+## by switchless calls.
+##
+##==============================================================================
+if (OE_SGX)
+    set(SWITCHLESS_EDL_FILE ${EDL_DIR}/sgx/switchless.edl)
+
+    add_custom_command(
+        OUTPUT switchless_u.h switchless_u.c switchless_args.h
+        DEPENDS ${SWITCHLESS_EDL_FILE} edger8r
+        COMMAND edger8r --search-path ${EDL_DIR} --untrusted ${SWITCHLESS_EDL_FILE})
+
+    add_custom_target(switchless_untrusted_edl
+        DEPENDS switchless_u.h switchless_u.c switchless_args.h)
+endif()
+
+##==============================================================================
+##
 ## These rules generate the edge routines for the internal SGX-specific
 ## ECALLs/OCALLs used by liboehost/liboecore.
 ##
@@ -155,7 +173,6 @@ if (OE_SGX)
     sgx/enclave.c
     sgx/enclavemanager.c
     sgx/exception.c
-    sgx/sgx_u_wrapper.c
     sgx/load.c
     sgx/loadelf.c
     sgx/loadpe.c
@@ -163,12 +180,15 @@ if (OE_SGX)
     sgx/quote.c
     sgx/registers.c
     sgx/report.c
+    sgx/sgx_u_wrapper.c
     sgx/sgxload.c
     sgx/sgxmeasure.c
     sgx/sgxquote.c
     sgx/sgxsign.c
     sgx/sgxtypes.c
-    sgx/switchless.c)
+    sgx/switchless.c
+    sgx/switchless_u_wrapper.c)
+
 
   # OS specific as well.
   if (UNIX)
@@ -289,7 +309,7 @@ endif()
 add_dependencies(oehost syscall_untrusted_edl)
 add_dependencies(oehost tee_untrusted_edl)
 if(OE_SGX)
-  add_dependencies(oehost sgx_untrusted_edl)
+  add_dependencies(oehost sgx_untrusted_edl switchless_untrusted_edl)
 endif()
 
 # TODO: Replace these with `find_package` and add as dependencies to

--- a/host/optee/linux/enclave.c
+++ b/host/optee/linux/enclave.c
@@ -220,9 +220,6 @@ static TEEC_Result _handle_generic_rpc(
                 *(uint64_t*)input_buffer, (uint64_t*)output_buffer);
             break;
 
-        case OE_OCALL_WAKE_HOST_WORKER:
-            return TEEC_ERROR_NOT_SUPPORTED;
-
         default:
         {
             /* No function found with the number */

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -316,8 +316,7 @@ static const char* oe_ocall_str(oe_func_t ocall)
         "MALLOC",
         "FREE",
         "SLEEP",
-        "GET_TIME",
-        "WAKE_HOST_WORKER",
+        "GET_TIME"
     };
     // clang-format on
 
@@ -337,8 +336,7 @@ static const char* oe_ecall_str(oe_func_t ecall)
         "DESTRUCTOR",
         "INIT_ENCLAVE",
         "CALL_ENCLAVE_FUNCTION",
-        "VIRTUAL_EXCEPTION_HANDLER",
-        "INIT_CONTEXT_SWITCHLESS",
+        "VIRTUAL_EXCEPTION_HANDLER"
     };
     // clang-format on
 
@@ -411,10 +409,6 @@ static oe_result_t _handle_ocall(
 
         case OE_OCALL_GET_TIME:
             oe_handle_get_time(arg_in, arg_out);
-            break;
-
-        case OE_OCALL_WAKE_HOST_WORKER:
-            oe_handle_wake_host_worker(arg_in);
             break;
 
         default:

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -74,6 +74,7 @@ static void _initialize_exception_handling(void)
 static void _initialize_enclave_host()
 {
     oe_once(&_enclave_init_once, _initialize_exception_handling);
+    oe_register_switchless_ocall_function_table();
     oe_register_tee_ocall_function_table();
     oe_register_sgx_ocall_function_table();
     oe_register_syscall_ocall_function_table();

--- a/host/sgx/sgx_u_wrapper.c
+++ b/host/sgx/sgx_u_wrapper.c
@@ -31,14 +31,8 @@ static oe_result_t _call_sgx_enclave_function(
         output_bytes_written);
 }
 
-/* Ignore missing edge-routine prototypes. */
-#if defined(__GNUC__)
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#endif
-
 /* Include the generated source. */
 #include "sgx_u.c"
-#include "sgx_u.h"
 
 /* Registers the sgx OCALL function table. */
 oe_result_t oe_register_sgx_ocall_function_table(void)

--- a/host/sgx/sgx_u_wrapper.c
+++ b/host/sgx/sgx_u_wrapper.c
@@ -7,7 +7,7 @@
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>
 
-// Override oe_call_enclave_function() with _call_sgx_enclave_function().
+/* Override oe_call_enclave_function() with _call_sgx_enclave_function(). */
 #define oe_call_enclave_function _call_sgx_enclave_function
 
 /* The ocall edge routines will use this function to route ecalls. */
@@ -31,7 +31,8 @@ static oe_result_t _call_sgx_enclave_function(
         output_bytes_written);
 }
 
-/* Include the generated source. */
+/* Include the oeedger8r generated C file. The macros defined above customize
+ * the generated code for internal use. */
 #include "sgx_u.c"
 
 /* Registers the sgx OCALL function table. */

--- a/host/sgx/switchless_u_wrapper.c
+++ b/host/sgx/switchless_u_wrapper.c
@@ -7,10 +7,11 @@
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>
 
-// Override oe_call_enclave_function() with _call_switchless_enclave_function().
+/* Override oe_call_enclave_function() with _call_switchless_enclave_function().
+ */
 #define oe_call_enclave_function _call_switchless_enclave_function
 
-// Obscure the generated creation function by renaming it.
+/* Obscure the generated creation function by renaming it. */
 #define oe_create_switchless_enclave __unused_oe_create_switchless_enclave
 
 /* The ocall edge routines will use this function to route switchless ecalls. */
@@ -34,7 +35,8 @@ static oe_result_t _call_switchless_enclave_function(
         output_bytes_written);
 }
 
-/* Include the generated source. */
+/* Include the oeedger8r generated C file. The macros defined above customize
+ * the generated code for internal use. */
 #include "switchless_u.c"
 
 /* Registers the switchless OCALL function table. */

--- a/host/sgx/switchless_u_wrapper.c
+++ b/host/sgx/switchless_u_wrapper.c
@@ -7,14 +7,14 @@
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>
 
-// Override oe_call_enclave_function() with _call_tee_enclave_function().
-#define oe_call_enclave_function _call_tee_enclave_function
+// Override oe_call_enclave_function() with _call_switchless_enclave_function().
+#define oe_call_enclave_function _call_switchless_enclave_function
 
 // Obscure the generated creation function by renaming it.
-#define oe_create_tee_enclave __unused_oe_create_tee_enclave
+#define oe_create_switchless_enclave __unused_oe_create_switchless_enclave
 
-/* The ocall edge routines will use this function to route ecalls. */
-static oe_result_t _call_tee_enclave_function(
+/* The ocall edge routines will use this function to route switchless ecalls. */
+static oe_result_t _call_switchless_enclave_function(
     oe_enclave_t* enclave,
     uint32_t function_id,
     const void* input_buffer,
@@ -25,7 +25,7 @@ static oe_result_t _call_tee_enclave_function(
 {
     return oe_call_enclave_function_by_table_id(
         enclave,
-        OE_TEE_ECALL_FUNCTION_TABLE_ID,
+        OE_SWITCHLESS_ECALL_FUNCTION_TABLE_ID,
         function_id,
         input_buffer,
         input_buffer_size,
@@ -35,14 +35,14 @@ static oe_result_t _call_tee_enclave_function(
 }
 
 /* Include the generated source. */
-#include "tee_u.c"
+#include "switchless_u.c"
 
-/* Registers the tee OCALL function table. */
-oe_result_t oe_register_tee_ocall_function_table(void)
+/* Registers the switchless OCALL function table. */
+oe_result_t oe_register_switchless_ocall_function_table(void)
 {
-    const uint64_t table_id = OE_TEE_OCALL_FUNCTION_TABLE_ID;
-    const oe_ocall_func_t* ocalls = __tee_ocall_function_table;
-    const size_t num_ocalls = OE_COUNTOF(__tee_ocall_function_table);
+    const uint64_t table_id = OE_SWITCHLESS_OCALL_FUNCTION_TABLE_ID;
+    const oe_ocall_func_t* ocalls = __switchless_ocall_function_table;
+    const size_t num_ocalls = OE_COUNTOF(__switchless_ocall_function_table);
 
     return oe_register_ocall_function_table(table_id, ocalls, num_ocalls);
 }

--- a/host/syscall_u_wrapper.c
+++ b/host/syscall_u_wrapper.c
@@ -16,6 +16,9 @@
 /* Override oe_call_enclave_function() calls with _call_enclave_function(). */
 #define oe_call_enclave_function _call_enclave_function
 
+// Obscure the generated creation function by renaming it.
+#define oe_create_syscall_enclave __unused_oe_create_syscall_enclave
+
 /* The ocall edge routines will use this function to route ecalls. */
 static oe_result_t _call_enclave_function(
     oe_enclave_t* enclave,
@@ -36,11 +39,6 @@ static oe_result_t _call_enclave_function(
         output_buffer_size,
         output_bytes_written);
 }
-
-/* Ignore missing edge-routine prototypes. */
-#if defined(__GNUC__)
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#endif
 
 #include "syscall_u.c"
 

--- a/host/syscall_u_wrapper.c
+++ b/host/syscall_u_wrapper.c
@@ -16,7 +16,7 @@
 /* Override oe_call_enclave_function() calls with _call_enclave_function(). */
 #define oe_call_enclave_function _call_enclave_function
 
-// Obscure the generated creation function by renaming it.
+/* Obscure the generated creation function by renaming it. */
 #define oe_create_syscall_enclave __unused_oe_create_syscall_enclave
 
 /* The ocall edge routines will use this function to route ecalls. */
@@ -40,6 +40,8 @@ static oe_result_t _call_enclave_function(
         output_bytes_written);
 }
 
+/* Include the oeedger8r generated C file. The macros defined above customize
+ * the generated code for internal use. */
 #include "syscall_u.c"
 
 static oe_once_type _once = OE_H_ONCE_INITIALIZER;

--- a/host/tee_u_wrapper.c
+++ b/host/tee_u_wrapper.c
@@ -7,10 +7,10 @@
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>
 
-// Override oe_call_enclave_function() with _call_tee_enclave_function().
+/* Override oe_call_enclave_function() with _call_tee_enclave_function(). */
 #define oe_call_enclave_function _call_tee_enclave_function
 
-// Obscure the generated creation function by renaming it.
+/* Obscure the generated creation function by renaming it. */
 #define oe_create_tee_enclave __unused_oe_create_tee_enclave
 
 /* The ocall edge routines will use this function to route ecalls. */
@@ -34,7 +34,8 @@ static oe_result_t _call_tee_enclave_function(
         output_bytes_written);
 }
 
-/* Include the generated source. */
+/* Include the oeedger8r generated C file. The macros defined above customize
+ * the generated code for internal use. */
 #include "tee_u.c"
 
 /* Registers the tee OCALL function table. */

--- a/include/openenclave/internal/calls.h
+++ b/include/openenclave/internal/calls.h
@@ -75,7 +75,6 @@ typedef enum _oe_func
     OE_ECALL_INIT_ENCLAVE,
     OE_ECALL_CALL_ENCLAVE_FUNCTION,
     OE_ECALL_VIRTUAL_EXCEPTION_HANDLER,
-    OE_ECALL_INIT_CONTEXT_SWITCHLESS,
     /* Caution: always add new ECALL function numbers here */
     OE_ECALL_MAX,
 
@@ -86,7 +85,6 @@ typedef enum _oe_func
     OE_OCALL_FREE,
     OE_OCALL_SLEEP,
     OE_OCALL_GET_TIME,
-    OE_OCALL_WAKE_HOST_WORKER,
     /* Caution: always add new OCALL function numbers here */
     OE_OCALL_MAX, /* This value is never used */
 
@@ -409,6 +407,9 @@ oe_result_t oe_ocall(uint16_t func, uint64_t arg_in, uint64_t* arg_out);
 #define OE_SYSCALL_OCALL_FUNCTION_TABLE_ID 2
 #define OE_SYSCALL_ECALL_FUNCTION_TABLE_ID 2
 
+#define OE_SWITCHLESS_OCALL_FUNCTION_TABLE_ID 3
+#define OE_SWITCHLESS_ECALL_FUNCTION_TABLE_ID 3
+
 /* Register the OCALL table needed by the common TEE interface (host side). */
 oe_result_t oe_register_tee_ocall_function_table(void);
 
@@ -428,6 +429,14 @@ void oe_register_syscall_ocall_function_table(void);
 
 /* Register the ECALL table needed by the SYSCALL interface (enclave side). */
 void oe_register_syscall_ecall_function_table(void);
+
+/* Register the OCALL table needed by the switchless calling infrastructure
+ * (host side). */
+oe_result_t oe_register_switchless_ocall_function_table(void);
+
+/* Register the OCALL table needed by the switchless calling infrastructure
+ * (enclave side). */
+oe_result_t oe_register_switchless_ecall_function_table(void);
 
 OE_EXTERNC_END
 

--- a/include/openenclave/internal/switchless.h
+++ b/include/openenclave/internal/switchless.h
@@ -9,7 +9,7 @@
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/thread.h>
 
-typedef struct _host_worker_thread_context
+typedef struct _host_worker_context
 {
     volatile oe_call_host_function_args_t* call_arg;
     oe_enclave_t* enclave;

--- a/syscall/syscall_t_wrapper.c
+++ b/syscall/syscall_t_wrapper.c
@@ -38,6 +38,8 @@ static oe_result_t _call_host_function(
         false /* non-switchless */);
 }
 
+/* Include the oeedger8r generated C file. The macros defined above customize
+ * the generated code for internal use. */
 #include "syscall_t.c"
 
 static oe_once_t _once = OE_ONCE_INITIALIZER;

--- a/tools/oeedger8r/src/Sources.ml
+++ b/tools/oeedger8r/src/Sources.ml
@@ -582,7 +582,7 @@ let get_call_user_function (fd : func_decl) =
 let get_ecall_function get_deepcopy (tf : trusted_func) =
   let fd = tf.tf_fdecl in
   [
-    sprintf "void ecall_%s(" fd.fname;
+    sprintf "static void ecall_%s(" fd.fname;
     "    uint8_t* input_buffer,";
     "    size_t input_buffer_size,";
     "    uint8_t* output_buffer,";
@@ -855,7 +855,7 @@ let get_host_ecall_wrapper get_deepcopy enclave_name (tf : trusted_func) =
 let get_ocall_function get_deepcopy (uf : untrusted_func) =
   let fd = uf.uf_fdecl in
   [
-    sprintf "void ocall_%s(" fd.fname;
+    sprintf "static void ocall_%s(" fd.fname;
     "    uint8_t* input_buffer,";
     "    size_t input_buffer_size,";
     "    uint8_t* output_buffer,";


### PR DESCRIPTION
oecore:
- Switchless no longer uses core ecalls and ocalls.
  All the lower-level edge calls it uses are now expressed in EDL
- common/switchless.edl contains internal ecalls for switchless calls.
  It can be made user visible if needed.

oeedger8r
- Emit static keyword for generated local functions. This prevents compiler warnings
  about missing prototypes.
- Remove workarounds in wrapper files for internal EDLs.

OPTEE support
- Switchless calling is supported only in SGX. However the files were incorrectly put
  in core on the enclave side instead of in core/sgx. The files are now moved to correct
  locations.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>