### PR TITLE
Remove oesign's dependency on libsgx_enclave_common and libsgx_dcap_ql

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -36,7 +36,7 @@ if (OE_SGX)
 
     add_custom_target(switchless_untrusted_edl
         DEPENDS switchless_u.h switchless_u.c switchless_args.h)
-endif()
+endif ()
 
 ##==============================================================================
 ##
@@ -45,7 +45,7 @@ endif()
 ##
 ##==============================================================================
 
-if(OE_SGX)
+if (OE_SGX)
     set(SGX_EDL_FILE ${EDL_DIR}/sgx/sgx.edl)
 
     add_custom_command(
@@ -55,7 +55,7 @@ if(OE_SGX)
 
     add_custom_target(sgx_untrusted_edl
         DEPENDS sgx_u.h sgx_u.c sgx_args.h)
-endif()
+endif ()
 
 ##==============================================================================
 ##
@@ -131,9 +131,9 @@ elseif (WIN32)
     windows/hostthread.c
     windows/syscall.c
     windows/time.c)
-else()
-  message(FATAL_ERROR "Unknown OS. Only supported OSes are Linux and Windows")
-endif()
+else ()
+  message(FATAL_ERROR "Unknown OS. The only supported OSes are Linux and Windows")
+endif ()
 
 if (OE_SGX AND WIN32)
   # Use clang to compile the oe_enter function that calls ENCLU.
@@ -149,7 +149,7 @@ if (OE_SGX AND WIN32)
              -I${PROJECT_SOURCE_DIR}/include
              ${CMAKE_CURRENT_SOURCE_DIR}/sgx/enter.c
              -o enter.obj)
-endif()
+endif ()
 
 # SGX specific files.
 if (OE_SGX)
@@ -202,7 +202,7 @@ if (OE_SGX)
       sgx/linux/sgxioctl.c
       sgx/linux/switchless.c
       sgx/linux/xstate.c)
-  else()
+  else ()
     list(APPEND PLATFORM_HOST_ONLY_SRC
       sgx/windows/sgxquoteproviderloader.c)
 
@@ -212,22 +212,22 @@ if (OE_SGX)
       sgx/windows/exception.c
       sgx/windows/switchless.c
       sgx/windows/xstate.c)
-  endif()
+  endif ()
 
   set(PLATFORM_FLAGS "-m64")
-elseif(OE_TRUSTZONE)
+elseif (OE_TRUSTZONE)
   list(APPEND PLATFORM_SDK_ONLY_SRC
     optee/log.c)
 
   if (UNIX)
     list(APPEND PLATFORM_SDK_ONLY_SRC
       optee/linux/enclave.c)
-  else()
+  else ()
     message(FATAL_ERROR "OP-TEE is not yet supported on platforms other than Linux.")
-  endif()
+  endif ()
 
   set(PLATFORM_FLAGS "")
-endif()
+endif ()
 
 if (OE_SGX AND WIN32)
   # oedebugrt is accessed via a bridge on Win32 and need not be linked.
@@ -244,7 +244,7 @@ if (OE_SGX AND WIN32)
   set_source_files_properties(
     sgx/calls.c
     PROPERTIES COMPILE_FLAGS "/Z7")
-endif()
+endif ()
 
 # Common host verification files that work on any OS/architecture.
 list(APPEND PLATFORM_HOST_ONLY_SRC
@@ -286,9 +286,9 @@ add_library(oehostverify STATIC ${PLATFORM_HOST_ONLY_SRC})
 target_link_libraries(oehostverify PUBLIC oe_includes)
 target_link_libraries(oehost PUBLIC oe_includes)
 
-if(WIN32)
+if (WIN32)
   target_link_libraries(oehost PUBLIC ws2_32)
-endif()
+endif ()
 
 if (OE_SGX AND UNIX)
   # Link oedebugrt static library.
@@ -302,13 +302,13 @@ if (OE_SGX AND UNIX)
     sgx/enter.c
     PROPERTIES
     COMPILE_FLAGS "-O2 -fno-omit-frame-pointer")
-endif()
+endif ()
 
 add_dependencies(oehost syscall_untrusted_edl)
 add_dependencies(oehost tee_untrusted_edl)
-if(OE_SGX)
+if (OE_SGX)
   add_dependencies(oehost sgx_untrusted_edl switchless_untrusted_edl)
-endif()
+endif ()
 
 # TODO: Replace these with `find_package` and add as dependencies to
 # the CMake package.
@@ -488,3 +488,5 @@ install(TARGETS oehostapp EXPORT openenclave-targets)
 install(TARGETS oehostverify EXPORT openenclave-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host
   COMPONENT OEHOSTVERIFY)
+
+include(measure/CMakeLists.txt)

