### PR TITLE
Add _verify_claims_hash before extract the claims

### DIFF
--- a/common/result.c
+++ b/common/result.c
@@ -130,8 +130,8 @@ const char* oe_result_str(oe_result_t result)
             return "OE_ALREADY_EXISTS";
         case OE_ALREADY_INITIALIZED:
             return "OE_ALREADY_INITIALIZED";
-        case QE_QUOTE_HASH_MISMATCH:
-            return "QE_QUOTE_HASH_MISMATCH";
+        case OE_QUOTE_HASH_MISMATCH:
+            return "OE_QUOTE_HASH_MISMATCH";
         case __OE_RESULT_MAX:
             break;
     }
@@ -200,7 +200,7 @@ bool oe_is_valid_result(uint32_t result)
         case OE_THREAD_JOIN_ERROR:
         case OE_ALREADY_EXISTS:
         case OE_ALREADY_INITIALIZED:
-        case QE_QUOTE_HASH_MISMATCH:
+        case OE_QUOTE_HASH_MISMATCH:
         {
             return true;
         }

--- a/common/result.c
+++ b/common/result.c
@@ -130,6 +130,8 @@ const char* oe_result_str(oe_result_t result)
             return "OE_ALREADY_EXISTS";
         case OE_ALREADY_INITIALIZED:
             return "OE_ALREADY_INITIALIZED";
+        case QE_QUOTE_HASH_MISMATCH:
+            return "QE_QUOTE_HASH_MISMATCH";
         case __OE_RESULT_MAX:
             break;
     }
@@ -198,6 +200,7 @@ bool oe_is_valid_result(uint32_t result)
         case OE_THREAD_JOIN_ERROR:
         case OE_ALREADY_EXISTS:
         case OE_ALREADY_INITIALIZED:
+        case QE_QUOTE_HASH_MISMATCH:
         {
             return true;
         }

