### PR TITLE
Make Windows file syscalls support Unicode paths

### DIFF
--- a/include/openenclave/internal/syscall/host.h
+++ b/include/openenclave/internal/syscall/host.h
@@ -8,7 +8,9 @@
 
 OE_EXTERNC_BEGIN
 
-char* oe_win_path_to_posix(const char* path);
+#if defined(_WIN32)
+char* oe_win_path_to_posix(PCWSTR path);
+#endif
 
 OE_EXTERNC_END
 

--- a/tests/syscall/dup/host/host.c
+++ b/tests/syscall/dup/host/host.c
@@ -1,45 +1,81 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 #include <openenclave/host.h>
 #include <openenclave/internal/syscall/host.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
 #include "test_dup_u.h"
 
-int main(int argc, const char* argv[])
+void test_dup_posix(const char* enclave_path, const char* posix_path)
 {
-    oe_result_t r;
-    oe_enclave_t* enclave = NULL;
     const uint32_t flags = oe_get_create_flags();
-    const oe_enclave_type_t type = OE_ENCLAVE_TYPE_SGX;
 
-    if (argc != 3)
-    {
-        fprintf(stderr, "Usage: %s ENCLAVE_PATH TMP_DIR\n", argv[0]);
-        return 1;
-    }
-
-    const char* enclave_path = argv[1];
-    char* tmp_dir = (char*)argv[2];
-
-    r = oe_create_test_dup_enclave(
-        enclave_path, type, flags, NULL, 0, &enclave);
+    oe_enclave_t* enclave = NULL;
+    oe_result_t r = oe_create_test_dup_enclave(
+        enclave_path, OE_ENCLAVE_TYPE_AUTO, flags, NULL, 0, &enclave);
     OE_TEST(r == OE_OK);
-#if defined(_WIN32)
-    char* win_path = oe_win_path_to_posix(tmp_dir);
-    tmp_dir = win_path;
-#endif
-    r = test_dup(enclave, tmp_dir);
+
+    r = test_dup(enclave, posix_path);
     OE_TEST(r == OE_OK);
 
     r = oe_terminate_enclave(enclave);
     OE_TEST(r == OE_OK);
 
     printf("=== passed all tests (test_dup)\n");
+}
+
 #if defined(_WIN32)
-    free(win_path);
-#endif
+/* argv strings are in UTF-16LE */
+int wmain(int argc, wchar_t* argv[])
+{
+    if (argc != 3)
+    {
+        fprintf(stderr, "Usage: %ls ENCLAVE_PATH TMP_DIR\n", argv[0]);
+        return 1;
+    }
+
+    /* create_enclave takes an ANSI path instead of a Unicode path, so we have
+     * to try to convert here */
+    char enclave_path[MAX_PATH];
+    if (WideCharToMultiByte(
+            CP_ACP,
+            0,
+            argv[1],
+            -1,
+            enclave_path,
+            sizeof(enclave_path),
+            NULL,
+            NULL) == 0)
+    {
+        fprintf(stderr, "Invalid enclave path\n");
+        return 1;
+    }
+    char* posix_path = oe_win_path_to_posix(argv[2]);
+
+    test_dup_posix(enclave_path, posix_path);
+
+    free(posix_path);
 
     return 0;
 }
+
+#else /* !_WIN32 */
+
+/* argv strings are in UTF-8 */
+int main(int argc, const char* argv[])
+{
+    if (argc != 3)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH TMP_DIR\n", argv[0]);
+        return 1;
+    }
+
+    test_dup_posix(argv[1], argv[2]);
+
+    return 0;
+}
+#endif

--- a/tests/syscall/fs/host/host.c
+++ b/tests/syscall/fs/host/host.c
@@ -1,6 +1,9 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 #include <openenclave/host.h>
 #include <openenclave/internal/syscall/host.h>
 #include <openenclave/internal/tests.h>
@@ -13,44 +16,26 @@
 
 int rmdir(const char* path);
 
