### PR TITLE
Get td_t structure based on SGX tcs rather than fs register

### DIFF
--- a/enclave/core/sgx/asmdefs.h
+++ b/enclave/core/sgx/asmdefs.h
@@ -15,6 +15,7 @@
 #define PAGE_SIZE 4096
 #define STATIC_STACK_SIZE 8 * 100
 #define OE_WORD_SIZE 8
+#define TD_FROM_TCS (5 * PAGE_SIZE)
 
 #define CODE_ERET 0x200000000
 

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -39,20 +39,30 @@
 oe_enter:
 .cfi_startproc
 
+.get_td:
+
+    // Get the location of the td_t structure for this thread. This value is
+    // expected to be present in %r11 for the remainder of oe_enter.
+    //
+    // Upon first entry to the enclave, td->base.self in the td_t structure
+    // is not yet initialized. However, the loader in host/sgx/create.c places
+    // the td_t structure as a specific offset from TCS.
+    lea TD_FROM_TCS(%rbx), %r11
+
 .save_host_registers:
     // Backup the current host rbp, rsp, and context to previous.
-    mov %fs:td_host_rbp, %r8
-    mov %r8, %fs:td_host_previous_rbp
-    mov %fs:td_host_rsp, %r8
-    mov %r8, %fs:td_host_previous_rsp
-    mov %fs:td_host_ecall_context, %r8
-    mov %r8, %fs:td_host_previous_ecall_context
+    mov td_host_rbp(%r11), %r8
+    mov %r8, td_host_previous_rbp(%r11)
+    mov td_host_rsp(%r11), %r8
+    mov %r8, td_host_previous_rsp(%r11)
+    mov td_host_ecall_context(%r11), %r8
+    mov %r8, td_host_previous_ecall_context(%r11)
 
     // Save host registers (restored on EEXIT)
-    mov %rcx, %fs:td_host_rcx // host return address here
-    mov %rsp, %fs:td_host_rsp
-    mov %rbp, %fs:td_host_rbp
-    mov %rdx, %fs:td_host_ecall_context
+    mov %rcx, td_host_rcx(%r11) // host return address here
+    mov %rsp, td_host_rsp(%r11)
+    mov %rbp, td_host_rbp(%r11)
+    mov %rdx, td_host_ecall_context(%r11)
 
 .determine_entry_type:
     // Check if this is exception dispatching request.
@@ -66,7 +76,7 @@ oe_enter:
 
     // Check whether this is a clean entry or a nested entry
     // clean-entry-check.
-    mov %fs:td_depth, %r8
+    mov td_depth(%r11), %r8
     cmp $0, %r8
     je .clean_entry
     jmp .nested_entry
@@ -103,7 +113,7 @@ oe_enter:
     lfence
 
     // Restore stack pointer and enclave registers:
-    mov %fs:td_last_sp, %rsp
+    mov td_last_sp(%r11), %rsp
 
     // align the stack
     and $-16, %rsp
@@ -142,8 +152,8 @@ oe_enter:
     popfq
 
     // Get the host stack pointer.
-    mov %fs:td_host_rsp, %r8
-    mov %fs:td_host_rbp, %r9
+    mov td_host_rsp(%r11), %r8
+    mov td_host_rbp(%r11), %r9
 
     // Construct the frame and align the stack.
     pushq $0
@@ -160,20 +170,24 @@ oe_enter:
 #define OM_HOST_RBP                 (-2*8)(%rbp)
 #define OM_HOST_OUTPUT_ARG1         (-3*8)(%rbp)
 #define OM_HOST_OUTPUT_ARG2         (-4*8)(%rbp)
-#define OM_HOST_RETURN_ADDR         (-5*8)(%rbp)
+#define OM_ENC_TD                   (-5*8)(%rbp)
+#define OM_HOST_RETURN_ADDR         (-6*8)(%rbp)
 
     // Allocate stack.
     sub $OM_STACK_LENGTH, %rsp
 
     // Save the host stack pointers to enclave stack.
-    mov %fs:td_host_rsp, %r8
-    mov %fs:td_host_rbp, %r9
+    mov td_host_rsp(%r11), %r8
+    mov td_host_rbp(%r11), %r9
     mov %r8, OM_HOST_RSP
     mov %r9, OM_HOST_RBP
 
     // Save the host return address to enclave stack.
-    mov %fs:td_host_rcx, %r8
+    mov td_host_rcx(%r11), %r8
     mov %r8, OM_HOST_RETURN_ADDR
+
+    // Save reference to the td structure to enclave stack.
+    mov %r11, OM_ENC_TD
 
     // Call __oe_handle_main(ARG1=RDI, ARG2=RSI, CSSA=RDX, TCS=RCX, OUTPUTARG1=R8, OUTPUTARG2=R9)
     mov %rax, %rdx
@@ -186,11 +200,14 @@ oe_enter:
     mov OM_HOST_OUTPUT_ARG1, %rdi
     mov OM_HOST_OUTPUT_ARG2, %rsi
 
+    // Restore td pointer
+    mov OM_ENC_TD, %r11
+
 .determine_exit_type:
 
     // Check the depth of the ECALL stack (zero for clean exit)
     // exit-type-check.
-    mov %fs:td_depth, %r8
+    mov td_depth(%r11), %r8
     cmp $0, %r8
     je .clean_exit
 
@@ -199,7 +216,7 @@ oe_enter:
     // exit-type-check.
     lfence
 
-    mov %rsp, %fs:td_last_sp
+    mov %rsp, td_last_sp(%r11)
 
     jmp .clear_enclave_registers
 
