### PR TITLE
oesign: fix a gcc9 build error

### DIFF
--- a/tools/oesign/main.c
+++ b/tools/oesign/main.c
@@ -661,7 +661,7 @@ int oesign(
         /* Load private key into memory */
         if (_load_pem_file(keyfile, &pem_data, &pem_size) != 0)
         {
-            Err("Failed to load file: %s", keyfile);
+            Err("Failed to load file: %s", keyfile ? keyfile : "NULL");
             goto done;
         }
 


### PR DESCRIPTION
With gcc9, build fails because `keyfile` argument can theoretically be NULL.  This is possibly because the value is checked for NULL later in `_load_pem_file()`, even though I can't see any call paths which lead to `keyfile` to actually being NULL at this point.

    /home/build/openenclave/tools/oesign/main.c: In function ‘oesign’:
    /home/build/openenclave/tools/oesign/main.c:664:13: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
      664 |             Err("Failed to load file: %s", keyfile);
          |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Fix the build error by checking the value for NULL before using it.
