### PR TITLE
Rename SGX-specific ocalls with SGX names

### DIFF
--- a/common/sgx/edl/cpu.edl
+++ b/common/sgx/edl/cpu.edl
@@ -16,7 +16,7 @@ enclave
 {
     untrusted
     {
-        oe_result_t oe_get_cpuid_table_ocall(
+        oe_result_t oe_sgx_get_cpuid_table_ocall(
             [out, size=cpuid_table_buffer_size] void* cpuid_table_buffer,
             size_t cpuid_table_buffer_size);
     };

--- a/common/sgx/edl/debug.edl
+++ b/common/sgx/edl/debug.edl
@@ -9,9 +9,6 @@
 **     Internal ECALLs/OCALLs to be used by liboehost/liboecore for operations
 **     related to debugging.
 **
-**     Note that this functionality is not inherently specific to SGX, it is
-**     just only implemented for SGX as of this writing.
-**
 **==============================================================================
 */
 
@@ -25,7 +22,7 @@ enclave
     {
         // Translate the addresses in buffer[] into symbol names.
         // (similar to Linux backtrace_symbols().
-        oe_result_t oe_backtrace_symbols_ocall(
+        oe_result_t oe_sgx_backtrace_symbols_ocall(
             [user_check] oe_enclave_t* oe_enclave,
             [in, count=size] const uint64_t* buffer,
             size_t size,

--- a/common/sgx/edl/thread.edl
+++ b/common/sgx/edl/thread.edl
@@ -8,9 +8,6 @@
 **
 **     Internal OCALLs to be used by liboehost/liboecore for thread operations.
 **
-**     Note that this functionality is not inherently specific to SGX, it is
-**     just only implemented for SGX as of this writing.
-**
 **==============================================================================
 */
 
@@ -22,7 +19,7 @@ enclave
 
     untrusted
     {
-        void oe_thread_wake_wait_ocall(
+        void oe_sgx_thread_wake_wait_ocall(
             [user_check] oe_enclave_t* oe_enclave,
             uint64_t waiter_tcs,
             uint64_t self_tcs);

--- a/enclave/core/sgx/backtrace.c
+++ b/enclave/core/sgx/backtrace.c
@@ -112,7 +112,7 @@ char** oe_backtrace_symbols_impl(
         goto done;
 
     /* First call might return OE_BUFFER_TOO_SMALL. */
-    if (oe_backtrace_symbols_ocall(
+    if (oe_sgx_backtrace_symbols_ocall(
             &retval,
             oe_get_enclave(),
             (const uint64_t*)buffer,
@@ -132,7 +132,7 @@ char** oe_backtrace_symbols_impl(
                   realloc_fcn(symbols_buffer, symbols_buffer_size)))
             goto done;
 
-        if (oe_backtrace_symbols_ocall(
+        if (oe_sgx_backtrace_symbols_ocall(
                 &retval,
                 oe_get_enclave(),
                 (const uint64_t*)buffer,

--- a/enclave/core/sgx/cpuid.c
+++ b/enclave/core/sgx/cpuid.c
@@ -26,8 +26,8 @@ oe_result_t oe_initialize_cpuid(void)
     oe_result_t result = OE_UNEXPECTED;
     uint32_t retval;
 
-    OE_CHECK(
-        oe_get_cpuid_table_ocall(&retval, _cpuid_table, sizeof(_cpuid_table)));
+    OE_CHECK(oe_sgx_get_cpuid_table_ocall(
+        &retval, _cpuid_table, sizeof(_cpuid_table)));
 
     OE_CHECK((oe_result_t)retval);
 

--- a/enclave/core/sgx/thread.c
+++ b/enclave/core/sgx/thread.c
@@ -46,7 +46,7 @@ static int _thread_wake_wait(oe_thread_data_t* waiter, oe_thread_data_t* self)
     uint64_t waiter_tcs = (uint64_t)td_to_tcs((td_t*)waiter);
     uint64_t self_tcs = (uint64_t)td_to_tcs((td_t*)self);
 
-    if (oe_thread_wake_wait_ocall(oe_get_enclave(), waiter_tcs, self_tcs) !=
+    if (oe_sgx_thread_wake_wait_ocall(oe_get_enclave(), waiter_tcs, self_tcs) !=
         OE_OK)
         goto done;
 

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -361,7 +361,7 @@ done:
 }
 
 #if !defined(OEHOSTMR)
-oe_result_t oe_get_cpuid_table_ocall(
+oe_result_t oe_sgx_get_cpuid_table_ocall(
     void* cpuid_table_buffer,
     size_t cpuid_table_buffer_size)
 {

--- a/host/sgx/ocalls.c
+++ b/host/sgx/ocalls.c
@@ -86,7 +86,7 @@ void HandleThreadWake(oe_enclave_t* enclave, uint64_t arg_in)
 #endif
 }
 
-void oe_thread_wake_wait_ocall(
+void oe_sgx_thread_wake_wait_ocall(
     oe_enclave_t* enclave,
     uint64_t waiter_tcs,
     uint64_t self_tcs)
@@ -387,7 +387,7 @@ done:
     return ret;
 }
 
-oe_result_t oe_backtrace_symbols_ocall(
+oe_result_t oe_sgx_backtrace_symbols_ocall(
     oe_enclave_t* oe_enclave,
     const uint64_t* buffer,
     size_t size,


### PR DESCRIPTION
Rename ocalls in SGX-specific edl files to have SGX-specific names. This avoids potential naming conflicts with implementations from other TEEs.

Note that attestation-specific ocalls are left alone since they will hopefully be moved into plugins and these builtin EDL functions will be deprecated.