### PR TITLE
Fix bug with the CXX argument in add_enclave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix #2607 so that libmbedcrypto now includes mbedtls_hkdf().
+- `CXX` is always `TRUE` in `add_enclave_sgx()` and `add_enclave_optee()`. Fixes #2786.
 
 ### Removed
 - Removed oe-gdb script which has been deprecated since v0.6. Use oegdb instead.

--- a/cmake/add_enclave.cmake
+++ b/cmake/add_enclave.cmake
@@ -9,6 +9,7 @@
 #  add_enclave(<TARGET target>
 #              [<UUID uuid>]
 #              [CXX]
+#              [ADD_LVI_MITIGATION ON/OFF]
 #              <SOURCES sources>
 #              [<CONFIG config>]
 #              [<KEY key>])
@@ -121,11 +122,10 @@ function(sign_enclave_sgx)
 endfunction()
 
 function(add_enclave_sgx)
-  set(options CXX)
-  set(oneValueArgs TARGET CONFIG KEY SIGNING_ENGINE ENGINE_LOAD_PATH ENGINE_KEY_ID ADD_LVI_MITIGATION)
+  set(oneValueArgs TARGET CONFIG KEY SIGNING_ENGINE ENGINE_LOAD_PATH ENGINE_KEY_ID CXX ADD_LVI_MITIGATION)
   set(multiValueArgs SOURCES)
   cmake_parse_arguments(ENCLAVE
-    "${options}"
+    ""
     "${oneValueArgs}"
     "${multiValueArgs}"
     ${ARGN})
@@ -188,11 +188,10 @@ function(add_enclave_sgx)
 endfunction()
 
 macro(add_enclave_optee)
-   set(options CXX)
-   set(oneValueArgs TARGET UUID KEY)
+   set(oneValueArgs TARGET UUID KEY CXX)
    set(multiValueArgs SOURCES)
    cmake_parse_arguments(ENCLAVE
-     "${options}"
+     ""
      "${oneValueArgs}"
      "${multiValueArgs}"
      ${ARGN})

