### PR TITLE
Remove accidental dependencies on libc headers from oecore

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -71,8 +71,11 @@ set(MUSL_SRC_DIR ${PROJECT_SOURCE_DIR}/3rdparty/musl/musl/src)
 
 if (USE_SNMALLOC)
     add_enclave_library(oeallocator OBJECT
-        sgx/snmalloc/snmalloc_wrapper.cpp
-    )
+        sgx/snmalloc/snmalloc_wrapper.cpp)
+
+    list (APPEND W_NO_CONVERSION
+        sgx/snmalloc/snmalloc_wrapper.cpp)
+
     enclave_link_libraries(oeallocator PUBLIC oe_includes)
     set_source_files_properties(sgx/snmalloc/snmalloc_wrapper.cpp PROPERTIES COMPILE_FLAGS -std=c++17\ -mcx16\ -fno-exceptions)
     enclave_compile_options(oeallocator PUBLIC
@@ -154,6 +157,9 @@ endif ()
 
 if (USE_DLMALLOC)
     list(APPEND PLATFORM_SRC malloc.c)
+
+    list(APPEND NEEDS_STDC_NAMES malloc.c)
+
     # Unfortunately dlmalloc uses GNU extension that allows arithmetic
     # null pointers.
     set_source_files_properties(malloc.c
@@ -199,15 +205,34 @@ add_enclave_library(oecore STATIC
     wchar.c
     ${PLATFORM_SRC})
 
-# Suppress type conversion warnings introduced by 3rdparty code
-set_source_files_properties(${MUSL_SRC_DIR}/prng/rand.c ROPERTIES
-    COMPILE_FLAGS -Wno-conversion)
-set_source_files_properties(${MUSL_SRC_DIR}/string/memmove.c PROPERTIES
-    COMPILE_FLAGS -Wno-sign-conversion)
-set_source_files_properties(${MUSL_SRC_DIR}/string/memset.c PROPERTIES
-    COMPILE_FLAGS -Wno-conversion)
-set_source_files_properties(__secs_to_tm.c PROPERTIES
-    COMPILE_FLAGS -Wno-conversion)
+# Some files in oecore come directly from the musl source. For these files,
+# corelibc functions with stdc names are required.
+# Additionally, suppress type conversion warnings introduced by 3rdparty code
+set (CORELIBC_INCLUDES ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
+
+list (APPEND NEEDS_STDC_NAMES
+    ${MUSL_SRC_DIR}/prng/rand.c
+    ${MUSL_SRC_DIR}/string/memmove.c
+    ${MUSL_SRC_DIR}/string/memset.c
+    ${MUSL_SRC_DIR}/string/memcmp.c
+    ${MUSL_SRC_DIR}/string/memcpy.c
+    __secs_to_tm.c
+    debugmalloc.c
+    strtok_r.c)
+
+list (APPEND W_NO_CONVERSION
+    ${MUSL_SRC_DIR}/prng/rand.c
+    ${MUSL_SRC_DIR}/string/memmove.c
+    ${MUSL_SRC_DIR}/string/memset.c
+    __secs_to_tm.c)
+
+set_property(SOURCE ${W_NO_CONVERSION} APPEND_STRING PROPERTY
+    COMPILE_FLAGS " -Wno-conversion")
+
+set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND_STRING PROPERTY
+    COMPILE_FLAGS " -I${CORELIBC_INCLUDES}")
+set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND PROPERTY
+    COMPILE_DEFINITIONS OE_NEED_STDC_NAMES)
 
 maybe_build_using_clangw(oecore)
 
@@ -220,6 +245,12 @@ enclave_include_directories(oecore PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 enclave_link_libraries(oecore PUBLIC oe_includes)
 if (OE_TRUSTZONE)
     enclave_link_libraries(oecore PUBLIC oelibutee_includes)
+
+    # OP-TEE header 3rdparty/optee/libutee/liboeutee/user_ta_header.h
+    # includes stdint.h. As a result all OP-TEE needs the corelibc headers
+    # in its include path.
+    enclave_include_directories(oecore PRIVATE
+        ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 endif ()
 
 enclave_link_libraries(oecore PUBLIC oe_includes)
@@ -230,10 +261,6 @@ endif()
 if (CMAKE_C_COMPILER_ID MATCHES GNU)
     enclave_compile_options(oecore PRIVATE -Wjump-misses-init)
 endif()
-
-# This directory contains enclave core libc headers:
-enclave_include_directories(oecore PRIVATE
-    ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 
 if (OE_SGX)
     set_source_files_properties(sgx/keys.c PROPERTIES COMPILE_FLAGS -Wno-type-limits)

--- a/enclave/core/__secs_to_tm.c
+++ b/enclave/core/__secs_to_tm.c
@@ -1,9 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-/* Use OE STDC time.h & limits.h defs for MUSL __secs_to_tm.c */
-#define OE_NEED_STDC_NAMES
-
 /* Define this to satisfy compiler for unused function in time_impl.h */
 typedef struct __locale_struct* locale_t;
 #include "../../3rdparty/musl/musl/src/include/features.h"

--- a/enclave/core/arena.c
+++ b/enclave/core/arena.c
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 
 #include "arena.h"
+#include <openenclave/corelibc/string.h>
 #include <openenclave/edger8r/common.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/safemath.h>
 #include <openenclave/internal/thread.h>
 #include <openenclave/internal/utils.h>
-#include <string.h>
 
 // The per-thread shared memory arena
 static __thread shared_memory_arena_t _arena = {0};

--- a/enclave/core/ctype.c
+++ b/enclave/core/ctype.c
@@ -1,7 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#include <ctype.h>
+#include <openenclave/corelibc/ctype.h>
 
 static const unsigned short _ctype_b[384] = {
     0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,

--- a/enclave/core/malloc.c
+++ b/enclave/core/malloc.c
@@ -2,14 +2,13 @@
 // Licensed under the MIT License.
 
 /* The use of dlmalloc/malloc.c below requires stdc names from these headers.
- * Ensure that all corelibc headers are included with std names before
- * including other headers. */
-#define OE_NEED_STDC_NAMES
+ * OE_NEED_STDC_NAMES is set by enclave/core/CMakeLists.txt for this file
+ * to make the following corelibc headers include corresponding stdc names
+ * for types and functions. */
 #include <openenclave/corelibc/errno.h> // For errno & error defs
 #include <openenclave/corelibc/sched.h> // For sched_yield
 #include <openenclave/corelibc/stdio.h>
 #include <openenclave/corelibc/string.h>
-#undef OE_NEED_STDC_NAMES
 
 #include <openenclave/enclave.h>
 #include <openenclave/internal/fault.h>

--- a/enclave/core/oe_nodebug_alloc.h
+++ b/enclave/core/oe_nodebug_alloc.h
@@ -5,7 +5,7 @@
 #define _OE_NODEBUG_ALLOC_H
 
 #include <openenclave/bits/defs.h>
-#include <stddef.h>
+#include <openenclave/corelibc/stddef.h>
 
 OE_EXTERNC_BEGIN
 

--- a/include/openenclave/edger8r/host.h
+++ b/include/openenclave/edger8r/host.h
@@ -23,6 +23,7 @@
 #include <openenclave/edger8r/common.h>
 #include <openenclave/host.h> // for oe_ocall_func_t
 
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <wchar.h>

--- a/tools/oeedger8r/src/Headers.ml
+++ b/tools/oeedger8r/src/Headers.ml
@@ -153,12 +153,6 @@ let generate_args (ec : enclave_content) =
   let guard_macro =
     "EDGER8R_" ^ String.uppercase_ascii ec.enclave_name ^ "_ARGS_H"
   in
-  let include_errno =
-    let ufs = ec.ufunc_decls in
-    let s = "#include <errno.h>" in
-    if List.exists (fun uf -> uf.uf_propagate_errno) ufs then s
-    else sprintf "/* %s - Errno propagation not enabled so not included. */" s
-  in
   let user_includes =
     let includes = ec.include_list in
     if includes <> [] then List.map (sprintf "#include \"%s\"") includes
@@ -172,8 +166,6 @@ let generate_args (ec : enclave_content) =
   [
     "#ifndef " ^ guard_macro;
     "#define " ^ guard_macro;
-    "";
-    include_errno;
     "";
     "#include <openenclave/bits/result.h>";
     "";


### PR DESCRIPTION
There are numerous places in oecore where standard C headers are included as system headers (i.e. #include <stdlib.h>) when the intention is really to use the corresponding corelibc header. In those instances explicitly include the corelibc header.

In instances in which standard C names are needed by 3rd party code, include those names only when compiling those files rather than making it the default for all files in oecore.

This PR is a revised version of #2767 with far fewer changes