### PR TITLE
Add standard gai_strerror() API support

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -184,6 +184,7 @@ add_enclave_library(oecore STATIC
     ctype.c
     debugmalloc.c
     errno.c
+    gai_strerror.c
     gmtime.c
     hexdump.c
     hostcalls.c

--- a/enclave/core/gai_strerror.c
+++ b/enclave/core/gai_strerror.c
@@ -1,0 +1,48 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/corelibc/netdb.h>
+
+typedef struct _error_info
+{
+    int errnum;
+    const char* message;
+} error_info_t;
+
+// The following messages are copied from
+// ../../3rdparty/musl/musl/src/network/gai_strerror.c
+//
+// Unlike MUSL's implementation of strerror() which puts all strings
+// in a header file we can include, MUSL's implementation of gai_strerror()
+// instead puts the strings into the .c file itself along with code we
+// don't want.  As such, we have to copy the strings into this file rather
+// than being able to include them from MUSL.
+static error_info_t _errors[] = {
+    {OE_EAI_BADFLAGS, "Invalid flags"},
+    {OE_EAI_NONAME, "Name does not resolve"},
+    {OE_EAI_AGAIN, "Try again"},
+    {OE_EAI_FAIL, "Non-recoverable error"},
+    {OE_EAI_NODATA, "Unknown error"},
+    {OE_EAI_FAMILY, "Unrecognized address family or invalid length"},
+    {OE_EAI_SOCKTYPE, "Unrecognized socket type"},
+    {OE_EAI_SERVICE, "Unrecognized service"},
+    {OE_EAI_ADDRFAMILY, "Unknown error"},
+    {OE_EAI_MEMORY, "Out of memory"},
+    {OE_EAI_SYSTEM, "System error"},
+    {OE_EAI_OVERFLOW, "Overflow"},
+};
+
+static size_t _num_errors = sizeof(_errors) / sizeof(_errors[0]);
+
+static const char _unknown[] = "Unknown error";
+
+const char* oe_gai_strerror(int errnum)
+{
+    for (size_t i = 0; i < _num_errors; i++)
+    {
+        if (_errors[i].errnum == errnum)
+            return (char*)_errors[i].message;
+    }
+
+    return (char*)_unknown;
+}

--- a/include/openenclave/corelibc/netdb.h
+++ b/include/openenclave/corelibc/netdb.h
@@ -1,0 +1,46 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/* DISCLAIMER:
+ * This header is published with no guarantees of stability and is not part
+ * of the Open Enclave public API surface. It is only intended to be used
+ * internally by the OE runtime. */
+
+#ifndef _OE_NETDB_H
+#define _OE_NETDB_H
+
+#include <openenclave/internal/syscall/netdb.h>
+
+OE_EXTERNC_BEGIN
+
+/*
+**==============================================================================
+**
+** OE names:
+**
+**==============================================================================
+*/
+
+const char* oe_gai_strerror(int errnum);
+
+/*
+**==============================================================================
+**
+** Standard-C names:
+**
+**==============================================================================
+*/
+
+#if defined(OE_NEED_STDC_NAMES)
+
+OE_INLINE
+const char* gai_strerror(int errnum)
+{
+    return oe_gai_strerror(errnum);
+}
+
+#endif /* defined(OE_NEED_STDC_NAMES) */
+
+OE_EXTERNC_END
+
+#endif /* _OE_NETDB_H */

--- a/tests/syscall/resolver/enc/enc.c
+++ b/tests/syscall/resolver/enc/enc.c
@@ -4,8 +4,8 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/time.h>
 
+#include <openenclave/corelibc/netdb.h>
 #include <openenclave/internal/syscall/arpa/inet.h>
-#include <openenclave/internal/syscall/netdb.h>
 #include <openenclave/internal/syscall/netinet/in.h>
 #include <openenclave/internal/tests.h>
 
@@ -190,6 +190,18 @@ int ecall_getaddrinfo(struct oe_addrinfo** res)
         OE_TEST("_clone_addrinfo() failed" == NULL);
 
     oe_freeaddrinfo(ai);
+
+    return 0;
+}
+
+int ecall_gai_strerror()
+{
+    const char* message = oe_gai_strerror(OE_EAI_FAMILY);
+
+    OE_TEST(message != NULL);
+    OE_TEST(message[0] != '\0');
+
+    printf("EAI_FAMILY message is: %s\n", message);
 
     return 0;
 }

--- a/tests/syscall/resolver/host/host.c
+++ b/tests/syscall/resolver/host/host.c
@@ -117,12 +117,16 @@ int main(int argc, const char* argv[])
 
     OE_TEST(
         ecall_getnameinfo(client_enclave, &ret, host, sizeof(host)) == OE_OK);
+    OE_TEST(ret == OE_OK);
 
     {
         OE_TEST(strlen(host) > 0); // Can't be sure what the host result will
                                    // be. Windows returns the node name
         printf("host received: host = %s\n", host);
     }
+
+    OE_TEST(ecall_gai_strerror(client_enclave, &ret) == OE_OK);
+    OE_TEST(ret == OE_OK);
 
     OE_TEST(oe_terminate_enclave(client_enclave) == OE_OK);
 

--- a/tests/syscall/resolver/resolver_test.edl
+++ b/tests/syscall/resolver/resolver_test.edl
@@ -28,5 +28,7 @@ enclave {
         public int ecall_getnameinfo(
             [in, out, count=bufflen] char* buffer,
             size_t bufflen);
+
+        public int ecall_gai_strerror();
     };
 };


### PR DESCRIPTION
This is a standard resolver API that was previously missing from the OE SDK.

API references:
* https://pubs.opengroup.org/onlinepubs/009695399/functions/gai_strerror.html
* https://tools.ietf.org/html/rfc3493
* https://linux.die.net/man/3/gai_strerror
* https://docs.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-gai_strerrorw