### PR TITLE
[CI/CD] End-to-End Testing Updates

### DIFF
--- a/.jenkins/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/build_azure_managed_images.Jenkinsfile
@@ -171,7 +171,7 @@ def buildWindowsManagedImage(String os_series, String img_name_suffix, String la
                             --gallery-image-definition ${img_name_suffix} \
                             --gallery-image-version ${gallery_image_version} \
                             --managed-image \$MANAGED_IMG_ID \
-                            --target-regions "WestEurope" \
+                            --target-regions ${env.REPLICATION_REGIONS.split(',').join(' ')} \
                             --replica-count 1
                     """
                     def az_rg_create_script = """

--- a/.jenkins/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/build_azure_managed_images.Jenkinsfile
@@ -144,25 +144,18 @@ def buildWindowsManagedImage(String os_series, String img_name_suffix, String la
 
                         az vm deallocate --ids \$VM_ID
                         az vm generalize --ids \$VM_ID
-                        MANAGED_IMG_ID=`az image create \
-                            --resource-group ${vm_rg_name} \
-                            --name ${managed_image_name_id}-${img_name_suffix} \
-                            --hyper-v-generation ${AZURE_IMAGES_MAP[os_series]["generation"]} \
-                            --source ${img_name_suffix} | jq -r '.id'`
 
                         # If the target image doesn't exist, the below command
                         # will not fail because it is idempotent.
-                        retrycmd_if_failure 30 300 30m az image delete \
+                        az image delete \
                             --resource-group ${RESOURCE_GROUP} \
                             --name ${managed_image_name_id}-${img_name_suffix}
 
-                        retrycmd_if_failure 30 300 30m az resource move \
-                            --ids \$MANAGED_IMG_ID \
-                            --destination-group ${RESOURCE_GROUP}
-
-                        MANAGED_IMG_ID=`az image show \
+                        MANAGED_IMG_ID=`az image create \
                             --resource-group ${RESOURCE_GROUP} \
-                            --name ${managed_image_name_id}-${img_name_suffix} | jq -r '.id'`
+                            --name ${managed_image_name_id}-${img_name_suffix} \
+                            --hyper-v-generation ${AZURE_IMAGES_MAP[os_series]["generation"]} \
+                            --source \$VM_ID | jq -r '.id'`
 
                         # If the target image version doesn't exist, the below
                         # command will not fail because it is idempotent.

--- a/.jenkins/e2e_testing.Jenkinsfile
+++ b/.jenkins/e2e_testing.Jenkinsfile
@@ -17,7 +17,7 @@ IMAGE_VERSION = NOW.format(DateTimeFormatter.ofPattern("yyyy")) + "." + \
 DOCKER_TAG = "e2e-${IMAGE_VERSION}-${BUILD_NUMBER}"
 
 
-node("images-build-e2e") {
+node(env.IMAGES_BUILD_LABEL) {
     stage("Determine the Azure managed images id") {
         timeout(GLOBAL_TIMEOUT_MINUTES) {
             cleanWs()
@@ -37,7 +37,7 @@ stage("Build Docker Images") {
           parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
                        string(name: 'BRANCH_NAME', value: env.BRANCH),
                        string(name: 'DOCKER_TAG', value: DOCKER_TAG),
-                       string(name: 'AGENTS_LABEL', value: "images-build-e2e"),
+                       string(name: 'AGENTS_LABEL', value: env.IMAGES_BUILD_LABEL),
                        booleanParam(name: 'TAG_LATEST',value: false)]
 }
 
@@ -50,7 +50,7 @@ stage("Build Jenkins Agents images") {
                        string(name: 'GALLERY_NAME', value: env.E2E_IMAGES_GALLERY_NAME),
                        string(name: 'IMAGE_ID', value: IMAGE_ID),
                        string(name: 'DOCKER_TAG', value: DOCKER_TAG),
-                       string(name: 'AGENTS_LABEL', value: "images-build-e2e")]
+                       string(name: 'AGENTS_LABEL', value: env.IMAGES_BUILD_LABEL)]
 }
 
 stage("Run tests on new Agents") {
@@ -58,15 +58,15 @@ stage("Run tests on new Agents") {
           parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
                        string(name: 'BRANCH_NAME', value: env.BRANCH),
                        string(name: 'DOCKER_TAG', value: DOCKER_TAG),
-                       string(name: 'UBUNTU_1604_CUSTOM_LABEL', value: "xenial-e2e"),
-                       string(name: 'UBUNTU_1804_CUSTOM_LABEL', value: "bionic-e2e"),
-                       string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: "nonSGX-e2e"),
-                       string(name: 'RHEL_8_CUSTOM_LABEL', value: "rhel-8-e2e"),
-                       string(name: 'WINDOWS_2016_CUSTOM_LABEL', value: "windows-2016-e2e"),
-                       string(name: 'WINDOWS_2016_DCAP_CUSTOM_LABEL', value: "windows-2016-dcap-e2e"),
-                       string(name: 'WINDOWS_2019_CUSTOM_LABEL', value: "windows-2019-e2e"),
-                       string(name: 'WINDOWS_2019_DCAP_CUSTOM_LABEL', value: "windows-2019-dcap-e2e"),
-                       string(name: 'WINDOWS_NONSGX_CUSTOM_LABEL', value: "nonSGX-Windows-e2e")]
+                       string(name: 'UBUNTU_1604_CUSTOM_LABEL', value: env.UBUNTU_1604_LABEL),
+                       string(name: 'UBUNTU_1804_CUSTOM_LABEL', value: env.UBUNTU_1804_LABEL),
+                       string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: env.UBUNTU_NONSGX_LABEL),
+                       string(name: 'RHEL_8_CUSTOM_LABEL', value: env.RHEL_8_LABEL),
+                       string(name: 'WINDOWS_2016_CUSTOM_LABEL', value: env.WINDOWS_2016_LABEL),
+                       string(name: 'WINDOWS_2016_DCAP_CUSTOM_LABEL', value: env.WINDOWS_2016_DCAP_LABEL),
+                       string(name: 'WINDOWS_2019_CUSTOM_LABEL', value: env.WINDOWS_2019_LABEL),
+                       string(name: 'WINDOWS_2019_DCAP_CUSTOM_LABEL', value: env.WINDOWS_2019_DCAP_LABEL),
+                       string(name: 'WINDOWS_NONSGX_CUSTOM_LABEL', value: env.WINDOWS_NONSGX_LABEL)]
 }
 
 if(env.PRODUCTION_IMAGES_GALLERY_NAME) {

--- a/.jenkins/e2e_testing.Jenkinsfile
+++ b/.jenkins/e2e_testing.Jenkinsfile
@@ -48,6 +48,7 @@ stage("Build Jenkins Agents images") {
                        string(name: 'OE_DEPLOY_IMAGE', value: "oetools-deploy:${DOCKER_TAG}"),
                        string(name: 'RESOURCE_GROUP', value: env.RESOURCE_GROUP),
                        string(name: 'GALLERY_NAME', value: env.E2E_IMAGES_GALLERY_NAME),
+                       string(name: 'REPLICATION_REGIONS', value: env.REPLICATION_REGIONS),
                        string(name: 'IMAGE_ID', value: IMAGE_ID),
                        string(name: 'DOCKER_TAG', value: DOCKER_TAG),
                        string(name: 'AGENTS_LABEL', value: env.IMAGES_BUILD_LABEL)]
@@ -76,6 +77,7 @@ if(env.PRODUCTION_IMAGES_GALLERY_NAME) {
                          string(name: 'BRANCH_NAME', value: env.BRANCH),
                          string(name: 'RESOURCE_GROUP', value: env.RESOURCE_GROUP),
                          string(name: 'PRODUCTION_IMAGES_GALLERY_NAME', value: env.PRODUCTION_IMAGES_GALLERY_NAME),
+                         string(name: 'REPLICATION_REGIONS', value: env.REPLICATION_REGIONS),
                          string(name: 'IMAGE_ID', value: IMAGE_ID),
                          string(name: 'IMAGE_VERSION', value: IMAGE_VERSION),
                          string(name: 'DOCKER_TAG', value: DOCKER_TAG),

--- a/.jenkins/provision/templates/packer/azure_managed_image/packer-rhel.json
+++ b/.jenkins/provision/templates/packer/azure_managed_image/packer-rhel.json
@@ -6,6 +6,9 @@
     "client_secret": "{{ env `SERVICE_PRINCIPAL_PASSWORD` }}",
     "tenant_id": "{{ env `TENANT_ID` }}",
     "location": "{{ env `REGION` }}",
+    "jenkins_resource_group": "{{ env `JENKINS_RESOURCE_GROUP` }}",
+    "jenkins_vnet_name": "{{ env `JENKINS_VNET_NAME` }}",
+    "jenkins_subnet_name": "{{ env `JENKINS_SUBNET_NAME` }}",
     "ansible_dir": "{{ env `WORKSPACE` }}/scripts/ansible",
     "gallery_name": "{{ env `GALLERY_NAME` }}",
     "gallery_image_version": "{{ env `GALLERY_IMAGE_VERSION` }}",
@@ -32,6 +35,10 @@
 
     "managed_image_name": "{{ user `managed_image_name_id` }}-{{ user `managed_image_name_suffix` }}",
     "managed_image_resource_group_name": "{{ user `resource_group` }}",
+
+    "virtual_network_resource_group_name": "{{ user `jenkins_resource_group` }}",
+    "virtual_network_name": "{{ user `jenkins_vnet_name` }}",
+    "virtual_network_subnet_name": "{{ user `jenkins_subnet_name` }}",
 
     "os_type": "{{ user `os_type` }}",
     "image_publisher": "{{ user `image_publisher` }}",

--- a/.jenkins/provision/templates/packer/azure_managed_image/packer-rhel.json
+++ b/.jenkins/provision/templates/packer/azure_managed_image/packer-rhel.json
@@ -12,7 +12,8 @@
     "ansible_dir": "{{ env `WORKSPACE` }}/scripts/ansible",
     "gallery_name": "{{ env `GALLERY_NAME` }}",
     "gallery_image_version": "{{ env `GALLERY_IMAGE_VERSION` }}",
-    "managed_image_name_id": "{{ env `MANAGED_IMAGE_NAME_ID` }}"
+    "managed_image_name_id": "{{ env `MANAGED_IMAGE_NAME_ID` }}",
+    "replication_regions": "{{ env `REPLICATION_REGIONS` }}"
   },
   "builders": [{
     "type": "azure-arm",
@@ -27,9 +28,7 @@
       "gallery_name": "{{ user `gallery_name` }}",
       "image_name": "{{ user `gallery_image_name` }}",
       "image_version": "{{ user `gallery_image_version` }}",
-      "replication_regions": [
-        "westeurope"
-      ]
+      "replication_regions": "{{ user `replication_regions` }}"
     },
     "shared_image_gallery_timeout": "180m",
 

--- a/.jenkins/provision/templates/packer/azure_managed_image/packer-ubuntu.json
+++ b/.jenkins/provision/templates/packer/azure_managed_image/packer-ubuntu.json
@@ -6,6 +6,9 @@
     "client_secret": "{{ env `SERVICE_PRINCIPAL_PASSWORD` }}",
     "tenant_id": "{{ env `TENANT_ID` }}",
     "location": "{{ env `REGION` }}",
+    "jenkins_resource_group": "{{ env `JENKINS_RESOURCE_GROUP` }}",
+    "jenkins_vnet_name": "{{ env `JENKINS_VNET_NAME` }}",
+    "jenkins_subnet_name": "{{ env `JENKINS_SUBNET_NAME` }}",
     "docker_registry": "{{ env `DOCKER_REGISTRY` }}",
     "docker_user_name": "{{ env `DOCKER_USER_NAME` }}",
     "docker_user_password": "{{ env `DOCKER_USER_PASSWORD` }}",
@@ -36,6 +39,10 @@
 
     "managed_image_name": "{{ user `managed_image_name_id` }}-{{ user `managed_image_name_suffix` }}",
     "managed_image_resource_group_name": "{{ user `resource_group` }}",
+
+    "virtual_network_resource_group_name": "{{ user `jenkins_resource_group` }}",
+    "virtual_network_name": "{{ user `jenkins_vnet_name` }}",
+    "virtual_network_subnet_name": "{{ user `jenkins_subnet_name` }}",
 
     "os_type": "{{ user `os_type` }}",
     "image_publisher": "{{ user `image_publisher` }}",

--- a/.jenkins/provision/templates/packer/azure_managed_image/packer-ubuntu.json
+++ b/.jenkins/provision/templates/packer/azure_managed_image/packer-ubuntu.json
@@ -16,7 +16,8 @@
     "ansible_dir": "{{ env `WORKSPACE` }}/scripts/ansible",
     "gallery_name": "{{ env `GALLERY_NAME` }}",
     "gallery_image_version": "{{ env `GALLERY_IMAGE_VERSION` }}",
-    "managed_image_name_id": "{{ env `MANAGED_IMAGE_NAME_ID` }}"
+    "managed_image_name_id": "{{ env `MANAGED_IMAGE_NAME_ID` }}",
+    "replication_regions": "{{ env `REPLICATION_REGIONS` }}"
   },
   "builders": [{
     "type": "azure-arm",
@@ -31,9 +32,7 @@
       "gallery_name": "{{ user `gallery_name` }}",
       "image_name": "{{ user `gallery_image_name` }}",
       "image_version": "{{ user `gallery_image_version` }}",
-      "replication_regions": [
-        "westeurope"
-      ]
+      "replication_regions": "{{ user `replication_regions` }}"
     },
     "shared_image_gallery_timeout": "180m",
 

--- a/.jenkins/update_production_infrastructure.Jenkinsfile
+++ b/.jenkins/update_production_infrastructure.Jenkinsfile
@@ -1,0 +1,92 @@
+@Library("OpenEnclaveCommon") _
+oe = new jenkins.common.Openenclave()
+
+GLOBAL_TIMEOUT_MINUTES = 240
+
+OETOOLS_REPO_NAME = "oejenkinscidockerregistry.azurecr.io"
+OETOOLS_REPO_CREDENTIAL_ID = "oejenkinscidockerregistry"
+
+DOCKER_IMAGES_NAMES = ["oetools-full-16.04", "oetools-full-18.04", "oetools-minimal-18.04", "oetools-deploy"]
+AZURE_IMAGES_MAP = [
+    // Mapping between shared gallery image definition name and
+    // generated Azure managed image name
+    "ubuntu-16.04":    "${env.IMAGE_ID}-ubuntu-16.04-SGX",
+    "ubuntu-18.04":    "${env.IMAGE_ID}-ubuntu-18.04-SGX",
+    "rhel-8":          "${env.IMAGE_ID}-rhel-8-SGX",
+    "ws2016-nonSGX":   "${env.IMAGE_ID}-ws2016-nonSGX",
+    "ws2016-SGX":      "${env.IMAGE_ID}-ws2016-SGX",
+    "ws2016-SGX-DCAP": "${env.IMAGE_ID}-ws2016-SGX-DCAP",
+    "ws2019-SGX":      "${env.IMAGE_ID}-ws2019-SGX",
+    "ws2019-SGX-DCAP": "${env.IMAGE_ID}-ws2019-SGX-DCAP"
+]
+IMAGES_BUILD_LABEL = env.IMAGES_BUILD_LABEL ?: "nonSGX"
+
+
+def update_production_docker_images() {
+    node("nonSGX") {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
+            stage("Backup current production Docker images") {
+                docker.withRegistry("https://${OETOOLS_REPO_NAME}", OETOOLS_REPO_CREDENTIAL_ID) {
+                    for (image_name in DOCKER_IMAGES_NAMES) {
+                        def image = docker.image("${OETOOLS_REPO_NAME}/${image_name}:latest")
+                        oe.exec_with_retry { image.pull() }
+                        oe.exec_with_retry { image.push("latest-backup") }
+                    }
+                }
+            }
+        }
+    }
+    node(IMAGES_BUILD_LABEL) {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
+            stage("Update production Docker images") {
+                docker.withRegistry("https://${OETOOLS_REPO_NAME}", OETOOLS_REPO_CREDENTIAL_ID) {
+                    for (image_name in DOCKER_IMAGES_NAMES) {
+                        def image = docker.image("${OETOOLS_REPO_NAME}/${image_name}:${env.DOCKER_TAG}")
+                        oe.exec_with_retry { image.pull() }
+                        oe.exec_with_retry { image.push("latest") }
+                    }
+                }
+            }
+        }
+    }
+}
+
+def update_production_azure_gallery_images(String image_name) {
+    node(IMAGES_BUILD_LABEL) {
+        timeout(GLOBAL_TIMEOUT_MINUTES) {
+            stage("Update production Azure managed image: ${image_name}") {
+                def az_update_image_script = """
+                    az login --service-principal -u \$SERVICE_PRINCIPAL_ID -p \$SERVICE_PRINCIPAL_PASSWORD --tenant \$TENANT_ID --output table
+                    az account set --subscription \$SUBSCRIPTION_ID --output table
+
+                    MANAGED_IMG_ID=`az image show \
+                        --resource-group ${env.RESOURCE_GROUP} \
+                        --name ${AZURE_IMAGES_MAP[image_name]} | jq -r '.id'`
+
+                    az sig image-version delete \
+                        --resource-group ${env.RESOURCE_GROUP} \
+                        --gallery-name ${env.PRODUCTION_IMAGES_GALLERY_NAME} \
+                        --gallery-image-definition ${image_name} \
+                        --gallery-image-version ${env.IMAGE_VERSION}
+
+                    az sig image-version create \
+                        --resource-group ${env.RESOURCE_GROUP} \
+                        --gallery-name ${env.PRODUCTION_IMAGES_GALLERY_NAME} \
+                        --gallery-image-definition ${image_name} \
+                        --gallery-image-version ${env.IMAGE_VERSION} \
+                        --managed-image \$MANAGED_IMG_ID \
+                        --target-regions "WestEurope" \
+                        --replica-count 1
+                """
+                oe.azureEnvironment(az_update_image_script, "oetools-deploy:${env.DOCKER_TAG}")
+            }
+        }
+    }
+}
+
+def parallel_steps = [ "Update Docker images": { update_production_docker_images() } ]
+AZURE_IMAGES_MAP.keySet().each { image_name ->
+  parallel_steps["Update Azure gallery ${image_name} image"] = { update_production_azure_gallery_images(image_name) }
+}
+
+parallel parallel_steps

