### PR TITLE
Fixed bug in issue #2807 and found the end of tcbList correctly

### DIFF
--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -502,6 +502,7 @@ static oe_result_t _read_tcb_info(
     uint64_t value = 0;
     const uint8_t* date_str = NULL;
     size_t date_size = 0;
+    uint64_t square_bracket_count;
 
     parsed_info->tcb_info_start = *itr;
     OE_CHECK(_read('{', itr, end));
@@ -590,8 +591,18 @@ static oe_result_t _read_tcb_info(
                 OE_TCB_LEVEL_STATUS_UNKNOWN)
             {
                 // Found matching TCB level, go to the end of the array.
-                while (*itr < end && **itr != ']')
+                // Need a counter for '[', ']' to avoid early itr stop due to
+                // potential '[', ']' inside array;
+                square_bracket_count = 0;
+                while (*itr < end &&
+                       (**itr != ']' || square_bracket_count != 0))
+                {
+                    if (**itr == '[')
+                        square_bracket_count++;
+                    else if (**itr == ']')
+                        square_bracket_count--;
                     (*itr)++;
+                }
             }
 
             // Read end of array or comma separator.

--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -502,7 +502,7 @@ static oe_result_t _read_tcb_info(
     uint64_t value = 0;
     const uint8_t* date_str = NULL;
     size_t date_size = 0;
-    uint64_t square_bracket_count;
+    uint64_t square_bracket_count = 0;
 
     parsed_info->tcb_info_start = *itr;
     OE_CHECK(_read('{', itr, end));

--- a/tests/report/data_v2/tcbInfoAdvisoryIds.json
+++ b/tests/report/data_v2/tcbInfoAdvisoryIds.json
@@ -75,7 +75,8 @@
           "pcesvn": 4
         },
         "tcbDate":"2018-01-04T01:02:03Z",
-        "tcbStatus": "ConfigurationNeeded"
+        "tcbStatus": "ConfigurationNeeded",
+        "advisoryIDs":["INTEL-SA-00079", "INTEL-SA-00076"]
       },
       {
         "tcb": {


### PR DESCRIPTION
Fixes #2807 
The issue 2807 points out a bug that the end of `tcbLists` is incorrectly marked by the first `]` after the matched tcb entry. It will make `itr` stop earlier than the end of `tcbList`, and cause an error for the following signature reading. Instead `itr` would stops at any `]` inside a tcb entry, such as the end of AdvisoryIDs value which is enclosed by `[]`.
To verify this, I modify a test case `tests/report/data_v2/tcbInfoAdvisoryIds.json.` and added an `AdvisoryIDs` field in one unmatched tcb entry. And current design threw a bug:
```
2020-04-08T18:09:53.000000Z [(E)ERROR] tid(0x7ffff7fa5740) | report_enc::OE_JSON_INFO_PARSE_ERROR [../common/sgx/tcbinfo.c:_read_property_name_and_colon:175]
2020-04-08T18:09:53.000000Z [(E)ERROR] tid(0x7ffff7fa5740) | report_enc::OE_JSON_INFO_PARSE_ERROR [../common/sgx/tcbinfo.c:oe_parse_tcb_info_json:679]
Test failed: ../tests/report/host/tcbinfo.cpp(464): TestVerifyTCBInfoV2_AdvisoryIDs ecall_result == OE_OK
```
```
// oe_parse_tcb_info_json:679:
OE_TRACE_VERBOSE("Reading signature");
OE_CHECK(_read_property_name_and_colon("signature", &itr, end));
```

Debug into itr, it's not stop at the end of tcb entry and beginning of signature field.
```
itr: "{\n        \"tcb\": {\n          \"sgxtcbcomp"...
```

And I fixed bug by introducing a variable square_bracket_count initialized as 0. After a tcb match and process tries to move `itr` to the end of `tcbList`, the square_bracket_count will increase by 1 each time read a `[` and decrease by 1 each time read a `]`. So `itr` will stop only when it reads a `]` as well as square_bracket_count has been balanced back to 0. And that will handle all the `[]` cases inside the `tcbList` and skip those `]`.

After the fixing, it passed the modified test case and debug into itr, it stop at the beginning of signature field correctly.
```
itr:  "\"signature\":\"...
```