### PR TITLE
Add a host verification sample

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -14,14 +14,19 @@ if (HAS_QUOTE_PROVIDER)
         GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
 endif ()
 
-install(DIRECTORY local_attestation
-          DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples
-          PATTERN "gen_pubkey_header.sh"
-          PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
-          GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
+if (BUILD_ENCLAVES)
+  install(DIRECTORY local_attestation
+            DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples
+            PATTERN "gen_pubkey_header.sh"
+            PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+            GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
 
-install(DIRECTORY helloworld file-encryptor data-sealing switchless
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples)
+  install(DIRECTORY helloworld file-encryptor data-sealing switchless
+          DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples)
+endif ()
+
+install(DIRECTORY host_verify
+	DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples)
 
 if (WIN32)
   install(FILES README_Windows.md

--- a/samples/README_Linux.md
+++ b/samples/README_Linux.md
@@ -123,8 +123,8 @@ The following samples demonstrate how to develop enclave applications using OE A
 
 #### [File-Encryptor](file-encryptor/README.md)
 
-- Shows how to encrypt and decrypt data inside an enclave
-- Uses AES mbedTLS API to perform encryption and decryption
+- Show how to encrypt and decrypt data inside an enclave
+- Use AES mbedTLS API to perform encryption and decryption
 
 #### [Data-Sealing](data-sealing/README.md)
 
@@ -159,3 +159,8 @@ The following samples demonstrate how to develop enclave applications using OE A
 - Demonstrate how to configure an enclave to enable switchless calls originated within it
 - Recommend the number of host worker threads required for switchless calls in practice
 - Demonstrate how to enable switchless calls in an enclave application
+
+#### [Host-side Enclave Verification](host_verify/README.md)
+
+- Explain the concept of host-side enclave verification
+- Demonstrate attestation of a remote SGX enclave from outside an enclave

--- a/samples/README_Windows.md
+++ b/samples/README_Windows.md
@@ -74,8 +74,8 @@ The following samples demonstrate how to develop enclave applications using OE A
 
 #### [File-Encryptor](file-encryptor/README.md)
 
-- Shows how to encrypt and decrypt data inside an enclave
-- Uses AES mbedTLS API to perform encryption and decryption
+- Show how to encrypt and decrypt data inside an enclave
+- Use AES mbedTLS API to perform encryption and decryption
 
 #### [Data-Sealing](data-sealing/README.md)
 
@@ -110,3 +110,8 @@ The following samples demonstrate how to develop enclave applications using OE A
 - Demonstrate how to configure an enclave to enable switchless calls originated within it
 - Recommend the number of host worker threads required for switchless calls in practice
 - Demonstrate how to enable switchless calls in an enclave application
+
+#### [Host-side Enclave Verification](host_verify/README.md)
+
+- Explain the concept of host-side enclave verification
+- Demonstrate attestation of a remote SGX enclave from outside an enclave

--- a/samples/host_verify/CMakeLists.txt
+++ b/samples/host_verify/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+cmake_minimum_required(VERSION 3.11)
+
+project("Remote Host-side Enclave Verification Sample" LANGUAGES C CXX)
+
+find_package(OpenEnclave CONFIG REQUIRED)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_executable(host_verify host.c)
+
+target_include_directories(host_verify PRIVATE)
+
+target_link_libraries(host_verify openenclave::oehostverify)
+
+add_custom_target(run
+  DEPENDS host_verify)
+
+if(NOT (EXISTS "sgx_cert_ec.der" OR EXISTS "sgx_cert_rsa.der" OR EXISTS "sgx_report.bin"))
+  add_custom_target(run1
+    DEPENDS host_verify
+    COMMAND host_verify -h)
+  add_dependencies(run run1)
+else()
+  if(EXISTS "sgx_cert_ec.der")
+    add_custom_target(run1
+      DEPENDS host_verify
+      COMMAND host_verify -c sgx_cert_ec.der)
+    add_dependencies(run run1)
+  endif()
+  if(EXISTS "sgx_cert_rsa.der")
+    add_custom_target(run2
+      DEPENDS host_verify
+      COMMAND host_verify -c sgx_cert_rsa.der)
+    add_dependencies(run run2)
+  endif()
+  if(EXISTS "sgx_report.bin")
+    add_custom_target(run3
+      DEPENDS host_verify
+      COMMAND host_verify -r sgx_report.bin)
+    add_dependencies(run run3)
+  endif()
+endif()

--- a/samples/host_verify/Makefile
+++ b/samples/host_verify/Makefile
@@ -1,0 +1,53 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+include ../config.mk
+
+CFLAGS=$(shell pkg-config oehost-$(COMPILER) --cflags)
+LDFLAGS=$(shell pkg-config oehost-$(COMPILER) --libs)
+
+EXISTS_FILE=0
+EXISTS_SGX_CERT_EC=0
+EXISTS_SGX_CERT_RSA=0
+EXISTS_SGX_REPORT=0
+
+ifneq ($(wildcard, sgx_cert_ec.der), "")
+	EXISTS_SGX_CERT_EC=1
+	EXISTS_FILE=1
+endif
+
+ifneq ($(wildcard, sgx_cert_rsa.der), "")
+	EXISTS_SGX_CERT_RSA=1
+	EXISTS_FILE=1
+endif
+
+ifneq ($(wildcard, sgx_report.bin), "")
+	EXISTS_SGX_REPORT=1
+	EXISTS_FILE=1
+endif
+
+.PHONY: all build clean run
+
+all: build
+
+build:
+	@ echo "Compilers used: $(CC), $(CXX)"
+	$(CC) -g -c $(CFLAGS) host.c
+	$(CC) -o host_verify host.o $(LDFLAGS)
+
+clean:
+	rm -f host_verify host.o
+
+run:
+ifeq (EXISTS_FILE, 0)
+	./host_verify -h
+endif
+ifeq (EXISTS_SGX_CERT_EC, 1)
+	./host_verify -c sgx_cert_ec.der
+endif
+ifeq (EXISTS_SGX_CERT_RSA, 1)
+	./host_verify -c sgx_cert_rsa.der
+endif
+ifeq (EXISTS_SGX_REPORT, 1)
+	./host_verify -r sgx_report.bin
+endif

--- a/samples/host_verify/README.md
+++ b/samples/host_verify/README.md
@@ -1,0 +1,69 @@
+
+# The host-side enclave verification sample
+
+- Demonstrates the attestation of a remote enclave
+- Requires only the `openenclave/host_verify.h` header, as well as some C standard header files
+
+Prerequisites: you may want to read [Common Sample Information](../README.md#common-sample-information) before going further
+
+## About the host-side enclave verification sample
+
+When an application is doing host-side enclave verification, it means that a host application is trying to authenticate a remote enclave's hardware and software settings so that the application can determine whether or not to trust the remote enclave.
+
+The sample does remote host-side enclave attestation by taking either of the two arguments:
+
+- An SGX report
+- An SGX certificate
+
+A user can generate a report or certificate with `oecert`. See [here](https://github.com/openenclave/openenclave/blob/master/tests/tools/oecert/README.md) for more details.
+
+In the main function, if it sees the attribute `-r`, then it will continue to read the next argument to get the report and call `verify_report()` to verify the report.
+Likewise, if it sees the attribute `-c`, then it will continue to read the next argument to get the certificate and call `verify_cert()` to verify the certificate.
+If it sees the attribute `-h`, it will show the usage of this program.
+There is also an `enclave_identity_verifier()` function, which is called by `verify_cert()` and shows the information of a certificate if you feed it to the program.
+
+## Build and run
+
+Open Enclave SDK supports building the sample on both Linux and Windows.
+Linux supports two types of build systems, GNU Make with `pkg-config` and CMake,
+while Windows supports only CMake.
+
+### Linux
+
+#### CMake
+
+This uses the CMake package provided by the Open Enclave SDK.
+
+```bash
+cd host_verify
+mkdir build && cd build
+cmake ..
+make run
+```
+
+#### GNU Make
+
+```bash
+cd host_verify
+make build
+make run
+```
+
+### Windows
+
+#### CMake
+
+```bash
+mkdir build && cd build
+cmake .. -G Ninja -DNUGET_PACKAGE_PATH=C:\oe_prereqs
+ninja
+ninja run
+```
+
+When you see the following message displayed on the screen, it means you have successfully run the sample.
+
+```bash
+Usage:
+  ./host_verify -r <report_file>
+  ./host_verify -c <certificate_file>
+```

--- a/samples/host_verify/host.c
+++ b/samples/host_verify/host.c
@@ -1,0 +1,200 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host_verify.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+size_t get_filesize(FILE* fp)
+{
+    size_t size = 0;
+    fseek(fp, 0, SEEK_END);
+    size = (size_t)ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+
+    return size;
+}
+
+bool read_binary_file(
+    const char* filename,
+    uint8_t** data_ptr,
+    size_t* size_ptr)
+{
+    FILE* fp = fopen(filename, "rb");
+    size_t size = 0;
+    uint8_t* data = NULL;
+    size_t bytes_read = 0;
+    bool result = false;
+
+    *data_ptr = NULL;
+    *size_ptr = 0;
+
+    if (fp == NULL)
+    {
+        fprintf(stderr, "Failed to find file: %s\n", filename);
+        goto exit;
+    }
+
+    // Find file size
+    size = get_filesize(fp);
+    if (size == 0)
+    {
+        fprintf(stderr, "Empty file: %s\n", filename);
+        goto exit;
+    }
+
+    data = (uint8_t*)malloc(size);
+    if (data == NULL)
+    {
+        fprintf(
+            stderr,
+            "Failed to allocate memory of size %lu\n",
+            (unsigned long)size);
+        goto exit;
+    }
+
+    bytes_read = fread(data, sizeof(uint8_t), size, fp);
+    if (bytes_read != size)
+    {
+        fprintf(stderr, "Failed to read file: %s\n", filename);
+        goto exit;
+    }
+
+    result = true;
+
+exit:
+    if (fp)
+    {
+        fclose(fp);
+    }
+
+    if (!result)
+    {
+        if (data != NULL)
+        {
+            free(data);
+            data = NULL;
+        }
+        bytes_read = 0;
+    }
+
+    *data_ptr = data;
+    *size_ptr = bytes_read;
+
+    return result;
+}
+
+oe_result_t verify_report(const char* report_filename)
+{
+    oe_result_t result = OE_FAILURE;
+    size_t report_file_size = 0;
+    uint8_t* report_data = NULL;
+
+    if (read_binary_file(report_filename, &report_data, &report_file_size))
+    {
+        result = oe_verify_remote_report(
+            report_data, report_file_size, NULL, 0, NULL);
+    }
+
+    if (report_data != NULL)
+    {
+        free(report_data);
+    }
+
+    return result;
+}
+
+oe_result_t enclave_identity_verifier(oe_identity_t* identity, void* arg)
+{
+    (void)arg;
+
+    printf(
+        "Enclave certificate contains the following identity information:\n");
+    printf("identity.security_version = %d\n", identity->security_version);
+
+    printf("identity->unique_id:\n0x ");
+    for (int i = 0; i < 32; i++)
+        printf("%0x ", (uint8_t)identity->unique_id[i]);
+
+    printf("\nidentity->signer_id:\n0x ");
+    for (int i = 0; i < 32; i++)
+        printf("%0x ", (uint8_t)identity->signer_id[i]);
+
+    printf("\nidentity->product_id:\n0x ");
+    for (int i = 0; i < 16; i++)
+        printf("%0x ", (uint8_t)identity->product_id[i]);
+
+    return OE_OK;
+}
+
+oe_result_t verify_cert(const char* filename)
+{
+    oe_result_t result = OE_FAILURE;
+    size_t cert_file_size = 0;
+    uint8_t* cert_data = NULL;
+
+    if (read_binary_file(filename, &cert_data, &cert_file_size))
+    {
+        result = oe_verify_attestation_certificate(
+            cert_data, cert_file_size, enclave_identity_verifier, NULL);
+    }
+
+    if (cert_data != NULL)
+    {
+        free(cert_data);
+    }
+
+    return result;
+}
+
+int main(int argc, const char* argv[])
+{
+    const char* filename = NULL;
+    oe_result_t result = OE_FAILURE;
+    int n = 0;
+
+    if (argc <= 2)
+    {
+        fprintf(
+            stdout,
+            "Usage:\n  %s -r <report_file>\n  %s -c <certificate_file>\n",
+            argv[0],
+            argv[0]);
+
+        if (argc == 2 && memcmp(argv[1], "-h", 2) == 0)
+        {
+            return 0;
+        }
+
+        return 1;
+    }
+
+    for (n = 1; n < argc; n++)
+    {
+        if (memcmp(argv[n], "-r", 2) == 0)
+        {
+            filename = argv[++n];
+            fprintf(stdout, "Verifying report %s...\n", filename);
+            result = verify_report(filename);
+            fprintf(
+                stdout,
+                "Report verification %s (%u).\n\n",
+                (result == OE_OK) ? "succeeded" : "failed",
+                result);
+        }
+        else if (memcmp(argv[n], "-c", 2) == 0)
+        {
+            filename = argv[++n];
+            fprintf(stdout, "Verifying certificate %s...\n", filename);
+            result = verify_cert(filename);
+            fprintf(
+                stdout,
+                "\n\nCertificate verification %s (%u).\n\n",
+                (result == OE_OK) ? "succeeded" : "failed",
+                result);
+        }
+    }
+
+    return 0;
+}

--- a/samples/test-samples.cmake
+++ b/samples/test-samples.cmake
@@ -6,8 +6,7 @@
 #
 #     cmake -DHAS_QUOTE_PROVIDER=ON -DSOURCE_DIR=~/openenclave -DBUILD_DIR=~/openenclave/build -DPREFIX_DIR=/opt/openenclave -P ~/openenclave/samples/test-samples.cmake
 
-# These three samples can run in simulation, and therefore run in every configuration.
-set(SAMPLES_LIST helloworld file-encryptor switchless)
+set(SAMPLES_LIST helloworld file-encryptor switchless host_verify)
 
 if ($ENV{OE_SIMULATION})
   message(WARNING "Running only sample simulation tests due to OE_SIMULATION=$ENV{OE_SIMULATION}!")
@@ -94,7 +93,7 @@ foreach (SAMPLE ${SAMPLES_LIST})
         else ()
 	  message(STATUS "Samples test '${SAMPLE}' with pkg-config passed!")
         endif ()
-	endif ()
+    endif ()
   endif ()
 
   # Simulation mode is not supported on Windows currently.


### PR DESCRIPTION
This host verification sample is in a directory named remote host attestation, which, besides some C standard header files, only requires `host_verify.h` and all the header files it uses.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>