### PR TITLE
Change heap-pages of tests to a value appropriate for snmalloc.

### DIFF
--- a/tests/SampleApp/enc/SampleApp.cpp
+++ b/tests/SampleApp/enc/SampleApp.cpp
@@ -40,6 +40,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/SampleAppCRT/enc/SampleAppCRT.cpp
+++ b/tests/SampleAppCRT/enc/SampleAppCRT.cpp
@@ -101,6 +101,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/VectorException/enc/enc.c
+++ b/tests/VectorException/enc/enc.c
@@ -382,6 +382,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/abortStatus/enc/enc.cpp
+++ b/tests/abortStatus/enc/enc.cpp
@@ -57,6 +57,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    256,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     64,   /* StackPageCount */
     5);   /* TCSCount */

--- a/tests/argv/enc/enc.c
+++ b/tests/argv/enc/enc.c
@@ -91,6 +91,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/attestation_cert_apis/enc/enc.cpp
+++ b/tests/attestation_cert_apis/enc/enc.cpp
@@ -308,6 +308,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     1);   /* TCSCount */

--- a/tests/attestation_plugin/enc/enc.c
+++ b/tests/attestation_plugin/enc/enc.c
@@ -198,6 +198,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     1);   /* TCSCount */

--- a/tests/backtrace/enc/enc.cpp
+++ b/tests/backtrace/enc/enc.cpp
@@ -164,6 +164,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/cmake_name_conflict/enc/enc.c
+++ b/tests/cmake_name_conflict/enc/enc.c
@@ -16,6 +16,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/cppException/enc/cppException.cpp
+++ b/tests/cppException/enc/cppException.cpp
@@ -820,7 +820,8 @@ bool ExceptionInUnwind()
 
 static bool g_bar04_status = false;
 
-void bar04() try
+void bar04()
+try
 {
     throw 'X';
 }
@@ -864,7 +865,8 @@ class BarClass10
 class BarClass11 : public BarClass10
 {
   public:
-    BarClass11(int i) try
+    BarClass11(int i)
+    try
     {
         if (i < 0)
         {

--- a/tests/cppException/enc/enc.cpp
+++ b/tests/cppException/enc/enc.cpp
@@ -53,6 +53,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     64,   /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/create-errors/enc/enc.c
+++ b/tests/create-errors/enc/enc.c
@@ -14,7 +14,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */
 

--- a/tests/create-rapid/enc/enc.cpp
+++ b/tests/create-rapid/enc/enc.cpp
@@ -13,7 +13,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    8,    /* HeapPageCount */
+    4096, /* HeapPageCount */
     8,    /* StackPageCount */
     1);   /* TCSCount */
 

--- a/tests/crypto/enclave/enc/enc.c
+++ b/tests/crypto/enclave/enc/enc.c
@@ -194,7 +194,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */
 

--- a/tests/crypto_crls_cert_chains/enc/enc.cpp
+++ b/tests/crypto_crls_cert_chains/enc/enc.cpp
@@ -56,6 +56,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/debug-mode/enc/props-debug.c
+++ b/tests/debug-mode/enc/props-debug.c
@@ -7,6 +7,6 @@ OE_SET_ENCLAVE_SGX(
     1234, /* ProductID */
     5678, /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     512,  /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/debug-mode/enc/props.c
+++ b/tests/debug-mode/enc/props.c
@@ -7,6 +7,6 @@ OE_SET_ENCLAVE_SGX(
     1234,  /* ProductID */
     5678,  /* SecurityVersion */
     false, /* AllowDebug */
-    1024,  /* HeapPageCount */
+    4096,  /* HeapPageCount */
     512,   /* StackPageCount */
     4);    /* TCSCount */

--- a/tests/debug-mode/enc/sign-debug.conf
+++ b/tests/debug-mode/enc/sign-debug.conf
@@ -3,7 +3,7 @@
 
 # Enclave settings:
 Debug=1
-NumHeapPages=1024
+NumHeapPages=4096
 NumStackPages=1024
 NumTCS=2
 ProductID=1

--- a/tests/debug-mode/enc/sign.conf
+++ b/tests/debug-mode/enc/sign.conf
@@ -3,7 +3,7 @@
 
 # Enclave settings:
 Debug=0
-NumHeapPages=1024
+NumHeapPages=4096
 NumStackPages=1024
 NumTCS=2
 ProductID=1

--- a/tests/debugger/oegdb/enc/enc.c
+++ b/tests/debugger/oegdb/enc/enc.c
@@ -65,6 +65,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/ecall/enc/enc.cpp
+++ b/tests/ecall/enc/enc.cpp
@@ -155,6 +155,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/ecall_ocall/enc/enc.cpp
+++ b/tests/ecall_ocall/enc/enc.cpp
@@ -149,6 +149,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    256,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     16,   /* StackPageCount */
     5);   /* TCSCount */

--- a/tests/echo/enc/enc.c
+++ b/tests/echo/enc/enc.c
@@ -65,6 +65,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/enclaveparam/enc/enc.c
+++ b/tests/enclaveparam/enc/enc.c
@@ -34,6 +34,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     64,   /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/file/enc/enc.cpp
+++ b/tests/file/enc/enc.cpp
@@ -46,6 +46,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/getenclave/enc/enc.c
+++ b/tests/getenclave/enc/enc.c
@@ -36,6 +36,6 @@ OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     64,   /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/hexdump/enc/enc.c
+++ b/tests/hexdump/enc/enc.c
@@ -27,7 +27,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */
 

--- a/tests/hostcalls/enc/enc.cpp
+++ b/tests/hostcalls/enc/enc.cpp
@@ -75,7 +75,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     16);  /* TCSCount */
 

--- a/tests/initializers/enc/enc.c
+++ b/tests/initializers/enc/enc.c
@@ -87,7 +87,7 @@ OE_SET_ENCLAVE_SGX(
     1234, /* ProductID */
     5678, /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     64,   /* StackPageCount */
     4);   /* TCSCount */
 

--- a/tests/libc/enc/enc.c
+++ b/tests/libc/enc/enc.c
@@ -167,7 +167,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    512,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     4);   /* TCSCount */
 

