### PR TITLE
Add support for a thread-aware allocator in OpenEnclave

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = 3rdparty/optee/optee_client
 	url = https://github.com/ms-iot/optee_client
 	branch = ms-iot-openenclave
+[submodule "3rdparty/snmalloc"]
+	path = 3rdparty/snmalloc
+	url = https://github.com/Microsoft/snmalloc.git

--- a/3rdparty/libunwind/stubs.h
+++ b/3rdparty/libunwind/stubs.h
@@ -90,7 +90,7 @@ static __inline void* __libunwind_mmap(
     int fd,
     off_t offset)
 {
-    void* dlmemalign(size_t alignment, size_t size);
+    void* oe_nodebug_memalign(size_t alignment, size_t size);
     void* result = MAP_FAILED;
 
     if (addr || fd != -1 || offset)
@@ -102,7 +102,7 @@ static __inline void* __libunwind_mmap(
     if (flags != (MAP_PRIVATE | MAP_ANONYMOUS))
         goto done;
 
-    result = dlmemalign(4096, length);
+    result = oe_nodebug_memalign(4096, length);
 
 done:
 
@@ -111,13 +111,13 @@ done:
 
 static __inline int __libunwind_munmap(void* addr, size_t length)
 {
-    extern void dlfree(void* ptr);
+    extern void oe_nodebug_free(void* ptr);
 
     if (!addr)
         return -1;
 
     if (length)
-        dlfree(addr);
+        oe_nodebug_free(addr);
 
     return 0;
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,14 @@ endif ()
 
 option(ADD_WINDOWS_ENCLAVE_TESTS "Build Windows enclave tests" OFF)
 
+# NOTE: Building OpenEnclave using snmalloc for memory allocation is an experimental option.
+# Longer term, there will be a pluggable allocator mechanism to allow users to choose from a
+# selection of allocators.
+option(USE_SNMALLOC "[EXPERIMENTAL] Build using snmalloc. If this is not set, dlmalloc is used." OFF)
+if (NOT USE_SNMALLOC)
+  set(USE_DLMALLOC true)
+endif ()
+
 find_program(VALGRIND "valgrind")
 if (VALGRIND)
   set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --error-exitcode=1")

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -66,6 +66,18 @@ endif()
 set(PLATFORM_SRC "")
 set(MUSL_SRC_DIR ${PROJECT_SOURCE_DIR}/3rdparty/musl/musl/src)
 
+if (USE_SNMALLOC)
+    add_enclave_library(oeallocator OBJECT
+        sgx/snmalloc/snmalloc_wrapper.cpp
+    )
+    enclave_link_libraries(oeallocator PUBLIC oe_includes)
+    set_source_files_properties(sgx/snmalloc/snmalloc_wrapper.cpp PROPERTIES COMPILE_FLAGS -std=c++17\ -mcx16\ -fno-exceptions)
+    enclave_compile_options(oeallocator PUBLIC
+        -fPIC
+        -fvisibility=hidden)
+    install_enclaves(TARGETS oeallocator EXPORT openenclave-targets)
+endif ()
+
 if (OE_SGX)
     list(APPEND PLATFORM_SRC
         ../../common/sgx/endorsements.c
@@ -137,6 +149,14 @@ if (OE_TRUSTZONE OR (OE_SGX AND (UNIX OR USE_CLANGW)))
     list(APPEND PLATFORM_SRC init_fini.c)
 endif ()
 
+if (USE_DLMALLOC)
+    list(APPEND PLATFORM_SRC malloc.c)
+    # Unfortunately dlmalloc uses GNU extension that allows arithmetic
+    # null pointers.
+    set_source_files_properties(malloc.c
+        PROPERTIES COMPILE_FLAGS "-Wno-conversion -Wno-null-pointer-arithmetic")
+endif()
+
 add_enclave_library(oecore STATIC
     ../../common/safecrt.c
     ../../common/argv.c
@@ -159,7 +179,6 @@ add_enclave_library(oecore STATIC
     hexdump.c
     hostcalls.c
     intstr.c
-    malloc.c
     once.c
     printf.c
     pthread.c
@@ -199,6 +218,11 @@ if (OE_TRUSTZONE)
     enclave_link_libraries(oecore PUBLIC oelibutee_includes)
 endif ()
 
+enclave_link_libraries(oecore PUBLIC oe_includes)
+if (USE_SNMALLOC)
+    enclave_link_libraries(oecore PUBLIC oeallocator)
+endif()
+
 if (CMAKE_C_COMPILER_ID MATCHES GNU)
     enclave_compile_options(oecore PRIVATE -Wjump-misses-init)
 endif()
@@ -206,11 +230,6 @@ endif()
 # This directory contains enclave core libc headers:
 enclave_include_directories(oecore PRIVATE
     ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
-
-# Unfortunately dlmalloc uses GNU extension that allows arithmetic
-# null pointers.
-set_source_files_properties(malloc.c
-    PROPERTIES COMPILE_FLAGS "-Wno-conversion -Wno-null-pointer-arithmetic")
 
 if (OE_SGX)
     set_source_files_properties(sgx/keys.c PROPERTIES COMPILE_FLAGS -Wno-type-limits)

--- a/enclave/core/atexit.c
+++ b/enclave/core/atexit.c
@@ -5,6 +5,7 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/syscall/unistd.h>
 #include <openenclave/internal/thread.h>
+#include "oe_nodebug_alloc.h"
 
 /*
 **==============================================================================
@@ -34,7 +35,8 @@ static oe_spinlock_t _spin = OE_SPINLOCK_INITIALIZER;
 **
 ** _new_atexit_entry()
 **
-**     Allocate an oe_atexit_entry_t structure from the heap using sbrk().
+**     Allocate an oe_atexit_entry_t structure from the heap,
+**     using oe_nodebug_malloc().
 **
 **==============================================================================
 */
@@ -43,8 +45,8 @@ static oe_atexit_entry_t* _new_atexit_entry(void (*func)(void*), void* arg)
 {
     oe_atexit_entry_t* entry;
 
-    if ((entry = (oe_atexit_entry_t*)oe_sbrk(sizeof(oe_atexit_entry_t))) ==
-        (void*)-1)
+    if ((entry = (oe_atexit_entry_t*)oe_nodebug_malloc(
+             sizeof(oe_atexit_entry_t))) == (void*)-1)
         return NULL;
 
     entry->func = func;

--- a/enclave/core/debugmalloc.c
+++ b/enclave/core/debugmalloc.c
@@ -1,7 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#define USE_DL_PREFIX
 #include "debugmalloc.h"
 #include <openenclave/corelibc/errno.h>
 #include <openenclave/enclave.h>
@@ -13,9 +12,10 @@
 #include <openenclave/internal/thread.h>
 #include <openenclave/internal/types.h>
 #include <openenclave/internal/utils.h>
-#include "../3rdparty/dlmalloc/dlmalloc/malloc.h"
 
 #if defined(OE_USE_DEBUG_MALLOC)
+
+#include "oe_nodebug_alloc.h"
 
 /*
 **==============================================================================
@@ -312,7 +312,7 @@ void* oe_debug_malloc(size_t size)
     void* block;
     const size_t block_size = _calculate_block_size(0, size);
 
-    if (!(block = dlmalloc(block_size)))
+    if (!(block = oe_nodebug_malloc(block_size)))
         return NULL;
 
     /* Fill block with 0xAA (Allocated) bytes */
@@ -339,7 +339,7 @@ void oe_debug_free(void* ptr)
         size_t block_size = _get_block_size(ptr);
         oe_memset_s(block, block_size, 0xDD, block_size);
 
-        dlfree(block);
+        oe_nodebug_free(block);
     }
 }
 
@@ -404,7 +404,7 @@ void* oe_debug_memalign(size_t alignment, size_t size)
     void* block;
     header_t* header;
 
-    if (!(block = dlmemalign(alignment, block_size)))
+    if (!(block = oe_nodebug_memalign(alignment, block_size)))
         return NULL;
 
     header = (header_t*)((uint8_t*)block + padding_size);

--- a/enclave/core/malloc.c
+++ b/enclave/core/malloc.c
@@ -11,6 +11,8 @@
 #include <openenclave/internal/safecrt.h>
 #include <openenclave/internal/thread.h>
 #include "debugmalloc.h"
+#include "oe_alloc_thread.h"
+#include "oe_nodebug_alloc.h"
 
 /* The use of dlmalloc/malloc.c below requires stdc names from these headers */
 #define OE_NEED_STDC_NAMES
@@ -61,6 +63,23 @@ static int _dlmalloc_stats_fprintf(FILE* stream, const char* format, ...);
 #define FREE dlfree
 #define MALLOC_USABLE_SIZE dlmalloc_usable_size
 #endif
+
+void* oe_nodebug_malloc(size_t s)
+{
+    return dlmalloc(s);
+}
+void oe_nodebug_free(void* ptr)
+{
+    return dlfree(ptr);
+}
+void* oe_nodebug_realloc(void* ptr, size_t s)
+{
+    return dlrealloc(ptr, s);
+}
+void* oe_nodebug_memalign(size_t alignment, size_t size)
+{
+    return dlmemalign(alignment, size);
+}
 
 static oe_allocation_failure_callback_t _failure_callback;
 
@@ -247,4 +266,12 @@ oe_result_t oe_get_malloc_stats(oe_malloc_stats_t* stats)
 done:
     oe_mutex_unlock(&_mutex);
     return result;
+}
+
+void oe_alloc_thread_startup()
+{
+}
+
+void oe_alloc_thread_teardown()
+{
 }

--- a/enclave/core/oe_alloc_thread.h
+++ b/enclave/core/oe_alloc_thread.h
@@ -1,0 +1,17 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_ALLOC_THREAD_H
+#define _OE_ALLOC_THREAD_H
+
+#include <openenclave/bits/defs.h>
+
+OE_EXTERNC_BEGIN
+
+// Thread-specific startup and teardown calls for the memory allocator
+void oe_alloc_thread_startup();
+void oe_alloc_thread_teardown();
+
+OE_EXTERNC_END
+
+#endif /* _OE_ALLOC_THREAD_H */

--- a/enclave/core/oe_nodebug_alloc.h
+++ b/enclave/core/oe_nodebug_alloc.h
@@ -1,0 +1,21 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_NODEBUG_ALLOC_H
+#define _OE_NODEBUG_ALLOC_H
+
+#include <openenclave/bits/defs.h>
+#include <stddef.h>
+
+OE_EXTERNC_BEGIN
+
+// A small number of places want to use the underlying allocator
+// without the debug shim on top, hence those explicit symbols.
+void* oe_nodebug_malloc(size_t s);
+void oe_nodebug_free(void* ptr);
+void* oe_nodebug_realloc(void* ptr, size_t s);
+void* oe_nodebug_memalign(size_t alignment, size_t size);
+
+OE_EXTERNC_END
+
+#endif /* _OE_NODEBUG_ALLOC_H */

--- a/enclave/core/sgx/backtrace.c
+++ b/enclave/core/sgx/backtrace.c
@@ -11,6 +11,7 @@
 #include <openenclave/internal/print.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/safecrt.h>
+#include "../oe_nodebug_alloc.h"
 #include "sgx_t.h"
 #include "tee_t.h"
 
@@ -183,16 +184,12 @@ done:
 char** oe_backtrace_symbols(void* const* buffer, int size)
 {
     /* Backtrace must use the internal allocator to bypass debug-malloc. */
-    extern void* dlmalloc(size_t size);
-    extern void* dlrealloc(void* ptr, size_t size);
-    extern void dlfree(void* ptr);
-    return oe_backtrace_symbols_impl(buffer, size, dlmalloc, dlrealloc, dlfree);
+    return oe_backtrace_symbols_impl(
+        buffer, size, oe_nodebug_malloc, oe_nodebug_realloc, oe_nodebug_free);
 }
 
 void oe_backtrace_symbols_free(char** ptr)
 {
     /* Backtrace must use the internal allocator to bypass debug-malloc. */
-    extern void dlfree(void* ptr);
-
-    dlfree(ptr);
+    oe_nodebug_free(ptr);
 }

--- a/enclave/core/sgx/linux/threadlocal.c
+++ b/enclave/core/sgx/linux/threadlocal.c
@@ -9,6 +9,7 @@
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/safecrt.h>
 #include <openenclave/internal/utils.h>
+#include "../../oe_alloc_thread.h"
 #include "../td.h"
 
 /*
@@ -330,6 +331,9 @@ oe_result_t oe_thread_local_init(td_t* td)
 
             _thread_locals_relocated = true;
         }
+
+        // Must occur after thread local storage initialization
+        oe_alloc_thread_startup();
     }
 
     result = OE_OK;
@@ -381,6 +385,7 @@ oe_result_t oe_thread_local_cleanup(td_t* td)
     uint8_t* tls_start = _get_thread_local_data_start(td);
     if (tls_start)
     {
+        oe_alloc_thread_teardown();
         oe_memset_s(tls_start, (uint64_t)(fs - tls_start), 0, 0);
     }
 

--- a/enclave/core/sgx/snmalloc/snmalloc_wrapper.cpp
+++ b/enclave/core/sgx/snmalloc/snmalloc_wrapper.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/sgxtypes.h>
+#include "../../oe_alloc_thread.h"
+#include "../../oe_nodebug_alloc.h"
+
+namespace snmalloc
+{
+__thread void* allocator_local;
+
+class ThreadAllocUntyped
+{
+  public:
+    static void* get();
+};
+
+void* ThreadAllocUntyped::get()
+{
+    return allocator_local;
+}
+} // namespace snmalloc
+
+#define USE_RESERVE_MULTIPLE 1
+#define IS_ADDRESS_SPACE_CONSTRAINED
+
+// In standard configuration, snmalloc defines the oe_* symbols
+// directly. In debug configuration, snmalloc defines oe_nodebug_* symbols
+// instead, and oe_* symbols are directed to the debug shim.
+#if defined(OE_USE_DEBUG_MALLOC)
+#define SNMALLOC_NAME_MANGLE(a) oe_nodebug_##a
+
+extern "C" void* oe_malloc(size_t size)
+{
+    return oe_debug_malloc(size);
+}
+
+extern "C" void* oe_calloc(size_t nmemb, size_t size)
+{
+    return oe_debug_calloc(nmemb, size);
+}
+
+extern "C" void* oe_realloc(void* ptr, size_t size)
+{
+    return oe_debug_realloc(ptr, size);
+}
+
+extern "C" void* oe_memalign(size_t alignment, size_t size)
+{
+    return oe_debug_memalign(alignment, size);
+}
+
+extern "C" void* oe_free(void* ptr, size_t size)
+{
+    return oe_debug_free(ptr, size);
+}
+
+extern "C" size_t oe_malloc_usable_size(void* ptr)
+{
+    return oe_debug_malloc_usable_size(ptr);
+}
+#else
+#define SNMALLOC_NAME_MANGLE(a) oe_##a
+#endif
+// The Open Enclave runtime manages the thread local allocator pointer, see td_t
+#define SNMALLOC_EXTERNAL_THREAD_ALLOC
+// Enable the Open Enclave PAL(Platform Abstraction Layer) for Open Enclave,
+// see pal_open_enclave.h for details
+#define OPEN_ENCLAVE
+#include "../../../../3rdparty/snmalloc/src/override/malloc.cc"
+
+// A small number of places want to use the underlying allocator
+// without the debug shim on top, hence those explicit symbols.
+#ifndef OE_USE_DEBUG_MALLOC
+extern "C" void* oe_nodebug_malloc(size_t s)
+{
+    return oe_malloc(s);
+}
+extern "C" void oe_nodebug_free(void* ptr)
+{
+    return oe_free(ptr);
+}
+extern "C" void* oe_nodebug_realloc(void* ptr, size_t s)
+{
+    return oe_realloc(ptr, s);
+}
+extern "C" void* oe_nodebug_memalign(size_t alignment, size_t size)
+{
+    return oe_memalign(alignment, size);
+}
+#endif
+
+extern "C" void oe_alloc_thread_startup()
+{
+    allocator_local = current_alloc_pool()->acquire();
+}
+
+extern "C" void oe_alloc_thread_teardown()
+{
+    current_alloc_pool()->release(ThreadAlloc::get());
+    allocator_local = nullptr;
+}
+
+typedef void (*oe_allocation_failure_callback_t)(
+    const char* file,
+    size_t line,
+    const char* func,
+    size_t size);
+
+extern "C" void oe_set_allocation_failure_callback(
+    oe_allocation_failure_callback_t function)
+{
+    (void)function;
+}
+
+extern "C" void oe_memalign_free(void* ptr)
+{
+    oe_free(ptr);
+}

--- a/libc/libunwind_stubs.c
+++ b/libc/libunwind_stubs.c
@@ -2,14 +2,12 @@
 // Licensed under the MIT License.
 
 #define _GNU_SOURCE
-#define USE_DL_PREFIX
 #include <assert.h>
 #include <openenclave/enclave.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#include "../3rdparty/dlmalloc/dlmalloc/malloc.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -45,6 +45,7 @@ tools/oeedger8r/intel/.*
 3rdparty/musl/endian\.h\.suffix
 3rdparty/optee/optee_client
 3rdparty/optee/optee_os
+3rdparty/snmalloc
 cmake/NuGetDescription.txt
 docs/CODEOWNERS
 LICENSE

--- a/tests/bigmalloc/enc/enc.c
+++ b/tests/bigmalloc/enc/enc.c
@@ -12,8 +12,8 @@ oe_result_t test_malloc()
     const size_t GIGABYTE = 1024 * 1024 * 1024;
     size_t heap_remaining;
     uint8_t* ptr = NULL;
-    extern void* dlmalloc(size_t n);
-    extern void dlfree(void* ptr);
+    extern void* oe_malloc(size_t n);
+    extern void oe_free(void* ptr);
     oe_result_t return_value = OE_UNEXPECTED;
 
     /* Determine how much heap memory remains */
@@ -43,7 +43,7 @@ oe_result_t test_malloc()
     {
         const size_t allocation_size = (size_t)(0.99 * (double)heap_remaining);
 
-        if (!(ptr = (uint8_t*)dlmalloc(allocation_size)))
+        if (!(ptr = (uint8_t*)oe_malloc(allocation_size)))
         {
             return_value = OE_OUT_OF_MEMORY;
             goto done;
@@ -59,7 +59,7 @@ oe_result_t test_malloc()
 done:
 
     if (ptr)
-        dlfree(ptr);
+        oe_free(ptr);
 
     return return_value;
 }


### PR DESCRIPTION
As DC8 kit has become available in Azure, we have started scale-testing CCF (https://github.com/microsoft/CCF/) with higher numbers of threads. We have found to our disappointment that throughput decreased, because allocations and deallocations all contend a single lock in dlmalloc. OpenEnclave using dlmalloc (ie. the current code) is unable to effectively take advantage of multi-core hardware for workloads that involve dynamic allocation (ie. most general-purpose code).

We validated this result empirically on our "virtual" builds, by preloading dlmalloc and observing the same impact on throughput that we saw in the enclaves. The default system allocator, and other thread-aware allocators like jemalloc or snmalloc scaled as expected of course.

After adapting OpenEnclave to use snmalloc, we can run concurrent workloads in enclave without a bottleneck on memory allocation:

CCF SmallBank benchmark, 1m transactions, Standard_DC8 VM:

OpenEnclave with dlmalloc:

1 worker thread: 35k Tx/s
2 worker threads: 37k Tx/s
3 worker threads: 29k Tx/s
4 worker threads: 27k Tx/s

OpenEnclave with snmalloc:

1 worker thread: 39k Tx/s
2 worker threads: 77k Tx/s
3 worker threads: 110k Tx/s
4 worker threads: 115k Tx/s
5 worker threads: 143k Tx/s
6 worker threads: 156k Tx/s

There is still plenty of work to do improve performance in CCF, but removing this extreme contention on allocation helps quite a bit!

We have gone with snmalloc for the following reasons:

1. Its performance characteristics are excellent: https://github.com/microsoft/snmalloc/blob/master/snmalloc.pdf
2. It's actively maintained by Microsoft, extensively covered with tests and benchmarks, and registered with the MSRC, so we are confident any security issues will get addressed correctly.
3. It's easy to plug into OpenEnclave, thanks to its platform abstraction layer. It's so easy that it's been done twice before: #1301, #1420

I have not written a design document for this PR because it does not affect any public APIs, as far as I can tell.