### PR TITLE
Fixed #2807, wrap up _move_to_end_of_tcb_levels()

### DIFF
--- a/tests/qeidentity/data_v2/qe_identity_with_advisoryids.json
+++ b/tests/qeidentity/data_v2/qe_identity_with_advisoryids.json
@@ -22,7 +22,8 @@
         {
           "tcb":{"isvsvn":1},
           "tcbDate":"2018-08-15T00:00:00Z",
-          "tcbStatus":"OutOfDate"
+          "tcbStatus":"OutOfDate",
+          "advisoryIDs":["INTEL-SA-00079", "INTEL-SA-00076"]
         }
       ]
     },


### PR DESCRIPTION
#2815 fixed #2807 but missed that function `_read_qe_identity_info_v2()` had the same bug.
So I wrapped up a function `_move_to_end_of_tcb_levels()` to correctly move `itr` to the end of a `tcbLevels` array and implemented in both `_read_tcb_info` and  `_read_qe_identity_info_v2`

I also modified `/tests/qeidentity/data_v2/qe_identity_with_advisoryids.json` to reflect new test case.

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>