--- a/tests/libcxx/enc/enc.cpp
+++ b/tests/libcxx/enc/enc.cpp
@@ -285,7 +285,7 @@ OE_SET_ENCLAVE_SGX(
 #ifdef FULL_LIBCXX_TESTS /* Full tests require large heap memory. */
     12288,               /* HeapPageCount */
 #else
-    512, /* HeapPageCount */
+    4096, /* HeapPageCount */
 #endif
     512, /* StackPageCount */
     8);  /* TCSCount */

--- a/tests/libcxxrt/enc/enc.cpp
+++ b/tests/libcxxrt/enc/enc.cpp
@@ -70,6 +70,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/libunwind/enc/enc.c
+++ b/tests/libunwind/enc/enc.c
@@ -87,6 +87,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/mbed/enc/enc.c
+++ b/tests/mbed/enc/enc.c
@@ -225,6 +225,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    512,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     512,  /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/mixed_c_cpp/enc/enc.cpp
+++ b/tests/mixed_c_cpp/enc/enc.cpp
@@ -14,7 +14,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     4);   /* TCSCount */
 

--- a/tests/ocall-create/enc/enc.c
+++ b/tests/ocall-create/enc/enc.c
@@ -88,6 +88,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    256,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/ocall/enc/enc.cpp
+++ b/tests/ocall/enc/enc.cpp
@@ -100,6 +100,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     16);  /* TCSCount */

--- a/tests/oeedger8r/enc/testother.cpp
+++ b/tests/oeedger8r/enc/testother.cpp
@@ -23,6 +23,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/oeedger8r/enc/teststruct.cpp
+++ b/tests/oeedger8r/enc/teststruct.cpp
@@ -387,6 +387,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/pingpong-shared/enc/enc.cpp
+++ b/tests/pingpong-shared/enc/enc.cpp
@@ -13,7 +13,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     4);   /* TCSCount */
 

--- a/tests/pingpong/enc/enc.cpp
+++ b/tests/pingpong/enc/enc.cpp
@@ -13,7 +13,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     4);   /* TCSCount */
 

