### PR TITLE
Fix backtrace test under gcc 8

### DIFF
--- a/tests/backtrace/enc/enc.cpp
+++ b/tests/backtrace/enc/enc.cpp
@@ -77,7 +77,15 @@ static void _print_backtrace(
         // Iterate through the expected symbols
         for (size_t i = 0; i < num_expected_symbols; i++)
         {
-            if (strcmp(expected_symbols[i], symbols[idx]) == 0)
+            // GCC sometimes adds .constprop, .clone and other suffixes to
+            // functions. Given func4, GCC could generate func4.constprop.0
+            // that does a bit of the work done by func4, leaving the rest
+            // for func4 to do. To handle the presence of such functions in
+            // the backtrace, ignore suffixes in this comparision.
+            if (strncmp(
+                    expected_symbols[i],
+                    symbols[idx],
+                    strlen(expected_symbols[i])) == 0)
             {
                 // Expected and actual symbols match.
                 // Move past the current frame.
@@ -144,7 +152,6 @@ extern "C" bool test_unwind(size_t num_syms, const char** syms)
     {
         char** _syms = backtrace_symbols(b.buffer, b.size);
         OE_TEST(_syms != NULL);
-
         _print_backtrace(b.buffer, (size_t)b.size, num_syms, syms);
 
         free(_syms);


### PR DESCRIPTION
GCC generates functions with .constprop, .clone and other suffixes
with optimizations turned on. In this test, GCC generates
func4.constprop.0 function that does a part of the logic in func4.
This generated function was part of the backtrace, and the
test failed since it was expecting func4. The fix is to ignore the
suffixes in compating expected and actual symbols.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>