--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -102,11 +102,13 @@ static oe_result_t _verify_local_report(
 }
 
 static oe_result_t _verify_claims_hash(
-    sgx_quote_t* quote,
+    const uint8_t* report,
+    oe_report_type_t report_type,
     const uint8_t* claims,
     size_t claims_size)
 {
     oe_result_t result = OE_UNEXPECTED;
+    int hash_cmp = 0;
     OE_SHA256 hash;
     oe_sha256_context_t hash_ctx = {0};
 
@@ -114,10 +116,22 @@ static oe_result_t _verify_claims_hash(
     OE_CHECK(oe_sha256_update(&hash_ctx, claims, claims_size));
     OE_CHECK(oe_sha256_final(&hash_ctx, &hash));
 
-    if (memcmp(&hash, &quote->report_body.report_data, OE_SHA256_SIZE) == 0)
-        result = OE_OK;
+    if (report_type == OE_REPORT_TYPE_SGX_REMOTE)
+    {
+        hash_cmp = memcmp(
+            &((sgx_quote_t*)report)->report_body.report_data,
+            &hash,
+            OE_SHA256_SIZE);
+    }
+    else if (report_type == OE_REPORT_TYPE_SGX_LOCAL)
+    {
+        hash_cmp = memcmp(
+            &((sgx_report_t*)report)->body.report_data, &hash, OE_SHA256_SIZE);
+    }
     else
-        result = QE_QUOTE_HASH_MISMATCH;
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    result = (hash_cmp == 0) ? OE_OK : OE_QUOTE_HASH_MISMATCH;
 done:
     return result;
 }
@@ -349,13 +363,11 @@ static oe_result_t _extract_claims(
 
     // verify the integrity of the serialized claims with hash stored in
     // report_data.
-    if (header->report_type == OE_REPORT_TYPE_SGX_REMOTE)
-    {
-        OE_CHECK(_verify_claims_hash(
-            (sgx_quote_t*)header->report,
-            evidence + report_size,
-            evidence_size - report_size));
-    }
+    OE_CHECK(_verify_claims_hash(
+        header->report,
+        header->report_type,
+        evidence + report_size,
+        evidence_size - report_size));
 
     claims_header = (oe_sgx_plugin_claims_header_t*)(evidence + report_size);
 

--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -114,10 +114,10 @@ static oe_result_t _verify_claims_hash(
     OE_CHECK(oe_sha256_update(&hash_ctx, claims, claims_size));
     OE_CHECK(oe_sha256_final(&hash_ctx, &hash));
 
-    if (memcmp(&hash, &quote->report_body.report_data, OE_SHA256_SIZE))
-        result = OE_FAILURE;
-    else
+    if (memcmp(&hash, &quote->report_body.report_data, OE_SHA256_SIZE) == 0)
         result = OE_OK;
+    else
+        result = QE_QUOTE_HASH_MISMATCH;
 done:
     return result;
 }

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -348,7 +348,7 @@ typedef enum _oe_result
      * The hash of claims section in the quote does not match the hash value
      * held in the report_data field. This occurs when claims are tampered.
      */
-    QE_QUOTE_HASH_MISMATCH,
+    OE_QUOTE_HASH_MISMATCH,
 
     __OE_RESULT_MAX = OE_ENUM_MAX,
 } oe_result_t;

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -344,6 +344,12 @@ typedef enum _oe_result
      */
     OE_ALREADY_INITIALIZED,
 
+    /**
+     * The hash of claims section in the quote does not match the hash value
+     * held in the report_data field. This occurs when claims are tampered.
+     */
+    QE_QUOTE_HASH_MISMATCH,
+
     __OE_RESULT_MAX = OE_ENUM_MAX,
 } oe_result_t;
 /**< typedef enum _oe_result oe_result_t*/

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -592,23 +592,19 @@ void verify_sgx_evidence(
     OE_TEST(oe_free_claims_list(claims, claims_size) == OE_OK);
 
     // Test sgx_remote_evidence with tampered claims in evidence
-    if (!is_local)
-    {
-        printf(
-            "====== running verify_sgx_evidence failed with hampered claims\n");
-        header->data[header->data_size - 1] ^= 1;
+    printf("====== running verify_sgx_evidence failed with hampered claims\n");
+    header->data[header->data_size - 1] ^= 1;
 
-        OE_TEST(
-            oe_verify_evidence(
-                evidence,
-                evidence_size,
-                endorsements,
-                endorsements_size,
-                NULL,
-                0,
-                &claims,
-                &claims_size) == QE_QUOTE_HASH_MISMATCH);
+    OE_TEST(
+        oe_verify_evidence(
+            evidence,
+            evidence_size,
+            endorsements,
+            endorsements_size,
+            NULL,
+            0,
+            &claims,
+            &claims_size) == OE_QUOTE_HASH_MISMATCH);
 
-        header->data[header->data_size - 1] ^= 1;
-    }
+    header->data[header->data_size - 1] ^= 1;
 }

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -607,7 +607,7 @@ void verify_sgx_evidence(
                 NULL,
                 0,
                 &claims,
-                &claims_size) == OE_FAILURE);
+                &claims_size) == QE_QUOTE_HASH_MISMATCH);
 
         header->data[header->data_size - 1] ^= 1;
     }

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -589,6 +589,26 @@ void verify_sgx_evidence(
                                      custom_claims[i].value_size) == 0);
         }
     }
-
     OE_TEST(oe_free_claims_list(claims, claims_size) == OE_OK);
+
+    // Test sgx_remote_evidence with tampered claims in evidence
+    if (!is_local)
+    {
+        printf(
+            "====== running verify_sgx_evidence failed with hampered claims\n");
+        header->data[header->data_size - 1] ^= 1;
+
+        OE_TEST(
+            oe_verify_evidence(
+                evidence,
+                evidence_size,
+                endorsements,
+                endorsements_size,
+                NULL,
+                0,
+                &claims,
+                &claims_size) == OE_FAILURE);
+
+        header->data[header->data_size - 1] ^= 1;
+    }
 }


### PR DESCRIPTION
Fixes #2658
This pull request is to fix #2658.
One step missing from evidence verification is that the hash of the serialized claims should be verified against the report data, which is the hash of original claims, to guarantee the integrity of the claims, before deserializing the claims.
This pull request added a function _verify_claims_hash which performs such verification. The function is called in the _extract_claims so that claims will be deserialized only after it pass the claims hash verification.
Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>