### PR TITLE
Allocate and associate ocall buffers with TCS.

### DIFF
--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -894,6 +894,7 @@ oe_result_t oe_terminate_enclave(oe_enclave_t* enclave)
         {
             oe_thread_binding_t* binding = &enclave->bindings[i];
             CloseHandle(binding->event.handle);
+            free(binding->ocall_buffer);
         }
 
 #endif

--- a/host/sgx/enclave.h
+++ b/host/sgx/enclave.h
@@ -71,6 +71,10 @@ typedef struct _thread_binding
     /* This field allows the simulation mode exception handler to read enclave
      * properties of the current thread binding */
     struct _oe_enclave* enclave;
+
+    /* Buffer used for ocall parameters */
+    void* ocall_buffer;
+    uint64_t ocall_buffer_size;
 } oe_thread_binding_t;
 
 /* Whether this binding is busy */

--- a/tests/ecall_ocall/ecall_ocall.edl
+++ b/tests/ecall_ocall/ecall_ocall.edl
@@ -21,6 +21,9 @@ enclave {
 
         public void enc_set_factor(
             uint32_t factor);
+
+        // Make an ocall and pass the given number.
+        public void enc_make_ocall(int n);
         };
 
     untrusted {
@@ -31,5 +34,9 @@ enclave {
             uint32_t enclave_id,
             uint32_t value,
             uint32_t total);
+
+        // If *n > 1, call make_ocall(*n-1) on the next enclave.
+        // Assert that *n does not change.
+        void host_ocall_pointer([in]int *n);
     };
 };

--- a/tests/ecall_ocall/enc/enc.cpp
+++ b/tests/ecall_ocall/enc/enc.cpp
@@ -140,6 +140,11 @@ void enc_set_factor(uint32_t factor)
     g_factor = factor;
 }
 
+void enc_make_ocall(int n)
+{
+    host_ocall_pointer(&n);
+}
+
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */


### PR DESCRIPTION
Each tcs identifies an enclave thread. oe_thread_binding_t houses data
associated with an enclave thread, that is accessible by both host and
enclave. Naturally, ocall buffers can also be housed in the thread-binding.

ecall_context_t houses data shared between enclave thread and host for
making a single ecall. ecall_context_t uses the ocall buffer from the
thread-binding. ecall_context_t itself lives only as long as the ecall.

Note: If ever OE goes back to supporting reentrant ecalls and ocalls,
a single ocall buffer per tcs will not suffice.

Closes #2590 

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>