### PR TITLE
Add missing dependencies to `oehostmr`

### DIFF
--- a/host/measure/CMakeLists.txt
+++ b/host/measure/CMakeLists.txt
@@ -100,9 +100,9 @@ if (WIN32)
   target_link_libraries(oehostmr PUBLIC crypt32)
 endif ()
 
+add_dependencies(oehostmr syscall_untrusted_edl tee_untrusted_edl)
 if (OE_SGX)
-  add_custom_target(edger8r_result DEPENDS sgx_u.h switchless_u.h switchless_u.c)
-  add_dependencies(oehostmr edger8r_result)
+  add_dependencies(oehostmr sgx_untrusted_edl switchless_untrusted_edl)
 endif ()
 
 # TODO: Replace these with `find_package` and add as dependencies to


### PR DESCRIPTION
This PR fixes #2711, which adds the missing dependencies of oeedger8er-generated files to `oehostmr`.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>