### PR TITLE
Remove oeedger8r's dependance on stdc for enclave code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Simulation Mode on Windows.
 - Support `transition_using_threads` EDL attribute for ecalls in oeedger8r.
   OE SDK now supports both switchless OCALLs and ECALLs.
+- Published corelibc headers required by oeedger8r-generated code.
+  Disclaimer: these headers do not make any guarantees about stability. They
+  are intended to be used by generated code and are not part of the OE public
+  API surface.
 
 ### Changed
 - Moved `oe_asymmetric_key_type_t`, `oe_asymmetric_key_format_t`, and

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -196,6 +196,7 @@ add_enclave_library(oecore STATIC
     tee_t_wrapper.c
     time.c
     tracee.c
+    wchar.c
     ${PLATFORM_SRC})
 
 # Suppress type conversion warnings introduced by 3rdparty code

--- a/enclave/core/sgx/sgx_t_wrapper.c
+++ b/enclave/core/sgx/sgx_t_wrapper.c
@@ -1,8 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#define OE_NEED_STDC_NAMES
-
 #include <openenclave/enclave.h>
 
 #include <openenclave/corelibc/stdio.h>

--- a/enclave/core/sgx/switchless_t_wrapper.c
+++ b/enclave/core/sgx/switchless_t_wrapper.c
@@ -1,8 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#define OE_NEED_STDC_NAMES
-
 #include <openenclave/enclave.h>
 
 #include <openenclave/corelibc/stdio.h>

--- a/enclave/core/tee_t_wrapper.c
+++ b/enclave/core/tee_t_wrapper.c
@@ -1,8 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#define OE_NEED_STDC_NAMES
-
 #include <openenclave/enclave.h>
 
 #include <openenclave/corelibc/stdio.h>