-int main(int argc, const char* argv[])
+int test_fs_posix(
+    const char* enclave_path,
+    const char* src_dir,
+    const char* tmp_dir)
 {
-    oe_result_t r;
-    oe_enclave_t* enclave = NULL;
     const uint32_t flags = oe_get_create_flags();
-    const oe_enclave_type_t type = OE_ENCLAVE_TYPE_SGX;
-
-    if (argc != 4)
-    {
-        fprintf(stderr, "Usage: %s ENCLAVE_PATH SRC_DIR BIN_DIR\n", argv[0]);
-        return 1;
-    }
-
     if ((flags & OE_ENCLAVE_FLAG_SIMULATE))
     {
         printf("=== Skipped unsupported test in simulation mode (sealKey)\n");
         return SKIP_RETURN_CODE;
     }
 
-    const char* enclave_path = argv[1];
-    char* src_dir = (char*)argv[2];
-    char* tmp_dir = (char*)argv[3];
-
-    // Windows does not support umask.
-    // Please set up the right permission to the parent directory.
-#if !defined(_WIN32)
-    umask(0022);
-#endif
-
     rmdir(tmp_dir);
 
-    r = oe_create_fs_enclave(enclave_path, type, flags, NULL, 0, &enclave);
+    const oe_enclave_type_t type = OE_ENCLAVE_TYPE_SGX;
+    oe_enclave_t* enclave = NULL;
+    oe_result_t r =
+        oe_create_fs_enclave(enclave_path, type, flags, NULL, 0, &enclave);
     OE_TEST(r == OE_OK);
 
-#if defined(_WIN32)
-    src_dir = oe_win_path_to_posix(src_dir);
-    tmp_dir = oe_win_path_to_posix(tmp_dir);
-#endif
     r = test_fs(enclave, src_dir, tmp_dir);
     OE_TEST(r == OE_OK);
 
@@ -58,10 +43,61 @@ int main(int argc, const char* argv[])
     OE_TEST(r == OE_OK);
 
     printf("=== passed all tests (hostfs)\n");
-#if defined(_WIN32)
-    free(src_dir);
-    free(tmp_dir);
-#endif
 
     return 0;
 }
+
+#if defined(_WIN32)
+int wmain(int argc, wchar_t* argv[])
+{
+    if (argc != 4)
+    {
+        fprintf(stderr, "Usage: %ls ENCLAVE_PATH SRC_DIR BIN_DIR\n", argv[0]);
+        return 1;
+    }
+
+    /* create_enclave takes an ANSI path instead of a Unicode path, so we have
+     * to try to convert here */
+    char enclave_path[MAX_PATH];
+    if (WideCharToMultiByte(
+            CP_ACP,
+            0,
+            argv[1],
+            -1,
+            enclave_path,
+            sizeof(enclave_path),
+            NULL,
+            NULL) == 0)
+    {
+        fprintf(stderr, "Invalid enclave path\n");
+        return 1;
+    }
+    char* src_dir = oe_win_path_to_posix((PCWSTR)argv[2]);
+    char* tmp_dir = oe_win_path_to_posix((PCWSTR)argv[3]);
+
+    // Windows does not support umask.
+    // Please set up the right permission to the parent directory.
+
+    int ret = test_fs_posix(enclave_path, src_dir, tmp_dir);
+
+    free(src_dir);
+    free(tmp_dir);
+
+    return ret;
+}
+
+#else /* !_WIN32 */
+
+int main(int argc, const char* argv[])
+{
+    if (argc != 4)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH SRC_DIR BIN_DIR\n", argv[0]);
+        return 1;
+    }
+
+    umask(0022);
+
+    return test_fs_posix(argv[1], argv[2], argv[3]);
+}
+#endif

--- a/tests/syscall/hostfs/host/host.c
+++ b/tests/syscall/hostfs/host/host.c
@@ -1,36 +1,26 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 #include <openenclave/host.h>
 #include <openenclave/internal/syscall/host.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
 #include "test_hostfs_u.h"
 
-int main(int argc, const char* argv[])
+void test_hostfs_posix(const char* enclave_path, const char* tmp_dir)
 {
     oe_result_t r;
     oe_enclave_t* enclave = NULL;
     const uint32_t flags = oe_get_create_flags();
     const oe_enclave_type_t type = OE_ENCLAVE_TYPE_SGX;
 
-    if (argc != 3)
-    {
-        fprintf(stderr, "Usage: %s ENCLAVE_PATH TMP_DIR\n", argv[0]);
-        return 1;
-    }
-
-    const char* enclave_path = argv[1];
-    const char* tmp_dir = argv[2];
-
     r = oe_create_test_hostfs_enclave(
         enclave_path, type, flags, NULL, 0, &enclave);
     OE_TEST(r == OE_OK);
 
-#if defined(_WIN32)
-    char* win_path = oe_win_path_to_posix(tmp_dir);
-    tmp_dir = win_path;
-#endif
     r = test_hostfs(enclave, tmp_dir);
     OE_TEST(r == OE_OK);
 
@@ -38,9 +28,54 @@ int main(int argc, const char* argv[])
     OE_TEST(r == OE_OK);
 
     printf("=== passed all tests (test_hostfs)\n");
+}
+
 #if defined(_WIN32)
