### PR TITLE
Add CGC mailing list to documentation

### DIFF
--- a/docs/CodeOfConduct.md
+++ b/docs/CodeOfConduct.md
@@ -55,8 +55,10 @@ a project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting any member of the [Community Governance Committee](
-Committers.md#Committee_Members). All complaints will be reviewed and investigated
+reported by contacting the [Community Governance Committee](Committers.md)
+at oesdkcgc@lists.confidentialcomputing.io, or by contacting any individual
+[member of the Community Governance Committee](Committers.md#Committee_Members).
+All complaints will be reviewed and investigated
 and will result in a response that is deemed necessary and appropriate to the
 circumstances. The project team is obligated to maintain confidentiality with
 regard to the reporter of an incident.

--- a/docs/Committers.md
+++ b/docs/Committers.md
@@ -24,6 +24,9 @@ vote of all members of the Community Governance Committee.
 The running minutes for the Community Governance Community meetings are located
 at [aka.ms/openenclave/cgc](https://aka.ms/openenclave/cgc).
 
+The Committee can be reached by sending email to
+oesdkcgc@lists.confidentialcomputing.io.
+
 Committee Members
 -----------------
 


### PR DESCRIPTION
Addresses the half of issue #2742 about the CGC.
The general oesdk mailing list is now covered in PR #2814

Signed-off-by: Dave Thaler <dthaler@microsoft.com>