### PR TITLE
Add Aeva to committee

### DIFF
--- a/docs/Committers.md
+++ b/docs/Committers.md
@@ -29,6 +29,7 @@ Committee Members
 
 | Name                 | Company     | Email                         | GitHub Alias   |
 |----------------------|-------------|-------------------------------|----------------|
+| Aeva van der Veen    | Microsoft   | aeva@dont.io                  | AevaOnline     |
 | Akash Gupta          | Microsoft   | akagup@microsoft.com          | gupta-ak       |
 | Amaury Chamayou      | Microsoft   | amaury.chamayou@microsoft.com | achamayou      |
 | Anand Krishnamoorthi | Microsoft   | anakrish@microsoft.com        | anakrish       |

--- a/docs/Committers.md
+++ b/docs/Committers.md
@@ -33,7 +33,7 @@ Committee Members
 | Akash Gupta          | Microsoft   | akagup@microsoft.com          | gupta-ak       |
 | Amaury Chamayou      | Microsoft   | amaury.chamayou@microsoft.com | achamayou      |
 | Anand Krishnamoorthi | Microsoft   | anakrish@microsoft.com        | anakrish       |
-| Andrew Schwartzmeyer | Microsoft   | andschwa@microsoft.com        | andschwa       |
+| Andrew Schwartzmeyer | Microsoft   | andrew@schwartzmeyer.com      | andschwa       |
 | Dave Thaler          | Microsoft   | dthaler@microsoft.com         | dthaler        |
 | John Kordich         | Independent | jkordich@gmail.com            | johnkord       |
 | Jordan Hand          | Microsoft   | jorhand@microsoft.com         | jhand2         |


### PR DESCRIPTION
Note that in the last CGC meeting the committee chose to not require all
committee members to be committers, so we need to adjust the written
rules (and the name of this document).