+int wmain(int argc, const wchar_t* argv[])
+{
+    if (argc != 3)
+    {
+        fprintf(stderr, "Usage: %ls ENCLAVE_PATH TMP_DIR\n", argv[0]);
+        return 1;
+    }
+
+    /* create_enclave takes an ANSI path instead of a Unicode path, so we have
+     * to try to convert here */
+    char enclave_path[MAX_PATH];
+    if (WideCharToMultiByte(
+            CP_ACP,
+            0,
+            argv[1],
+            -1,
+            enclave_path,
+            sizeof(enclave_path),
+            NULL,
+            NULL) == 0)
+    {
+        fprintf(stderr, "Invalid enclave path\n");
+        return 1;
+    }
+    char* win_path = oe_win_path_to_posix(argv[2]);
+
+    test_hostfs_posix(enclave_path, win_path);
+
     free(win_path);
-#endif
 
     return 0;
 }
+
+#else /* !_WIN32 */
+
+int main(int argc, const char* argv[])
+{
+    if (argc != 3)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH TMP_DIR\n", argv[0]);
+        return 1;
+    }
+
+    test_hostfs_posix(argv[1], argv[2]);
+
+    return 0;
+}
+#endif

--- a/tests/win_paths/host/host.cpp
+++ b/tests/win_paths/host/host.cpp
@@ -7,113 +7,118 @@
 #include <shlwapi.h>
 
 OE_EXTERNC_BEGIN
-char* oe_syscall_path_to_win(const char* path);
+PCWSTR oe_syscall_path_to_win(const char* path);
 OE_EXTERNC_END
 