--- a/tests/SampleApp/enc/CMakeLists.txt
+++ b/tests/SampleApp/enc/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# TODO: Does this need CXX?
-
 set (EDL_FILE ../SampleApp.edl)
 
 add_custom_command(

--- a/tests/SampleAppCRT/enc/CMakeLists.txt
+++ b/tests/SampleAppCRT/enc/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# TODO: Does this need CXX?
-
 set (EDL_FILE ../SampleAppCRT.edl)
 
 add_custom_command(

--- a/tests/create-rapid/enc/CMakeLists.txt
+++ b/tests/create-rapid/enc/CMakeLists.txt
@@ -8,7 +8,6 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO: Does this need CXX?
 add_enclave(TARGET create_rapid_enc UUID 688ab13f-5bc0-40af-8dc6-01d007fd2210 SOURCES enc.cpp ${CMAKE_CURRENT_BINARY_DIR}/create_rapid_t.c)
 
 enclave_include_directories(create_rapid_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/ecall/enc/CMakeLists.txt
+++ b/tests/ecall/enc/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# TODO: Does this need CXX?
-
 set (EDL_FILE ../ecall.edl)
 
 add_custom_command(

--- a/tests/file/enc/CMakeLists.txt
+++ b/tests/file/enc/CMakeLists.txt
@@ -8,7 +8,6 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO: Does this need CXX?
 add_enclave(TARGET file_enc UUID f7ee9123-07ec-4d46-81ac-47a109b1d406 SOURCES enc.cpp ${CMAKE_CURRENT_BINARY_DIR}/file_t.c)
 enclave_include_directories(file_enc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 enclave_link_libraries(file_enc oelibc)

--- a/tests/hostcalls/enc/CMakeLists.txt
+++ b/tests/hostcalls/enc/CMakeLists.txt
@@ -8,7 +8,6 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO: Does this need CXX?
 add_enclave(TARGET hostcalls_enc UUID 60814a64-61e9-4fd9-9159-e158d73f6a2e SOURCES enc.cpp ${CMAKE_CURRENT_BINARY_DIR}/hostcalls_t.c)
 
 enclave_include_directories(hostcalls_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/pingpong-shared/enc/CMakeLists.txt
+++ b/tests/pingpong-shared/enc/CMakeLists.txt
@@ -8,7 +8,6 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO: Does this need CXX?
 add_enclave(TARGET pingpong-shared_enc UUID e229cc0f-3199-4ad3-91a7-47906fcbcc59 SOURCES enc.cpp ${CMAKE_CURRENT_BINARY_DIR}/pingpong_t.c)
 enclave_include_directories(pingpong-shared_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 enclave_link_libraries(pingpong-shared_enc oelibc)

--- a/tests/pingpong/enc/CMakeLists.txt
+++ b/tests/pingpong/enc/CMakeLists.txt
@@ -8,7 +8,6 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO: Does this need CXX?
 add_enclave(TARGET pingpong_enc UUID 0a6cbbd3-160a-4c86-9d9d-c9cf1956be16 SOURCES enc.cpp ${CMAKE_CURRENT_BINARY_DIR}/pingpong_t.c)
 enclave_include_directories(pingpong_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 enclave_link_libraries(pingpong_enc oelibc)

--- a/tests/print/enc/CMakeLists.txt
+++ b/tests/print/enc/CMakeLists.txt
@@ -8,7 +8,6 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO: Does this need CXX?
 add_enclave(TARGET print_enc UUID 58f3e795-00c3-45e0-9435-3e6fcf734acc SOURCES enc.cpp ${CMAKE_CURRENT_BINARY_DIR}/print_t.c)
 
 enclave_compile_options(print_enc PRIVATE

--- a/tests/qeidentity/enc/CMakeLists.txt
+++ b/tests/qeidentity/enc/CMakeLists.txt
@@ -8,7 +8,6 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO: Does this need CXX?
 add_enclave(TARGET qeidentity_enc UUID a656f3b1-d319-4692-bcd6-a2f50d9fb1e5 SOURCES enc.cpp ${CMAKE_CURRENT_BINARY_DIR}/tests_t.c)
 
 if(HAS_QUOTE_PROVIDER)

--- a/tests/report/enc/CMakeLists.txt
+++ b/tests/report/enc/CMakeLists.txt
@@ -8,7 +8,6 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO: Does this need CXX?
 add_enclave(TARGET report_enc UUID 20b1a091-50da-4e57-b58c-0a8489cb64a6
   SOURCES enc.cpp datetime.cpp ../common/tests.cpp tests_t.c)
 

--- a/tests/safecrt/enc/CMakeLists.txt
+++ b/tests/safecrt/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_enclave(TARGET safecrt_enc UUID 91dc6667-7a33-4bbc-ab3e-ab4fca5215b7 CXX
+add_enclave(TARGET safecrt_enc UUID 91dc6667-7a33-4bbc-ab3e-ab4fca5215b7
   SOURCES ../common/test.cpp enc.cpp safecrt_t.c)
 
 enclave_include_directories(safecrt_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/stdc/enc/CMakeLists.txt
+++ b/tests/stdc/enc/CMakeLists.txt
@@ -8,7 +8,6 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO: Does this need CXX?
 add_enclave(TARGET stdc_enc UUID 9a30506a-87f6-4214-a007-f15b11c98f8b SOURCES enc.cpp ${CMAKE_CURRENT_BINARY_DIR}/stdc_t.c)
 
 enclave_compile_options(stdc_enc PRIVATE

--- a/tests/syscall/poller/enc/CMakeLists.txt
+++ b/tests/syscall/poller/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
     DEPENDS ${EDL_FILE} edger8r
     COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_enclave(TARGET poller_enc CXX
+add_enclave(TARGET poller_enc
     SOURCES enc.cpp ../client.cpp ../server.cpp ../poller.cpp ${CMAKE_CURRENT_BINARY_DIR}/poller_t.c)
 
 enclave_link_libraries(poller_enc oelibcxx oeenclave oehostepoll oehostsock)


### PR DESCRIPTION
This PR fixes the `CXX` argument in `add_enclave`, which was always `TRUE` after the argument was forwarded to `add_enclave_sgx` and `add_enclave_optee` (see more detail in #2786 ).

The fix is treating `CXX` as oneValueArg instead of option so that the argument can be correctly forwarded.

Fixes #2786 

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>