### PR TITLE
Update the ansible script to install the dependencies of LVI mitigation

### DIFF
--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/lvi-setup.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/lvi-setup.yml
@@ -50,17 +50,6 @@
     dest: '{{ local_lvi_directory }}/'
     remote_src: yes
 
-- name: Copy out LVI binaries
-  copy:
-    src: '{{ item.path }}'
-    dest: '{{ local_lvi_directory }}/'
-    mode: 'u=rx,g=rx,o=rx'
-  with_items:
-    - { path: '{{ scripts_lvi_directory }}/clang-7-lvi'}
-    - { path: '{{ scripts_lvi_directory }}/clang++-7-lvi'}
-    - { path: '{{ scripts_lvi_directory }}/gcc-lvi'}
-    - { path: '{{ scripts_lvi_directory }}/g++-lvi'}
-
 - name: Create symbolic link to as
   file:
     src: '{{ local_lvi_directory }}/external/toolset/as'
@@ -76,6 +65,20 @@
     force: yes
   when: glibc_version.stdout >= '2.27'
 
+- name: Copy scripts
+  copy:
+    src: '{{ scripts_lvi_directory }}/'
+    dest: '{{ local_lvi_directory }}/bin'
+    mode: 'u=rx,g=rx,o=rx'
+
+- name: Create clang-7 wrapper
+  shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=clang-7 --path={{ local_lvi_directory }}/bin"
+  when: clang.stdout != ""
+
+- name: Create clang++-7 wrapper
+  shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=clang++-7 --path={{ local_lvi_directory }}/bin"
+  when: clangcpp.stdout != ""
+
 - name: Create symbolic links to clang
   file:
     src: '{{ item.path }}'
@@ -83,11 +86,17 @@
     state: link
     force: yes
   with_items:
-    - { path: '{{ local_lvi_directory }}/clang-7-lvi', dest: 'clang-7' }
-    - { path: '{{ local_lvi_directory }}/clang++-7-lvi', dest: 'clang++-7' }
     - { path: '{{ clang.stdout }}', dest: 'clang-7_symlink' }
     - { path: '{{ clangcpp.stdout }}', dest: 'clang++-7_symlink'}
   when: clang.stdout != "" and clangcpp.stdout != ""
+
+- name: Create gcc wrapper
+  shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=gcc --path={{ local_lvi_directory }}/bin"
+  when: gcc.stdout != ""
+
+- name: Create g++ wrapper
+  shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=g++ --path={{ local_lvi_directory }}/bin"
+  when: gcpp.stdout != ""
 
 - name: Create symbolic links to gcc
   file:
@@ -96,7 +105,6 @@
     state: link
     force: yes
   with_items:
-    - { path: '{{ gcc.stdout }}', dest: 'gcc_symlink', when: gcc.stdout != "" }
-    - { path: '{{ gcpp.stdout }}', dest: 'g++_symlink', when: gcpp.stdout != "" }
-    - { path: '{{ local_lvi_directory }}/gcc-lvi', dest: 'gcc' }
-    - { path: '{{ local_lvi_directory }}/g++-lvi', dest: 'g++' }
+    - { path: '{{ gcc.stdout }}', dest: 'gcc_symlink' }
+    - { path: '{{ gcpp.stdout }}', dest: 'g++_symlink' }
+  when: gcc.stdout != "" and gcpp.stdout != ""


### PR DESCRIPTION
This PR is a follow-up of #2743; i.e., updating the ansible script to correctly install the dependencies of LVI mitigation.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>