### PR TITLE
Remove OE_SET_ENCLAVE_SGX; Explain why enclave has two threads.

### DIFF
--- a/samples/switchless/enclave/enc.c
+++ b/samples/switchless/enclave/enc.c
@@ -39,11 +39,3 @@ void enclave_decrement_regular(int* n)
 {
     *n = *n - 1;
 }
-
-OE_SET_ENCLAVE_SGX(
-    1,    /* ProductID */
-    1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    64,   /* StackPageCount */
-    2);   /* TCSCount */

--- a/samples/switchless/enclave/switchless.conf
+++ b/samples/switchless/enclave/switchless.conf
@@ -5,6 +5,9 @@
 Debug=1
 NumHeapPages=1024
 NumStackPages=64
+# The enclave has two threads.
+# One thread (main) makes switchless ocalls.
+# Another thread is a worker thread for servicing switchless ecalls.
 NumTCS=2
 ProductID=1
 SecurityVersion=1


### PR DESCRIPTION
To be consistent with other samples, OE_SET_ENCLAVE_SGX is removed.

The sample originally had one enclave thread to demonstrate switchless ocalls.
The sample has been updated to demonstrate switchless ecalls using a single
enclave worker thread to service switchless ecalls. This makes the number of
threads (NumTCS) 2.

Fixes #2715

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>