--- a/enclave/core/wchar.c
+++ b/enclave/core/wchar.c
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/corelibc/wchar.h>
+
+size_t oe_wcslen(const wchar_t* s)
+{
+    const wchar_t* a;
+    for (a = s; *s; s++)
+        ;
+    return (size_t)(s - a);
+}

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -17,3 +17,13 @@ install(FILES openenclave/attestation/plugin.h DESTINATION ${CMAKE_INSTALL_INCLU
 install(FILES openenclave/attestation/sgx/attester.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(FILES openenclave/attestation/sgx/verifier.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/ COMPONENT OEHOSTVERIFY)
 install(TARGETS oe_includes EXPORT openenclave-targets)
+
+# Install parts of oelibc needed by edger8r-generated code
+list(APPEND CORELIBC_DEPS
+    openenclave/corelibc/errno.h
+    openenclave/corelibc/limits.h
+    openenclave/corelibc/stdlib.h
+    openenclave/corelibc/string.h
+    openenclave/corelibc/wchar.h)
+install(FILES ${CORELIBC_DEPS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/corelibc)
+install(FILES openenclave/corelibc/bits/defs.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/corelibc/bits)

--- a/include/openenclave/bits/types.h
+++ b/include/openenclave/bits/types.h
@@ -34,6 +34,15 @@ typedef long intptr_t;
 typedef long time_t;
 typedef long suseconds_t;
 
+#ifndef __cplusplus
+#if __WCHAR_MAX__ > 0x10000
+// honor -fshort-wchar
+typedef int wchar_t;
+#else
+typedef short wchar_t;
+#endif
+#endif
+
 #elif defined(_MSC_VER)
 typedef long long ssize_t;
 typedef unsigned long long size_t;
@@ -50,6 +59,11 @@ typedef long long ptrdiff_t;
 typedef long long intptr_t;
 typedef long long time_t;
 typedef long long suseconds_t;
+
+#ifndef __cplusplus
+typedef short wchar_t;
+#endif
+
 #else
 #error "unknown compiler - please adapt basic types"
 #endif

--- a/include/openenclave/bits/types.h
+++ b/include/openenclave/bits/types.h
@@ -35,12 +35,7 @@ typedef long time_t;
 typedef long suseconds_t;
 
 #ifndef __cplusplus
-#if __WCHAR_MAX__ > 0x10000
-// honor -fshort-wchar
-typedef int wchar_t;
-#else
-typedef short wchar_t;
-#endif
+typedef __WCHAR_TYPE__ wchar_t;
 #endif
 
 #elif defined(_MSC_VER)
@@ -59,11 +54,6 @@ typedef long long ptrdiff_t;
 typedef long long intptr_t;
 typedef long long time_t;
 typedef long long suseconds_t;
-
-#ifndef __cplusplus
-typedef short wchar_t;
-#endif
-
 #else
 #error "unknown compiler - please adapt basic types"
 #endif

--- a/include/openenclave/corelibc/bits/defs.h
+++ b/include/openenclave/corelibc/bits/defs.h
@@ -1,6 +1,11 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
 #ifndef _OE_CORELIBC_BITS_DEFS_H
 #define _OE_CORELIBC_BITS_DEFS_H
 

--- a/include/openenclave/corelibc/limits.h
+++ b/include/openenclave/corelibc/limits.h
@@ -1,6 +1,11 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
 #ifndef _OE_LIMITS_H
 #define _OE_LIMITS_H
 

--- a/include/openenclave/corelibc/stdlib.h
+++ b/include/openenclave/corelibc/stdlib.h
@@ -1,11 +1,16 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
 #ifndef _OE_STDLIB_H
 #define _OE_STDLIB_H
 
+#include <openenclave/bits/defs.h>
 #include <openenclave/bits/types.h>
-#include <openenclave/corelibc/bits/defs.h>
 #include <openenclave/corelibc/limits.h>
 
 OE_EXTERNC_BEGIN

--- a/include/openenclave/corelibc/string.h
+++ b/include/openenclave/corelibc/string.h
@@ -1,6 +1,11 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
 #ifndef _OE_STRING_H
 #define _OE_STRING_H
 

--- a/include/openenclave/corelibc/wchar.h
+++ b/include/openenclave/corelibc/wchar.h
@@ -1,2 +1,11 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
+
+#ifndef _OE_WCHAR_H
+#define _OE_WCHAR_H
+
+#include <openenclave/bits/types.h>
+
+size_t oe_wcslen(const wchar_t* s);
+
+#endif

--- a/include/openenclave/corelibc/wchar.h
+++ b/include/openenclave/corelibc/wchar.h
@@ -1,11 +1,20 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
 #ifndef _OE_WCHAR_H
 #define _OE_WCHAR_H
 
 #include <openenclave/bits/types.h>
 
+OE_EXTERNC_BEGIN
+
 size_t oe_wcslen(const wchar_t* s);
+
+OE_EXTERNC_END
 
 #endif

--- a/include/openenclave/edger8r/common.h
+++ b/include/openenclave/edger8r/common.h
@@ -66,24 +66,24 @@ done:
     return result;
 }
 
-#define OE_ADD_SIZE(total, size)                                 \
-    do                                                           \
-    {                                                            \
-        if (sizeof(total) > sizeof(size_t) && total > SIZE_MAX)  \
-        {                                                        \
-            _result = OE_INVALID_PARAMETER;                      \
-            goto done;                                           \
-        }                                                        \
-        if (sizeof(size) > sizeof(size_t) && size > SIZE_MAX)    \
-        {                                                        \
-            _result = OE_INVALID_PARAMETER;                      \
-            goto done;                                           \
-        }                                                        \
-        if (oe_add_size((size_t*)&total, (size_t)size) != OE_OK) \
-        {                                                        \
-            _result = OE_INTEGER_OVERFLOW;                       \
-            goto done;                                           \
-        }                                                        \
+#define OE_ADD_SIZE(total, size)                                   \
+    do                                                             \
+    {                                                              \
+        if (sizeof(total) > sizeof(size_t) && total > OE_SIZE_MAX) \
+        {                                                          \
+            _result = OE_INVALID_PARAMETER;                        \
+            goto done;                                             \
+        }                                                          \
+        if (sizeof(size) > sizeof(size_t) && size > OE_SIZE_MAX)   \
+        {                                                          \
+            _result = OE_INVALID_PARAMETER;                        \
+            goto done;                                             \
+        }                                                          \
+        if (oe_add_size((size_t*)&total, (size_t)size) != OE_OK)   \
+        {                                                          \
+            _result = OE_INTEGER_OVERFLOW;                         \
+            goto done;                                             \
+        }                                                          \
     } while (0)
 
 /**

--- a/include/openenclave/edger8r/enclave.h
+++ b/include/openenclave/edger8r/enclave.h
@@ -22,6 +22,11 @@
 #include <openenclave/bits/types.h>
 #include <openenclave/edger8r/common.h>
 
+#include <openenclave/corelibc/errno.h>
+#include <openenclave/corelibc/stdlib.h>
+#include <openenclave/corelibc/string.h>
+#include <openenclave/corelibc/wchar.h>
+
 OE_EXTERNC_BEGIN
 
 /**

--- a/include/openenclave/edger8r/host.h
+++ b/include/openenclave/edger8r/host.h
@@ -23,6 +23,10 @@
 #include <openenclave/edger8r/common.h>
 #include <openenclave/host.h> // for oe_ocall_func_t
 
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+
 OE_EXTERNC_BEGIN
 
 /**
@@ -77,6 +81,29 @@ oe_result_t oe_switchless_call_enclave_function(
     void* output_buffer,
     size_t output_buffer_size,
     size_t* output_bytes_written);
+
+/*
+ * In some instances oeedger8r generates the same code for both the host and
+ * enclave side. Since enclave applications are not required to link stdc,
+ * the edger8r uses oe-specific implementations. For the host side, simply
+ * implement these functions as wrappers for the stdc functions since oehost
+ * has a hard dependancy on stdc.
+ */
+
+OE_INLINE void* oe_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+OE_INLINE size_t oe_strlen(const char* s)
+{
+    return strlen(s);
+}
+
+OE_INLINE size_t oe_wcslen(const wchar_t* s)
+{
+    return wcslen(s);
+}
 
 OE_EXTERNC_END
 

--- a/syscall/devices/hostepoll/hostepoll.c
+++ b/syscall/devices/hostepoll/hostepoll.c
@@ -6,6 +6,7 @@
 #include <openenclave/enclave.h>
 
 #include <openenclave/corelibc/stdio.h>
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/corelibc/string.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>

--- a/syscall/devices/hostfs/hostfs.c
+++ b/syscall/devices/hostfs/hostfs.c
@@ -26,6 +26,7 @@
 #include <openenclave/internal/syscall/dirent.h>
 #include <openenclave/internal/syscall/sys/mount.h>
 #include <openenclave/corelibc/stdio.h>
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/corelibc/string.h>
 #include <openenclave/internal/syscall/fcntl.h>
 #include <openenclave/internal/syscall/sys/ioctl.h>

--- a/syscall/poll.c
+++ b/syscall/poll.c
@@ -3,6 +3,7 @@
 
 #include <openenclave/enclave.h>
 
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/internal/syscall/fdtable.h>
 #include <openenclave/internal/syscall/raise.h>
 #include <openenclave/internal/syscall/sys/poll.h>

--- a/syscall/syscall_t_wrapper.c
+++ b/syscall/syscall_t_wrapper.c
@@ -1,8 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#define OE_NEED_STDC_NAMES
-
 #include <openenclave/enclave.h>
 
 #include <openenclave/corelibc/stdio.h>

--- a/tests/atexit/enc/enc.cpp
+++ b/tests/atexit/enc/enc.cpp
@@ -4,6 +4,7 @@
 #include <limits.h>
 #include <openenclave/enclave.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "atexit_t.h"
 

--- a/tests/backtrace/enc/enc.cpp
+++ b/tests/backtrace/enc/enc.cpp
@@ -6,6 +6,7 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/print.h>
 #include <openenclave/internal/tests.h>
+#include <stdlib.h>
 #include <string.h>
 #include "backtrace_t.h"
 

--- a/tools/oeedger8r/src/Headers.ml
+++ b/tools/oeedger8r/src/Headers.ml
@@ -173,9 +173,6 @@ let generate_args (ec : enclave_content) =
     "#ifndef " ^ guard_macro;
     "#define " ^ guard_macro;
     "";
-    "#include <stdint.h>";
-    "#include <stdlib.h> /* for wchar_t */";
-    "";
     include_errno;
     "";
     "#include <openenclave/bits/result.h>";

--- a/tools/oeedger8r/src/Sources.ml
+++ b/tools/oeedger8r/src/Sources.ml
@@ -287,7 +287,7 @@ let get_ptr_array get_deepcopy (plist : pdecl list) =
   if count <> [] then
     [
       "size_t _ptrs_index = 0;";
-      sprintf "void** _ptrs = malloc(sizeof(void*) * (%s));"
+      sprintf "void** _ptrs = oe_malloc(sizeof(void*) * (%s));"
         (String.concat " + " count);
       "if (_ptrs == NULL)";
       "{";
@@ -330,9 +330,9 @@ let get_filled_marshal_struct get_deepcopy (fd : func_decl) =
       ];
       (* for string parameter fill the len field *)
       ( if is_str_ptr ptype then
-        [ sprintf "_args.%s_len = (%s) ? (strlen(%s) + 1) : 0;" arg arg arg ]
+        [ sprintf "_args.%s_len = (%s) ? (oe_strlen(%s) + 1) : 0;" arg arg arg ]
       else if is_wstr_ptr ptype then
-        [ sprintf "_args.%s_len = (%s) ? (wcslen(%s) + 1) : 0;" arg arg arg ]
+        [ sprintf "_args.%s_len = (%s) ? (oe_wcslen(%s) + 1) : 0;" arg arg arg ]
       else [] );
     ]
     |> List.flatten
@@ -718,7 +718,7 @@ let get_ocall_function_wrapper get_deepcopy enclave_name (uf : untrusted_func) =
     "    " ^ String.concat "\n    " (get_output_buffer get_deepcopy fd);
     "";
     "    /* Retrieve propagated errno from OCALL. */";
-    ( if uf.uf_propagate_errno then "    errno = _pargs_out->_ocall_errno;\n"
+    ( if uf.uf_propagate_errno then "    oe_errno = _pargs_out->_ocall_errno;\n"
     else sprintf "    /* Errno propagation not enabled. */" );
     "";
     "    _result = OE_OK;";
@@ -764,10 +764,6 @@ let generate_trusted (ec : enclave_content) (ep : Intel.Util.edger8r_params) =
     sprintf "#include \"%s_t.h\"" ec.file_shortnm;
     "";
     "#include <openenclave/edger8r/enclave.h>";
-    "";
-    "#include <stdlib.h>";
-    "#include <string.h>";
-    "#include <wchar.h>";
     "";
     "OE_EXTERNC_BEGIN";
     "";
@@ -819,7 +815,7 @@ let get_host_ecall_wrapper get_deepcopy enclave_name (tf : trusted_func) =
     "    memset(&_args, 0, sizeof(_args));";
     "    " ^ String.concat "\n    " (get_filled_marshal_struct get_deepcopy fd);
     "";
-    "    " ^ String.concat "\n    " (get_input_buffer get_deepcopy fd "malloc");
+    "    " ^ String.concat "\n    " (get_input_buffer get_deepcopy fd "oe_malloc");
     "";
     "    /* Call enclave function. */";
     "    if ((_result = " ^ ecall_function ^ "(";
@@ -940,10 +936,6 @@ let generate_untrusted (ec : enclave_content) (ep : Intel.Util.edger8r_params) =
     sprintf "#include \"%s_u.h\"" ec.file_shortnm;
     "";
     "#include <openenclave/edger8r/host.h>";
-    "";
-    "#include <stdlib.h>";
-    "#include <string.h>";
-    "#include <wchar.h>";
     "";
     "OE_EXTERNC_BEGIN";
     "";


### PR DESCRIPTION
An enclave application is not required to link oelibc. To make this dependancy more clear and avoid name collisions, switch to using `oe_*` names for stdc functions and about use of `OE_NEEDS_STDC_NAMES`.