### PR TITLE
Remove epoll.edl dependance on internal headers

### DIFF
--- a/common/edl/epoll.edl
+++ b/common/edl/epoll.edl
@@ -15,8 +15,7 @@
 enclave
 {
 
-    include "openenclave/internal/syscall/sys/epoll.h"
-    include "openenclave/internal/syscall/types.h"
+    include "openenclave/bits/edl/syscall_types.h"
 
     untrusted
     {

--- a/common/edl/poll.edl
+++ b/common/edl/poll.edl
@@ -14,7 +14,15 @@
 
 enclave {
 
+    include "openenclave/bits/types.h"
     include "openenclave/bits/edl/syscall_types.h"
+
+    struct oe_host_pollfd
+    {
+        oe_host_fd_t fd;
+        short int events;
+        short int revents;
+    };
 
     struct oe_pollfd
     {

--- a/include/openenclave/bits/defs.h
+++ b/include/openenclave/bits/defs.h
@@ -166,4 +166,20 @@
 #define OE_DEPRECATED(FUNC, MSG) FUNC
 #endif
 
+/*
+ * Define packed types, such as:
+ *     OE_PACK_BEGIN
+ *     struct foo {int a,b};
+ *     OE_PACK_END
+ */
+#if defined(__GNUC__)
+#define OE_PACK_BEGIN _Pragma("pack(push, 1)")
+#define OE_PACK_END _Pragma("pack(pop)")
+#elif _MSC_VER
+#define OE_PACK_BEGIN __pragma(pack(push, 1))
+#define OE_PACK_END __pragma(pack(pop))
+#else
+#error "OE_PACK_BEGIN and OE_PACK_END not implemented"
+#endif
+
 #endif /* _OE_BITS_DEFS_H */

--- a/include/openenclave/bits/edl/syscall_types.h
+++ b/include/openenclave/bits/edl/syscall_types.h
@@ -4,6 +4,9 @@
 #ifndef _OE_EDL_SYSCALL_TYPES_H
 #define _OE_EDL_SYSCALL_TYPES_H
 
+#include <openenclave/bits/defs.h>
+#include <openenclave/bits/types.h>
+
 /* DISCLAIMER:
  * This header is published with no guarantees of stability and is not part
  * of the Open Enclave public API surface. It is only intended to be used
@@ -13,4 +16,30 @@ typedef int64_t oe_host_fd_t;
 
 typedef uint64_t oe_nfds_t;
 
+typedef union _oe_epoll_data_t {
+    void* ptr;
+    int fd;
+    uint32_t u32;
+    uint64_t u64;
+} oe_epoll_data_t;
+
+/*
+ * The epoll events are packed in x86_64 but not on other architectures. This is
+ * probably because the x86 has no problem with unaligned accesses where as
+ * unaligned accesses are usually very inefficient, even if they are allowed, in
+ * other architectures. We maintain consistency with MUSL's and the linux
+ * kernel's handling on that architecture.
+ */
+#if !defined(__aarch64__)
+OE_PACK_BEGIN
 #endif
+struct oe_epoll_event
+{
+    uint32_t events;
+    oe_epoll_data_t data;
+};
+#if !defined(__aarch64__)
+OE_PACK_END
+#endif
+
+#endif // _OE_EDL_SYSCALL_TYPES_H

--- a/include/openenclave/internal/defs.h
+++ b/include/openenclave/internal/defs.h
@@ -18,22 +18,6 @@
 #define OE_ZERO_SIZED_ARRAY /* empty */
 #endif
 
-/*
- * Define packed types, such as:
- *     OE_PACK_BEGIN
- *     struct foo {int a,b};
- *     OE_PACK_END
- */
-#if defined(__GNUC__)
-#define OE_PACK_BEGIN _Pragma("pack(push, 1)")
-#define OE_PACK_END _Pragma("pack(pop)")
-#elif _MSC_VER
-#define OE_PACK_BEGIN __pragma(pack(push, 1))
-#define OE_PACK_END __pragma(pack(pop))
-#else
-#error "OE_PACK_BEGIN and OE_PACK_END not implemented"
-#endif
-
 /* OE_CHECK_SIZE */
 #define OE_CHECK_SIZE(N, M)          \
     typedef unsigned char OE_CONCAT( \

--- a/include/openenclave/internal/syscall/sys/epoll.h
+++ b/include/openenclave/internal/syscall/sys/epoll.h
@@ -5,6 +5,7 @@
 #define _OE_SYS_EPOLL_H
 
 #include <openenclave/bits/defs.h>
+#include <openenclave/bits/edl/syscall_types.h>
 #include <openenclave/bits/types.h>
 #include <openenclave/internal/syscall/sys/bits/sigset.h>
 #include <openenclave/internal/types.h>
@@ -41,16 +42,6 @@ enum OE_EPOLL_EVENTS
     OE_EPOLLONESHOT = 1u << 30,
     OE_EPOLLET = 1u << 31
 };
-
-#define __OE_EPOLL_DATA oe_epoll_data
-#define __OE_EPOLL_DATA_T oe_epoll_data_t
-#include <openenclave/internal/syscall/sys/bits/epoll_data.h>
-#undef __OE_EPOLL_DATA
-#undef __OE_EPOLL_DATA_T
-
-#define __OE_EPOLL_EVENT oe_epoll_event
-#include <openenclave/internal/syscall/sys/bits/epoll_event.h>
-#undef __OE_EPOLL_EVENT
 
 int oe_epoll_create(int size);
 

--- a/include/openenclave/internal/syscall/types.h
+++ b/include/openenclave/internal/syscall/types.h
@@ -6,17 +6,10 @@
 
 #include <openenclave/bits/edl/syscall_types.h>
 #include <openenclave/bits/types.h>
+#include <openenclave/internal/bits/poll.h>
 #include <openenclave/internal/defs.h>
 
 OE_EXTERNC_BEGIN
-
-/* Version of struct oe_pollfd with wider descriptor. */
-struct oe_host_pollfd
-{
-    oe_host_fd_t fd;
-    short int events;
-    short int revents;
-};
 
 OE_STATIC_ASSERT(sizeof(struct oe_host_pollfd) == (2 * sizeof(uint64_t)));
 OE_STATIC_ASSERT(OE_OFFSETOF(struct oe_host_pollfd, fd) == 0);


### PR DESCRIPTION
Move the structures needed by by epoll.edl from an internal header to the syscall_types.h bits header. They are based on a public libc structures and will not change.

The epoll_event struct must be defined in C and not EDL because it is a packed structure.