### PR TITLE
Update the checks of GCC version to bypass the failing libcxx test case

### DIFF
--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -59,11 +59,11 @@ foreach(testcase ${alltests})
         endif()
     endif()
 
-# the following test fails on GCC version 7, see  #1523 -- Skipping this test in GCC 7.0 -> 7.5
+# the following test fails on GCC version 7, see  #1523 -- Skipping this test in GCC 7.0 -> 8.0
     if ("${name}" MATCHES "std_utilities_function.objects_comparisons_constexpr_init.pass")
         if(ENCLAVE_CXX_COMPILER_ID MATCHES GNU
             AND ENCLAVE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7
-            AND ENCLAVE_CXX_COMPILER_VERSION VERSION_LESS 7.5)
+            AND ENCLAVE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
             continue()
         endif()
     endif()

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -144,11 +144,11 @@ foreach(testcase ${alltests})
         endif()
     endif()
 
-# the following test fails on GCC version 7, see  #1523 -- Skipping this test in GCC 7.0 -> 7.5
+# the following test fails on GCC version 7, see  #1523 -- Skipping this test in GCC 7.0 -> 8.0
     if ("${name}" MATCHES "std_utilities_function.objects_comparisons_constexpr_init.pass")
         if(CMAKE_CXX_COMPILER_ID MATCHES GNU
                AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7
-               AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.5)
+               AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
             continue()
         endif()
     endif()


### PR DESCRIPTION
This PR fixes #1523 (was reopened), which updates the checks of GCC version (from `< 7.5` to `< 8.0`) to correctly bypass the failing libcxx test case: `constexpr_init.pass.cpp`.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>