### PR TITLE
Refactor common TEE EDL into separate files based on functionality

### DIFF
--- a/common/edl/asym_keys.edl
+++ b/common/edl/asym_keys.edl
@@ -1,0 +1,74 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/*
+**==============================================================================
+**
+** asym_keys.edl:
+**
+**     This file declares asymmetric key sructures used by attestation.edl
+**     as well as the public API surface.
+**
+**==============================================================================
+*/
+
+enclave
+{
+    /**
+     * This enumeration defines the type of a asymmetric key.
+     * This definition is shared by the enclave and the host.
+     */
+    enum oe_asymmetric_key_type_t {
+        /**
+         * A secp256r1/NIST P-256 elliptic curve key.
+         */
+        OE_ASYMMETRIC_KEY_EC_SECP256P1 = 1,
+
+        /**
+         * Unused.
+         */
+        _OE_ASYMMETRIC_KEY_TYPE_MAX = OE_ENUM_MAX
+    };
+
+    /**
+     * This enumeration defines the format of the asymmetric key.
+     * This definition is shared by the enclave and the host.
+     */
+    enum oe_asymmetric_key_format_t {
+        /**
+         * The PEM format.
+         */
+        OE_ASYMMETRIC_KEY_PEM = 1,
+
+        /**
+         * Unused.
+         */
+        _OE_ASYMMETRIC_KEY_FORMAT_MAX = OE_ENUM_MAX
+    };
+
+    /**
+     * This struct contains the parameters for asymmetric key derivation.
+     * This definition is shared by the enclave and the host.
+     */
+    struct oe_asymmetric_key_params_t {
+        /**
+         *  The type of asymmetric key.
+         */
+        oe_asymmetric_key_type_t type;
+
+        /**
+         * The exported format of the key.
+         */
+        oe_asymmetric_key_format_t format;
+
+        /**
+         * Optional user data to add to the key derivation.
+         */
+        [size=user_data_size] void* user_data;
+
+        /**
+         * The size of user_data.
+         */
+        size_t user_data_size;
+    };
+};

--- a/common/edl/attestation.edl
+++ b/common/edl/attestation.edl
@@ -1,0 +1,23 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/*
+**==============================================================================
+**
+** attestation.edl:
+**
+**     This file declares internal ECALLs used by liboehost/liboecore for
+**     gathering/verifying attestion information from the enclave.
+**
+**==============================================================================
+*/
+
+enclave
+{
+    trusted
+    {
+        public oe_result_t oe_verify_report_ecall(
+            [in, size=report_size] const void* report,
+            size_t report_size);
+    };
+};

--- a/common/edl/keys.edl
+++ b/common/edl/keys.edl
@@ -1,0 +1,39 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/*
+**==============================================================================
+**
+** keys.edl:
+**
+**     This file declares internal ECALLs used by liboehost/liboecore
+**     for retrieving public keys from the enclave.
+**
+**==============================================================================
+*/
+
+enclave
+{
+    from "asym_keys.edl" import *;
+
+    trusted
+    {
+        public oe_result_t oe_get_public_key_ecall(
+            [in] const oe_asymmetric_key_params_t* key_params,
+            [in, size=key_info_size] const void* key_info,
+            size_t key_info_size,
+            [out, size=key_buffer_size] void* key_buffer,
+            size_t key_buffer_size,
+            [out] size_t* key_buffer_size_out);
+
+        public oe_result_t oe_get_public_key_by_policy_ecall(
+            uint32_t seal_policy,
+            [in] const oe_asymmetric_key_params_t* key_params,
+            [out, size=key_buffer_size] void* key_buffer,
+            size_t key_buffer_size,
+            [out] size_t* key_buffer_size_out,
+            [out, size=key_info_size] void* key_info,
+            size_t key_info_size,
+            [out] size_t* key_info_size_out);
+    };
+};

--- a/common/edl/logging.edl
+++ b/common/edl/logging.edl
@@ -1,0 +1,38 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/*
+**==============================================================================
+**
+** logging.edl:
+**
+**     This file declares internal ECALLs/OCALLs used by liboehost/liboecore
+**     for logging to the host.
+**
+**==============================================================================
+*/
+
+enclave
+{
+
+    trusted
+    {
+        public void oe_log_init_ecall(
+            [in, string] const char* enclave_path,
+            uint32_t log_level);
+    };
+
+    untrusted
+    {
+        void oe_log_ocall(
+            uint32_t log_level,
+            [in, string] const char* message);
+
+        // Write a string to the console. Write to STDOUT if device=0. Write
+        // to STDERR if device=1. Write strnlen(str, maxlen) bytes.
+        void oe_write_ocall(
+            int device,
+            [in, string] const char* str,
+            size_t maxlen);
+    };
+};

