### PR TITLE
Fix socketpair/CMakeLists.txt and resolver/CMakeLists.txt.

### DIFF
--- a/tests/syscall/resolver/CMakeLists.txt
+++ b/tests/syscall/resolver/CMakeLists.txt
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 
 add_subdirectory(host)
-add_subdirectory(enc)
+
+if (BUILD_ENCLAVES)
+    add_subdirectory(enc)
+endif()
 
 add_enclave_test(tests/resolver resolver_host resolver_enc)

--- a/tests/syscall/socketpair/CMakeLists.txt
+++ b/tests/syscall/socketpair/CMakeLists.txt
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 
 add_subdirectory(host)
-add_subdirectory(enc)
+
+if (BUILD_ENCLAVES)
+    add_subdirectory(enc)
+endif()
 
 add_enclave_test(tests/socketpair socketpair_host socketpair_enc)


### PR DESCRIPTION
A following up pr from #2826 
Change cmake config that only to build if BUILD_ENCLAVES, to avoid unexpected build error while enclaves are cross-compiled.

Signed-off-by: Alvin Chen <alvin@chen.asia>