### PR TITLE
Fixed bug in data-sealing sample.

### DIFF
--- a/samples/data-sealing/common/shared.h
+++ b/samples/data-sealing/common/shared.h
@@ -21,6 +21,7 @@
 #define ERROR_CIPHER_ERROR 5
 #define ERROR_UNSEALED_DATA_FAIL 6
 #define ERROR_SEALED_DATA_FAIL 7
+#define ERROR_INVALID_PARAMETER 8
 
 typedef struct _sealed_data_t
 {
@@ -31,7 +32,7 @@ typedef struct _sealed_data_t
     size_t key_info_size;
     size_t original_data_size;
     size_t encrypted_data_len;
-    unsigned char encrypted_data[];
+    unsigned char encrypted_data[1];
 } sealed_data_t;
 
 #endif /* _SHARED_H */

--- a/samples/data-sealing/host/host.cpp
+++ b/samples/data-sealing/host/host.cpp
@@ -60,7 +60,7 @@ int unseal_data_and_verify_result(
     unsigned char* target_data,
     size_t target_data_size)
 {
-    oe_result_t result = OE_OK;
+    oe_result_t result = OE_FAILURE;
     int ret = 0;
     unsigned char* data = NULL;
     size_t data_size = 0;
@@ -80,8 +80,8 @@ int unseal_data_and_verify_result(
     cout << "Host: Unsealed result:" << endl;
     printf("data=%s\n", data);
 
-    printf("data_size=%ld\n", data_size);
-    printf("target_data_size=%ld\n", target_data_size);
+    printf("data_size=%zd\n", data_size);
+    printf("target_data_size=%zd\n", target_data_size);
 
     if (strncmp(
             (const char*)data, (const char*)target_data, target_data_size) != 0)
@@ -95,6 +95,9 @@ int unseal_data_and_verify_result(
 exit:
     if (data)
         free(data);
+
+    if (ret != 0)
+        result = OE_FAILURE;
 
     cout << "Host: exit unseal_data_and_verify_result with "
          << oe_result_str(result) << endl;
@@ -229,6 +232,10 @@ exit:
     // Free host memory allocated by the enclave.
     if (sealed_data != NULL)
         free(sealed_data);
+
+    if (ret != 0)
+        result = OE_FAILURE;
+
     return result;
 }
 


### PR DESCRIPTION
Previously, the data sealing sample was failing all the time, but not detected by CI/CD because the wrong return code was returned.  This change fixes this.

Fixes #2692.