### PR TITLE
Fixed #2829, now make and cmake are compatible for remote_attestation

### DIFF
--- a/samples/remote_attestation/common/CMakeLists.txt
+++ b/samples/remote_attestation/common/CMakeLists.txt
@@ -1,9 +1,6 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-add_custom_command(OUTPUT enclave_a_pubkey.h
-  DEPENDS public_key_a ${CMAKE_SOURCE_DIR}/gen_pubkey_header.sh
-  COMMAND ${OE_BASH} ${CMAKE_SOURCE_DIR}/gen_pubkey_header.sh enclave_a_pubkey.h ${CMAKE_BINARY_DIR}/enclave_a/public_a.pem)
 # Use the edger8r to generate C bindings from the EDL file.
 add_custom_command(OUTPUT remoteattestation_t.h remoteattestation_t.c remoteattestation_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/remoteattestation.edl

--- a/samples/remote_attestation/enclave_a/Makefile
+++ b/samples/remote_attestation/enclave_a/Makefile
@@ -33,7 +33,7 @@ genkey: public.pem
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../remoteattestation.edl --trusted --trusted-dir ../common
-	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I. -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
 	$(CC) -g -c $(CFLAGS) $(CINCLUDES) -I.. -DOE_API_VERSION=2 ../common/remoteattestation_t.c
 	$(CXX) -o enclave_a attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o $(LDFLAGS)
 

--- a/samples/remote_attestation/enclave_a/ecalls.cpp
+++ b/samples/remote_attestation/enclave_a/ecalls.cpp
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 #include <common/dispatcher.h>
 #include <common/remoteattestation_t.h>
+#include <enclave_b_pubkey.h>
 #include <openenclave/enclave.h>
-#include "enclave_b_pubkey.h"
 
 // For this purpose of this example: demonstrating how to do remote attestation
 // g_enclave_secret_data is hardcoded as part of the enclave. In this sample,

--- a/samples/remote_attestation/enclave_b/Makefile
+++ b/samples/remote_attestation/enclave_b/Makefile
@@ -32,7 +32,7 @@ genkey: public.pem
 
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
-	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I. -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
 	$(CC) -g -c $(CFLAGS) $(CINCLUDES) -I.. -DOE_API_VERSION=2 ../common/remoteattestation_t.c
 	$(CXX) -o enclave_b attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o $(LDFLAGS)
 

--- a/samples/remote_attestation/enclave_b/ecalls.cpp
+++ b/samples/remote_attestation/enclave_b/ecalls.cpp
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 #include <common/dispatcher.h>
 #include <common/remoteattestation_t.h>
+#include <enclave_a_pubkey.h>
 #include <openenclave/enclave.h>
-#include "enclave_a_pubkey.h"
 
 // For this purpose of this example: demonstrating how to do remote attestation
 // g_enclave_secret_data is hardcoded as part of the enclave. In this sample,


### PR DESCRIPTION
Fixed #2829 .
Now make and cmake are compatible for remote_attestation.
Both make run succeeded in either running order.
Reinstall OE_SDK and run the remote_attestation sample.
Build by make first.
```
wangqc@qiucwang-oe-dev-1 ~/samples> cd remote_attestation/
wangqc@qiucwang-oe-dev-1 ~/s/remote_attestation> ls
CMakeLists.txt  Makefile  README.md  common/  enclave_a/  enclave_b/  gen_pubkey_header.sh*  host/  images/  remoteattestation.edl
wangqc@qiucwang-oe-dev-1 ~/s/remote_attestation> make build
make -C enclave_a
make[1]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
make genkey
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
openssl genrsa -out private.pem -3 3072
Generating RSA private key, 3072 bit long modulus (2 primes)
.....................................................................................................................................................++++
....................................................................................++++
e is 3 (0x03)
openssl rsa -in private.pem -out public.pem -pubout
writing RSA key
../gen_pubkey_header.sh ../enclave_b/enclave_a_pubkey.h public.pem
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make -C ../enclave_b genkey
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
openssl genrsa -out private.pem -3 3072
Generating RSA private key, 3072 bit long modulus (2 primes)
...............................++++
.....++++
e is 3 (0x03)
openssl rsa -in private.pem -out public.pem -pubout
writing RSA key
../gen_pubkey_header.sh ../enclave_a/enclave_b_pubkey.h public.pem
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make build
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
Compilers used: clang-7, clang++-7
oeedger8r ../remoteattestation.edl --trusted --trusted-dir ../common
Generating edge routines for the Open Enclave SDK.
Success.
clang++-7 -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libcxx -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include  -I. -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
clang-7 -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include  -I.. -DOE_API_VERSION=2 ../common/remoteattestation_t.c
clang++-7 -o enclave_a attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o -L/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave -nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,now -Wl,-gc-sections -loeenclave -loecryptombed -lmbedx509 -lmbedcrypto -loelibcxx -loelibc -loesyscall -loecore
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make sign
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
oesign sign -e enclave_a -c enc.conf -k private.pem
Created enclave_a.signed
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make[1]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make -C enclave_b
make[1]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
make genkey
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
../gen_pubkey_header.sh ../enclave_a/enclave_b_pubkey.h public.pem
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make -C ../enclave_a genkey
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
../gen_pubkey_header.sh ../enclave_b/enclave_a_pubkey.h public.pem
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make build
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
Compilers used: clang-7, clang++-7
clang++-7 -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libcxx -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include  -I. -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
clang-7 -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include  -I.. -DOE_API_VERSION=2 ../common/remoteattestation_t.c
clang++-7 -o enclave_b attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o -L/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave -nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,now -Wl,-gc-sections -loeenclave -loecryptombed -lmbedx509 -lmbedcrypto -loelibcxx -loelibc -loesyscall -loecore
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make sign
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
oesign sign -e enclave_b -c enc.conf -k private.pem
Created enclave_b.signed
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make[1]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make -C host
make[1]: Entering directory '/home/wangqc/samples/remote_attestation/host'
Compilers used: clang-7, clang++-7
oeedger8r ../remoteattestation.edl --untrusted
Generating edge routines for the Open Enclave SDK.
Success.
clang-7 -g -c -fstack-protector-strong -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include  remoteattestation_u.c
clang++-7 -g -c -fstack-protector-strong -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include  host.cpp
clang++-7 -o attestation_host host.o remoteattestation_u.o -L/opt/openenclave/share/pkgconfig/../../lib/openenclave/host -rdynamic -Wl,-z,noexecstack -loehost -ldl -lpthread -lsgx_enclave_common -lsgx_dcap_ql -lssl -lcrypto
make[1]: Leaving directory '/home/wangqc/samples/remote_attestation/host'

wangqc@qiucwang-oe-dev-1 ~/s/remote_attestation> make run
host/attestation_host ./enclave_a/enclave_a.signed ./enclave_b/enclave_b.signed
Host: Creating two enclaves
Host: Enclave library ./enclave_a/enclave_a.signed
Enclave: ***../common/crypto.cpp(76): mbedtls initialized.
Host: Enclave successfully created.
Host: Enclave library ./enclave_b/enclave_b.signed
Enclave: ***../common/crypto.cpp(76): mbedtls initialized.
Host: Enclave successfully created.
Host: requesting a remote report and the encryption key from 1st enclave
Enclave: ***ecalls.cpp(43): enter get_remote_report_with_pubkey
Enclave: ***../common/dispatcher.cpp(96): get_remote_report_with_pubkey
Enclave: ***../common/attestation.cpp(59): generate_remote_report succeeded.
Enclave: ***../common/dispatcher.cpp(133): get_remote_report_with_pubkey succeeded
Host: 1st enclave's public key: 
-----BEGIN PUBLIC KEY-----
(skip..)
-----END PUBLIC KEY-----
Host: requesting 2nd enclave to attest 1st enclave's the remote report and the public key
Enclave: ***../common/attestation.cpp(163): remote attestation succeeded.
Enclave: ***../common/dispatcher.cpp(179): verify_report_and_set_pubkey succeeded.
Host: Requesting a remote report and the encryption key from 2nd enclave=====
Enclave: ***../common/dispatcher.cpp(96): get_remote_report_with_pubkey
Enclave: ***../common/attestation.cpp(59): generate_remote_report succeeded.
Enclave: ***../common/dispatcher.cpp(133): get_remote_report_with_pubkey succeeded
Host: 2nd enclave's public key: 
-----BEGIN PUBLIC KEY-----
(skip..)
-----END PUBLIC KEY-----
Host: Requesting first enclave to attest 2nd enclave's remote report and the public key=====
Enclave: ***../common/attestation.cpp(163): remote attestation succeeded.
Enclave: ***../common/dispatcher.cpp(179): verify_report_and_set_pubkey succeeded.
Host: Remote attestation Succeeded
Host: Terminating enclaves
Enclave: ***../common/crypto.cpp(90): mbedtls cleaned up.
Host: Enclave successfully terminated.
Enclave: ***../common/crypto.cpp(90): mbedtls cleaned up.
Host: Enclave successfully terminated.
Host:  succeeded 
```

Then build with cmake.
```
wangqc@qiucwang-oe-dev-1 ~/s/remote_attestation> mkdir build && cd build
wangqc@qiucwang-oe-dev-1 ~/s/r/build> cmake ..
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Looking for crypto library - found
-- Looking for dl library - found
VERBOSE-- Looking for sgx_enclave_common library - found
VERBOSE-- Looking for sgx_dcap_ql library - found
-- Performing Test OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED
-- Performing Test OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED - Failed
-- Performing Test OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED
-- Performing Test OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED - Failed
-- Configuring done
-- Generating done
-- Build files have been written to: /home/wangqc/samples/remote_attestation/build

wangqc@qiucwang-oe-dev-1 ~/s/r/build> make run
[  4%] Generating remoteattestation_u.h, remoteattestation_u.c, remoteattestation_args.h
Generating edge routines for the Open Enclave SDK.
Success.
Scanning dependencies of target remote_attestation_host
[  9%] Building CXX object host/CMakeFiles/remote_attestation_host.dir/host.cpp.o
[ 13%] Building C object host/CMakeFiles/remote_attestation_host.dir/remoteattestation_u.c.o
[ 18%] Linking CXX executable remote_attestation_host
[ 18%] Built target remote_attestation_host
Scanning dependencies of target public_key_a
[ 22%] Generating private_a.pem, public_a.pem
Generating RSA private key, 3072 bit long modulus (2 primes)
.............................................++++
...........................................................++++
e is 3 (0x03)
writing RSA key
[ 22%] Built target public_key_a
[ 27%] Generating remoteattestation_t.h, remoteattestation_t.c, remoteattestation_args.h
Generating edge routines for the Open Enclave SDK.
Success.
Scanning dependencies of target common
[ 31%] Building CXX object common/CMakeFiles/common.dir/attestation.cpp.o
[ 36%] Building CXX object common/CMakeFiles/common.dir/crypto.cpp.o
[ 40%] Building CXX object common/CMakeFiles/common.dir/dispatcher.cpp.o
[ 45%] Building C object common/CMakeFiles/common.dir/remoteattestation_t.c.o
[ 50%] Linking CXX static library libcommon.a
[ 50%] Built target common
[ 54%] Generating enclave_a_pubkey.h
Scanning dependencies of target enclave_b
[ 59%] Building CXX object enclave_b/CMakeFiles/enclave_b.dir/ecalls.cpp.o
[ 63%] Linking CXX executable enclave_b
[ 63%] Built target enclave_b
Scanning dependencies of target enclave_b_signed
[ 68%] Generating private_b.pem, public_b.pem
Generating RSA private key, 3072 bit long modulus (2 primes)
.++++
..................................++++
e is 3 (0x03)
writing RSA key
[ 72%] Generating enclave_b.signed
Created /home/wangqc/samples/remote_attestation/build/enclave_b/enclave_b.signed
[ 72%] Built target enclave_b_signed
Scanning dependencies of target public_key_b
[ 77%] Built target public_key_b
[ 81%] Generating enclave_b_pubkey.h
Scanning dependencies of target enclave_a
[ 86%] Building CXX object enclave_a/CMakeFiles/enclave_a.dir/ecalls.cpp.o
[ 90%] Linking CXX executable enclave_a
[ 90%] Built target enclave_a
Scanning dependencies of target enclave_a_signed
[ 95%] Generating enclave_a.signed
Created /home/wangqc/samples/remote_attestation/build/enclave_a/enclave_a.signed
[100%] Built target enclave_a_signed
Scanning dependencies of target sign
[100%] Built target sign
Scanning dependencies of target run
Host: Creating two enclaves
Host: Enclave library /home/wangqc/samples/remote_attestation/build/enclave_a/enclave_a.signed
Enclave: ***/home/wangqc/samples/remote_attestation/common/crypto.cpp(76): mbedtls initialized.
Host: Enclave successfully created.
Host: Enclave library /home/wangqc/samples/remote_attestation/build/enclave_b/enclave_b.signed
Enclave: ***/home/wangqc/samples/remote_attestation/common/crypto.cpp(76): mbedtls initialized.
Host: Enclave successfully created.
Host: requesting a remote report and the encryption key from 1st enclave
Enclave: ***/home/wangqc/samples/remote_attestation/enclave_a/ecalls.cpp(43): enter get_remote_report_with_pubkey
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(96): get_remote_report_with_pubkey
Enclave: ***/home/wangqc/samples/remote_attestation/common/attestation.cpp(59): generate_remote_report succeeded.
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(133): get_remote_report_with_pubkey succeeded
Host: 1st enclave's public key: 
-----BEGIN PUBLIC KEY-----
(skip..)
-----END PUBLIC KEY-----
Host: requesting 2nd enclave to attest 1st enclave's the remote report and the public key
Enclave: ***/home/wangqc/samples/remote_attestation/common/attestation.cpp(163): remote attestation succeeded.
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(179): verify_report_and_set_pubkey succeeded.
Host: Requesting a remote report and the encryption key from 2nd enclave=====
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(96): get_remote_report_with_pubkey
Enclave: ***/home/wangqc/samples/remote_attestation/common/attestation.cpp(59): generate_remote_report succeeded.
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(133): get_remote_report_with_pubkey succeeded
Host: 2nd enclave's public key: 
-----BEGIN PUBLIC KEY-----
(skip..)
-----END PUBLIC KEY-----
Host: Requesting first enclave to attest 2nd enclave's remote report and the public key=====
Enclave: ***/home/wangqc/samples/remote_attestation/common/attestation.cpp(163): remote attestation succeeded.
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(179): verify_report_and_set_pubkey succeeded.
Host: Remote attestation Succeeded
Host: Terminating enclaves
Enclave: ***/home/wangqc/samples/remote_attestation/common/crypto.cpp(90): mbedtls cleaned up.
Host: Enclave successfully terminated.
Enclave: ***/home/wangqc/samples/remote_attestation/common/crypto.cpp(90): mbedtls cleaned up.
Host: Enclave successfully terminated.
Host:  succeeded 
[100%] Built target run
```

Clean folder and build by cmake first.
```
wangqc@qiucwang-oe-dev-1 ~/s/r/build> cd ..
wangqc@qiucwang-oe-dev-1 ~/s/remote_attestation> rm -rf build/
wangqc@qiucwang-oe-dev-1 ~/s/remote_attestation> make clean
make -C enclave_a clean
make[1]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
rm -f *.o enclave_a enclave_a.signed ../common/remoteattestation_t.* ../common/remoteattestation_args.h *.pem enclave_b_pubkey.h
make[1]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make -C enclave_b clean
make[1]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
rm -f *.o enclave_b enclave_b.signed ../common/remoteattestation_t.* ../common/remoteattestation_args.h *.pem enclave_a_pubkey.h
make[1]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make -C host clean
make[1]: Entering directory '/home/wangqc/samples/remote_attestation/host'
rm -f attestation_host *.o remoteattestation_u.*  remoteattestation_args.h
make[1]: Leaving directory '/home/wangqc/samples/remote_attestation/host'
wangqc@qiucwang-oe-dev-1 ~/s/remote_attestation> mkdir build && cd build
wangqc@qiucwang-oe-dev-1 ~/s/r/build> cmake ..
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Looking for crypto library - found
-- Looking for dl library - found
VERBOSE-- Looking for sgx_enclave_common library - found
VERBOSE-- Looking for sgx_dcap_ql library - found
-- Performing Test OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED
-- Performing Test OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED - Failed
-- Performing Test OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED
-- Performing Test OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED - Failed
-- Configuring done
-- Generating done
-- Build files have been written to: /home/wangqc/samples/remote_attestation/build

wangqc@qiucwang-oe-dev-1 ~/s/r/build> make run
[  4%] Generating remoteattestation_u.h, remoteattestation_u.c, remoteattestation_args.h
Generating edge routines for the Open Enclave SDK.
Success.
Scanning dependencies of target remote_attestation_host
[  9%] Building CXX object host/CMakeFiles/remote_attestation_host.dir/host.cpp.o
[ 13%] Building C object host/CMakeFiles/remote_attestation_host.dir/remoteattestation_u.c.o
[ 18%] Linking CXX executable remote_attestation_host
[ 18%] Built target remote_attestation_host
Scanning dependencies of target public_key_a
[ 22%] Generating private_a.pem, public_a.pem
Generating RSA private key, 3072 bit long modulus (2 primes)
...........................................++++
.......................++++
e is 3 (0x03)
writing RSA key
[ 22%] Built target public_key_a
[ 27%] Generating remoteattestation_t.h, remoteattestation_t.c, remoteattestation_args.h
Generating edge routines for the Open Enclave SDK.
Success.
Scanning dependencies of target common
[ 31%] Building CXX object common/CMakeFiles/common.dir/attestation.cpp.o
[ 36%] Building CXX object common/CMakeFiles/common.dir/crypto.cpp.o
[ 40%] Building CXX object common/CMakeFiles/common.dir/dispatcher.cpp.o
[ 45%] Building C object common/CMakeFiles/common.dir/remoteattestation_t.c.o
[ 50%] Linking CXX static library libcommon.a
[ 50%] Built target common
[ 54%] Generating enclave_a_pubkey.h
Scanning dependencies of target enclave_b
[ 59%] Building CXX object enclave_b/CMakeFiles/enclave_b.dir/ecalls.cpp.o
[ 63%] Linking CXX executable enclave_b
[ 63%] Built target enclave_b
Scanning dependencies of target enclave_b_signed
[ 68%] Generating private_b.pem, public_b.pem
Generating RSA private key, 3072 bit long modulus (2 primes)
........................++++
....................................++++
e is 3 (0x03)
writing RSA key
[ 72%] Generating enclave_b.signed
Created /home/wangqc/samples/remote_attestation/build/enclave_b/enclave_b.signed
[ 72%] Built target enclave_b_signed
Scanning dependencies of target public_key_b
[ 77%] Built target public_key_b
[ 81%] Generating enclave_b_pubkey.h
Scanning dependencies of target enclave_a
[ 86%] Building CXX object enclave_a/CMakeFiles/enclave_a.dir/ecalls.cpp.o
[ 90%] Linking CXX executable enclave_a
[ 90%] Built target enclave_a
Scanning dependencies of target enclave_a_signed
[ 95%] Generating enclave_a.signed
Created /home/wangqc/samples/remote_attestation/build/enclave_a/enclave_a.signed
[100%] Built target enclave_a_signed
Scanning dependencies of target sign
[100%] Built target sign
Scanning dependencies of target run
Host: Creating two enclaves
Host: Enclave library /home/wangqc/samples/remote_attestation/build/enclave_a/enclave_a.signed
Enclave: ***/home/wangqc/samples/remote_attestation/common/crypto.cpp(76): mbedtls initialized.
Host: Enclave successfully created.
Host: Enclave library /home/wangqc/samples/remote_attestation/build/enclave_b/enclave_b.signed
Enclave: ***/home/wangqc/samples/remote_attestation/common/crypto.cpp(76): mbedtls initialized.
Host: Enclave successfully created.
Host: requesting a remote report and the encryption key from 1st enclave
Enclave: ***/home/wangqc/samples/remote_attestation/enclave_a/ecalls.cpp(43): enter get_remote_report_with_pubkey
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(96): get_remote_report_with_pubkey
Enclave: ***/home/wangqc/samples/remote_attestation/common/attestation.cpp(59): generate_remote_report succeeded.
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(133): get_remote_report_with_pubkey succeeded
Host: 1st enclave's public key: 
-----BEGIN PUBLIC KEY-----
(skip..)
-----END PUBLIC KEY-----
Host: requesting 2nd enclave to attest 1st enclave's the remote report and the public key
Enclave: ***/home/wangqc/samples/remote_attestation/common/attestation.cpp(163): remote attestation succeeded.
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(179): verify_report_and_set_pubkey succeeded.
Host: Requesting a remote report and the encryption key from 2nd enclave=====
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(96): get_remote_report_with_pubkey
Enclave: ***/home/wangqc/samples/remote_attestation/common/attestation.cpp(59): generate_remote_report succeeded.
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(133): get_remote_report_with_pubkey succeeded
Host: 2nd enclave's public key: 
-----BEGIN PUBLIC KEY-----
(skip..)
-----END PUBLIC KEY-----
Host: Requesting first enclave to attest 2nd enclave's remote report and the public key=====
Enclave: ***/home/wangqc/samples/remote_attestation/common/attestation.cpp(163): remote attestation succeeded.
Enclave: ***/home/wangqc/samples/remote_attestation/common/dispatcher.cpp(179): verify_report_and_set_pubkey succeeded.
Host: Remote attestation Succeeded
Host: Terminating enclaves
Enclave: ***/home/wangqc/samples/remote_attestation/common/crypto.cpp(90): mbedtls cleaned up.
Host: Enclave successfully terminated.
Enclave: ***/home/wangqc/samples/remote_attestation/common/crypto.cpp(90): mbedtls cleaned up.
Host: Enclave successfully terminated.
Host:  succeeded 
[100%] Built target run
```

Then build from make.
```
wangqc@qiucwang-oe-dev-1 ~/s/r/build> cd ..
wangqc@qiucwang-oe-dev-1 ~/s/remote_attestation> make build
make -C enclave_a
make[1]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
make genkey
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
openssl genrsa -out private.pem -3 3072
Generating RSA private key, 3072 bit long modulus (2 primes)
...............................................................................................++++
................++++
e is 3 (0x03)
openssl rsa -in private.pem -out public.pem -pubout
writing RSA key
../gen_pubkey_header.sh ../enclave_b/enclave_a_pubkey.h public.pem
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make -C ../enclave_b genkey
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
openssl genrsa -out private.pem -3 3072
Generating RSA private key, 3072 bit long modulus (2 primes)
...++++
..................++++
e is 3 (0x03)
openssl rsa -in private.pem -out public.pem -pubout
writing RSA key
../gen_pubkey_header.sh ../enclave_a/enclave_b_pubkey.h public.pem
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make build
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
Compilers used: clang-7, clang++-7
oeedger8r ../remoteattestation.edl --trusted --trusted-dir ../common
Generating edge routines for the Open Enclave SDK.
Success.
clang++-7 -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libcxx -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include  -I. -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
clang-7 -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include  -I.. -DOE_API_VERSION=2 ../common/remoteattestation_t.c
clang++-7 -o enclave_a attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o -L/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave -nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,now -Wl,-gc-sections -loeenclave -loecryptombed -lmbedx509 -lmbedcrypto -loelibcxx -loelibc -loesyscall -loecore
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make sign
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
oesign sign -e enclave_a -c enc.conf -k private.pem
Created enclave_a.signed
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make[1]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make -C enclave_b
make[1]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
make genkey
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
../gen_pubkey_header.sh ../enclave_a/enclave_b_pubkey.h public.pem
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make -C ../enclave_a genkey
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_a'
../gen_pubkey_header.sh ../enclave_b/enclave_a_pubkey.h public.pem
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_a'
make build
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
Compilers used: clang-7, clang++-7
clang++-7 -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libcxx -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include  -I. -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
clang-7 -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include  -I.. -DOE_API_VERSION=2 ../common/remoteattestation_t.c
clang++-7 -o enclave_b attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o -L/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave -nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,now -Wl,-gc-sections -loeenclave -loecryptombed -lmbedx509 -lmbedcrypto -loelibcxx -loelibc -loesyscall -loecore
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make sign
make[2]: Entering directory '/home/wangqc/samples/remote_attestation/enclave_b'
oesign sign -e enclave_b -c enc.conf -k private.pem
Created enclave_b.signed
make[2]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make[1]: Leaving directory '/home/wangqc/samples/remote_attestation/enclave_b'
make -C host
make[1]: Entering directory '/home/wangqc/samples/remote_attestation/host'
Compilers used: clang-7, clang++-7
oeedger8r ../remoteattestation.edl --untrusted
Generating edge routines for the Open Enclave SDK.
Success.
clang-7 -g -c -fstack-protector-strong -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include  remoteattestation_u.c
clang++-7 -g -c -fstack-protector-strong -mllvm -x86-speculative-load-hardening -I/opt/openenclave/share/pkgconfig/../../include  host.cpp
clang++-7 -o attestation_host host.o remoteattestation_u.o -L/opt/openenclave/share/pkgconfig/../../lib/openenclave/host -rdynamic -Wl,-z,noexecstack -loehost -ldl -lpthread -lsgx_enclave_common -lsgx_dcap_ql -lssl -lcrypto
make[1]: Leaving directory '/home/wangqc/samples/remote_attestation/host'

wangqc@qiucwang-oe-dev-1 ~/s/remote_attestation> make run
host/attestation_host ./enclave_a/enclave_a.signed ./enclave_b/enclave_b.signed
Host: Creating two enclaves
Host: Enclave library ./enclave_a/enclave_a.signed
Enclave: ***../common/crypto.cpp(76): mbedtls initialized.
Host: Enclave successfully created.
Host: Enclave library ./enclave_b/enclave_b.signed
Enclave: ***../common/crypto.cpp(76): mbedtls initialized.
Host: Enclave successfully created.
Host: requesting a remote report and the encryption key from 1st enclave
Enclave: ***ecalls.cpp(43): enter get_remote_report_with_pubkey
Enclave: ***../common/dispatcher.cpp(96): get_remote_report_with_pubkey
Enclave: ***../common/attestation.cpp(59): generate_remote_report succeeded.
Enclave: ***../common/dispatcher.cpp(133): get_remote_report_with_pubkey succeeded
Host: 1st enclave's public key: 
-----BEGIN PUBLIC KEY-----
(skip..)
-----END PUBLIC KEY-----
Host: requesting 2nd enclave to attest 1st enclave's the remote report and the public key
Enclave: ***../common/attestation.cpp(163): remote attestation succeeded.
Enclave: ***../common/dispatcher.cpp(179): verify_report_and_set_pubkey succeeded.
Host: Requesting a remote report and the encryption key from 2nd enclave=====
Enclave: ***../common/dispatcher.cpp(96): get_remote_report_with_pubkey
Enclave: ***../common/attestation.cpp(59): generate_remote_report succeeded.
Enclave: ***../common/dispatcher.cpp(133): get_remote_report_with_pubkey succeeded
Host: 2nd enclave's public key: 
-----BEGIN PUBLIC KEY-----
(skip..)
-----END PUBLIC KEY-----
Host: Requesting first enclave to attest 2nd enclave's remote report and the public key=====
Enclave: ***../common/attestation.cpp(163): remote attestation succeeded.
Enclave: ***../common/dispatcher.cpp(179): verify_report_and_set_pubkey succeeded.
Host: Remote attestation Succeeded
Host: Terminating enclaves
Enclave: ***../common/crypto.cpp(90): mbedtls cleaned up.
Host: Enclave successfully terminated.
Enclave: ***../common/crypto.cpp(90): mbedtls cleaned up.
Host: Enclave successfully terminated.
Host:  succeeded 
```

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>