### PR TITLE
add acc contributor template with no sgx package install

### DIFF
--- a/scripts/ansible/oe-contributors-acc-setup-no-psw.yml
+++ b/scripts/ansible/oe-contributors-acc-setup-no-psw.yml
@@ -1,0 +1,19 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+    - hosts: localhost
+      any_errors_fatal: true
+      become: yes
+      tasks:
+        - import_role:
+            name: linux/openenclave
+            tasks_from: environment-setup.yml
+
+        - import_role:
+            name: linux/intel
+            tasks_from: sgx-driver.yml
+
+        - import_role:
+            name: linux/az-dcap-client
+            tasks_from: stable-install.yml


### PR DESCRIPTION
Template for setting up automated Linux regression testing for Intel Packages. Allow installation of all dependencies but not including the SGX packages.