### PR TITLE
Fix scripts/install-windows-prereqs.ps1 script

### DIFF
--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -350,26 +350,11 @@ function Install-Git {
 }
 
 function Install-OpenSSL {
-    $installDir = $installDir = Join-Path $env:ProgramFiles "OpenSSL-Win64"
+    $installDir = Join-Path $env:ProgramFiles "OpenSSL-Win64"
     Install-Tool -InstallerPath $PACKAGES["openssl"]["local_file"] `
                  -InstallDirectory $installDir `
                  -ArgumentList @("/silent", "/eula=accept") `
-                 -EnvironmentPath @($installDir)
-
-    $binDir = Join-Path $installDir "bin"
-    $systemPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
-    $currentPath = $env:PATH
-    if($binDir -notin $systemPath) {
-         $systemPath = "$binDir;$systemPath"
-    }
-    if($binDir -notin $currentPath) {
-         $currentPath = "$binDir;$currentPath"
-    }
-    $env:PATH = $currentPath
-    setx.exe /M PATH $systemPath
-    if($LASTEXITCODE) {
-        Throw "Failed to set the new system path"
-    }
+                 -EnvironmentPath @("$installDir\bin")
 }
 
 function Install-7Zip {

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -586,6 +586,9 @@ function Install-DCAP-Dependencies {
         Write-Host "Installing Microsoft.Azure.DCAP library to $targetPath"
         pushd "$OE_NUGET_DIR\Microsoft.Azure.DCAP\tools"
         & ".\InstallAzureDCAP.ps1" $targetPath
+        if($LASTEXITCODE) {
+            Throw "Failed to install Azure DCAP Client"
+        }
         popd
     }
     if (($LaunchConfiguration -eq "SGX1FLC") -or ($LaunchConfiguration -eq "SGX1FLC-NoDriver") -or ($DCAPClientType -eq "Azure"))


### PR DESCRIPTION
* Fix scripts/install-windows-prereqs.ps1
  * Append the OpenSSL bin directory to the system PATH via the
    `-EnvironmentPath` parameter from the `Install-Tool` function.
    The logic behind `-EnvironmentPath` parameter makes sure that
    the PATH is not updated twice if the directory is already
    appended.
  * Remove redundant extra logic, from the `Install-OpenSSL`
    function, to append bin directory to system PATH. This also
    caused OpenSSL bin directory to be appended to the system PATH
    on every script execution. Therefore, it broke the idempotency
    of the entire script.
* Add missing error check for `.\InstallAzureDCAP.ps1`

Signed-off-by: Ionut Balutoiu ibalutoiu@cloudbasesolutions.com