### PR TITLE
Remove libsgx_urts as it is not needed and causes segfaults with clang-7

### DIFF
--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -154,9 +154,9 @@ set(HOST_CXXFLAGS_GCC ${HOST_CFLAGS_GCC})
 ##==============================================================================
 
 if(HAS_QUOTE_PROVIDER)
-    set(SGX_LIBS "-lsgx_enclave_common -lsgx_dcap_ql -lsgx_urts")
+    set(SGX_LIBS "-lsgx_enclave_common -lsgx_dcap_ql")
 else()
-    set(SGX_LIBS "-lsgx_enclave_common -lsgx_urts")
+    set(SGX_LIBS "-lsgx_enclave_common")
 endif()
 
 set(HOSTVERIFY_CLIBS "-rdynamic -Wl,-z,noexecstack -L\${libdir}/openenclave/host -loehostverify -ldl -lpthread")

--- a/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
@@ -6,7 +6,6 @@ intel_sgx_packages:
   - "sgx-aesm-service"
   - "libsgx-enclave-common"
   - "libsgx-enclave-common-devel"
-  - "libsgx-urts"
   - "libsgx-ae-pce"
   - "libsgx-ae-qe3"
 
@@ -14,6 +13,5 @@ packages_validation_distribution_files:
   - "/usr/include/sgx_attributes.h"
   - "/usr/include/sgx_enclave_common.h"
   - "/usr/lib64/libsgx_enclave_common.so"
-  - "/usr/lib64/libsgx_urts.so"
   - "/usr/lib64/libsgx_pce.signed.so"
   - "/usr/lib64/libsgx_qe3.signed.so"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
@@ -5,7 +5,6 @@
 intel_sgx_packages:
   - "libsgx-enclave-common"
   - "libsgx-enclave-common-dev"
-  - "libsgx-urts"
   - "libsgx-ae-qve"
   - "libsgx-ae-pce"
   - "libsgx-ae-qe3"


### PR DESCRIPTION
Remove libsgx_urts as it is not needed and causes segfaults with clang-7.