--- a/common/edl/memory.edl
+++ b/common/edl/memory.edl
@@ -1,0 +1,23 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/*
+**==============================================================================
+**
+** memory.edl:
+**
+**     This file declares internal ECALLs used by liboehost/liboecore for
+**     manipulating memory allocations across the enclave boundary.
+**
+**==============================================================================
+*/
+
+enclave
+{
+    untrusted
+    {
+        void* oe_realloc_ocall(
+            [user_check] void* ptr,
+            size_t size);
+    };
+};

--- a/common/edl/tee.edl
+++ b/common/edl/tee.edl
@@ -4,7 +4,7 @@
 /*
 **==============================================================================
 **
-** internal.edl:
+** tee.edl:
 **
 **     This file declares internal ECALLs/OCALLs used by liboehost/liboecore
 **     for usage with any TEE technology.
@@ -14,108 +14,14 @@
 
 enclave
 {
-    /**
-     * This enumeration defines the type of a asymmetric key.
-     * This definition is shared by the enclave and the host.
+    /* The end goal is to publish all EDL files as part of the SDK. At that time
+     * enclave developers will simply import the edl files/functions they
+     * need and this file will no longer be required. These files are imported
+     * as a convenience to allow refactoring of system EDL files without the need
+     * to add a new build definition for each file.
      */
-    enum oe_asymmetric_key_type_t {
-        /**
-         * A secp256r1/NIST P-256 elliptic curve key.
-         */
-        OE_ASYMMETRIC_KEY_EC_SECP256P1 = 1,
-
-        /**
-         * Unused.
-         */
-        _OE_ASYMMETRIC_KEY_TYPE_MAX = OE_ENUM_MAX
-    };
-
-    /**
-     * This enumeration defines the format of the asymmetric key.
-     * This definition is shared by the enclave and the host.
-     */
-    enum oe_asymmetric_key_format_t {
-        /**
-         * The PEM format.
-         */
-        OE_ASYMMETRIC_KEY_PEM = 1,
-
-        /**
-         * Unused.
-         */
-        _OE_ASYMMETRIC_KEY_FORMAT_MAX = OE_ENUM_MAX
-    };
-
-    /**
-     * This struct contains the parameters for asymmetric key derivation.
-     * This definition is shared by the enclave and the host.
-     */
-    struct oe_asymmetric_key_params_t {
-        /**
-         *  The type of asymmetric key.
-         */
-        oe_asymmetric_key_type_t type;
-
-        /**
-         * The exported format of the key.
-         */
-        oe_asymmetric_key_format_t format;
-
-        /**
-         * Optional user data to add to the key derivation.
-         */
-        [size=user_data_size] void* user_data;
-
-        /**
-         * The size of user_data.
-         */
-        size_t user_data_size;
-    };
-
-    trusted
-    {
-        public void oe_log_init_ecall(
-            [in, string] const char* enclave_path,
-            uint32_t log_level);
-
-        public oe_result_t oe_verify_report_ecall(
-            [in, size=report_size] const void* report,
-            size_t report_size);
-
-        public oe_result_t oe_get_public_key_ecall(
-            [in] const oe_asymmetric_key_params_t* key_params,
-            [in, size=key_info_size] const void* key_info,
-            size_t key_info_size,
-            [out, size=key_buffer_size] void* key_buffer,
-            size_t key_buffer_size,
-            [out] size_t* key_buffer_size_out);
-
-        public oe_result_t oe_get_public_key_by_policy_ecall(
-            uint32_t seal_policy,
-            [in] const oe_asymmetric_key_params_t* key_params,
-            [out, size=key_buffer_size] void* key_buffer,
-            size_t key_buffer_size,
-            [out] size_t* key_buffer_size_out,
-            [out, size=key_info_size] void* key_info,
-            size_t key_info_size,
-            [out] size_t* key_info_size_out);
-    };
-
-    untrusted
-    {
-        void oe_log_ocall(
-            uint32_t log_level,
-            [in, string] const char* message);
-
-        void* oe_realloc_ocall(
-            [user_check] void* ptr,
-            size_t size);
-
-        // Write a string to the console. Write to STDOUT if device=0. Write
-        // to STDERR if device=1. Write strnlen(str, maxlen) bytes.
-        void oe_write_ocall(
-            int device,
-            [in, string] const char* str,
-            size_t maxlen);
-    };
+    from "attestation.edl" import *;
+    from "keys.edl" import *;
+    from "logging.edl" import *;
+    from "memory.edl" import *;
 };

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -6,38 +6,58 @@ if (OE_SGX)
     set(SGX_EDL_DIR ${CMAKE_SOURCE_DIR}/common/sgx/edl)
 endif()
 
