### PR TITLE
oe-gdb: Automatically continue execution upon cpuid SIGILL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased][Unreleased_log]
 --------------
+### Added
+- oegdb command `oegdb-ignore-sigill <instruction>` to add the given instruction to
+  list of instructions to ignore SIGLL for and automatically continue execution.
+  `oegdb-ignore-sigill cpuid` is automatically executed at debugger startup.
 
 [0.9.0][v0.9.0_log]
 ------------

--- a/debugger/pythonExtension/CMakeLists.txt
+++ b/debugger/pythonExtension/CMakeLists.txt
@@ -5,8 +5,10 @@
 configure_file(gdb_sgx_plugin.py  ${OE_LIBDIR}/openenclave/debugger/gdb-sgx-plugin/gdb_sgx_plugin.py COPYONLY)
 configure_file(load_symbol_cmd.py  ${OE_LIBDIR}/openenclave/debugger/gdb-sgx-plugin/load_symbol_cmd.py COPYONLY)
 configure_file(readelf.py  ${OE_LIBDIR}/openenclave/debugger/gdb-sgx-plugin/readelf.py COPYONLY)
+configure_file(signal_handler.py  ${OE_LIBDIR}/openenclave/debugger/gdb-sgx-plugin/signal_handler.py COPYONLY)
 
 # Installation
 install (FILES gdb_sgx_plugin.py DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/debugger/gdb-sgx-plugin/)
 install (FILES load_symbol_cmd.py DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/debugger/gdb-sgx-plugin/)
 install (FILES readelf.py DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/debugger/gdb-sgx-plugin/)
+install (FILES signal_handler.py DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/debugger/gdb-sgx-plugin/)

--- a/debugger/pythonExtension/gdb_sgx_plugin.py
+++ b/debugger/pythonExtension/gdb_sgx_plugin.py
@@ -7,6 +7,7 @@ import struct
 import os.path
 from ctypes import create_string_buffer
 import load_symbol_cmd
+import signal_handler
 
 POINTER_SIZE = 8
 
@@ -309,6 +310,7 @@ def oe_debugger_init():
     oe_debugger_cleanup()
     EnclaveCreationBreakpoint()
     EnclaveTerminationBreakpoint()
+    signal_handler.register()
     return
 
 def oe_debugger_cleanup():
@@ -320,6 +322,7 @@ def oe_debugger_cleanup():
         gdb.execute("remove-symbol-file -a %s" % (oe_enclave_addr), False, True)
     g_loaded_oe_enclave_addrs.clear()
     g_enclave_list_parsed = False
+    signal_handler.unregister()
     return
 
 def exit_handler(event):

--- a/debugger/pythonExtension/signal_handler.py
+++ b/debugger/pythonExtension/signal_handler.py
@@ -1,0 +1,56 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+import gdb
+import sys
+
+# Instructions for which SIGILL is ignored.
+ignored_instructions = set()
+
+# Get mnemonic at pc.
+def get_sigill_mnemonic():
+    try:
+        frame = gdb.newest_frame()
+        # Disassemble to find out the instruction
+        # See: https://wiki.osdev.org/X86-64_Instruction_Encoding
+        max_instruction_length = 15
+        start_pc = frame.pc()
+        end_pc = start_pc + max_instruction_length
+        asm = frame.architecture().disassemble(start_pc= start_pc,
+                                               end_pc = end_pc)
+
+        insn = asm[0]['asm']
+        mnemonic = insn.split()[0]
+        return mnemonic
+    except:
+        return None
+
+def oe_stop_event_handler(event):
+    if isinstance(event, gdb.SignalEvent) and event.stop_signal == "SIGILL":
+        insn = get_sigill_mnemonic()
+        if insn in ignored_instructions:
+            print("oegdb: Ignoring sigill from " + insn +  ".")
+            gdb.execute("continue", from_tty=True, to_string=False)
+
+class IgnoreSigill(gdb.Command):
+    """ Ignore SIGILL raised by given instruction """
+    def __init__(self):
+        super(IgnoreSigill, self).__init__('oegdb-ignore-sigill', gdb.COMMAND_USER)
+
+    def invoke(self, arg, from_tty):
+        ignored_instructions.add(arg)
+        if from_tty:
+            print("oegdb: Added " + arg + " to SIGILL ignore list.")
+
+
+def register():
+    IgnoreSigill()
+    gdb.events.stop.connect(oe_stop_event_handler)
+    print("oegdb: Registered stop event handler to handle SIGILL.\n")
+    gdb.execute("oegdb-ignore-sigill cpuid", from_tty=True)
+
+def unregister():
+    try:
+        gdb.events.stop.disconnect(oe_stop_event_handler)
+    except:
+        pass

--- a/tests/debugger/oegdb/commands.gdb
+++ b/tests/debugger/oegdb/commands.gdb
@@ -1,8 +1,14 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
+# Pring gdb version
+python import os; os.system("gdb -v")
+
 # Enable pending breakpoints
 set breakpoint pending on
+
+# Add rdtsc to sigill ignore list
+oegdb-ignore-sigill rdtsc
 
 # Set a breakpoint in main (host)
 b main


### PR DESCRIPTION
OE SDK's crypto library (mbedtls) uses cpuid instruction to check for
aesni capability. This causes a SIGILL exception that is eventually
handled by the enclave by emulating the cpuid exception.

This SIGILL however causes the debugger to stop. Anyone that debugs
a crypto application would be first greeted with this SIGILL as the
crypto library initialized.

This PR changes oegdb to continue executing without stopping when
SIGILLs are raised due to cpuid.