### PR TITLE
[CI/CD] Add option to update production environment

### DIFF
--- a/.jenkins/Dockerfile.deploy
+++ b/.jenkins/Dockerfile.deploy
@@ -24,9 +24,9 @@ RUN apt-get update && \
     rm terraform_0.12.18_linux_amd64.zip && \
     curl https://oejenkinsciartifacts.blob.core.windows.net/oe-engine/latest/bin/oe-engine -o /usr/bin/oe-engine && \
     chmod +x /usr/bin/oe-engine && \
-    wget https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip && \
-    unzip packer_1.4.5_linux_amd64.zip -d /usr/sbin && \
-    rm packer_1.4.5_linux_amd64.zip && \
+    wget https://releases.hashicorp.com/packer/1.5.5/packer_1.5.5_linux_amd64.zip && \
+    unzip packer_1.5.5_linux_amd64.zip -d /usr/sbin && \
+    rm packer_1.5.5_linux_amd64.zip && \
     groupadd --gid ${GID} ${GNAME} && \
     useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME} && \
     /ansible/install-ansible.sh && \

--- a/.jenkins/e2e_testing.Jenkinsfile
+++ b/.jenkins/e2e_testing.Jenkinsfile
@@ -1,9 +1,39 @@
-// Build Docker images triggering 'OpenEnclave-Docker-Images' job with code from current branch and repository
+import java.time.*
+import java.time.format.DateTimeFormatter
+
+@Library("OpenEnclaveCommon") _
+oe = new jenkins.common.Openenclave()
+
+GLOBAL_TIMEOUT_MINUTES = 240
+
+OETOOLS_REPO_NAME = "oejenkinscidockerregistry.azurecr.io"
+OETOOLS_REPO_CREDENTIAL_ID = "oejenkinscidockerregistry"
+OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID = "oeciteamdockerhub"
+
+IMAGE_ID = ""
+NOW = LocalDateTime.now()
+IMAGE_VERSION = NOW.format(DateTimeFormatter.ofPattern("yyyy")) + "." + \
+                NOW.format(DateTimeFormatter.ofPattern("MM")) + "." + \
+                NOW.format(DateTimeFormatter.ofPattern("dd"))
+DOCKER_TAG = "e2e-${IMAGE_VERSION}-${BUILD_NUMBER}"
+
+
+node("images-build-e2e") {
+    stage("Determine the Azure managed images id") {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
+            cleanWs()
+            checkout scm
+            def last_commit_id = sh(script: "git rev-parse --short HEAD", returnStdout: true).tokenize().last()
+            IMAGE_ID = IMAGE_VERSION + "-" + last_commit_id
+        }
+    }
+}
+
 stage("Build Docker Images") {
     build job: '/CI-CD_Infrastructure/OpenEnclave-Build-Docker-Images',
           parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
                        string(name: 'BRANCH_NAME', value: env.BRANCH),
-                       string(name: 'DOCKER_TAG', value: "e2e"),
+                       string(name: 'DOCKER_TAG', value: DOCKER_TAG),
                        string(name: 'AGENTS_LABEL', value: "images-build-e2e"),
                        booleanParam(name: 'TAG_LATEST',value: false)]
 }
@@ -12,17 +42,19 @@ stage("Build Jenkins Agents images") {
     build job: '/CI-CD_Infrastructure/OpenEnclave-Build-Azure-Managed-Images',
           parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
                        string(name: 'BRANCH_NAME', value: env.BRANCH),
-                       string(name: 'OE_DEPLOY_IMAGE', value: "oetools-deploy:e2e"),
-                       string(name: 'IMAGE_ID', value: "e2e"),
-                       string(name: 'DOCKER_TAG', value: "e2e"),
+                       string(name: 'OE_DEPLOY_IMAGE', value: "oetools-deploy:${DOCKER_TAG}"),
+                       string(name: 'RESOURCE_GROUP', value: env.RESOURCE_GROUP),
+                       string(name: 'GALLERY_NAME', value: env.E2E_IMAGES_GALLERY_NAME),
+                       string(name: 'IMAGE_ID', value: IMAGE_ID),
+                       string(name: 'DOCKER_TAG', value: DOCKER_TAG),
                        string(name: 'AGENTS_LABEL', value: "images-build-e2e")]
 }
 
 stage("Run tests on new Agents") {
-    build job: '/CI-CD_Infrastructure/OpenEnclave-Custom-Label-Testing',
+    build job: '/CI-CD_Infrastructure/OpenEnclave-Testing',
           parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
                        string(name: 'BRANCH_NAME', value: env.BRANCH),
-                       string(name: 'DOCKER_TAG', value: "e2e"),
+                       string(name: 'DOCKER_TAG', value: DOCKER_TAG),
                        string(name: 'UBUNTU_1604_CUSTOM_LABEL', value: "xenial-e2e"),
                        string(name: 'UBUNTU_1804_CUSTOM_LABEL', value: "bionic-e2e"),
                        string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: "nonSGX-e2e"),