-#define VOLUME_PATH_PROXY "<VOL>"
-#define CURRENT_PATH_PROXY "<CUR>"
+#define VOLUME_PATH_PROXY L"<VOL>"
+#define CURRENT_PATH_PROXY L"<CUR>"
 #define PATH_PROXY_LENGTH 5
 
 typedef struct _test
 {
     const char* posix_path;
-    const char* win_path;
+    PCWSTR win_path;
 } test_t;
 
 static bool _has_test_failed = false;
 
 const test_t tests[] = {
     /* Test handling of explicit volume rooted paths */
-    {"D:", "D:\\"},
-    {"D:\\", "D:\\"},
-    {"D:\\..", "D:\\"},
-    {"D:/..", "D:\\"},
-    {"D:\\\\.", "D:\\"},
-    {"D://.", "D:\\"},
-    {"/x", "X:\\"},
-    {"/x/", "X:\\"},
-    {"/x/rootfile.txt", "X:\\rootfile.txt"},
+    {"D:", L"D:\\"},
+    {"D:\\", L"D:\\"},
+    {"D:\\..", L"D:\\"},
+    {"D:/..", L"D:\\"},
+    {"D:\\\\.", L"D:\\"},
+    {"D://.", L"D:\\"},
+    {"/x", L"X:\\"},
+    {"/x/", L"X:\\"},
+    {"/x/rootfile.txt", L"X:\\rootfile.txt"},
 
     /* Test current volume rooted paths */
     {"\\", VOLUME_PATH_PROXY},
     {"/", VOLUME_PATH_PROXY},
-    {"\\rootfile.txt", VOLUME_PATH_PROXY "rootfile.txt"},
-    {"/rootfile.txt", VOLUME_PATH_PROXY "rootfile.txt"},
+    {"\\rootfile.txt", VOLUME_PATH_PROXY L"rootfile.txt"},
+    {"/rootfile.txt", VOLUME_PATH_PROXY L"rootfile.txt"},
 
     /* Test Windows paths should not be interpreted as X:\ paths after
        canonicalization */
-    {"D:\\..\\.\\x", "D:\\x"},
-    {"D:\\.\\..\\x\\", "D:\\x\\"},
-    {"D:/../x/.", "D:\\x"},
-    {"D:\\x\\..\\", "D:\\"},
-    {"D:/x/file.txt", "D:\\x\\file.txt"},
-    {"D:\\.\\x\\.\\file.txt", "D:\\x\\file.txt"},
+    {"D:\\..\\.\\x", L"D:\\x"},
+    {"D:\\.\\..\\x\\", L"D:\\x\\"},
+    {"D:/../x/.", L"D:\\x"},
+    {"D:\\x\\..\\", L"D:\\"},
+    {"D:/x/file.txt", L"D:\\x\\file.txt"},
+    {"D:\\.\\x\\.\\file.txt", L"D:\\x\\file.txt"},
 
     /* Test converting relative paths to absolute paths */
     {".", CURRENT_PATH_PROXY},
-    {"..", CURRENT_PATH_PROXY ".."},
-    {"..\\..\\", CURRENT_PATH_PROXY "..\\..\\"},
-    {".././..", CURRENT_PATH_PROXY "..\\.."},
-    {"foo", CURRENT_PATH_PROXY "foo"},
-    {"foo\\bar", CURRENT_PATH_PROXY "foo\\bar"},
-    {"foo/bar/../baz/../../../foo/./bar/", CURRENT_PATH_PROXY "..\\foo\\bar\\"},
+    {"..", CURRENT_PATH_PROXY L".."},
+    {"..\\..\\", CURRENT_PATH_PROXY L"..\\..\\"},
+    {".././..", CURRENT_PATH_PROXY L"..\\.."},
+    {"foo", CURRENT_PATH_PROXY L"foo"},
+    {"foo\\bar", CURRENT_PATH_PROXY L"foo\\bar"},
+    {"foo/bar/../baz/../../../foo/./bar/",
+     CURRENT_PATH_PROXY L"..\\foo\\bar\\"},
 
     /* Test special handling of /dev/null */
-    {"/dev/null", "NUL"},
-    {"\\dev\\null", "C:\\dev\\null"},
-    {"\\\\dev\\null", "\\\\dev\\null"},
+    {"/dev/null", L"NUL"},
+    {"\\dev\\null", L"C:\\dev\\null"},
+    {"\\\\dev\\null", L"\\\\dev\\null"},
     /* NOTE: Linux will treat this as the null device still,
      * but OE chooses not to handle */
-    {"/dev/./null", VOLUME_PATH_PROXY "dev\\.\\null"},
+    {"/dev/./null", VOLUME_PATH_PROXY L"dev\\.\\null"},
+
+    /* Test handling of a Unicode path */
+    {"\xE2\x98\x83", CURRENT_PATH_PROXY L"\x2603"},
 };
 
 void _combine_paths(
-    char* result_path,
+    PWSTR result_path,
     uint32_t result_path_size,
-    const char* root_path,
-    const char* path)
+    const wchar_t* root_path,
+    const wchar_t* path)
 {
-    char combined_path[MAX_PATH] = {0};
-    size_t root_path_length = strnlen(root_path, MAX_PATH);
+    wchar_t combined_path[MAX_PATH] = {0};
+    size_t root_path_length = wcsnlen(root_path, MAX_PATH);
     if (result_path_size <=
-        strnlen(root_path, MAX_PATH) + strnlen(path, MAX_PATH))
+        wcsnlen(root_path, MAX_PATH) + wcsnlen(path, MAX_PATH))
     {
         fprintf(stderr, "Unexpected: Combined test paths > MAX_PATH");
         abort();
     }
-    if (!PathCombineA(combined_path, root_path, path))
+    if (!PathCombineW(combined_path, root_path, path))
     {
-        fprintf(stderr, "PathCombineA failed with %#x\n", GetLastError());
+        fprintf(stderr, "PathCombineW failed with %#x\n", GetLastError());
         abort();
     }
-    else if (!PathCanonicalizeA(result_path, combined_path))
+    else if (!PathCanonicalizeW(result_path, combined_path))
     {
-        fprintf(stderr, "PathCanonicalizeA failed with %#x\n", GetLastError());
+        fprintf(stderr, "PathCanonicalizeW failed with %#x\n", GetLastError());
         abort();
     }
 }
 
 void _get_expected_path(
-    const char* path,
+    const wchar_t* path,
     uint32_t path_length,
-    char* expected_path_buffer,
+    wchar_t* expected_path_buffer,
     uint32_t expected_path_buffer_size)
 {
     const uint32_t volume_path_length = 4;
-    static char volume_path[volume_path_length] = {0};
+    static wchar_t volume_path[volume_path_length] = {0};
     if (volume_path[0] == '\0' &&
-        !GetVolumePathNameA(".", volume_path, volume_path_length))
-        printf("GetVolumePathNameA failed with %#x\n", GetLastError());
+        !GetVolumePathNameW(L".", volume_path, volume_path_length))
+        printf("GetVolumePathNameW failed with %#x\n", GetLastError());
 
