### PR TITLE
Add OESDK mailing list to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,12 @@ Licensing
 
 This project is released under the
 [MIT License](https://github.com/openenclave/openenclave/blob/master/LICENSE).
+
+Send Feedback
+=============
+
+Send general questions, announcements, and discussion to the
+[oesdk@lists.confidentialcomputing.io Mailing List](https://lists.confidentialcomputing.io/g/oesdk).
+
+To report a problem or suggest a new feature, file a
+[GitHub issue](https://github.com/openenclave/openenclave/issues).


### PR DESCRIPTION
Addresses half of issue #2742
Discussion around the CGC mailing list is left to PR #2744

Factored out the non-CGC part in the hopes that this can be merged now

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>