### PR TITLE
Fix the regression of full libcxx tests on Linux

### DIFF
--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -26,6 +26,10 @@ enclave_compile_options(libcxxtest-support PRIVATE
     -Wno-sign-conversion
     )
 
+if (ENABLE_FULL_LIBCXX_TESTS)
+    enclave_compile_definitions(libcxxtest-support PRIVATE FULL_LIBCXX_TESTS)
+endif ()
+
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
     enclave_compile_options(libcxxtest-support PRIVATE
         -Wno-error=maybe-uninitialized

--- a/tests/libcxx/enc/enc.cpp
+++ b/tests/libcxx/enc/enc.cpp
@@ -279,9 +279,13 @@ int enc_test(char test_name[STRLEN])
 }
 
 OE_SET_ENCLAVE_SGX(
-    1,    /* ProductID */
-    1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    512,  /* HeapPageCount */
-    512,  /* StackPageCount */
-    8);   /* TCSCount */
+    1,                   /* ProductID */
+    1,                   /* SecurityVersion */
+    true,                /* AllowDebug */
+#ifdef FULL_LIBCXX_TESTS /* Full tests require large heap memory. */
+    12288,               /* HeapPageCount */
+#else
+    512, /* HeapPageCount */
+#endif
+    512, /* StackPageCount */
+    8);  /* TCSCount */


### PR DESCRIPTION
This PR fixes #2587.

The root cause of the regression is that previous fix for enabling libcxx tests on Windows (#2403) lowers the heap memory of the enclave to meet the memory constraint on Windows. However, a sub-set of the libcxx tests that enabled only with full tests require much larger heap memory, causing the full libcxx tests suite to fail on CI.

The fix is to increase the heap memory when enabling full libcxx tests (`ENABLE_FULL_LIBCXX_TESTS=ON`).

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>