### PR TITLE
Skip tests with older gcc version

### DIFF
--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -8,6 +8,9 @@ else()
     file(STRINGS "tests.supported.default" alltests)
 endif()
 
+# The list of tests requires `std=c++17`.
+file(STRINGS "tests.supported.cxx17" CXX_17_TEST_LIST)
+
 # List of unsupported tests with GCC.
 set(GCC_UNSUPPORTED_LIST
     "libcxx_containers_unord_next_pow2.pass"
@@ -42,6 +45,18 @@ set(GCC_UNSUPPORTED_LIST
     "std_utilities_optional_optional.object_optional.object.ctor_deduct.pass"
     "std_utilities_tuple_tuple.tuple_tuple.cnstr_implicit_deduction_guides.pass"
     "std_utilities_utility_pairs_pairs.pair_implicit_deduction_guides.pass"
+)
+
+# List the unsupported on GCC version less than 7.
+# Refer to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77446 for the issue.
+set(GCC_LESS_7_UNSUPPORTED_LIST
+    "std_strings_string.view_string.view.find_find_char_size.pass"
+    "std_strings_string.view_string.view.find_find_first_not_of_pointer_size.pass"
+    "std_strings_string.view_string.view.find_find_first_not_of_pointer_size_size.pass"
+    "std_strings_string.view_string.view.find_find_first_of_char_size.pass"
+    "std_strings_string.view_string.view.find_find_last_not_of_pointer_size.pass"
+    "std_strings_string.view_string.view.find_find_last_of_pointer_size.pass"
+    "std_strings_string.view_string.view.find_find_last_of_pointer_size_size.pass"
 )
 
 add_subdirectory(host)
@@ -105,6 +120,13 @@ foreach(testcase ${alltests})
     if ("${name}" MATCHES "std_containers_associative_map_map.access_at.pass")
         string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
         if (ENCLAVE_CXX_COMPILER_ID MATCHES GNU AND BUILD_TYPE_UPPER MATCHES REL)
+            continue()
+        endif()
+    endif()
+
+    # Skip the following tests on GCC version less than 7 because a bug is not fixed or C++17 features are not supported.
+    if ("${name}" IN_LIST GCC_LESS_7_UNSUPPORTED_LIST OR "${testcase}" IN_LIST CXX_17_TEST_LIST)
+        if (ENCLAVE_CXX_COMPILER_ID MATCHES GNU AND ENCLAVE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
             continue()
         endif()
     endif()

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -49,9 +49,6 @@ set(BUILD_INFO_FILE "${CMAKE_CURRENT_BINARY_DIR}/build_info.cmake")
 file(WRITE "${BUILD_INFO_FILE}" "set(LINUX_CXX_COMPILER_ID \"${CMAKE_CXX_COMPILER_ID}\")\n")
 file(APPEND "${BUILD_INFO_FILE}" "set(LINUX_CXX_COMPILER_VERSION \"${CMAKE_CXX_COMPILER_VERSION}\")\n")
 
-# The list of tests requires `std=c++17`.
-file(STRINGS "../tests.supported.cxx17" cxx17tests)
-
 # helper function to create enclave binary
 function(add_libcxx_test_enc NAME CXXFILE)
     add_enclave(TARGET libcxxtest-${NAME}_enc UUID 486dcdcc-f0c6-4bdd-91e0-c7566794f899 CXX
@@ -89,7 +86,7 @@ function(add_libcxx_test_enc NAME CXXFILE)
     enclave_compile_definitions(libcxxtest-${NAME}_enc PRIVATE -DWITH_MAIN -D__TEST__="${CXXFILE}")
     enclave_link_libraries(libcxxtest-${NAME}_enc libcxxtest-support)
 
-    if (CXXFILE IN_LIST cxx17tests)
+    if (CXXFILE IN_LIST CXX_17_TEST_LIST)
         set_enclave_property(TARGET libcxxtest-${NAME}_enc PROPERTY CXX_STANDARD 17)
     endif()
 
@@ -165,6 +162,13 @@ foreach(testcase ${alltests})
     if ("${name}" MATCHES "std_containers_associative_map_map.access_at.pass")
         string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
         if (CMAKE_CXX_COMPILER_ID MATCHES GNU AND BUILD_TYPE_UPPER MATCHES REL)
+            continue()
+        endif()
+    endif()
+
+    # Skip the following tests on GCC version less than 7 because a bug is not fixed or C++17 features are not supported.
+    if ("${name}" IN_LIST GCC_LESS_7_UNSUPPORTED_LIST OR "${testcase}" IN_LIST CXX_17_TEST_LIST)
+        if (CMAKE_CXX_COMPILER_ID MATCHES GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
             continue()
         endif()
     endif()


### PR DESCRIPTION
Some tests pass with gcc 7 (default to ubuntu 18.04) but fail with gcc 5 (default to ubuntu 16.04).
Those tests include ones
- Trigger a bug that is resolved in gcc 7 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77446).
- Use C++17 features that are not yet supported in gcc 5 (https://gcc.gnu.org/projects/cxx-status.html#cxx17).

This PR skips those tests when the gcc version is too old (<7).

Fixes #2783 

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>