--- a/.jenkins/update_production_infrastructure.Jenkinsfile
+++ b/.jenkins/update_production_infrastructure.Jenkinsfile
@@ -75,7 +75,7 @@ def update_production_azure_gallery_images(String image_name) {
                         --gallery-image-definition ${image_name} \
                         --gallery-image-version ${env.IMAGE_VERSION} \
                         --managed-image \$MANAGED_IMG_ID \
-                        --target-regions "WestEurope" \
+                        --target-regions ${env.REPLICATION_REGIONS.split(',').join(' ')} \
                         --replica-count 1
                 """
                 oe.azureEnvironment(az_update_image_script, "oetools-deploy:${env.DOCKER_TAG}")


### PR DESCRIPTION
* Use private address for Packer Linux Azure managed images build.
* Capture the Azure managed image directly into the target
resource group, and remove the redundant step of `az resource move`.
  
  The `az resource move` was not ideal anyway, since it locks
the target resource group during the operation. This messed the
parallel stages to build CI images, and it adds redundant
execution times.
* Move logic to update CI production infrastructure into separate pipeline

  * Add new pipeline `update_production_infrastructure.Jenkinsfile` to be used
    in a separate Jenkins job to update the production CI infrastructure.
  * Use parallel steps to update Azure gallery images definitions.