### PR TITLE
Log TCB level variables for OE_TCB_LEVEL_INVALID

### DIFF
--- a/common/sgx/quote.c
+++ b/common/sgx/quote.c
@@ -642,8 +642,8 @@ oe_result_t oe_get_sgx_quote_validity(
 
     // Fetch revocation info validity dates.
     OE_CHECK_MSG(
-        oe_validate_revocation_list(&pck_cert, sgx_endorsements, &from, &until),
-
+        oe_validate_revocation_list(
+            sgx_quote, &pck_cert, sgx_endorsements, &from, &until),
         "Failed to validate revocation info. %s",
         oe_result_str(result));
     _update_validity(&latest_from, &earliest_until, &from, &until);

--- a/common/sgx/revocation.h
+++ b/common/sgx/revocation.h
@@ -22,12 +22,15 @@ OE_EXTERNC_BEGIN
  * Are valid and returns the validity dates for the given
  * revocation info.
  *
+ * @param[in] sgx_quote The SGX quote.
  * @param[in] pck_cert The PCK certificate.
  * @param[in] sgx_endorsements The SGX endorsements.
+ * @param[in] quote_tcb_level The TCB level of the quote.
  * @param[out] validity_from The date from which the revocation info is valid.
  * @param[out] validity_until The date which the revocation info expires.
  */
 oe_result_t oe_validate_revocation_list(
+    const sgx_quote_t* sgx_quote,
     oe_cert_t* pck_cert,
     const oe_sgx_endorsements_t* sgx_endorsements,
     oe_datetime_t* validity_from,


### PR DESCRIPTION
Log all SGX TCB level variables when the quote verification fails due to invalid TCB level status. Variables include:

- TCB Info
- FMSPC
- QE_ID
- CPU_SVN
- PCE_SVN
- PCE_ID

These variables help identify why quote verification fails.