### PR TITLE
Enable /W3 and fix /W3 warnings for Windows builds

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -114,7 +114,7 @@ elseif (MSVC)
 
   # Add Flags we want to use for both C and CXX
   add_compile_options(/WX)
-  add_compile_options(/W2)
+  add_compile_options(/W3)
 
   # Ignore compiler warnings:
   # * unicode character not supported

--- a/common/datetime.c
+++ b/common/datetime.c
@@ -229,20 +229,20 @@ oe_result_t oe_datetime_now(oe_datetime_t* value)
 {
     oe_result_t result = OE_UNEXPECTED;
     time_t now;
-    struct tm* timeinfo;
+    struct tm timeinfo;
 
     if (value == NULL)
         OE_RAISE(OE_INVALID_PARAMETER);
 
     time(&now);
-    timeinfo = gmtime(&now);
+    gmtime_r(&now, &timeinfo);
 
-    value->year = (uint32_t)timeinfo->tm_year + 1900;
-    value->month = (uint32_t)timeinfo->tm_mon + 1;
-    value->day = (uint32_t)timeinfo->tm_mday;
-    value->hours = (uint32_t)timeinfo->tm_hour;
-    value->minutes = (uint32_t)timeinfo->tm_min;
-    value->seconds = (uint32_t)timeinfo->tm_sec;
+    value->year = (uint32_t)timeinfo.tm_year + 1900;
+    value->month = (uint32_t)timeinfo.tm_mon + 1;
+    value->day = (uint32_t)timeinfo.tm_mday;
+    value->hours = (uint32_t)timeinfo.tm_hour;
+    value->minutes = (uint32_t)timeinfo.tm_min;
+    value->seconds = (uint32_t)timeinfo.tm_sec;
 
     result = OE_OK;
 done:

--- a/common/oe_host_socket.h
+++ b/common/oe_host_socket.h
@@ -104,7 +104,7 @@ int _getaddrinfo_read(
         *ai_family = p->ai_family;
         *ai_socktype = p->ai_socktype;
         *ai_protocol = p->ai_protocol;
-        *ai_addrlen = p->ai_addrlen;
+        *ai_addrlen = (oe_socklen_t)p->ai_addrlen;
 
         if (p->ai_canonname)
             *ai_canonnamelen = strlen(p->ai_canonname) + 1;

--- a/common/oe_host_string.h
+++ b/common/oe_host_string.h
@@ -38,10 +38,21 @@ int oe_strncmp(const char* s1, const char* s2, size_t n)
 
 /* host already has an oe_strlcat implementation */
 
+/*
+ * There are separate OE functions for strerror and strerror_s.
+ * Therefore we suppress the warning about not using more secure CRT functions.
+ */
 OE_INLINE
 char* oe_strerror(int errnum)
 {
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
     return strerror(errnum);
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 }
 
 OE_INLINE

--- a/common/safecrt.c
+++ b/common/safecrt.c
@@ -82,7 +82,7 @@ oe_result_t oe_memset_s(void* dst, size_t dst_size, int value, size_t num_bytes)
 
     /* memset_s cannot be optimized away by the compiler */
     while (num_bytes--)
-        *p++ = (volatile unsigned char)value;
+        *p++ = (unsigned char)value;
 
 done:
     return result;

--- a/debugger/debugrt/host/host.c
+++ b/debugger/debugrt/host/host.c
@@ -47,13 +47,26 @@ static bool raise_debugger_events()
         {
             // If specified, override oe_debugger_contract_version from the
             // environment.
-            char* version = getenv("OE_DEBUGGER_CONTRACT_VERSION");
-            if (version != NULL)
+            char* version;
+            size_t getenv_length;
+            getenv_s(&getenv_length, NULL, 0, "OE_DEBUGGER_CONTRACT_VERSION");
+
+            if (getenv_length > 0)
             {
-                int v = 0;
-                if (sscanf(version, "%d", &v) == 1)
+                version = (char*)malloc(sizeof(char) * getenv_length);
+                getenv_s(
+                    &getenv_length,
+                    version,
+                    sizeof(char) * getenv_length,
+                    "OE_DEBUGGER_CONTRACT_VERSION");
+
+                if (version != NULL)
                 {
-                    oe_debugger_contract_version = (uint32_t)v;
+                    int v = 0;
+                    if (sscanf_s(version, "%d", &v) == 1)
+                    {
+                        oe_debugger_contract_version = (uint32_t)v;
+                    }
                 }
             }
 

--- a/host/sgx/windows/exception.c
+++ b/host/sgx/windows/exception.c
@@ -4,6 +4,7 @@
 #include "exception.h"
 #include <openenclave/host.h>
 #include <openenclave/internal/calls.h>
+#include <openenclave/internal/registers.h>
 #include <stdio.h>
 #include <windows.h>
 #include "../enclave.h"
@@ -44,7 +45,7 @@ static LONG WINAPI _handle_simulation_mode_exception(
                 if (context->SegFs != enclave_fsbase)
                 {
                     // Update the FS register and continue execution.
-                    oe_set_fs_register_base(enclave_fsbase);
+                    oe_set_fs_register_base((void*)enclave_fsbase);
                     return OE_EXCEPTION_CONTINUE_EXECUTION;
                 }
             }

--- a/include/openenclave/host.h
+++ b/include/openenclave/host.h
@@ -29,6 +29,24 @@
 
 OE_EXTERNC_BEGIN
 
+#ifndef _WIN32
+#define _getpid getpid
+#define sscanf_s sscanf
+#define sprintf_s(buffer, size, format, argument) \
+    sprintf(buffer, format, argument)
+#define strcat_s(destination, destination_size, source) \
+    strcat(destination, source)
+#define strcpy_s(destination, destination_size, source) \
+    ;                                                   \
+    {                                                   \
+        (void)(destination_size);                       \
+        strcpy(destination, source);                    \
+    }
+#define _strdup strdup
+#define strncat_s(destination, destination_size, source, source_size) \
+    strncat(destination, source, source_size)
+#endif
+
 /**
  *  Flag passed into oe_create_enclave to run the enclave in debug mode.
  *  The flag allows the enclave to be created without the enclave binary

--- a/include/openenclave/internal/datetime.h
+++ b/include/openenclave/internal/datetime.h
@@ -13,6 +13,10 @@ OE_EXTERNC_BEGIN
 // ISO 8601 format: YYYY-MM-DDThh:mm:ssZ
 #define OE_DATETIME_FORMAT ("YYYY-MM-DDThh:mm:ssZ")
 
+#ifdef _WIN32
+#define gmtime_r(now, timeinfo) gmtime_s(timeinfo, now)
+#endif
+
 /**
  * Check whether the given issue date is a valid date time.
  */

--- a/tests/attestation_cert_apis/host/host.cpp
+++ b/tests/attestation_cert_apis/host/host.cpp
@@ -20,6 +20,8 @@
 #define TEST_RSA_KEY 1
 #define SKIP_RETURN_CODE 2
 
+#define FILENAME_LENGTH 80
+
 // This is the identity validation callback. An TLS connecting party (client or
 // server) can verify the passed in "identity" information to decide whether to
 // accept an connection reqest
@@ -92,16 +94,21 @@ void run_test(oe_enclave_t* enclave, int test_type)
 
     {
         // for testing purpose, output the whole cer in DER format
-        char filename[80];
+        char filename[FILENAME_LENGTH];
         FILE* file = NULL;
 
-        sprintf(
+        sprintf_s(
             filename,
+            sizeof(filename),
             "./cert_%s.der",
             test_type == TEST_RSA_KEY ? "rsa" : "ec");
         OE_TRACE_INFO(
             "Host: Log quote embedded certificate to file: [%s]\n", filename);
+#ifdef _WIN32
+        fopen_s(&file, filename, "wb");
+#else
         file = fopen(filename, "wb");
+#endif
         fwrite(cert, 1, cert_size, file);
         fclose(file);
     }

--- a/tests/crypto/enclave/host/host.c
+++ b/tests/crypto/enclave/host/host.c
@@ -38,7 +38,10 @@ int f_open(char* path, int flags, int mode)
      * also processed as binary (as they would be equivalently on Linux).
      */
     flags |= _O_BINARY;
+#pragma warning(push)
+#pragma warning(disable : 4996)
     return _open(path, flags, mode);
+#pragma warning(pop)
 #else
     return open(path, flags, mode);
 #endif
@@ -56,7 +59,7 @@ int f_openat(int dirfd, char* path, int flags, int mode)
 int f_read(int fd, char* ptr, size_t len)
 {
 #if defined(_WIN32)
-    return (int)_read(fd, ptr, len);
+    return (int)_read(fd, ptr, (int)len);
 #else
     return (int)read(fd, ptr, len);
 #endif

--- a/tests/crypto/read_file.c
+++ b/tests/crypto/read_file.c
@@ -5,10 +5,21 @@
 #include <openenclave/corelibc/string.h>
 #include "readfile.h"
 
+FILE* read_file(const char* filename, const char* mode)
+{
+    FILE* file;
+#ifdef _MSC_VER
+    fopen_s(&file, filename, mode);
+#else
+    file = fopen(filename, mode);
+#endif
+    return file;
+}
+
 oe_result_t read_cert(char* filename, char* cert)
 {
     size_t len_cert;
-    FILE* cfp = fopen(filename, "rb");
+    FILE* cfp = read_file(filename, "rb");
     if (cfp != NULL)
     {
         len_cert = fread(cert, sizeof(char), max_cert_size, cfp);
@@ -30,8 +41,8 @@ oe_result_t read_chain(
 {
     size_t len_cert1 = 0, len_cert2 = 0;
     char chain_temp[max_cert_size];
-    FILE* cfp1 = fopen(filename1, "rb");
-    FILE* cfp2 = fopen(filename2, "rb");
+    FILE* cfp1 = read_file(filename1, "rb");
+    FILE* cfp2 = read_file(filename2, "rb");
 
     if (cfp1 != NULL && cfp2 != NULL)
     {
@@ -61,9 +72,9 @@ oe_result_t read_chains(
     size_t len_cert1 = 0, len_cert2 = 0, len_cert3 = 0;
     char chain_temp1[max_cert_size];
     char chain_temp2[max_cert_size];
-    FILE* cfp1 = fopen(filename1, "rb");
-    FILE* cfp2 = fopen(filename2, "rb");
-    FILE* cfp3 = fopen(filename3, "rb");
+    FILE* cfp1 = read_file(filename1, "rb");
+    FILE* cfp2 = read_file(filename2, "rb");
+    FILE* cfp3 = read_file(filename3, "rb");
 
     if (cfp1 != NULL && cfp2 != NULL && cfp3 != NULL)
     {
@@ -89,7 +100,7 @@ oe_result_t read_chains(
 oe_result_t read_crl(char* filename, uint8_t* crl, size_t* crl_size)
 {
     size_t len_crl = 0;
-    FILE* cfp = fopen(filename, "rb");
+    FILE* cfp = read_file(filename, "rb");
 
     if (cfp != NULL)
     {
@@ -109,7 +120,7 @@ oe_result_t read_dates(char* filename, oe_datetime_t* time)
 {
     size_t len_date = 0;
     char buffer[max_date_size];
-    FILE* dfp = fopen(filename, "rb");
+    FILE* dfp = read_file(filename, "rb");
 
     if (dfp != NULL)
     {
@@ -121,7 +132,7 @@ oe_result_t read_dates(char* filename, oe_datetime_t* time)
     }
     buffer[len_date] = '\0';
 
-    sscanf(
+    sscanf_s(
         buffer,
         "%u :%u :%u :%u :%u :%u",
         &(time->year),
@@ -199,7 +210,7 @@ oe_result_t read_mod(char* filename, uint8_t* mod, size_t* mod_size)
     char buffer[(max_mod_size * 2) + 1];
     char* bufp = buffer;
 
-    FILE* mfp = fopen(filename, "rb");
+    FILE* mfp = read_file(filename, "rb");
     if (mfp != NULL)
     {
         numchars = fread(buffer, sizeof(char), max_mod_size * 2, mfp);
@@ -246,7 +257,7 @@ oe_result_t read_mixed_chain(
 oe_result_t read_sign(char* filename, uint8_t* sign, size_t* sign_size)
 {
     size_t len_sign;
-    FILE* sfp = fopen(filename, "rb");
+    FILE* sfp = read_file(filename, "rb");
     if (sfp != NULL)
     {
         len_sign = fread(sign, sizeof(char), max_sign_size, sfp);
@@ -280,7 +291,7 @@ oe_result_t read_pem_key(
     }
 
     /* Open file in binary mode. */
-    if (!(stream = fopen(filename, "rb")))
+    if (!(stream = read_file(filename, "rb")))
     {
         result = OE_FAILURE;
         goto done;
@@ -322,7 +333,7 @@ oe_result_t read_coordinates(
     size_t* y_size)
 {
     size_t len_x, len_y;
-    FILE* cfp = fopen(filename, "rb");
+    FILE* cfp = read_file(filename, "rb");
     if (cfp != NULL)
     {
         len_x = fread(x, sizeof(char), max_coordinates_size, cfp);

--- a/tests/crypto/readfile.h
+++ b/tests/crypto/readfile.h
@@ -22,6 +22,10 @@
 #define max_date_elements 6
 #define max_coordinates_size 32
 
+#ifndef _MSC_VER
+#define sscanf_s sscanf
+#endif
+
 oe_result_t read_cert(char* filename, char* cert);
 
 oe_result_t read_chain(
@@ -40,6 +44,8 @@ oe_result_t read_chains(
 oe_result_t read_crl(char* filename, uint8_t* crl, size_t* crl_size);
 
 oe_result_t read_dates(char* filename, oe_datetime_t* time);
+
+FILE* read_file(const char* filename, const char* mode);
 
 oe_result_t read_mod(char* filename, uint8_t* mod, size_t* mod_size);
 

--- a/tests/echo/echo.edl
+++ b/tests/echo/echo.edl
@@ -14,6 +14,7 @@ enclave {
             [out] char out[100],
             [string, in] char* str1,
             [user_check] char* str2,
-            [in] char str3[100]);
+            [in, size=out_length] char* str3,
+            int out_length);
     };
 };

--- a/tests/echo/enc/enc.c
+++ b/tests/echo/enc/enc.c
@@ -42,7 +42,8 @@ int enc_echo(char* in, char out[100])
         out,
         "oe_host_strdup1",
         host_allocated_str,
-        stack_allocated_str);
+        stack_allocated_str,
+        sizeof(stack_allocated_str));
     if (result != OE_OK)
     {
         return -1;

--- a/tests/echo/host/host.c
+++ b/tests/echo/host/host.c
@@ -11,13 +11,19 @@
 #include "../../../host/strings.h"
 #include "echo_u.h"
 
-int host_echo(char* in, char* out, char* str1, char* str2, char str3[100])
+int host_echo(
+    char* in,
+    char* out,
+    char* str1,
+    char* str2,
+    char* str3,
+    int out_length)
 {
     OE_TEST(strcmp(str1, "oe_host_strdup1") == 0);
     OE_TEST(strcmp(str2, "oe_host_strdup2") == 0);
     OE_TEST(strcmp(str3, "oe_host_strdup3") == 0);
 
-    strcpy(out, in);
+    strcpy_s(out, out_length, in);
 
     return 0;
 }

--- a/tests/file/host/host.cpp
+++ b/tests/file/host/host.cpp
@@ -22,7 +22,12 @@ void Log(const char* s, uint64_t x)
 MY_FILE* Fopen(const char* filename, const char* modes)
 {
     D(printf("Fopen(filename=%s, modes=%s)\n", filename, modes);)
-    FILE* is = fopen(filename, modes);
+    FILE* is;
+#ifdef _WIN32
+    fopen_s(&is, filename, modes);
+#else
+    is = fopen(filename, modes);
+#endif
     D(printf("Fopen(): return=%p\n", is);)
     return (MY_FILE*)is;
 }
@@ -55,8 +60,12 @@ static int _get_file_check_sum(const char* path, unsigned int* checksum)
     if (!path || !checksum)
         goto done;
 
-    /* Open the input file */
+        /* Open the input file */
+#ifdef _WIN32
+    if (fopen_s(&is, path, "rb") != 0)
+#else
     if (!(is = fopen(path, "rb")))
+#endif
         goto done;
 
     size_t n;

--- a/tests/host_verify/host/host.cpp
+++ b/tests/host_verify/host/host.cpp
@@ -64,7 +64,12 @@ oe_result_t enclave_identity_verifier(oe_identity_t* identity, void* arg)
 
 static bool _validate_file(const char* filename, bool assert)
 {
-    FILE* fp = fopen(filename, "rb");
+    FILE* fp;
+#ifdef _WIN32
+    fopen_s(&fp, filename, "rb");
+#else
+    fp = fopen(filename, "rb");
+#endif
 
     if (assert)
         OE_TEST(fp != NULL);
@@ -84,8 +89,11 @@ static oe_result_t _verify_cert(const char* filename, bool pass)
     size_t bytes_read;
 
     OE_TRACE_INFO("\n\nLoading and verifying %s\n\n", filename);
-
+#ifdef _WIN32
+    fopen_s(&fp, filename, "rb");
+#else
     fp = fopen(filename, "rb");
+#endif
     OE_TEST(fp != NULL);
 
     bytes_read = fread(buf, sizeof(uint8_t), sizeof(buf), fp);
@@ -129,7 +137,12 @@ static void _read_binary_file(
     uint8_t** data_ptr,
     size_t* size_ptr)
 {
-    FILE* fp = fopen(filename, "rb");
+    FILE* fp;
+#ifdef _WIN32
+    fopen_s(&fp, filename, "rb");
+#else
+    fp = fopen(filename, "rb");
+#endif
     size_t size = 0;
     uint8_t* data = NULL;
 

--- a/tests/libcxx/host/host.cpp
+++ b/tests/libcxx/host/host.cpp
@@ -280,7 +280,7 @@ int main(int argc, const char* argv[])
     }
 
     // Disable stdout buffering on host
-    setbuf(stdout, NULL);
+    setvbuf(stdout, NULL, _IONBF, 0);
 
     printf("=== %s: %s\n", argv[0], argv[1]);
 

--- a/tests/libunwind/host/host.cpp
+++ b/tests/libunwind/host/host.cpp
@@ -106,7 +106,7 @@ int main(int argc, const char* argv[])
     {
         oe_put_err("oe_create_libunwind_enclave(): result=%u", result);
     }
-    uint32_t pid = (uint32_t)getpid();
+    uint32_t pid = (uint32_t)_getpid();
 
     // Invoke "Test()" in the enclave.
     Test(enclave, pid);

--- a/tests/mbed/enc/enc.c
+++ b/tests/mbed/enc/enc.c
@@ -149,7 +149,7 @@ static oe_result_t _syscall_hook(
         case SYS_lseek:
         {
             int rval = 0;
-            result = mbed_test_lseek(&rval, (int)arg1, (off_t)arg2, (int)arg3);
+            result = mbed_test_lseek(&rval, (int)arg1, (int)arg2, (int)arg3);
             break;
         }
         case SYS_readv:

--- a/tests/mbed/host/host.c
+++ b/tests/mbed/host/host.c
@@ -13,6 +13,9 @@
 
 #include "mbed_u.h"
 
+#define PATH_LENGTH 1024
+#define TEMP_LENGTH 500
+
 void remove_postfix(char* str, char* postfix)
 {
     char* match;
@@ -44,20 +47,20 @@ char* find_data_file(char* str, size_t size)
      * finds the data file. */
     remove_postfix(token, "-lvi-cfg");
 
-    strncat(str, tail, strlen(tail));
+    strncat_s(str, size, tail, strlen(tail));
     printf("######## data_file: %s ###### \n", token);
     return token;
 }
 
-void datafileloc(char* data_file_name, char* path)
+void datafileloc(char* data_file_name, char* path, int length)
 {
     char* tail = "../enc/";
 #ifdef PROJECT_DIR
-    strcpy(path, PROJECT_DIR);
+    strcpy_s(path, length, PROJECT_DIR);
 #else
     char* separator;
 
-    if (getcwd(path, 1024) != NULL)
+    if (getcwd(path, length) != NULL)
         fprintf(stdout, "Current working dir: %s\n", path);
     else
         perror("getcwd() error");
@@ -70,8 +73,8 @@ void datafileloc(char* data_file_name, char* path)
 
     *separator = '\0'; /* separating string */
 #endif
-    strcat(path, tail);
-    strcat(path, data_file_name);
+    strcat_s(path, length, tail);
+    strcat_s(path, length, data_file_name);
 
 #if defined(_WIN32)
     /* On Windows, replace forward slashes with backslashes in the path */
@@ -87,14 +90,14 @@ void datafileloc(char* data_file_name, char* path)
 
 void Test(oe_enclave_t* enclave, int selftest, char* data_file_name)
 {
-    char path[1024];
+    char path[PATH_LENGTH];
     int return_value = 1;
     char* in_testname = NULL;
     char out_testname[STRLEN];
     struct mbed_args args = {0};
     if (!selftest)
     {
-        datafileloc(data_file_name, path);
+        datafileloc(data_file_name, path, PATH_LENGTH);
         in_testname = path;
     }
 
@@ -127,7 +130,7 @@ void ocall_exit(int arg)
 int main(int argc, const char* argv[])
 {
     oe_result_t result;
-    char temp[500];
+    char temp[TEMP_LENGTH];
     oe_enclave_t* enclave = NULL;
     int selftest = 0;
     uint32_t flags = oe_get_create_flags();
@@ -142,7 +145,7 @@ int main(int argc, const char* argv[])
 
     printf("=== %s: %s\n", argv[0], argv[1]);
 
-    strcpy(temp, argv[1]);
+    strcpy_s(temp, TEMP_LENGTH, argv[1]);
 
     if (strstr(argv[1], "selftest"))
     {

--- a/tests/mbed/host/ocalls.c
+++ b/tests/mbed/host/ocalls.c
@@ -1,6 +1,10 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#ifdef _WIN32
+#pragma warning(disable : 4996)
+#endif
+
 #include <assert.h>
 #include <fcntl.h>
 #include <openenclave/host.h>
@@ -18,7 +22,7 @@ int mbed_test_open(const char* path, int flags, mode_t mode)
 
 ssize_t mbed_test_read(int fd, char* buf, size_t buf_len)
 {
-    return read(fd, buf, buf_len);
+    return read(fd, buf, (int)buf_len);
 }
 
 int mbed_test_close(int fd)

--- a/tests/ocall/host/host.cpp
+++ b/tests/ocall/host/host.cpp
@@ -77,7 +77,7 @@ int main(int argc, const char* argv[])
     /* Call enc_set_tsd */
     {
         int ret_val = -1;
-        result = enc_set_tsd(enclave, &ret_val, strdup("TSD-DATA"));
+        result = enc_set_tsd(enclave, &ret_val, _strdup("TSD-DATA"));
         OE_TEST(OE_OK == result);
         OE_TEST(0 == ret_val);
     }

--- a/tests/oeedger8r/host/teststring.cpp
+++ b/tests/oeedger8r/host/teststring.cpp
@@ -9,6 +9,8 @@
 #include <wchar.h>
 #include "all_u.h"
 
+#define STR_LENGTH 50
+
 oe_result_t ecall_string_no_null_terminator_modified(
     oe_enclave_t* enclave,
     char* s1,
@@ -225,8 +227,8 @@ void test_string_edl_ecalls(oe_enclave_t* enclave)
 {
     const char* str_value = "Hello, World\n";
 
-    char str[50];
-    sprintf(str, "%s", str_value);
+    char str[STR_LENGTH];
+    sprintf_s(str, sizeof(str), "%s", str_value);
 
     // char*
     OE_TEST(ecall_string_fun1(enclave, str) == OE_OK);
@@ -241,7 +243,7 @@ void test_string_edl_ecalls(oe_enclave_t* enclave)
     OE_TEST(strcmp(str, "Goodbye\n") == 0);
 
     // Restore value.
-    sprintf(str, "%s", str_value);
+    sprintf_s(str, sizeof(str), "%s", str_value);
 
     // char* user check.
     OE_TEST(ecall_string_fun5(enclave, str) == OE_OK);
@@ -378,12 +380,12 @@ void ocall_string_fun7(char* s1, char* s2)
 void test_wstring_edl_ecalls(oe_enclave_t* enclave)
 {
     const wchar_t* str_value = L"Hello, World\n";
-    wchar_t str[50];
+    wchar_t str[STR_LENGTH];
 
     if (!g_enabled[TYPE_WCHAR_T])
         return;
 
-    swprintf(str, 50, L"%lS", str_value);
+    swprintf(str, sizeof(str) / sizeof(wchar_t), L"%lS", str_value);
 
     // wchar_t*
     OE_TEST(ecall_wstring_fun1(enclave, str) == OE_OK);
@@ -398,7 +400,7 @@ void test_wstring_edl_ecalls(oe_enclave_t* enclave)
     OE_TEST(wcscmp(str, L"Goodbye\n") == 0);
 
     // Restore value.
-    swprintf(str, 50, L"%lS", str_value);
+    swprintf(str, sizeof(str) / sizeof(wchar_t), L"%lS", str_value);
 
     // wchar_t* user check.
     OE_TEST(ecall_wstring_fun5(enclave, str) == OE_OK);

--- a/tests/pingpong-shared/enc/enc.cpp
+++ b/tests/pingpong-shared/enc/enc.cpp
@@ -4,9 +4,9 @@
 #include <openenclave/enclave.h>
 #include "pingpong_t.h"
 
-void Ping(const char* in, char* out)
+void Ping(const char* in, char* out, int out_length)
 {
-    Pong(in, out);
+    Pong(in, out, out_length);
 }
 
 OE_SET_ENCLAVE_SGX(

--- a/tests/pingpong-shared/host/host.cpp
+++ b/tests/pingpong-shared/host/host.cpp
@@ -14,7 +14,7 @@ void Log(const char* str, uint64_t x)
     printf("LOG: %s: %llu\n", str, OE_LLU(x));
 }
 
-void Pong(const char* in, char* out)
+void Pong(const char* in, char* out, int out_length)
 {
     // printf("Pong: %s %s\n", in, out);
 
@@ -24,7 +24,7 @@ void Pong(const char* in, char* out)
         {
             got_pong = true;
         }
-        strcpy(out, in);
+        strcpy_s(out, out_length, in);
     }
 }
 
@@ -51,8 +51,8 @@ OE_EXPORT int main_shared(int argc, const char* argv[])
         return 1;
     }
 
-    strcpy(buf, "String2");
-    result = Ping(enclave, "String1", buf);
+    strcpy_s(buf, sizeof(buf), "String2");
+    result = Ping(enclave, "String1", buf, sizeof(buf));
     if (result != OE_OK)
     {
         fprintf(stderr, "%s: Ping Failed\n", argv[0]);

--- a/tests/pingpong-shared/pingpong.edl
+++ b/tests/pingpong-shared/pingpong.edl
@@ -5,14 +5,16 @@ enclave {
     trusted {
         public void Ping(
             [in, string] const char* in,
-            [in, out, string] char* out);
+            [in, out, string] char* out,
+            int out_length);
 
     };
 
     untrusted {
         void Pong(
             [in, string] const char* in,
-            [in, out, string] char* out);
+            [in, out, string] char* out,
+            int out_length);
 
         void Log(
             [string, in] const char* str,

--- a/tests/pingpong/enc/enc.cpp
+++ b/tests/pingpong/enc/enc.cpp
@@ -4,9 +4,9 @@
 #include <openenclave/enclave.h>
 #include "pingpong_t.h"
 
-void Ping(const char* in, char* out)
+void Ping(const char* in, char* out, int out_length)
 {
-    Pong(in, out);
+    Pong(in, out, out_length);
 }
 
 OE_SET_ENCLAVE_SGX(

--- a/tests/pingpong/host/host.cpp
+++ b/tests/pingpong/host/host.cpp
@@ -14,17 +14,15 @@ void Log(const char* str, uint64_t x)
     printf("LOG: %s: %llu\n", str, OE_LLU(x));
 }
 
-void Pong(const char* in, char* out)
+void Pong(const char* in, char* out, int out_length)
 {
-    // printf("Pong: %s %s\n", in, out);
-
     if (in && out)
     {
         if (strcmp(in, "String1") == 0 && strcmp(out, "String2") == 0)
         {
             got_pong = true;
         }
-        strcpy(out, in);
+        strcpy_s(out, out_length, in);
     }
 }
 
@@ -51,8 +49,8 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    strcpy(buf, "String2");
-    result = Ping(enclave, "String1", buf);
+    strcpy_s(buf, sizeof(buf), "String2");
+    result = Ping(enclave, "String1", buf, sizeof(buf));
     if (result != OE_OK)
     {
         fprintf(stderr, "%s: Ping Failed\n", argv[0]);

--- a/tests/pingpong/pingpong.edl
+++ b/tests/pingpong/pingpong.edl
@@ -5,14 +5,16 @@ enclave {
     trusted {
         public void Ping(
             [in, string] const char* in,
-            [in, out, string] char* out);
+            [in, out, string] char* out,
+            int out_length);
 
     };
 
     untrusted {
         void Pong(
             [in, string] const char* in,
-            [in, out, string] char* out);
+            [in, out, string] char* out,
+            int out_length);
 
         void Log(
             [string, in] const char* str,

--- a/tests/report/common/tests.cpp
+++ b/tests/report/common/tests.cpp
@@ -1294,17 +1294,17 @@ void test_verify_report_with_collaterals()
 
         /* Test with time in the past */
         time_t t;
-        struct tm* timeinfo;
+        struct tm timeinfo;
         time(&t);
-        timeinfo = gmtime(&t);
+        gmtime_r(&t, &timeinfo);
 
         // convert tm to oe_datetime_t
-        oe_datetime_t past = {(uint32_t)timeinfo->tm_year + 1890,
-                              (uint32_t)timeinfo->tm_mon + 1,
-                              (uint32_t)timeinfo->tm_mday,
-                              (uint32_t)timeinfo->tm_hour,
-                              (uint32_t)timeinfo->tm_min,
-                              (uint32_t)timeinfo->tm_sec};
+        oe_datetime_t past = {(uint32_t)timeinfo.tm_year + 1890,
+                              (uint32_t)timeinfo.tm_mon + 1,
+                              (uint32_t)timeinfo.tm_mday,
+                              (uint32_t)timeinfo.tm_hour,
+                              (uint32_t)timeinfo.tm_min,
+                              (uint32_t)timeinfo.tm_sec};
         OE_TEST(
             VerifyReportWithCollaterals(
                 report_buffer_ptr,
@@ -1315,12 +1315,12 @@ void test_verify_report_with_collaterals()
                 NULL) == OE_VERIFY_FAILED_TO_FIND_VALIDITY_PERIOD);
 
         /* Test with time in the future */
-        oe_datetime_t future = {(uint32_t)timeinfo->tm_year + 1910,
-                                (uint32_t)timeinfo->tm_mon + 1,
-                                (uint32_t)timeinfo->tm_mday,
-                                (uint32_t)timeinfo->tm_hour,
-                                (uint32_t)timeinfo->tm_min,
-                                (uint32_t)timeinfo->tm_sec};
+        oe_datetime_t future = {(uint32_t)timeinfo.tm_year + 1910,
+                                (uint32_t)timeinfo.tm_mon + 1,
+                                (uint32_t)timeinfo.tm_mday,
+                                (uint32_t)timeinfo.tm_hour,
+                                (uint32_t)timeinfo.tm_min,
+                                (uint32_t)timeinfo.tm_sec};
         OE_TEST(
             VerifyReportWithCollaterals(
                 report_buffer_ptr,

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <openenclave/host.h>
+#include <openenclave/internal/datetime.h>
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/hexdump.h>
 #include <openenclave/internal/tests.h>
@@ -44,8 +45,12 @@ void generate_and_save_report(oe_enclave_t* enclave)
             0,
             &report,
             &report_size) == OE_OK);
-
-    FILE* file = fopen("./data/generated_report.bytes", "wb");
+    FILE* file;
+#ifdef _WIN32
+    fopen_s(&file, "./data/generated_report.bytes", "wb");
+#else
+    file = fopen("./data/generated_report.bytes", "wb");
+#endif
     fwrite(report, 1, report_size, file);
     fclose(file);
     oe_free_report(report);
@@ -194,22 +199,6 @@ int main(int argc, const char* argv[])
     TestVerifyTCBInfoV2(enclave, "./data_v2/tcbInfo_with_pceid.json");
     TestVerifyTCBInfoV2_AdvisoryIDs(
         enclave, "./data_v2/tcbInfoAdvisoryIds.json");
-
-    // Get current time and pass it to enclave.
-    std::time_t t = std::time(0);
-    std::tm* tm = std::gmtime(&t);
-
-    // convert std::tm to oe_datetime_t
-    oe_datetime_t now = {(uint32_t)tm->tm_year + 1900,
-                         (uint32_t)tm->tm_mon + 1,
-                         (uint32_t)tm->tm_mday,
-                         (uint32_t)tm->tm_hour,
-                         (uint32_t)tm->tm_min,
-                         (uint32_t)tm->tm_sec};
-
-    test_minimum_issue_date(enclave, now);
-
-    generate_and_save_report(enclave);
 #else
     test_local_report(&target_info);
     test_parse_report_negative();
@@ -221,22 +210,23 @@ int main(int argc, const char* argv[])
     OE_TEST(enclave_test_local_report(enclave, &target_info) == OE_OK);
     OE_TEST(enclave_test_parse_report_negative(enclave) == OE_OK);
     OE_TEST(enclave_test_local_verify_report(enclave) == OE_OK);
+#endif
 
     // Get current time and pass it to enclave.
     std::time_t t = std::time(0);
-    std::tm* tm = std::gmtime(&t);
+    std::tm tm;
+    gmtime_r(&t, &tm);
 
     // convert std::tm to oe_datetime_t
-    oe_datetime_t now = {(uint32_t)tm->tm_year + 1900,
-                         (uint32_t)tm->tm_mon + 1,
-                         (uint32_t)tm->tm_mday,
-                         (uint32_t)tm->tm_hour,
-                         (uint32_t)tm->tm_min,
-                         (uint32_t)tm->tm_sec};
+    oe_datetime_t now = {(uint32_t)tm.tm_year + 1900,
+                         (uint32_t)tm.tm_mon + 1,
+                         (uint32_t)tm.tm_mday,
+                         (uint32_t)tm.tm_hour,
+                         (uint32_t)tm.tm_min,
+                         (uint32_t)tm.tm_sec};
     test_minimum_issue_date(enclave, now);
 
     generate_and_save_report(enclave);
-#endif
 
     /* Terminate the enclave */
     if ((result = oe_terminate_enclave(enclave)) != OE_OK)

--- a/tests/stack_smashing_protector/host/host.cpp
+++ b/tests/stack_smashing_protector/host/host.cpp
@@ -32,7 +32,8 @@ int main(int argc, const char* argv[])
     /* Call enc_set_thread_variable */
     {
         int ret_val = -1;
-        result = enc_set_thread_variable(enclave, &ret_val, strdup("TSD-DATA"));
+        result =
+            enc_set_thread_variable(enclave, &ret_val, _strdup("TSD-DATA"));
         OE_TEST(OE_OK == result);
         OE_TEST(0 == ret_val);
     }

--- a/tests/switchless/host/host.c
+++ b/tests/switchless/host/host.c
@@ -53,7 +53,7 @@ int host_echo_switchless(
     OE_TEST(strcmp(str1, "host string parameter") == 0);
     OE_TEST(strcmp(str2, "host string on stack") == 0);
 
-    strcpy(out, in);
+    strcpy_s(out, STRING_LEN, in);
 
     return 0;
 }
@@ -67,7 +67,7 @@ int host_echo_regular(
     OE_TEST(strcmp(str1, "host string parameter") == 0);
     OE_TEST(strcmp(str2, "host string on stack") == 0);
 
-    strcpy(out, in);
+    strcpy_s(out, STRING_LEN, in);
 
     return 0;
 }
@@ -129,12 +129,12 @@ int main(int argc, const char* argv[])
 
     if (argc >= 3)
     {
-        sscanf(argv[2], "%" SCNu64, &num_host_threads);
+        sscanf_s(argv[2], "%" SCNu64, &num_host_threads);
     }
 
     if (argc == 4)
     {
-        sscanf(argv[3], "%" SCNu64, &num_enclave_threads);
+        sscanf_s(argv[3], "%" SCNu64, &num_enclave_threads);
         if (num_enclave_threads > NUM_TCS)
         {
             fprintf(

--- a/tests/switchless_threads/host/host.c
+++ b/tests/switchless_threads/host/host.c
@@ -29,7 +29,7 @@ int host_echo_switchless(char* in, char* out, char* str1, char str2[STRING_LEN])
     OE_TEST(strcmp(str1, HOST_PARAM_STRING) == 0);
     OE_TEST(strcmp(str2, HOST_STACK_STRING) == 0);
 
-    strcpy(out, in);
+    strcpy_s(out, STRING_LEN, in);
 
     return 0;
 }
@@ -39,7 +39,7 @@ int host_echo_regular(char* in, char* out, char* str1, char str2[STRING_LEN])
     OE_TEST(strcmp(str1, HOST_PARAM_STRING) == 0);
     OE_TEST(strcmp(str2, HOST_STACK_STRING) == 0);
 
-    strcpy(out, in);
+    strcpy_s(out, STRING_LEN, in);
 
     return 0;
 }

--- a/tests/tools/oecert/host/host.cpp
+++ b/tests/tools/oecert/host/host.cpp
@@ -111,7 +111,11 @@ static oe_result_t _gen_cert(
         FILE* file = NULL;
 
         printf("Creating certificate file: %s\n", out_filename);
+#ifdef _WIN32
+        fopen_s(&file, out_filename, "wb");
+#else
         file = fopen(out_filename, "wb");
+#endif
         if (file == NULL)
         {
             printf("Failed to open file: %s\n", out_filename);
@@ -162,7 +166,11 @@ static oe_result_t _gen_report(
         // Write report to file
         {
             FILE* output = NULL;
+#ifdef _WIN32
+            fopen_s(&output, report_filename, "wb");
+#else
             output = fopen(report_filename, "wb");
+#endif
             if (!output)
             {
                 printf("Failed to open report file %s\n", report_filename);
@@ -201,7 +209,11 @@ static oe_result_t _gen_report(
             size_t collaterals_size = 0;
             oe_report_header_t* header = (oe_report_header_t*)remote_report;
 
-            sprintf(collateral_filename, "%s.col", report_filename);
+            sprintf_s(
+                collateral_filename,
+                sizeof(collateral_filename),
+                "%s.col",
+                report_filename);
             printf("Generatting collateral file: %s\n", collateral_filename);
 
             result = oe_get_sgx_endorsements(
@@ -216,7 +228,12 @@ static oe_result_t _gen_report(
                 goto exit;
             }
 
-            FILE* col_fp = fopen(collateral_filename, "wb");
+            FILE* col_fp;
+#ifdef _WIN32
+            fopen_s(&col_fp, collateral_filename, "wb");
+#else
+            col_fp = fopen(collateral_filename, "wb");
+#endif
             if (!col_fp)
             {
                 printf(
@@ -281,7 +298,12 @@ static int _parse_args(int argc, const char* argv[])
     _params.out_filename = "out.bin";
 
     // Verify enclave file is valid
-    FILE* fp = fopen(_params.enclave_filename, "rb");
+    FILE* fp;
+#ifdef _WIN32
+    fopen_s(&fp, _params.enclave_filename, "rb");
+#else
+    fp = fopen(_params.enclave_filename, "rb");
+#endif
     if (!fp)
     {
         printf("Failed to find file: %s\n", _params.enclave_filename);
@@ -361,7 +383,12 @@ static int _parse_args(int argc, const char* argv[])
 
 static oe_result_t _read_key(const char* filename, uint8_t** data, size_t* size)
 {
-    FILE* fp = fopen(filename, "rb");
+    FILE* fp;
+#ifdef _WIN32
+    fopen_s(&fp, filename, "rb");
+#else
+    fp = fopen(filename, "rb");
+#endif
     size_t file_size;
     oe_result_t result = OE_FAILURE;
     uint8_t* memory = NULL;

--- a/tests/tools/oecertdump/host/host.cpp
+++ b/tests/tools/oecertdump/host/host.cpp
@@ -191,7 +191,12 @@ static int _parse_args(int argc, const char* argv[])
     _params.out_filename = DEFAULT_OUTPUTFILE;
 
     // Verify enclave file is valid
-    FILE* fp = fopen(_params.enclave_filename, "rb");
+    FILE* fp;
+#ifdef _WIN32
+    fopen_s(&fp, _params.enclave_filename, "rb");
+#else
+    fp = fopen(_params.enclave_filename, "rb");
+#endif
     if (!fp)
     {
         printf("Failed to find file: %s\n", _params.enclave_filename);
@@ -284,7 +289,11 @@ int main(int argc, const char* argv[])
     }
 
     // Create log file
+#ifdef _WIN32
+    fopen_s(&log_file, _params.out_filename, "w");
+#else
     log_file = fopen(_params.out_filename, "w");
+#endif
     if (!log_file)
     {
         printf("Failed to open log file %s\n", _params.out_filename);

--- a/tools/oesign/getopt_long.c
+++ b/tools/oesign/getopt_long.c
@@ -41,6 +41,10 @@ int optopt = '?'; /* character checked for validity */
 int optreset;     /* reset getopt */
 char* optarg;     /* argument associated with option */
 
+#ifdef _WIN32
+size_t getenv_length; /* argument associated with getenv_s() */
+#endif
+
 #define BUILD_ASSERT_TYPE(POINTER, TYPE) \
     ((void)sizeof((int)((POINTER) == (TYPE)(POINTER))))
 #define CONST_CAST(TYPE, POINTER) \
@@ -48,9 +52,13 @@ char* optarg;     /* argument associated with option */
 #define IGNORE_FIRST (*options == '-' || *options == '+')
 #define PRINT_ERROR \
     ((opterr) && ((*options != ':') || (IGNORE_FIRST && options[1] != ':')))
+#ifdef _WIN32
+#define IS_POSIXLY_CORRECT \
+    (getenv_s(&getenv_length, NULL, 0, "POSIXLY_CORRECT") > 0)
+#else
 #define IS_POSIXLY_CORRECT (getenv("POSIXLY_CORRECT") != NULL)
+#endif
 #define PERMUTE (!IS_POSIXLY_CORRECT && !IGNORE_FIRST)
-
 #define IN_ORDER (!IS_POSIXLY_CORRECT && *options == '-')
 
 /* return values */

--- a/tools/oesign/main.c
+++ b/tools/oesign/main.c
@@ -89,7 +89,11 @@ static oe_result_t _update_and_write_signed_exe(
             goto done;
         }
 
+#ifdef _WIN32
+        if (fopen_s(&os, p, "wb") != 0)
+#else
         if (!(os = fopen(p, "wb")))
+#endif
         {
             Err("failed to open: %s", p);
             goto done;
@@ -189,7 +193,11 @@ static int _load_config_file(const char* path, ConfigFileOptions* options)
     str_t rhs = STR_NULL_INIT;
     size_t line = 1;
 
+#ifdef _WIN32
+    if (fopen_s(&is, path, "rb") != 0)
+#else
     if (!(is = fopen(path, "rb")))
+#endif
         goto done;
 
     if (str_dynamic(&str, NULL, 0) != 0)
@@ -347,8 +355,12 @@ static int _load_pem_file(const char* path, void** data, size_t* size)
     if (!(*data = (uint8_t*)malloc(*size + 1)))
         goto done;
 
-    /* Open the file */
+        /* Open the file */
+#ifdef _WIN32
+    if (fopen_s(&is, path, "rb") != 0)
+#else
     if (!(is = fopen(path, "rb")))
+#endif
         goto done;
 
     /* Read file into memory */


### PR DESCRIPTION
I change the compiler settings so that the compiler will treat /W3 warnings as errors. 

I fix the warnings as follows:

1. With `_CRT_SECURE_NO_WARNINGS` turned on, fix the rest of warnings.

2. Remove `CRT_SECURE_NO_WARNINGS` and add pragmas to suppress warnings. Then restore secure CRT functions and remove pragmas one by one.

3. Fix any other additional warnings (casting problems, pointer mismatches, etc.).

Most changes each have an `ifdef`-`else`-`endif` branch to deal with different functions used on different platforms. 

However, I need some advice on the following three things:

1. The compiler suggests changing `getenv()` to `_dupenv_s()`. However, I find that the buffer used by `_dupenv_s()` needs to be freed up manually. Therefore, code in the two associated files become a little messy. 

2. I change the `gmtime()` to `gmtime_s()` and `gmtime_r()` on Windows and Linux, respectively. However, I also change the declaration from `struct tm* tm;` to `struct tm tm;`. Here's why:
2a) If I use `struct tm* tm;` before calling them then there will be an uninitialized variable error, and 
2b) If I use `struct tm* tm = NULL;` both functions will not be happy with the NULL pointer and cause an error during ctest.

3. I only keep the pragma `#pragma warning(disable : 4996)` in the following files:
3a) `common/oe_host_string.h` for keeping both `oe_strerror()` and `oe_strerror_r()`.
3b)` tests/crypto/enclave/host/host.c` for using `_open()` instead of `_sopen_s()`, which I find difficult to change the original flags and modes to the corresponding flags and permissions.
3c) `tests/mbed/host/ocalls.c` for the reason mentioned above.

Fix part of #2075.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>