--- a/tests/print/enc/enc.cpp
+++ b/tests/print/enc/enc.cpp
@@ -57,6 +57,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/props/enc/props.c
+++ b/tests/props/enc/props.c
@@ -7,6 +7,6 @@ OE_SET_ENCLAVE_SGX(
     1234, /* ProductID */
     5678, /* SecurityVersion */
     true, /* AllowDebug */
-    512,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     512,  /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/props/enc/sign.conf
+++ b/tests/props/enc/sign.conf
@@ -3,7 +3,7 @@
 
 # Enclave settings:
 Debug=1
-NumHeapPages=512
+NumHeapPages=4096
 NumStackPages=512
 NumTCS=4
 ProductID=1111

--- a/tests/props/host/host.c
+++ b/tests/props/host/host.c
@@ -173,7 +173,7 @@ int main(int argc, const char* argv[])
             1111,                                        /* product_id */
             2222,                                        /* security_version */
             OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT, /* attributes */
-            512,                                         /* num_heap_pages  */
+            4096,                                        /* num_heap_pages  */
             512,                                         /* num_stack_pages */
             4);                                          /* num_tcs */
     }
@@ -185,7 +185,7 @@ int main(int argc, const char* argv[])
             1234,                                        /* product_id */
             5678,                                        /* security_version */
             OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT, /* attributes */
-            512,                                         /* num_heap_pages  */
+            4096,                                        /* num_heap_pages  */
             512,                                         /* num_stack_pages */
             4);                                          /* num_tcs */
     }

--- a/tests/qeidentity/enc/enc.cpp
+++ b/tests/qeidentity/enc/enc.cpp
@@ -35,6 +35,6 @@ OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/report/enc/enc.cpp
+++ b/tests/report/enc/enc.cpp
@@ -141,6 +141,6 @@ OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/safecrt/enc/enc.cpp
+++ b/tests/safecrt/enc/enc.cpp
@@ -36,7 +36,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */
 

--- a/tests/sealKey/enc/enc.cpp
+++ b/tests/sealKey/enc/enc.cpp
@@ -632,6 +632,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    256,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     64,   /* StackPageCount */
     5);   /* TCSCount */

--- a/tests/stack_smashing_protector/enc/enc.cpp
+++ b/tests/stack_smashing_protector/enc/enc.cpp
@@ -84,6 +84,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     16);  /* TCSCount */

--- a/tests/stdc/enc/enc.cpp
+++ b/tests/stdc/enc/enc.cpp
@@ -272,7 +272,7 @@ int test(char buf1[BUFSIZE], char buf2[BUFSIZE])
     OE_TEST(TestSetjmp() == 999);
 
     /* Cause malloc() to fail */
-    void* p = malloc(1024 * 1024 * 1024);
+    void* p = malloc(4096 * OE_PAGE_SIZE + 1);
     OE_TEST(p == NULL);
 
     OE_TEST(_called_allocation_failure_callback);
@@ -284,6 +284,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/stdcxx/enc/CMakeLists.txt
+++ b/tests/stdcxx/enc/CMakeLists.txt
@@ -19,6 +19,7 @@ enclave_compile_options(stdcxx_enc PRIVATE
     -fno-builtin-memset
     -fno-builtin-fprintf
     -fno-builtin-printf
+    -Og -ggdb
     )
 
 enclave_include_directories(stdcxx_enc PRIVATE

--- a/tests/stdcxx/enc/enc.cpp
+++ b/tests/stdcxx/enc/enc.cpp
@@ -241,6 +241,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    512,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     512,  /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/stdcxx/enc/global_init_exception.cpp
+++ b/tests/stdcxx/enc/global_init_exception.cpp
@@ -30,6 +30,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/switchless/enc/enc.c
+++ b/tests/switchless/enc/enc.c
@@ -79,6 +79,6 @@ OE_SET_ENCLAVE_SGX(
     1,        /* ProductID */
     1,        /* SecurityVersion */
     true,     /* AllowDebug */
-    64,       /* HeapPageCount */
+    4096,     /* HeapPageCount */
     64,       /* StackPageCount */
     NUM_TCS); /* TCSCount */

--- a/tests/switchless_threads/enc/enc.c
+++ b/tests/switchless_threads/enc/enc.c
@@ -70,6 +70,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     8);   /* TCSCount */

