### PR TITLE
Deduplicated windows and linux code for oe_thread_wait_wake_ocall

### DIFF
--- a/host/sgx/ocalls.c
+++ b/host/sgx/ocalls.c
@@ -94,13 +94,8 @@ void oe_thread_wake_wait_ocall(
     if (!waiter_tcs || !self_tcs)
         return;
 
-#if defined(__linux__)
     HandleThreadWake(enclave, waiter_tcs);
     HandleThreadWait(enclave, self_tcs);
-#elif defined(_WIN32)
-    HandleThreadWake(enclave, waiter_tcs);
-    HandleThreadWait(enclave, self_tcs);
-#endif
 }
 
 oe_result_t oe_get_quote_ocall(


### PR DESCRIPTION
oe_thread_wait_wake_ocall has preprocessor defines for different logic on Windows and Linux, but the behavior is the same for both. Remove the duplicated code.