--- a/host/measure/CMakeLists.txt
+++ b/host/measure/CMakeLists.txt
@@ -1,0 +1,189 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# Add a library oehostmr independent of libsgx_enclave_common/libsgx_dcap_ql
+if (UNIX)
+  set(PLATFORM_HOST_MR_SRC
+    crypto/openssl/init.c
+    crypto/openssl/key.c
+    crypto/openssl/rsa.c
+    crypto/openssl/sha.c
+    linux/hostthread.c
+    linux/windows.c)
+elseif (WIN32)
+  set(PLATFORM_HOST_MR_SRC
+    crypto/bcrypt/key.c
+    crypto/bcrypt/rsa.c
+    crypto/bcrypt/sha.c
+    crypto/bcrypt/pem.c
+    crypto/bcrypt/util.c
+    windows/hostthread.c
+
+    ../3rdparty/mbedtls/mbedtls/library/bignum.c
+    ../3rdparty/mbedtls/mbedtls/library/platform_util.c #Used by bignum.c
+    ../common/asn1.c
+    ../common/cert.c
+    crypto/bcrypt/cert.c
+    crypto/bcrypt/crl.c
+    crypto/bcrypt/ec.c
+    crypto/bcrypt/hmac.c
+    crypto/bcrypt/key.c
+    crypto/bcrypt/pem.c
+    crypto/bcrypt/random.c
+    crypto/bcrypt/rsa.c
+    crypto/bcrypt/sha.c
+    windows/hostthread.c
+    windows/syscall.c
+    windows/time.c)
+else ()
+  message(FATAL_ERROR "Unknown OS. The only supported OSes are Linux and Windows")
+endif ()
+
+if (OE_SGX)
+  list(APPEND PLATFORM_HOST_MR_SRC
+    sgx/create.c
+    sgx/elf.c
+    sgx/load.c
+    sgx/loadelf.c
+    sgx/loadpe.c
+    sgx/sgxload.c
+    sgx/sgxmeasure.c
+    sgx/sgxsign.c
+    sgx/sgxtypes.c)
+
+  # OS specific as well.
+  if (UNIX)
+    list(APPEND PLATFORM_HOST_MR_SRC
+      sgx/linux/xstate.c)
+  else ()
+    list(APPEND PLATFORM_HOST_MR_SRC
+      sgx/windows/xstate.c)
+  endif ()
+
+  set(PLATFORM_FLAGS "-m64")
+elseif (OE_TRUSTZONE)
+    list(APPEND PLATFORM_HOST_MR_SRC
+    optee/log.c)
+
+  if (UNIX)
+      list(APPEND PLATFORM_HOST_MR_SRC
+      optee/linux/enclave.c)
+  else ()
+    message(FATAL_ERROR "OP-TEE is not yet supported on platforms other than Linux.")
+  endif ()
+
+  set(PLATFORM_FLAGS "")
+endif ()
+
+# Common host verification files that work on any OS/architecture.
+list(APPEND PLATFORM_HOST_MR_SRC
+  ../common/safecrt.c
+  hexdump.c
+  dupenv.c
+  fopen.c
+  result.c
+  traceh.c)
+
+# Common files that are used in the OE SDK only.
+list(APPEND PLATFORM_HOST_MR_SRC
+  memalign.c
+  strings.c)
+
+add_library(oehostmr STATIC
+  ${PLATFORM_HOST_MR_SRC})
+
+target_link_libraries(oehostmr PUBLIC oe_includes)
+
+if (WIN32)
+  target_link_libraries(oehostmr PUBLIC ws2_32)
+  target_link_libraries(oehostmr PUBLIC Bcrypt)
+  target_link_libraries(oehostmr PUBLIC crypt32)
+endif ()
+
+if (OE_SGX)
+  add_custom_target(edger8r_result DEPENDS sgx_u.h switchless_u.h switchless_u.c)
+  add_dependencies(oehostmr edger8r_result)
+endif ()
+
+# TODO: Replace these with `find_package` and add as dependencies to
+# the CMake package.
+if (UNIX)
+  if (NOT TARGET openenclave::crypto)
+    find_library(CRYPTO_LIB NAMES crypto)
+    if (NOT CRYPTO_LIB)
+      message(FATAL_ERROR "-- Looking for crypto library - not found")
+    else ()
+      message("-- Looking for crypto library - found")
+      add_library(openenclave::crypto SHARED IMPORTED)
+      set_target_properties(openenclave::crypto PROPERTIES IMPORTED_LOCATION ${CRYPTO_LIB})
+    endif ()
+  endif ()
+
+  if (NOT TARGET openenclave::dl)
+    find_library(DL_LIB NAMES dl)
+    if (NOT DL_LIB)
+      message(FATAL_ERROR "-- Looking for dl library - not found")
+    else ()
+      message("-- Looking for dl library - found")
+      add_library(openenclave::dl SHARED IMPORTED)
+      set_target_properties(openenclave::dl PROPERTIES IMPORTED_LOCATION ${DL_LIB})
+    endif ()
+  endif ()
+endif ()
+
+find_package(Threads REQUIRED)
+
+if (UNIX)
+  target_link_libraries(oehostmr PRIVATE
+    openenclave::crypto
+    Threads::Threads)
+  if (OE_TRUSTZONE)
+    target_include_directories(oehostmr PRIVATE
+      ${OE_TZ_OPTEE_CLIENT_INC})
+    target_link_libraries(oehostmr PRIVATE teec)
+  endif ()
+elseif (WIN32)
+  target_include_directories(oehostmr PRIVATE
+    ${CMAKE_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include)
+endif ()
+
+# For including edge routines.
+target_include_directories(oehostmr PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+# Compile definitions and options
+target_compile_definitions(oehostmr
+  PUBLIC
+  # NOTE: This definition is public to the rest of our project's
+  # targets, but should not yet be exposed to consumers of our
+  # package.
+  $<BUILD_INTERFACE:OE_API_VERSION=2>
+  PRIVATE
+  OE_BUILD_UNTRUSTED
+  OE_REPO_BRANCH_NAME="${GIT_BRANCH}"
+  OE_REPO_LAST_COMMIT="${GIT_COMMIT}")
+
+if (USE_DEBUG_MALLOC)
+  target_compile_definitions(oehostmr PRIVATE OE_USE_DEBUG_MALLOC)
+endif ()
+
+if (UNIX)
+  target_compile_options(oehostmr
+    PRIVATE -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS}
+    PUBLIC -fstack-protector-strong)
+  target_compile_definitions(oehostmr
+    PRIVATE _GNU_SOURCE
+    PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
+endif ()
+
+if (CMAKE_C_COMPILER_ID MATCHES GNU)
+  target_compile_options(oehostmr PRIVATE -Wjump-misses-init)
+endif ()
+
+target_compile_options(oehostmr PRIVATE -DOEHOSTMR)
+set_property(TARGET oehostmr PROPERTY
+  ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/openenclave/host)
+
+if (UNIX)
+  target_link_libraries(oehostmr INTERFACE
+    -Wl,-z,noexecstack)
+endif ()

--- a/host/measure/README.md
+++ b/host/measure/README.md
@@ -1,0 +1,2 @@
+To reuse source code, a macro `OEHOSTMR` is used that some sentences refering to libsgx_enclave_common are stripped off. Thus this library has no dependency on libsgx_enclave_common(also libsgx_dcap_ql).
+The `liboehostmr` library reuses the source code from `liboehost` by using the preprocessor definition `OEHOSTMR`. When specified, `OEHOSTMR` removes any code references to libsgx_enclave_common or libsgx_dcap_ql so that `liboehostmr` has no dependencies on those libraries.

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -57,6 +57,7 @@ static char* get_fullpath(const char* path)
 #include "sgx_u.h"
 #include "sgxload.h"
 
+#if !defined(OEHOSTMR)
 static oe_once_type _enclave_init_once;
 
 static void _initialize_exception_handling(void)
@@ -80,6 +81,7 @@ static void _initialize_enclave_host()
     oe_register_sgx_ocall_function_table();
     oe_register_syscall_ocall_function_table();
 }
+#endif // OEHOSTMR
 
 static oe_result_t _add_filled_pages(
     oe_sgx_load_context_t* context,
@@ -345,6 +347,7 @@ done:
     return result;
 }
 
+#if !defined(OEHOSTMR)
 oe_result_t oe_get_cpuid_table_ocall(
     void* cpuid_table_buffer,
     size_t cpuid_table_buffer_size)
@@ -456,6 +459,7 @@ static oe_result_t _configure_enclave(
 done:
     return result;
 }
+#endif // OEHOSTMR
 
 oe_result_t oe_sgx_validate_enclave_properties(
     const oe_sgx_enclave_properties_t* properties,
@@ -684,6 +688,7 @@ done:
     return result;
 }
 
+#if !defined(OEHOSTMR)
 /*
 ** This method encapsulates all steps of the enclave creation process:
 **     - Loads an enclave image file
@@ -902,3 +907,4 @@ oe_result_t oe_terminate_enclave(oe_enclave_t* enclave)
 done:
     return result;
 }
+#endif // OEHOSTMR

--- a/tools/oesign/CMakeLists.txt
+++ b/tools/oesign/CMakeLists.txt
@@ -17,7 +17,9 @@ if (NOT HAVE_GETOPT_LONG)
   target_include_directories(oesign PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
-target_link_libraries(oesign oehost)
+# Link oesign against liboehostmr, which has no dependency on
+# lib_sgx_enclave_common and libsgx_dcap_ql.
+target_link_libraries(oesign oehostmr)
 
 # assemble into proper collector dir
 set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})


### PR DESCRIPTION
A static library liboemr.a is introduced, which has no dependency on these shared libraries.
All the dependent sentences are stripped away through a macro "OEMR" during preprocessing.

Fixes #2544 
Fixes #2264 