### PR TITLE
Fix a bug to prevent triggering re-compiling binaries

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -52,11 +52,11 @@ if(OE_SGX)
     set(SGX_EDL_FILE ${SGX_EDL_DIR}/platform.edl)
 
     add_custom_command(
-        OUTPUT platform_t.h platform_t.c platform_args.c
+        OUTPUT platform_t.h platform_t.c platform_args.h
         DEPENDS ${SGX_EDL_FILE} edger8r
         COMMAND edger8r --search-path ${SGX_EDL_DIR} --trusted ${SGX_EDL_FILE})
 
-    add_custom_target(platform_trusted_edl DEPENDS platform_t.h platform_t.c platform_args.c)
+    add_custom_target(platform_trusted_edl DEPENDS platform_t.h platform_t.c platform_args.h)
 endif()
 
 ##==============================================================================

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -104,12 +104,12 @@ endif ()
 set(SGX_EDL_FILE ${SGX_EDL_DIR}/platform.edl)
 if (OE_SGX)
   add_custom_command(
-      OUTPUT platform_u.h platform_u.c platform_args.c
+      OUTPUT platform_u.h platform_u.c platform_args.h
       DEPENDS ${SGX_EDL_FILE} edger8r
       COMMAND edger8r --search-path ${SGX_EDL_DIR} --untrusted ${SGX_EDL_FILE})
 
   add_custom_target(platform_untrusted_edl
-      DEPENDS platform_u.h platform_u.c platform_args.c)
+      DEPENDS platform_u.h platform_u.c platform_args.h)
 endif ()
 
 ##==============================================================================


### PR DESCRIPTION
The bug causes the build system to re-compile binaries every invocation of cmake, causing the timeout in sample tests.

Fixes #2856 


signed-off-by: Ming-Wei Shih <john.mwshih@gmail.com>