### PR TITLE
Change free to oe_free to make sure the memory is managed by same set of malloc/free

### DIFF
--- a/enclave/asym_keys.c
+++ b/enclave/asym_keys.c
@@ -339,7 +339,7 @@ done:
     if (key != NULL)
     {
         oe_secure_zero_fill(key, key_size);
-        free(key);
+        oe_free(key);
     }
 
     return result;


### PR DESCRIPTION
The mixed usage of malloc/oe_malloc, free/oe_free in OESDK may cause the memory cannot be freed correctly.
See more details in issue: https://github.com/openenclave/openenclave/issues/2640