@@ -30,4 +62,77 @@ stage("Run tests on new Agents") {
                        string(name: 'WINDOWS_2016_CUSTOM_LABEL', value: "windows-e2e"),
                        string(name: 'WINDOWS_2016_DCAP_CUSTOM_LABEL', value: "windows-dcap-e2e"),
                        string(name: 'WINDOWS_NONSGX_CUSTOM_LABEL', value: "nonSGX-Windows-e2e")]
+}
+
+if(params.UPDATE_PRODUCTION_INFRA) {
+    def docker_images_names = ["oetools-full-16.04",
+                               "oetools-full-18.04",
+                               "oetools-minimal-18.04",
+                               "oetools-deploy"]
+
+    node("nonSGX") {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
+            stage("Backup current production Docker images") {
+                docker.withRegistry("https://${OETOOLS_REPO_NAME}", OETOOLS_REPO_CREDENTIAL_ID) {
+                    for (image_name in docker_images_names) {
+                        def image = docker.image("${OETOOLS_REPO_NAME}/${image_name}:latest")
+                        oe.exec_with_retry { image.pull() }
+                        oe.exec_with_retry { image.push("latest-backup") }
+                    }
+                }
+            }
+        }
+    }
+
+    node("nonSGX-e2e") {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
+            stage("Update production Docker images") {
+                docker.withRegistry("https://${OETOOLS_REPO_NAME}", OETOOLS_REPO_CREDENTIAL_ID) {
+                    for (image_name in docker_images_names) {
+                        def image = docker.image("${OETOOLS_REPO_NAME}/${image_name}:${DOCKER_TAG}")
+                        oe.exec_with_retry { image.pull() }
+                        oe.exec_with_retry { image.push("latest") }
+                    }
+                }
+            }
+
+            stage("Update production Azure managed images") {
+                // Mapping between shared gallery image definition name and
+                // generated Azure managed image name
+                def azure_images_map = [
+                    "ubuntu-16.04":    "${IMAGE_ID}-ubuntu-16.04-SGX",
+                    "ubuntu-18.04":    "${IMAGE_ID}-ubuntu-18.04-SGX",
+                    "rhel-8":          "${IMAGE_ID}-rhel-8-SGX",
+                    "ws2016-nonSGX":   "${IMAGE_ID}-ws2016-nonSGX",
+                    "ws2016-SGX":      "${IMAGE_ID}-ws2016-SGX",
+                    "ws2016-SGX-DCAP": "${IMAGE_ID}-ws2016-SGX-DCAP"
+                ]
+                for (image_name in azure_images_map.keySet()) {
+                    oe.azureEnvironment("""
+                        az login --service-principal -u \$SERVICE_PRINCIPAL_ID -p \$SERVICE_PRINCIPAL_PASSWORD --tenant \$TENANT_ID --output table
+                        az account set --subscription \$SUBSCRIPTION_ID --output table
+
+                        MANAGED_IMG_ID=`az image show \
+                            --resource-group ${env.RESOURCE_GROUP} \
+                            --name ${azure_images_map[image_name]} | jq -r '.id'`
+
+                        az sig image-version delete \
+                            --resource-group ${env.RESOURCE_GROUP} \
+                            --gallery-name ${env.PRODUCTION_IMAGES_GALLERY_NAME} \
+                            --gallery-image-definition ${image_name} \
+                            --gallery-image-version ${IMAGE_VERSION}
+
+                        az sig image-version create \
+                            --resource-group ${env.RESOURCE_GROUP} \
+                            --gallery-name ${env.PRODUCTION_IMAGES_GALLERY_NAME} \
+                            --gallery-image-definition ${image_name} \
+                            --gallery-image-version ${IMAGE_VERSION} \
+                            --managed-image \$MANAGED_IMG_ID \
+                            --target-regions "WestEurope" \
+                            --replica-count 1
+                    """)
+                }
+            }
+        }
+    }
 }

--- a/.jenkins/provision/templates/packer/azure_managed_image/packer-rhel.json
+++ b/.jenkins/provision/templates/packer/azure_managed_image/packer-rhel.json
@@ -7,6 +7,8 @@
     "tenant_id": "{{ env `TENANT_ID` }}",
     "location": "{{ env `REGION` }}",
     "ansible_dir": "{{ env `WORKSPACE` }}/scripts/ansible",