--- a/tests/syscall/datagram/enc/enc.c
+++ b/tests/syscall/datagram/enc/enc.c
@@ -101,6 +101,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/syscall/dup/enc/enc.c
+++ b/tests/syscall/dup/enc/enc.c
@@ -100,6 +100,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/syscall/epoll/enc/enc.cpp
+++ b/tests/syscall/epoll/enc/enc.cpp
@@ -148,6 +148,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     9);   /* TCSCount */

--- a/tests/syscall/fs/enc/enc.cpp
+++ b/tests/syscall/fs/enc/enc.cpp
@@ -794,6 +794,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/syscall/hostfs/enc/enc.c
+++ b/tests/syscall/hostfs/enc/enc.c
@@ -55,6 +55,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/syscall/ids/enc/enc.c
+++ b/tests/syscall/ids/enc/enc.c
@@ -44,6 +44,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/syscall/poller/enc/enc.cpp
+++ b/tests/syscall/poller/enc/enc.cpp
@@ -328,6 +328,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     9);   /* TCSCount */

--- a/tests/syscall/resolver/enc/enc.c
+++ b/tests/syscall/resolver/enc/enc.c
@@ -198,6 +198,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    256,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     1);   /* TCSCount */

--- a/tests/syscall/sendmsg/enc/enc.c
+++ b/tests/syscall/sendmsg/enc/enc.c
@@ -35,6 +35,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    4096, /* HeapPageCount */
     1024, /* StackPageCount */
     2);   /* TCSCount */

--- a/tests/syscall/socket/enc/enc.c
+++ b/tests/syscall/socket/enc/enc.c
@@ -189,6 +189,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    256,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     1);   /* TCSCount */

--- a/tests/syscall/socketpair/enc/enc.c
+++ b/tests/syscall/socketpair/enc/enc.c
@@ -145,6 +145,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    256,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     256,  /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/thread/enc/enc.cpp
+++ b/tests/thread/enc/enc.cpp
@@ -305,6 +305,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     16,   /* StackPageCount */
     16);  /* TCSCount */

--- a/tests/thread_local/enc/enc.cpp
+++ b/tests/thread_local/enc/enc.cpp
@@ -179,6 +179,6 @@ OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
     true, /* AllowDebug */
-    64,   /* HeapPageCount */
+    4096, /* HeapPageCount */
     16,   /* StackPageCount */
     16);  /* TCSCount */

--- a/tests/thread_local_no_tdata/enc/enc.cpp
+++ b/tests/thread_local_no_tdata/enc/enc.cpp
@@ -39,6 +39,6 @@ OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
     true, /* AllowDebug */
-    64,   /* HeapPageCount */
+    4096, /* HeapPageCount */
     16,   /* StackPageCount */
     16);  /* TCSCount */

--- a/tests/threadcxx/enc/enc.cpp
+++ b/tests/threadcxx/enc/enc.cpp
@@ -298,6 +298,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     16,   /* StackPageCount */
     16);  /* TCSCount */

--- a/tests/tls_e2e/client_enc/client.cpp
+++ b/tests/tls_e2e/client_enc/client.cpp
@@ -397,6 +397,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     1);   /* TCSCount */

--- a/tests/tls_e2e/server_enc/server.cpp
+++ b/tests/tls_e2e/server_enc/server.cpp
@@ -438,6 +438,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     1);   /* TCSCount */

--- a/tests/tools/oecert/enc/enc.cpp
+++ b/tests/tools/oecert/enc/enc.cpp
@@ -116,6 +116,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     1);   /* TCSCount */

--- a/tests/tools/oecertdump/enc/enc.cpp
+++ b/tests/tools/oecertdump/enc/enc.cpp
@@ -305,6 +305,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
+    4096, /* HeapPageCount */
     128,  /* StackPageCount */
     1);   /* TCSCount */


### PR DESCRIPTION
This allows these tests to pass when the experimental feature
`USE_SNMALLOC` is turned on.

`snmalloc` requres a large enough heap-size for functioning and the tests had too small a heap-size to be able to use snmalloc. 4096 heap-pages is large enough for snmalloc, while not drastically increasing the test enclave sizes.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>