### PR TITLE
Fix fd not being deleted from epoll on close

### DIFF
--- a/include/openenclave/internal/syscall/fd.h
+++ b/include/openenclave/internal/syscall/fd.h
@@ -148,6 +148,8 @@ typedef struct _oe_epoll_ops
         struct oe_epoll_event* events,
         int maxevents,
         int timeout);
+
+    void (*on_close)(oe_fd_t* epoll, int fd);
 } oe_epoll_ops_t;
 
 struct _oe_fd

--- a/include/openenclave/internal/syscall/fdtable.h
+++ b/include/openenclave/internal/syscall/fdtable.h
@@ -18,6 +18,20 @@ int oe_fdtable_reassign(int fd, oe_fd_t* new_desc, oe_fd_t** old_desc);
 
 int oe_fdtable_release(int fd);
 
+/**
+ * Invokes **callback** for each fd of type **type** in the fdtable.
+ *
+ * The callback must not use any of the other fdtable functions.
+ *
+ * @param type The fd type of interest. Can be OE_FD_TYPE_ANY.
+ * @param arg An argument passed to the callback.
+ * @param callback The callback to be invoked.
+ */
+void oe_fdtable_foreach(
+    oe_fd_type_t type,
+    void* arg,
+    void (*callback)(oe_fd_t* desc, void* arg));
+
 OE_EXTERNC_END
 
 #endif // _OE_SYSCALL_FDTABLE_H

--- a/syscall/devices/hostepoll/hostepoll.c
+++ b/syscall/devices/hostepoll/hostepoll.c
@@ -809,6 +809,29 @@ done:
     return ret;
 }
 
+static void _epoll_on_close(oe_fd_t* epoll_, int fd)
+{
+    epoll_t* const epoll = _cast_epoll(epoll_);
+    oe_assert(epoll);
+
+    oe_assert(fd >= 0);
+
+    oe_mutex_lock(&epoll->lock);
+
+    /* Delete the mapping if it exists. */
+    for (size_t i = 0; i < epoll->map_size; i++)
+    {
+        if (epoll->map[i].fd == fd)
+        {
+            /* Swap with last element of array. */
+            epoll->map[i] = epoll->map[--epoll->map_size];
+            break;
+        }
+    }
+
+    oe_mutex_unlock(&epoll->lock);
+}
+
 static oe_epoll_ops_t _epoll_ops = {
     .fd.read = _epoll_read,
     .fd.write = _epoll_write,
@@ -821,6 +844,7 @@ static oe_epoll_ops_t _epoll_ops = {
     .fd.get_host_fd = _epoll_get_host_fd,
     .epoll_ctl = _epoll_ctl,
     .epoll_wait = _epoll_wait,
+    .on_close = _epoll_on_close,
 };
 
 static oe_epoll_ops_t _get_epoll_ops(void)

--- a/syscall/fdtable.c
+++ b/syscall/fdtable.c
@@ -192,6 +192,7 @@ static void _assert_fd(oe_fd_t* desc)
         {
             oe_assert(desc->ops.epoll.epoll_ctl);
             oe_assert(desc->ops.epoll.epoll_wait);
+            oe_assert(desc->ops.epoll.on_close);
             break;
         }
     }
@@ -361,4 +362,23 @@ oe_fd_t* oe_fdtable_get(int fd, oe_fd_type_t type)
 
 done:
     return ret;
+}
+
+void oe_fdtable_foreach(
+    oe_fd_type_t type,
+    void* arg,
+    void (*callback)(oe_fd_t* desc, void* arg))
+{
+    oe_assert(callback);
+
+    oe_spin_lock(&_lock);
+
+    for (size_t i = 0; i < _table_size; ++i)
+    {
+        oe_fd_t* const desc = _table[i];
+        if (desc && (type == OE_FD_TYPE_ANY || desc->type == type))
+            callback(desc, arg);
+    }
+
+    oe_spin_unlock(&_lock);
 }

--- a/syscall/unistd.c
+++ b/syscall/unistd.c
@@ -261,7 +261,7 @@ static void _close_epoll_callback(oe_fd_t* desc, void* arg)
     oe_assert(desc);
     oe_assert(desc->type == OE_FD_TYPE_EPOLL);
 
-    const int fd = (int)arg;
+    const int fd = (int)(intptr_t)arg;
     oe_assert(fd >= 0);
 
     desc->ops.epoll.on_close(desc, fd);

--- a/tests/syscall/epoll/epoll.edl
+++ b/tests/syscall/epoll/epoll.edl
@@ -9,5 +9,7 @@ enclave {
         public void trigger_and_add_event();
         public void trigger_and_delete_event();
         public void cancel_wait();
+
+        public void test_close_without_delete();
     };
 };

--- a/tests/syscall/epoll/host/host.cpp
+++ b/tests/syscall/epoll/host/host.cpp
@@ -25,6 +25,8 @@ int main(int argc, const char* argv[])
     r = oe_create_epoll_enclave(argv[1], type, flags, NULL, 0, &enclave);
     OE_TEST(r == OE_OK);
 
+    // Test concurrent use of epoll
+
     set_up(enclave);
 
     thread wait_thread(
@@ -40,6 +42,10 @@ int main(int argc, const char* argv[])
     cancel_wait(enclave);
     wait_thread.join();
     tear_down(enclave);
+
+    // Test closing file descriptors without deleting them from the epoll
+    // instance
+    OE_TEST(test_close_without_delete(enclave) == OE_OK);
 
     r = oe_terminate_enclave(enclave);
     OE_TEST(r == OE_OK);


### PR DESCRIPTION
If an fd is closed, it is implicitly deleted from all epoll instances
by the system. The enclave epoll mapping must also be updated.