+    "gallery_name": "{{ env `GALLERY_NAME` }}",
+    "gallery_image_version": "{{ env `GALLERY_IMAGE_VERSION` }}",
     "managed_image_name_id": "{{ env `MANAGED_IMAGE_NAME_ID` }}"
   },
   "builders": [{
@@ -16,6 +18,17 @@
     "client_secret": "{{ user `client_secret` }}",
     "tenant_id": "{{ user `tennant_id` }}",
     "subscription_id": "{{ user `subscription_id` }}",
+
+    "shared_image_gallery_destination": {
+      "resource_group": "{{ user `resource_group` }}",
+      "gallery_name": "{{ user `gallery_name` }}",
+      "image_name": "{{ user `gallery_image_name` }}",
+      "image_version": "{{ user `gallery_image_version` }}",
+      "replication_regions": [
+        "westeurope"
+      ]
+    },
+    "shared_image_gallery_timeout": "180m",
 
     "managed_image_name": "{{ user `managed_image_name_id` }}-{{ user `managed_image_name_suffix` }}",
     "managed_image_resource_group_name": "{{ user `resource_group` }}",

--- a/.jenkins/provision/templates/packer/azure_managed_image/packer-ubuntu.json
+++ b/.jenkins/provision/templates/packer/azure_managed_image/packer-ubuntu.json
@@ -11,6 +11,8 @@
     "docker_user_password": "{{ env `DOCKER_USER_PASSWORD` }}",
     "docker_tag": "{{ env `DOCKER_TAG` }}",
     "ansible_dir": "{{ env `WORKSPACE` }}/scripts/ansible",
+    "gallery_name": "{{ env `GALLERY_NAME` }}",
+    "gallery_image_version": "{{ env `GALLERY_IMAGE_VERSION` }}",
     "managed_image_name_id": "{{ env `MANAGED_IMAGE_NAME_ID` }}"
   },
   "builders": [{
@@ -20,6 +22,17 @@
     "client_secret": "{{ user `client_secret` }}",
     "tenant_id": "{{ user `tennant_id` }}",
     "subscription_id": "{{ user `subscription_id` }}",
+
+    "shared_image_gallery_destination": {
+      "resource_group": "{{ user `resource_group` }}",
+      "gallery_name": "{{ user `gallery_name` }}",
+      "image_name": "{{ user `gallery_image_name` }}",
+      "image_version": "{{ user `gallery_image_version` }}",
+      "replication_regions": [
+        "westeurope"
+      ]
+    },
+    "shared_image_gallery_timeout": "180m",
 
     "managed_image_name": "{{ user `managed_image_name_id` }}-{{ user `managed_image_name_suffix` }}",
     "managed_image_resource_group_name": "{{ user `resource_group` }}",

--- a/.jenkins/provision/templates/packer/azure_managed_image/rhel-8-variables.json
+++ b/.jenkins/provision/templates/packer/azure_managed_image/rhel-8-variables.json
@@ -1,6 +1,7 @@
 {
     "managed_image_name_suffix": "rhel-8-SGX",
     "os_type": "Linux",
+    "gallery_image_name": "rhel-8",
     "image_publisher": "RedHat",
     "image_offer": "RHEL",
     "image_sku": "8-gen2",

--- a/.jenkins/provision/templates/packer/azure_managed_image/ubuntu-16.04-variables.json
+++ b/.jenkins/provision/templates/packer/azure_managed_image/ubuntu-16.04-variables.json
@@ -1,9 +1,10 @@
 {
     "managed_image_name_suffix": "ubuntu-16.04-SGX",
     "os_type": "Linux",
+    "gallery_image_name": "ubuntu-16.04",
     "image_publisher": "Canonical",
-    "image_offer": "confidential-compute-preview",
-    "image_sku": "16.04-LTS",
+    "image_offer": "UbuntuServer",
+    "image_sku": "16_04-lts-gen2",
     "vm_size": "Standard_DC2s",
     "ansible_group": "linux-agents",
     "playbook_file_name": "oe-linux-acc-setup.yml"

--- a/.jenkins/provision/templates/packer/azure_managed_image/ubuntu-18.04-variables.json
+++ b/.jenkins/provision/templates/packer/azure_managed_image/ubuntu-18.04-variables.json
@@ -1,9 +1,10 @@
 {
     "managed_image_name_suffix": "ubuntu-18.04-SGX",
     "os_type": "Linux",
+    "gallery_image_name": "ubuntu-18.04",
     "image_publisher": "Canonical",
     "image_offer": "UbuntuServer",
-    "image_sku": "18.04-LTS",
+    "image_sku": "18_04-lts-gen2",
     "vm_size": "Standard_DC2s",
     "ansible_group": "linux-agents",
     "playbook_file_name": "oe-linux-acc-setup.yml"

--- a/.jenkins/provision/utils.sh
+++ b/.jenkins/provision/utils.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+
+function retrycmd_if_failure() {
+    set +o errexit
+    retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
+    for i in $(seq 1 "$retries"); do
+        if timeout "$timeout" "${@}"; then
+            break
+        fi
+        if [[ $i -eq $retries ]]; then
+            echo "Error: Failed to execute '$*' after $i attempts"
+            set -o errexit
+            return 1
+        fi
+        sleep "$wait_sleep"
+    done
+    echo "Executed '$*' $i times"
+    set -o errexit
+}


### PR DESCRIPTION
Allow the end-to-end testing job to update the production
enviroment (Azure images & Docker images), when the flag
`UPDATE_PRODUCTION_INFRA` is set.

This pull request adds the following updates as well:

* Bump Packer version from `1.4.5` to `1.5.5`.
* Use Azure shared images galleries for E2E images and
  production images.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>