-    static char current_path[MAX_PATH] = {0};
+    static wchar_t current_path[MAX_PATH] = {0};
     if (current_path[0] == '\0')
     {
-        DWORD current_path_length = GetCurrentDirectory(MAX_PATH, current_path);
+        DWORD current_path_length =
+            GetCurrentDirectoryW(MAX_PATH, current_path);
         if (current_path_length == 0)
-            printf("GetCurrentDirectory failed with %#x\n", GetLastError());
+            printf("GetCurrentDirectoryW failed with %#x\n", GetLastError());
     }
 
-    if (strstr(path, VOLUME_PATH_PROXY) == path)
+    if (wcsstr(path, VOLUME_PATH_PROXY) == path)
     {
         _combine_paths(
             expected_path_buffer,
@@ -121,7 +126,7 @@ void _get_expected_path(
             volume_path,
             path + PATH_PROXY_LENGTH);
     }
-    else if (strstr(path, CURRENT_PATH_PROXY) == path)
+    else if (wcsstr(path, CURRENT_PATH_PROXY) == path)
     {
         _combine_paths(
             expected_path_buffer,
@@ -131,24 +136,24 @@ void _get_expected_path(
     }
     else
     {
-        errno_t err = strncpy_s(
+        errno_t err = wcsncpy_s(
             expected_path_buffer, expected_path_buffer_size, path, path_length);
         if (err)
-            printf("strncpy_n failed with %#x\n", err);
+            printf("wcsncpy_n failed with %#x\n", err);
     }
 }
 
 inline void _test_path_to_win(const test_t* test)
 {
-    char expected_result[MAX_PATH] = {0};
+    wchar_t expected_result[MAX_PATH] = {0};
     _get_expected_path(
         test->win_path,
-        (uint32_t)strlen(test->win_path),
+        (uint32_t)wcslen(test->win_path),
         expected_result,
         MAX_PATH);
-    char* test_result = oe_syscall_path_to_win(test->posix_path);
+    PCWSTR test_result = oe_syscall_path_to_win(test->posix_path);
 
-    if (0 == strncmp(expected_result, test_result, MAX_PATH))
+    if (0 == wcsncmp(expected_result, test_result, MAX_PATH))
         printf("[PASSED] ");
     else
     {
@@ -157,13 +162,13 @@ inline void _test_path_to_win(const test_t* test)
     }
 
     printf(
-        "Input: %s, Expect: %s, Actual: %s\n",
+        "Input: %s, Expect: %ls, Actual: %ls\n",
         test->posix_path,
         expected_result,
         test_result);
 
     if (test_result)
-        free(test_result);
+        free((void*)test_result);
 }
 
 int main()


### PR DESCRIPTION
The full range of Unicode should now be supported for file syscalls with these changes.
Includes a test case to verify Unicode path conversion.
This also fixes a memory corruption bug at the end of _get_full_path_name which passed the wrong pointer to free().

**Background:** 
POSIX uses UTF-8 encoded in char* strings.  Windows instead treats char* strings as being in whatever the current ANSI code page is, and in general an ANSI code page cannot represent all Unicode characters so using any "char*" file API on windows inherently has problems of possibly failing to be able to represent actual file paths in use.   Instead, Windows uses UTF-16LE in wchar_t* strings (aka PWSTR) for the full range of Unicode.   Note that this also means that one can NOT reliably take a char* string buffer obtained from an enclave's file apis (which use UTF-8) and pass it to a Windows api like create_enclave, since the meaning of the bytes can be completely different between UTF-8 and the current ANSI code page.   Similarly, one cannot take char* argv[] from a console app and expect to pass it unmodified to an enclave that wants to pass it to a file API that supports UTF-8, since again the meaning of the bytes can be completely different.   As such, main() is problematic and instead wmain() is used for Unicode tests.   This PR is scoped to just the file syscalls, and leaves the following two issues unchanged as out of scope for this PR:
1. oe_create_enclave (and the underlying oe_fopen) use ANSI and so have problems with non-ASCII paths
2. The getaddrinfo and getnameinfo syscalls also blindly pass ANSI strings to UTF-8 apis and vice versa and so have problems with non-ASCII hostnames

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>