### PR TITLE
Install headers needed by oeedger8r-generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased][Unreleased_log]
 ------------
 
+### Added
+- Published corelibc headers required by oeedger8r-generated code.
+  Disclaimer: these headers do not make any guarantees about stability. They
+  are intended to be used by generated code and are not part of the OE public
+  API surface.
+
 ### Changed
 - Moved `oe_asymmetric_key_type_t`, `oe_asymmetric_key_format_t`, and
   `oe_asymmetric_key_params_t` to `bits/asym_keys.h` from `bits/types.h`.

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -196,6 +196,7 @@ add_enclave_library(oecore STATIC
     tee_t_wrapper.c
     time.c
     tracee.c
+    wchar.c
     ${PLATFORM_SRC})
 
 # Suppress type conversion warnings introduced by 3rdparty code

--- a/enclave/core/wchar.c
+++ b/enclave/core/wchar.c
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/corelibc/wchar.h>
+
+size_t oe_wcslen(const wchar_t* s)
+{
+    const wchar_t* a;
+    for (a = s; *s; s++)
+        ;
+    return (size_t)(s - a);
+}

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -17,3 +17,13 @@ install(FILES openenclave/attestation/plugin.h DESTINATION ${CMAKE_INSTALL_INCLU
 install(FILES openenclave/attestation/sgx/attester.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(FILES openenclave/attestation/sgx/verifier.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/ COMPONENT OEHOSTVERIFY)
 install(TARGETS oe_includes EXPORT openenclave-targets)
+
+# Install parts of oelibc needed by edger8r-generated code
+list(APPEND CORELIBC_DEPS
+    openenclave/corelibc/errno.h
+    openenclave/corelibc/limits.h
+    openenclave/corelibc/stdlib.h
+    openenclave/corelibc/string.h
+    openenclave/corelibc/wchar.h)
+install(FILES ${CORELIBC_DEPS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/corelibc)
+install(FILES openenclave/corelibc/bits/defs.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/corelibc/bits)

--- a/include/openenclave/bits/types.h
+++ b/include/openenclave/bits/types.h
@@ -34,6 +34,15 @@ typedef long intptr_t;
 typedef long time_t;
 typedef long suseconds_t;
 
+#ifndef __cplusplus
+#if __WCHAR_MAX__ > 0x10000
+// honor -fshort-wchar
+typedef int wchar_t;
+#else
+typedef short wchar_t;
+#endif
+#endif
+
 #elif defined(_MSC_VER)
 typedef long long ssize_t;
 typedef unsigned long long size_t;
@@ -50,6 +59,11 @@ typedef long long ptrdiff_t;
 typedef long long intptr_t;
 typedef long long time_t;
 typedef long long suseconds_t;
+
+#ifndef __cplusplus
+typedef short wchar_t;
+#endif
+
 #else
 #error "unknown compiler - please adapt basic types"
 #endif

--- a/include/openenclave/bits/types.h
+++ b/include/openenclave/bits/types.h
@@ -35,12 +35,7 @@ typedef long time_t;
 typedef long suseconds_t;
 
 #ifndef __cplusplus
-#if __WCHAR_MAX__ > 0x10000
-// honor -fshort-wchar
-typedef int wchar_t;
-#else
-typedef short wchar_t;
-#endif
+typedef __WCHAR_TYPE__ wchar_t;
 #endif
 
 #elif defined(_MSC_VER)
@@ -59,11 +54,6 @@ typedef long long ptrdiff_t;
 typedef long long intptr_t;
 typedef long long time_t;
 typedef long long suseconds_t;
-
-#ifndef __cplusplus
-typedef short wchar_t;
-#endif
-
 #else
 #error "unknown compiler - please adapt basic types"
 #endif

--- a/include/openenclave/corelibc/bits/defs.h
+++ b/include/openenclave/corelibc/bits/defs.h
@@ -1,6 +1,11 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
 #ifndef _OE_CORELIBC_BITS_DEFS_H
 #define _OE_CORELIBC_BITS_DEFS_H
 

--- a/include/openenclave/corelibc/limits.h
+++ b/include/openenclave/corelibc/limits.h
@@ -1,6 +1,11 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
 #ifndef _OE_LIMITS_H
 #define _OE_LIMITS_H
 

--- a/include/openenclave/corelibc/stdlib.h
+++ b/include/openenclave/corelibc/stdlib.h
@@ -1,11 +1,16 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
 #ifndef _OE_STDLIB_H
 #define _OE_STDLIB_H
 
+#include <openenclave/bits/defs.h>
 #include <openenclave/bits/types.h>
-#include <openenclave/corelibc/bits/defs.h>
 #include <openenclave/corelibc/limits.h>
 
 OE_EXTERNC_BEGIN

--- a/include/openenclave/corelibc/string.h
+++ b/include/openenclave/corelibc/string.h
@@ -1,6 +1,11 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
 #ifndef _OE_STRING_H
 #define _OE_STRING_H
 

--- a/include/openenclave/corelibc/wchar.h
+++ b/include/openenclave/corelibc/wchar.h
@@ -1,2 +1,11 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
+
+#ifndef _OE_WCHAR_H
+#define _OE_WCHAR_H
+
+#include <openenclave/bits/types.h>
+
+size_t oe_wcslen(const wchar_t* s);
+
+#endif

--- a/include/openenclave/corelibc/wchar.h
+++ b/include/openenclave/corelibc/wchar.h
@@ -1,11 +1,20 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
 #ifndef _OE_WCHAR_H
 #define _OE_WCHAR_H
 
 #include <openenclave/bits/types.h>
 
+OE_EXTERNC_BEGIN
+
 size_t oe_wcslen(const wchar_t* s);
+
+OE_EXTERNC_END
 
 #endif


### PR DESCRIPTION
In order to remove oeedger8r's dependance on stdc, a small number of corelibc headers must be published. Install these headers under openenclave/corelibc.

Additionally, add an implementation of wcslen for generated code to use.