-set(OE_EDL_INCLUDES ${OE_INCDIR}/openenclave/bits)
-
 ##==============================================================================
 ##
 ## These rules generate the edge routines for the internal TEE-agnostic
 ## ECALLs/OCALLs used by liboehost/liboecore.
-##
-## The generated _args.h is published in ${OE_EDL_INCLUDES}.
 ##
 ##==============================================================================
 
 set(TEE_EDL_FILE ${EDL_DIR}/tee.edl)
 
 add_custom_command(
-    OUTPUT tee_u.h tee_u.c tee_args.h ${OE_EDL_INCLUDES}/asym_keys.h
+    OUTPUT tee_u.h tee_u.c tee_args.h
     DEPENDS ${TEE_EDL_FILE} edger8r
-    COMMAND edger8r --search-path ${EDL_DIR} --untrusted ${TEE_EDL_FILE}
-
-    ## Publish the edger8r-generated header (*_args.h) that defines data structures.
-    ## Note that doing this on the host side to ensure publishing the header with
-    ## the case of `BUILD_ENCLAVES=OFF`.
-    COMMAND ${CMAKE_COMMAND} -E copy tee_args.h ${OE_EDL_INCLUDES}/asym_keys.h)
-
+    COMMAND edger8r --search-path ${EDL_DIR} --untrusted ${TEE_EDL_FILE})
 
 add_custom_target(tee_untrusted_edl
-    DEPENDS tee_u.h tee_u.c tee_args.h ${OE_EDL_INCLUDES}/asym_keys.h)
+    DEPENDS tee_u.h tee_u.c tee_args.h)
 
-# Add dependencies to `oe_includes` so that the published header will be ready before
-# other files consume it.
-add_dependencies(oe_includes tee_untrusted_edl)
+##==============================================================================
+##
+## Publish the edger8r-generated header (*_args.h) that defines data structures
+## which are part of the public API surface.
+## Note that doing this on the host side to ensure publishing the header with 
+## the case of `BUILD_ENCLAVES=OFF`.
+##
+##==============================================================================
 
-install(DIRECTORY ${OE_EDL_INCLUDES}
+set(OE_EDL_INCLUDE_DIR ${OE_INCDIR}/openenclave/bits)
+list(APPEND EDL_PUBLIC_STRUCTURES "${EDL_DIR}/asym_keys.edl")
+
+foreach (struct_file ${EDL_PUBLIC_STRUCTURES})
+  get_filename_component(name ${struct_file} NAME_WE)
+
+  add_custom_command(
+      OUTPUT ${name}_args.h
+      DEPENDS ${struct_file} edger8r
+      COMMAND edger8r --header-only --search-path ${EDL_DIR}
+                      --untrusted ${struct_file})
+
+  add_custom_command(
+      OUTPUT ${OE_EDL_INCLUDE_DIR}/${name}.h
+      COMMAND ${CMAKE_COMMAND} -E copy ${name}_args.h ${OE_EDL_INCLUDE_DIR}/${name}.h
+      DEPENDS ${name}_args.h)
+
+  add_custom_target(gen_edl_headers_${name}
+      DEPENDS ${OE_EDL_INCLUDE_DIR}/${name}.h)
+
+  # Add dependencies to `oe_includes` so that the published header will be ready before
+  # other files consume it.
+  add_dependencies(oe_includes gen_edl_headers_${name})
+endforeach ()
+
+install(DIRECTORY ${OE_EDL_INCLUDE_DIR}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave)
 
 ##==============================================================================


### PR DESCRIPTION
EDL functions which are common accross all TEEs were in a single tee.edl file. Refactor these to be split into different EDL files based on functionality.