### PR TITLE
POC: Ability to recover FS and GS

### DIFF
--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -971,6 +971,11 @@ void __oe_handle_main(
         if ((code == OE_CODE_ECALL) &&
             (func == OE_ECALL_VIRTUAL_EXCEPTION_HANDLER))
         {
+            // THIS change exists only for the specific test case which corrupts
+            // the td_t data structure itself instead of changing FS.
+            td->base.self_addr = (uint64_t)td;
+            //// END TEST CODE
+
             _handle_ecall(td, func, arg_in, output_arg1, output_arg2);
             return;
         }


### PR DESCRIPTION
Upon entry to an enclave, FS and GS registers are always set based on the
fsbase and gsbase values in the tcs. This guarantee provided by the hardware
can be leveraged to recover the FS and GS values if some advanced user code
has changed FS and GS registers.

Currently FS points to td_t and td_t is obtained via oe_get_td function.
oe_get_td can determine if FS has been changed by checking for the validity
of the memory location at FS:0. FS:0 is a valid td_t if FS[0] points to itself
and if it has td_magic.

If FS[0] does not point to td_t, then td_t (FS) can be recovered via the following
strategy:

1) Execute the following code pattern that raises an exception
      jmp raise_exception
      .string "special-magic-string"
      raise_exception: ud2
      mov %rax, td_t_local_variable

2) This will trigger the oe exception handling framework and we will reenter
  the enclave and reach the first-pass-exception handler. Similar to what happens
  for any hardware exception.
  The exception handler has the original FS (td_t) and GS values.
  Exception handler can inspect the bytes preceeding the faulting instruction to
  check if it is "special-magic-string" and if so, emulate the instruction by
  loading the SSA's RAX with original FS value and then moving SSA's RIP past
  the ud2 instruction. This is similar to how cpuid is emulated.

3) Upon continuing execution via ERESUME, control will resume at the next instruction
  past ud2 and RAX will be loaded with correct td_t* that oe_get_td can use.