### PR TITLE
Fix cpio cmake config that only to build if BUILD_ENCLAVES.

### DIFF
--- a/tests/syscall/cpio/CMakeLists.txt
+++ b/tests/syscall/cpio/CMakeLists.txt
@@ -1,8 +1,11 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-add_enclave_library(oecpio STATIC commands.c cpio.c strarr.c)
+if (BUILD_ENCLAVES)
+    add_enclave_library(oecpio STATIC commands.c cpio.c strarr.c)
 
-enclave_link_libraries(oecpio PRIVATE oelibc oecore)
+    enclave_link_libraries(oecpio PRIVATE oelibc oecore)
 
-maybe_build_using_clangw(oecpio)
+    maybe_build_using_clangw(oecpio)
+endif()
+


### PR DESCRIPTION
Change cpio cmake config that only to build if BUILD_ENCLAVES, to avoid unexpected cpio build error while enclaves are cross-compiled.