### PR TITLE
Refactor compiler detection logic into separate config.mk

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -28,6 +28,8 @@ if (WIN32)
         DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples
         RENAME README.md)
 else ()
+  install(FILES config.mk
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples)
   install(FILES README_Linux.md
         DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples
         RENAME README.md)

--- a/samples/attested_tls/client/enc/Makefile
+++ b/samples/attested_tls/client/enc/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)

--- a/samples/attested_tls/client/host/Makefile
+++ b/samples/attested_tls/client/host/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../../config.mk
 
 CFLAGS=$(shell pkg-config oehost-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --cflags)

--- a/samples/attested_tls/non_enc_client/Makefile
+++ b/samples/attested_tls/non_enc_client/Makefile
@@ -1,25 +1,11 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
+include ../../config.mk
+
 .PHONY: all build clean run
 
 all: build
-
-
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
 
 CFLAGS=$(shell pkg-config oehost-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --cflags)

--- a/samples/attested_tls/server/enc/Makefile
+++ b/samples/attested_tls/server/enc/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)

--- a/samples/attested_tls/server/host/Makefile
+++ b/samples/attested_tls/server/host/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../../config.mk
 
 CFLAGS=$(shell pkg-config oehost-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --cflags)

--- a/samples/config.mk
+++ b/samples/config.mk
@@ -1,0 +1,35 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# Perform common configuration for building sample enclaves and hosts.
+
+# Detect compiler.
+ifneq ($(CC),cc)
+        # CC explicitly specified.
+else ifneq ($(shell $(CC) --version | grep clang),)
+        # CC is default (cc), and aliases to clang.
+else
+        # CC is default (cc), and does not alias to clang.
+        CLANG_VERSION = $(shell for v in "9" "8" "7"; do \
+                                        if [ -n "$$(command -v clang-$$v)" ]; then \
+                                                echo $$v; \
+                                                break; \
+                                        fi; \
+                                done)
+
+        ifneq ($(CLANG_VERSION),)
+                CC = clang-$(CLANG_VERSION)
+                CXX = clang++-$(CLANG_VERSION)
+        endif
+endif
+
+# Choose the right pkg-config based on CC.
+C_COMPILER = clang
+CXX_COMPILER = clang++
+ifeq ($(shell $(CC) --version | grep clang),)
+        C_COMPILER = gcc
+        CXX_COMPILER = g++
+endif
+
+# Define COMPILER for samples that use only C.
+COMPILER = $(C_COMPILER)

--- a/samples/data-sealing/enclave_a_v1/Makefile
+++ b/samples/data-sealing/enclave_a_v1/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-	CXX_COMPILER=$(notdir $(CXX))
-	USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-	CC = clang-7
-	CXX = clang++-7
-	C_COMPILER=clang
-	CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)

--- a/samples/data-sealing/enclave_a_v2/Makefile
+++ b/samples/data-sealing/enclave_a_v2/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)

--- a/samples/data-sealing/enclave_b/Makefile
+++ b/samples/data-sealing/enclave_b/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-	CXX_COMPILER=$(notdir $(CXX))
-	USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-	CC = clang-7
-	CXX = clang++-7
-	C_COMPILER=clang
-	CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)

--- a/samples/data-sealing/host/Makefile
+++ b/samples/data-sealing/host/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-	CXX_COMPILER=$(notdir $(CXX))
-	USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-	CC = clang-7
-	CXX = clang++-7
-	C_COMPILER=clang
-	CXX_COMPILER=clang
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oehost-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --cflags)

--- a/samples/file-encryptor/enclave/Makefile
+++ b/samples/file-encryptor/enclave/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)

--- a/samples/file-encryptor/host/Makefile
+++ b/samples/file-encryptor/host/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oehost-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --cflags)

