### PR TITLE
Add getsockname and getpeername support for Windows

### DIFF
--- a/host/windows/syscall.c
+++ b/host/windows/syscall.c
@@ -2538,12 +2538,23 @@ int oe_syscall_getsockname_ocall(
     oe_socklen_t addrlen_in,
     oe_socklen_t* addrlen_out)
 {
-    OE_UNUSED(sockfd);
-    OE_UNUSED(addr);
-    OE_UNUSED(addrlen_in);
-    OE_UNUSED(addrlen_out);
+    int ret;
 
-    PANIC;
+    errno = 0;
+
+    ret = getsockname(_get_socket(sockfd), (struct sockaddr*)addr, &addrlen_in);
+
+    if (ret != 0)
+    {
+        _set_errno(_winsockerr_to_errno(WSAGetLastError()));
+    }
+    else
+    {
+        if (addrlen_out)
+            *addrlen_out = addrlen_in;
+    }
+
+    return ret;
 }
 
 int oe_syscall_getpeername_ocall(
@@ -2552,12 +2563,23 @@ int oe_syscall_getpeername_ocall(
     oe_socklen_t addrlen_in,
     oe_socklen_t* addrlen_out)
 {
-    OE_UNUSED(sockfd);
-    OE_UNUSED(addr);
-    OE_UNUSED(addrlen_in);
-    OE_UNUSED(addrlen_out);
+    int ret;
 
-    PANIC;
+    errno = 0;
+
+    ret = getpeername(_get_socket(sockfd), (struct sockaddr*)addr, &addrlen_in);
+
+    if (ret != 0)
+    {
+        _set_errno(_winsockerr_to_errno(WSAGetLastError()));
+    }
+    else
+    {
+        if (addrlen_out)
+            *addrlen_out = addrlen_in;
+    }
+
+    return ret;
 }
 
 int oe_syscall_shutdown_sockets_device_ocall(oe_host_fd_t sockfd)

--- a/tests/syscall/socket/host/host.c
+++ b/tests/syscall/socket/host/host.c
@@ -27,7 +27,7 @@ void* enclave_server_thread(void* arg)
     int retval = 0;
     oe_result_t r;
     const uint32_t flags = oe_get_create_flags();
-    const oe_enclave_type_t type = OE_ENCLAVE_TYPE_SGX;
+    const oe_enclave_type_t type = OE_ENCLAVE_TYPE_AUTO;
 
     r = oe_create_socket_test_enclave(arg, type, flags, NULL, 0, &enclave);
     OE_TEST(r == OE_OK);
@@ -166,7 +166,7 @@ static void _run_host_server_test(const char* path)
     char test_data_rtn[1024] = {0};
     ssize_t test_data_len = 1024;
     const uint32_t flags = oe_get_create_flags();
-    const oe_enclave_type_t type = OE_ENCLAVE_TYPE_SGX;
+    const oe_enclave_type_t type = OE_ENCLAVE_TYPE_AUTO;
     thread_t thread;
 
     sock_startup();


### PR DESCRIPTION
Also add missing test coverage for these two APIs plus shutdown()

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>