### PR TITLE
Add macro OE_TEST_CODE to print more detailed log for debugging

### DIFF
--- a/include/openenclave/internal/tests.h
+++ b/include/openenclave/internal/tests.h
@@ -21,6 +21,30 @@
 
 OE_EXTERNC_BEGIN
 
+#define OE_TEST_CODE_IF(EXP, CODE, OE_TEST_ABORT)   \
+    do                                              \
+    {                                               \
+        oe_result_t _result_ = (EXP);               \
+        oe_result_t _code_ = (CODE);                \
+        if (_result_ != _code_)                     \
+        {                                           \
+            OE_PRINT(                               \
+                STDERR,                             \
+                "Test failed: %s(%u): %s %s!=%s\n", \
+                __FILE__,                           \
+                __LINE__,                           \
+                __FUNCTION__,                       \
+                oe_result_str(_result_),            \
+                oe_result_str(_code_));             \
+            if (OE_TEST_ABORT)                      \
+                OE_ABORT();                         \
+        }                                           \
+    } while (0)
+
+#define OE_TEST_CODE(EXP, CODE) OE_TEST_CODE_IF(EXP, CODE, true)
+
+#define OE_TEST_CODE_IGNORE(EXP, CODE) OE_TEST_CODE_IF(EXP, CODE, false)
+
 #define OE_TEST_IF(COND, OE_TEST_ABORT)         \
     do                                          \
     {                                           \


### PR DESCRIPTION
- The issue: exiting macro `OE_TEST(COND)` only prints the text of the failed condition `COND` in log. In many calls to `OE_TEST`, the `COND` is a test whether an operation / expression returns the the expected `oe_result_t` error code, in a format like `EXP==CODE'. Without showing the actual returned error code, this is not as helpful for debugging.
  - For example, in code [tests/attestation_plugin/plugin/tests.c](https://github.com/openenclave/openenclave/blob/master/tests/attestation_plugin/plugin/tests.c) around line 65, there is a line `OE_TEST(oe_register_attester(&mock_attester1, NULL, 0) == OE_OK);`. If the test fails, the developer really want to know which error code is returned by function `oe_register_attester()`, but that's not what the log shows.

- The fix: adds a new macro `OE_TEST_CODE(EXP, CODE)` which prints both the error code returned by `EXP` as well as the expected `CODE`, in human-friendly `oe_result_t` string format.
  - In the above example, the code line can be changed to `OE_TEST_CODE(oe_register_attester(&mock_attester1, NULL, 0), OE_OK);`.