@@ -209,12 +226,16 @@ oe_enter:
     lfence
 
     // Clear the td_t.last_sp field (force oe_enter to calculate stack pointer)
-    movq $0, %fs:td_last_sp
+    movq $0, td_last_sp(%r11)
 
 .clear_enclave_registers:
 
     // Clear these so information will not be leaked to host
+    // Retain %r11 which is used to reference the td structure. It will be
+    // cleared immediately before EEXIT.
+    push %r11
     oe_cleanup_registers
+    pop %r11
 
 .restore_host_registers:
 
@@ -227,7 +248,7 @@ oe_enter:
 
     // Check td_t.simulate flag
     // simulation-flag-check.
-    mov %fs:td_simulate, %rax
+    mov td_simulate(%r11), %rax
     cmp $0, %rax
     jz .execute_eexit_instruction
 
@@ -235,6 +256,9 @@ oe_enter:
     // Stop speculative execution at fallthrough of conditional
     // simulate-flag-check.
     lfence
+
+    // Clear %r11 which was being used to maintain td pointer
+    xor %r11, %r11
 
     // Jump to return address:
     mov $1, %rax
@@ -245,6 +269,9 @@ oe_enter:
     // Stop speculative execution at target of conditional jump
     // simulate-flag-check.
     lfence
+
+    // Clear %r11 which was being used to maintain td pointer
+    xor %r11, %r11
 
     // EEXIT(RAX=EEXIT, RBX=RETADDR, RCX=AEP, RDI=ARG1, RSI=ARG2)
     //mov %rcx, %rbx

--- a/enclave/core/sgx/exit.S
+++ b/enclave/core/sgx/exit.S
@@ -51,11 +51,26 @@
 oe_asm_exit:
 .cfi_startproc
 
+.get_td:
+
+    // Save argument registers
+    push %rdi
+    push %rsi
+
+    // Get a pointer to the td structure. This value is expected to be present
+    // in %r9 for the remainder of oe_asm_exit
+    call oe_get_td
+    mov %rax, %r9
+
+    // Restore argument registers
+    pop %rsi
+    pop %rdi
+
 .determine_exit_type:
 
     // Check the depth of the ECALL stack (zero for clean exit)
     // exit-type-check.
-    mov %fs:td_depth, %r8
+    mov td_depth(%r9), %r8
     cmp $0, %r8
     je .clean_exit
 
@@ -64,7 +79,7 @@ oe_asm_exit:
     // exit-type-check.
     lfence 
 
-    mov %rsp, %fs:td_last_sp
+    mov %rsp, td_last_sp(%r9)
 
     jmp .clear_enclave_registers
 
@@ -74,24 +89,28 @@ oe_asm_exit:
     lfence
 
     // Clear the td_t.last_sp field (force oe_enter to calculate stack pointer)
-    movq $0, %fs:td_last_sp
+    movq $0, td_last_sp(%r9)
 
 .clear_enclave_registers:
 
-    // Clear these so information will not be leaked to host
+    // Clear registers so information will not be leaked to host
+    // Retain %r11 which is used to reference the td structure. It will be
+    // cleared immediately before EEXIT.
+    push %r9
     oe_cleanup_registers
+    pop %r9
 
 .restore_host_registers:
 
-    mov %fs:td_host_rcx, %rcx
-    mov %fs:td_host_rsp, %rsp
-    mov %fs:td_host_rbp, %rbp
+    mov td_host_rcx(%r9), %rcx
+    mov td_host_rsp(%r9), %rsp
+    mov td_host_rbp(%r9), %rbp
 
 .execute_eexit:
 
     // Check td_t.simulate flag
     // simulate-flag-check.
-    mov %fs:td_simulate, %rax
+    mov td_simulate(%r9), %rax
     cmp $0, %rax
     jz .execute_eexit_instruction
 
@@ -99,6 +118,9 @@ oe_asm_exit:
     // Stop speculative execution at fallthrough of conditional
     // simulate-flag-check.
     lfence
+
+    // Clear %r9 which was being used to maintain td pointer
+    xor %r11, %r11
 
     // Jump to return address:
     mov $1, %rax
@@ -109,6 +131,9 @@ oe_asm_exit:
     // Stop speculative execution at target of conditional jump
     // after simulate-flag-check.
     lfence
+
+    // Clear %r9 which was being used to maintain td pointer
+    xor %r11, %r11
     
     // EEXIT(RAX=EEXIT, RBX=RETADDR, RCX=AEP, RDI=ARG1, RSI=ARG2)
     mov %rcx, %rbx

--- a/enclave/core/sgx/td.c
+++ b/enclave/core/sgx/td.c
@@ -18,8 +18,6 @@
 #include "linux/threadlocal.h"
 #endif
 
-#define TD_FROM_TCS (5 * OE_PAGE_SIZE)
-
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, magic) == td_magic);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, depth) == td_depth);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, host_rcx) == td_host_rcx);


### PR DESCRIPTION
Currently in oe_enter, the thread data structure (td_t) is referenced as an offset of fs. Change this code to instead use an offset of the TCS structure; this offset is guaranteed by the loader.
    
This allows the td structure to be referenced throughout oe_enter even if %fs is modified during __oe_handle_main.

Additionally, Decouple td location from fs register in oe_asm_exit. Previously oe_asm_exit looked for the address of the td structure in the %fs register. Decouple this location by instead calling oe_get_td to get the address. This allows OE to more easily change where the td structure is kept in memory.