### PR TITLE
Change default CMAKE_BUILD_TYPE to Release from Debug.

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -27,7 +27,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Set default build type and sanitize.
 # TODO: See #756: Fix this since debug is the default.
 if (NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type" FORCE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
 endif ()
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebInfo")
 

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -70,6 +70,16 @@ else ()
 endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
+  # Enforce -O0 in debug mode.
+  string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPER)
+  if (CMAKE_BUILD_TYPE_UPPER STREQUAL "DEBUG")
+    # For gcc the -g option alredy includes -O0.
+    # Here we just apply -O0 for Clang.
+    if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
+      set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
+      set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
+    endif()
+  endif()
   # Enables all the warnings about constructions that some users consider questionable,
   # and that are easy to avoid. Treat at warnings-as-errors, which forces developers
   # to fix warnings as they arise, so they don't accumulate "to be fixed later".


### PR DESCRIPTION
It is insecure for end users to use the SDK in debug mode, especially in a production environment.
The SDK developers now need to specify "-DCMAKE_BUILD_TYPE=Debug" to compile in debug mode.