### PR TITLE
Append " -O0" compiling option in debug mode.

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -70,6 +70,16 @@ else ()
 endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
+  # Enforce -O0 in debug mode.
+  string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPER)
+  if (CMAKE_BUILD_TYPE_UPPER STREQUAL "DEBUG")
+    # For gcc the -g option alredy includes -O0.
+    # Here we just apply -O0 for Clang.
+    if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
+      set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
+      set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
+    endif()
+  endif()
   # Enables all the warnings about constructions that some users consider questionable,
   # and that are easy to avoid. Treat at warnings-as-errors, which forces developers
   # to fix warnings as they arise, so they don't accumulate "to be fixed later".


### PR DESCRIPTION
Append " -O0" to compiler options in debug mode.

For Clang " -O0" is added to CMAKE_C_FLAGS_DEBUG and CMAKE_CXX_FLAGS_DEBUG in debug mode.

For GNU compiler, according to https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html, the -g option already includes -O0 by default. -Og can disable optimization as -O0, but some symbol removing can cause severval tests fail. Here we just keep the default for debug mode.