### PR TITLE
Give warning when building with 32-bit targets

### DIFF
--- a/docs/GettingStartedDocs/Linux_using_oe_sdk.md
+++ b/docs/GettingStartedDocs/Linux_using_oe_sdk.md
@@ -3,6 +3,8 @@
 This document provides a brief overview of how to start exploring the Open Enclave SDK
 once you have it installed.
 
+**Note**: The SDK currently does not support 32-bit applications.
+
 ## Open Enclave SDK Layout
 
 On Linux, by default, the Open Enclave SDK is installed to `/opt/openenclave`.

--- a/docs/GettingStartedDocs/OP-TEE/Introduction.md
+++ b/docs/GettingStartedDocs/OP-TEE/Introduction.md
@@ -78,6 +78,10 @@ One of OP-TEE's test cases is known to fail on the TrustBox.
 
 [Tracking issue](https://github.com/openenclave/openenclave/issues/2275).
 
+### 32-bit targets are not supported
+
+[Tracking issue](https://github.com/openenclave/openenclave/issues/2493).
+
 ## Note on Forks
 
 While the SDK's support for Intel SGX is fairly self-contained, support for

--- a/docs/GettingStartedDocs/Windows_using_oe_sdk.md
+++ b/docs/GettingStartedDocs/Windows_using_oe_sdk.md
@@ -3,6 +3,8 @@
 This document provides a brief overview of how to start exploring the Open Enclave SDK
 once you have it installed.
 
+**Note**: The SDK currently does not support 32-bit applications.
+
 ## Open Enclave SDK Layout
 
 On Windows, if you installed the SDK using the NuGet package, it is by default installed to `%userprofile%\.nuget\packages`.

--- a/include/openenclave/bits/defs.h
+++ b/include/openenclave/bits/defs.h
@@ -8,6 +8,10 @@
 #error "Unsupported platform"
 #endif
 
+#if !defined(_WIN64) && !defined(__x86_64__) && !defined(__aarch64__)
+#error "32-bit targets are currently not supported"
+#endif
+
 /* OE_API_VERSION */
 #ifndef OE_API_VERSION
 #define OE_API_VERSION 2


### PR DESCRIPTION
This PR adds compile-time warning when building 32-bit targets.
Also, the PR updates document that explicitly states that OE currently does not support 32-bit targets.

Fixes #2492

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>