--- a/samples/helloworld/enclave/Makefile
+++ b/samples/helloworld/enclave/Makefile
@@ -1,25 +1,14 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc, default to clang-7
-
-COMPILER=$(notdir $(CC))
-ifeq ($(COMPILER), gcc)
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        COMPILER=clang
-endif
+include ../../config.mk
 
 ifeq ($(LVI_MITIGATION), ControlFlow)
-        ifeq ($(LVI_MITIGATION_BINDIR),)
-            $(error LVI_MITIGATION_BINDIR is not set)
-        endif
-        CC := $(LVI_MITIGATION_BINDIR)/$(CC)
-        COMPILER := $(COMPILER)-lvi-cfg
+	ifeq ($(LVI_MITIGATION_BINDIR),)
+		$(error LVI_MITIGATION_BINDIR is not set)
+	endif
+	CC := $(LVI_MITIGATION_BINDIR)/$(CC)
+	COMPILER := $(COMPILER)-lvi-cfg
 endif
 
 CFLAGS=$(shell pkg-config oeenclave-$(COMPILER) --cflags)

--- a/samples/helloworld/host/Makefile
+++ b/samples/helloworld/host/Makefile
@@ -1,18 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc, default to clang-7
-
-COMPILER=$(notdir $(CC))
-ifeq ($(COMPILER), gcc)
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        COMPILER=clang
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oehost-$(COMPILER) --cflags)
 LDFLAGS=$(shell pkg-config oehost-$(COMPILER) --libs)

--- a/samples/local_attestation/enclave_a/Makefile
+++ b/samples/local_attestation/enclave_a/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)

--- a/samples/local_attestation/enclave_b/Makefile
+++ b/samples/local_attestation/enclave_b/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)

--- a/samples/local_attestation/host/Makefile
+++ b/samples/local_attestation/host/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oehost-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --cflags)

--- a/samples/remote_attestation/enclave_a/Makefile
+++ b/samples/remote_attestation/enclave_a/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)

--- a/samples/remote_attestation/enclave_b/Makefile
+++ b/samples/remote_attestation/enclave_b/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)

--- a/samples/remote_attestation/host/Makefile
+++ b/samples/remote_attestation/host/Makefile
@@ -1,20 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc and g++, default to clang-7
-C_COMPILER=$(notdir $(CC))
-ifeq ($(C_COMPILER), gcc)
-        CXX_COMPILER=$(notdir $(CXX))
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        CXX = clang++-7
-        C_COMPILER=clang
-        CXX_COMPILER=clang++
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oehost-$(C_COMPILER) --cflags)
 CXXFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --cflags)

--- a/samples/switchless/enclave/Makefile
+++ b/samples/switchless/enclave/Makefile
@@ -1,18 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc, default to clang-7
-
-COMPILER=$(notdir $(CC))
-ifeq ($(COMPILER), gcc)
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        COMPILER=clang
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oeenclave-$(COMPILER) --cflags)
 LDFLAGS=$(shell pkg-config oeenclave-$(COMPILER) --libs)

--- a/samples/switchless/host/Makefile
+++ b/samples/switchless/host/Makefile
@@ -1,18 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Detect C and C++ compiler options
-# if not gcc, default to clang-7
-
-COMPILER=$(notdir $(CC))
-ifeq ($(COMPILER), gcc)
-        USE_GCC = true
-endif
-
-ifeq ($(USE_GCC),)
-        CC = clang-7
-        COMPILER=clang
-endif
+include ../../config.mk
 
 CFLAGS=$(shell pkg-config oehost-$(COMPILER) --cflags)
 LDFLAGS=$(shell pkg-config oehost-$(COMPILER) --libs)


### PR DESCRIPTION
Determine CC and CXX using the following strategy:

- If CC has been specified, use it (and CXX).
- If CC has not been specified
  - If CC defaults to clang in the system, use it
  - Else choose the latest available version of clang in 9, 8 and 7

Once CC and CXX have been setup, set C_COMPILER and CXX_COMPILER
appropriately to clang and clang++ or gcc and g++.
These two variables are used as keys to pkg-config to obtain
the compiler flags depending on the compiler.
