### PR TITLE
Remove accidental dependencies on libc headers from oecore

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -154,6 +154,9 @@ endif ()
 
 if (USE_DLMALLOC)
     list(APPEND PLATFORM_SRC malloc.c)
+
+    list (APPEND NEEDS_STDC_NAMES malloc.c)
+
     # Unfortunately dlmalloc uses GNU extension that allows arithmetic
     # null pointers.
     set_source_files_properties(malloc.c
@@ -198,15 +201,37 @@ add_enclave_library(oecore STATIC
     tracee.c
     ${PLATFORM_SRC})
 
-# Suppress type conversion warnings introduced by 3rdparty code
-set_source_files_properties(${MUSL_SRC_DIR}/prng/rand.c ROPERTIES
+# Some files in oecore come directly from the musl source. For these files,
+# corelibc functions with stdc names are required.
+# Additionally, suppress type conversion warnings introduced by 3rdparty code
+set (CORELIBC_INCLUDES ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
+
+list (APPEND NEEDS_STDC_NAMES
+    ${MUSL_SRC_DIR}/prng/rand.c
+    ${MUSL_SRC_DIR}/string/memmove.c
+    ${MUSL_SRC_DIR}/string/memset.c
+    ${MUSL_SRC_DIR}/string/memcmp.c
+    ${MUSL_SRC_DIR}/string/memcpy.c
+    sgx/sgx_t_wrapper.c
+    sgx/switchless_t_wrapper.c
+    __secs_to_tm.c
+    debugmalloc.c
+    strtok_r.c
+    tee_t_wrapper.c)
+
+list (APPEND W_NO_CONVERSION
+    ${MUSL_SRC_DIR}/prng/rand.c
+    ${MUSL_SRC_DIR}/string/memmove.c
+    ${MUSL_SRC_DIR}/string/memset.c
+    __secs_to_tm.c)
+
+set_source_files_properties(${W_NO_CONVERSION} PROPERTIES
     COMPILE_FLAGS -Wno-conversion)
-set_source_files_properties(${MUSL_SRC_DIR}/string/memmove.c PROPERTIES
-    COMPILE_FLAGS -Wno-sign-conversion)
-set_source_files_properties(${MUSL_SRC_DIR}/string/memset.c PROPERTIES
-    COMPILE_FLAGS -Wno-conversion)
-set_source_files_properties(__secs_to_tm.c PROPERTIES
-    COMPILE_FLAGS -Wno-conversion)
+
+set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND_STRING PROPERTY
+    COMPILE_FLAGS " -I${CORELIBC_INCLUDES}")
+set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND PROPERTY
+    COMPILE_DEFINITIONS OE_NEED_STDC_NAMES)
 
 maybe_build_using_clangw(oecore)
 
@@ -229,10 +254,6 @@ endif()
 if (CMAKE_C_COMPILER_ID MATCHES GNU)
     enclave_compile_options(oecore PRIVATE -Wjump-misses-init)
 endif()
-
-# This directory contains enclave core libc headers:
-enclave_include_directories(oecore PRIVATE
-    ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 
 if (OE_SGX)
     set_source_files_properties(sgx/keys.c PROPERTIES COMPILE_FLAGS -Wno-type-limits)

--- a/enclave/core/__secs_to_tm.c
+++ b/enclave/core/__secs_to_tm.c
@@ -1,9 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-/* Use OE STDC time.h & limits.h defs for MUSL __secs_to_tm.c */
-#define OE_NEED_STDC_NAMES
-
 /* Define this to satisfy compiler for unused function in time_impl.h */
 typedef struct __locale_struct* locale_t;
 #include "../../3rdparty/musl/musl/src/include/features.h"

--- a/enclave/core/arena.c
+++ b/enclave/core/arena.c
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 
 #include "arena.h"
+#include <openenclave/corelibc/string.h>
 #include <openenclave/edger8r/common.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/safemath.h>
 #include <openenclave/internal/thread.h>
 #include <openenclave/internal/utils.h>
-#include <string.h>
 
 // The per-thread shared memory arena
 static __thread shared_memory_arena_t _arena = {0};

--- a/enclave/core/ctype.c
+++ b/enclave/core/ctype.c
@@ -1,7 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#include <ctype.h>
+#include <openenclave/corelibc/ctype.h>
 
 static const unsigned short _ctype_b[384] = {
     0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,

--- a/enclave/core/malloc.c
+++ b/enclave/core/malloc.c
@@ -14,8 +14,6 @@
 #include "oe_alloc_thread.h"
 #include "oe_nodebug_alloc.h"
 
-/* The use of dlmalloc/malloc.c below requires stdc names from these headers */
-#define OE_NEED_STDC_NAMES
 #include <openenclave/corelibc/bits/stdfile.h> // For stderr & FILE
 #include <openenclave/corelibc/errno.h>        // For errno & error defs
 #include <openenclave/corelibc/sched.h>        // For sched_yield

--- a/enclave/core/oe_nodebug_alloc.h
+++ b/enclave/core/oe_nodebug_alloc.h
@@ -5,7 +5,7 @@
 #define _OE_NODEBUG_ALLOC_H
 
 #include <openenclave/bits/defs.h>
-#include <stddef.h>
+#include <openenclave/corelibc/stddef.h>
 
 OE_EXTERNC_BEGIN
 

--- a/enclave/core/sgx/sgx_t_wrapper.c
+++ b/enclave/core/sgx/sgx_t_wrapper.c
@@ -1,8 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#define OE_NEED_STDC_NAMES
-
 #include <openenclave/enclave.h>
 
 #include <openenclave/corelibc/stdio.h>

--- a/enclave/core/sgx/switchless_t_wrapper.c
+++ b/enclave/core/sgx/switchless_t_wrapper.c
@@ -1,8 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#define OE_NEED_STDC_NAMES
-
 #include <openenclave/enclave.h>
 
 #include <openenclave/corelibc/stdio.h>

--- a/enclave/core/tee_t_wrapper.c
+++ b/enclave/core/tee_t_wrapper.c
@@ -1,8 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#define OE_NEED_STDC_NAMES
-
 #include <openenclave/enclave.h>
 
 #include <openenclave/corelibc/stdio.h>

--- a/include/openenclave/edger8r/common.h
+++ b/include/openenclave/edger8r/common.h
@@ -66,24 +66,24 @@ done:
     return result;
 }
 
-#define OE_ADD_SIZE(total, size)                                 \
-    do                                                           \
-    {                                                            \
-        if (sizeof(total) > sizeof(size_t) && total > SIZE_MAX)  \
-        {                                                        \
-            _result = OE_INVALID_PARAMETER;                      \
-            goto done;                                           \
-        }                                                        \
-        if (sizeof(size) > sizeof(size_t) && size > SIZE_MAX)    \
-        {                                                        \
-            _result = OE_INVALID_PARAMETER;                      \
-            goto done;                                           \
-        }                                                        \
-        if (oe_add_size((size_t*)&total, (size_t)size) != OE_OK) \
-        {                                                        \
-            _result = OE_INTEGER_OVERFLOW;                       \
-            goto done;                                           \
-        }                                                        \
+#define OE_ADD_SIZE(total, size)                                   \
+    do                                                             \
+    {                                                              \
+        if (sizeof(total) > sizeof(size_t) && total > OE_SIZE_MAX) \
+        {                                                          \
+            _result = OE_INVALID_PARAMETER;                        \
+            goto done;                                             \
+        }                                                          \
+        if (sizeof(size) > sizeof(size_t) && size > OE_SIZE_MAX)   \
+        {                                                          \
+            _result = OE_INVALID_PARAMETER;                        \
+            goto done;                                             \
+        }                                                          \
+        if (oe_add_size((size_t*)&total, (size_t)size) != OE_OK)   \
+        {                                                          \
+            _result = OE_INTEGER_OVERFLOW;                         \
+            goto done;                                             \
+        }                                                          \
     } while (0)
 
 /**

--- a/syscall/devices/hostepoll/hostepoll.c
+++ b/syscall/devices/hostepoll/hostepoll.c
@@ -6,6 +6,7 @@
 #include <openenclave/enclave.h>
 
 #include <openenclave/corelibc/stdio.h>
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/corelibc/string.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>

--- a/syscall/devices/hostfs/hostfs.c
+++ b/syscall/devices/hostfs/hostfs.c
@@ -27,6 +27,7 @@
 #include <openenclave/internal/syscall/sys/mount.h>
 #include <openenclave/corelibc/stdio.h>
 #include <openenclave/corelibc/string.h>
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/internal/syscall/fcntl.h>
 #include <openenclave/internal/syscall/sys/ioctl.h>
 #include <openenclave/internal/syscall/raise.h>

--- a/syscall/poll.c
+++ b/syscall/poll.c
@@ -1,6 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/enclave.h>
 
 #include <openenclave/internal/syscall/fdtable.h>

--- a/tests/backtrace/enc/enc.cpp
+++ b/tests/backtrace/enc/enc.cpp
@@ -6,6 +6,7 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/print.h>
 #include <openenclave/internal/tests.h>
+#include <stdlib.h>
 #include <string.h>
 #include "backtrace_t.h"
 

--- a/tests/oeedger8r/edl/array.edl
+++ b/tests/oeedger8r/edl/array.edl
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 enclave  {
+    include "wchar.h"
+
     trusted {        
         // Test in, in-out, out, user_check attributes.
         // Also check ability to pass NULL.

--- a/tests/oeedger8r/edl/pointer.edl
+++ b/tests/oeedger8r/edl/pointer.edl
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 enclave {
+    include "wchar.h"
+
     trusted {
 
         public char* ecall_pointer_char(

--- a/tests/oeedger8r/edl/string.edl
+++ b/tests/oeedger8r/edl/string.edl
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 enclave {
+    include "wchar.h"
+
     trusted {
         // string attribute must be used only with in or in-out attributes.
         public void ecall_string_fun1([string, in] char* s);

--- a/tools/oeedger8r/src/Headers.ml
+++ b/tools/oeedger8r/src/Headers.ml
@@ -173,9 +173,6 @@ let generate_args (ec : enclave_content) =
     "#ifndef " ^ guard_macro;
     "#define " ^ guard_macro;
     "";
-    "#include <stdint.h>";
-    "#include <stdlib.h> /* for wchar_t */";
-    "";
     include_errno;
     "";
     "#include <openenclave/bits/result.h>";


### PR DESCRIPTION
There are numerous places in oecore and edger8r-generated code where standard C headers are included as system headers (i.e. #include <stdlib.h>) when the intention is really to use the corresponding corelibc header. In those instances explicitly include the corelibc header.

In instances in which standard C names are needed by 3rd party code, include those names only when compiling those files rather than making it the default for all files in oecore.