### PR TITLE
Fix loop condition in _epoll_ctl_del

### DIFF
--- a/syscall/devices/hostepoll/hostepoll.c
+++ b/syscall/devices/hostepoll/hostepoll.c
@@ -362,7 +362,7 @@ static int _epoll_ctl_del(epoll_t* epoll, int fd)
     {
         bool found = false;
 
-        for (size_t i = 0; epoll->map_size; i++)
+        for (size_t i = 0; i < epoll->map_size; i++)
         {
             if (epoll->map[i].fd == fd)
             {


### PR DESCRIPTION
Add a missing comparison in a for loop condition. However, this "bug"
will probably never occur because the map element should always be
found.