### PR TITLE
Fix #2688, add two new sgx tcb status.

### DIFF
--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -240,6 +240,20 @@ static oe_tcb_level_status_t _parse_tcb_status(
         status.fields.qe_identity_out_of_date = 1;
         status.fields.configuration_needed = 1;
     }
+    // Due to sgx LVI update, UpToDate tcb would be marked as SWHardeningNeeded,
+    // as sgx cannot tell if enclave writer has implemented SW mitigations for
+    // LVI. Set status SWHardeningNeeded as up_to_date for now to make sure
+    // services for those tcbs are not affected.
+    else if (_json_str_equal(str, length, "SWHardeningNeeded"))
+    {
+        status.fields.up_to_date = 1;
+        status.fields.sw_hardening_needed = 1;
+    }
+    else if (_json_str_equal(str, length, "ConfigurationAndSWHardeningNeeded"))
+    {
+        status.fields.configuration_needed = 1;
+        status.fields.sw_hardening_needed = 1;
+    }
 
     return status;
 }
@@ -413,9 +427,11 @@ done:
  * but with different set of values). "tcbDate" : oe_datetime_t when TCB level
  * was certified not to be vulnerable. ISO 8601 standard(YYYY-MM-DDThh:mm:ssZ).
  *    "tcbStatus" : one of "UpToDate" or "OutOfDate" or "Revoked" or
- *                  "ConfigurationNeeded" or "OutOfDateConfigurationNeeded"
- *    "advisoryIDs" : array of strings describing vulnerabilities that this TCB
- * level is vulnerable to.  Example: ["INTEL-SA-00079", "INTEL-SA-00076"]
+ *                  "ConfigurationNeeded" or "OutOfDateConfigurationNeeded" or
+ *                  "SWHardeningNeeded" or "ConfigurationAndSWHardeningNeeded"
+ *    "advisoryIDs" :
+ * array of strings describing vulnerabilities that this TCB level is vulnerable
+ * to.  Example: ["INTEL-SA-00079", "INTEL-SA-00076"]
  * }
  */
 static oe_result_t _read_tcb_info_tcb_level_v2(
@@ -940,10 +956,12 @@ static void _determine_platform_qe_tcb_level(
  *    "tcb" : object of type tcb (Note: TCB Info has the same object, but with
  *            different set of values).
  *    "tcbDate" : oe_datetime_t when TCB level was certified not to be
- * vulnerable. ISO 8601 standard(YYYY-MM-DDThh:mm:ssZ). "tcbStatus" : one of
- * "UpToDate" or "OutOfDate" or "Revoked" or "ConfigurationNeeded" or
- * "OutOfDateConfigurationNeeded" "advisoryIDs" : array of strings describing
- * vulnerabilities that this TCB level is vulnerable to.  Example:
+ * vulnerable. ISO 8601 standard(YYYY-MM-DDThh:mm:ssZ).
+ *    "tcbStatus" : one of "UpToDate" or "OutOfDate" or "Revoked" or
+ * "ConfigurationNeeded" or "OutOfDateConfigurationNeeded" or
+ * "SWHardeningNeeded" or "ConfigurationAndSWHardeningNeeded"
+ *    "advisoryIDs" : array of strings describing vulnerabilities that this TCB
+ * level is vulnerable to.  Example:
  * ["INTEL-SA-00079", "INTEL-SA-00076"]
  * }
  */

--- a/common/sgx/tcbinfo.h
+++ b/common/sgx/tcbinfo.h
@@ -24,13 +24,13 @@ typedef union _oe_tcb_level_status {
         uint32_t outofdate : 1;            //! "OutOfDate"
         uint32_t configuration_needed : 1; //! "ConfigurationNeeded"
         uint32_t up_to_date : 1;           //! "UpToDate"
-
         /*! "OutOfDateConfigurationNeeded"
          *
          * This tcb status indicates that the QE Identity Info is out of date
          * and the TCB Info requires configuration "ConfigurationNeeded"
          */
         uint32_t qe_identity_out_of_date : 1;
+        uint32_t sw_hardening_needed : 1; //! "SWHardeningNeeded"
     } fields;
     uint32_t AsUINT32;
 

--- a/tests/report/data_v2/tcbInfo.json
+++ b/tests/report/data_v2/tcbInfo.json
@@ -25,10 +25,56 @@
           "sgxtcbcomp14svn": 1,
           "sgxtcbcomp15svn": 1,
           "sgxtcbcomp16svn": 1,
-          "pcesvn":6
+          "pcesvn":8
         },
         "tcbDate":"2018-01-04T01:02:03Z",
         "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":7
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"SWHardeningNeeded"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"ConfigurationAndSWHardeningNeeded"
       },
       {
         "tcb": {

--- a/tests/report/data_v2/tcbInfoAdvisoryIds.json
+++ b/tests/report/data_v2/tcbInfoAdvisoryIds.json
@@ -25,7 +25,7 @@
           "sgxtcbcomp14svn": 1,
           "sgxtcbcomp15svn": 1,
           "sgxtcbcomp16svn": 1,
-          "pcesvn":6
+          "pcesvn":8
         },
         "tcbDate":"2018-01-04T01:02:03Z",
         "tcbStatus":"UpToDate",

--- a/tests/report/data_v2/tcbInfo_with_pceid.json
+++ b/tests/report/data_v2/tcbInfo_with_pceid.json
@@ -26,10 +26,56 @@
           "sgxtcbcomp14svn": 1,
           "sgxtcbcomp15svn": 1,
           "sgxtcbcomp16svn": 1,
-          "pcesvn":6
+          "pcesvn":8
         },
         "tcbDate":"2018-01-04T01:02:03Z",
         "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":7
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"SWHardeningNeeded"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"ConfigurationAndSWHardeningNeeded"
       },
       {
         "tcb": {

--- a/tests/report/host/tcbinfo.cpp
+++ b/tests/report/host/tcbinfo.cpp
@@ -270,17 +270,19 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
     oe_parsed_tcb_info_t parsed_info = {0};
 
     printf("TCB Info Version 2 tests:\n");
-    // ./data_v2/tcbInfo.json contains 5 tcb levels.
-    // The first level with pce svn = 6 is up to date.
-    // The second level with pce svn = 5 is OutOfDateConfigurationNeeded
-    // The third level with pce svn = 4 needs configuration.
-    // The fourth level with pce svn = 3 is out of date.
-    // The fifth level with pce svn = 2 is revoked.
+    // ./data_v2/tcbInfo.json contains 7 tcb levels.
+    // The first level with pce svn = 8 is up to date.
+    // The second level with pce svn = 7 is SWHardeningNeeded.
+    // The third level with pce svn = 6 is ConfigurationAndSWHardeningNeeded.
+    // The fourth level with pce svn = 5 is OutOfDateConfigurationNeeded
+    // The fifth level with pce svn = 4 needs configuration.
+    // The sixth level with pce svn = 3 is out of date.
+    // The seventh level with pce svn = 2 is revoked.
 
-    // Set platform pce svn to 8 and assert that
+    // Set platform pce svn to 9 and assert that
     // the determined status is up to date.
     platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
-    platform_tcb_level.pce_svn = 8;
+    platform_tcb_level.pce_svn = 9;
     TestVerifyTCBInfo(
         enclave,
         test_filename,
@@ -290,6 +292,37 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         version);
     OE_TEST(platform_tcb_level.status.fields.up_to_date == 1);
     printf("UptoDate TCB Level determination test passed.\n");
+
+    // Set platform pce svn to 7 and assert that
+    // the determined status is SWHardeningNeeded.
+    platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+    platform_tcb_level.pce_svn = 7;
+    TestVerifyTCBInfo(
+        enclave,
+        test_filename,
+        &platform_tcb_level,
+        &parsed_info,
+        OE_OK,
+        version);
+    OE_TEST(platform_tcb_level.status.fields.up_to_date == 1);
+    OE_TEST(platform_tcb_level.status.fields.sw_hardening_needed == 1);
+    printf("SWHardeningNeeded TCB Level determination test passed.\n");
+
+    // Set platform pce svn to 6 and assert that
+    // the determined status is ConfigurationAndSWHardeningNeeded.
+    platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+    platform_tcb_level.pce_svn = 6;
+    TestVerifyTCBInfo(
+        enclave,
+        test_filename,
+        &platform_tcb_level,
+        &parsed_info,
+        OE_TCB_LEVEL_INVALID,
+        version);
+    OE_TEST(platform_tcb_level.status.fields.configuration_needed == 1);
+    OE_TEST(platform_tcb_level.status.fields.sw_hardening_needed == 1);
+    printf("ConfigurationAndSWHardeningNeeded TCB Level determination test "
+           "passed.\n");
 
     // Set platform pce svn to 5 and assert that
     // the determined status is out of date configuration needed.
@@ -449,7 +482,7 @@ void TestVerifyTCBInfoV2_AdvisoryIDs(
     // Set platform pce svn to 8 and assert that
     // the determined status is up to date.
     platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
-    platform_tcb_level.pce_svn = 8;
+    platform_tcb_level.pce_svn = 9;
 
     // Contains nextUpdate field.
     memset(&parsed_info, 0, sizeof(parsed_info));


### PR DESCRIPTION
Fix #2688 
Add two new sgx tcb statuses: `SWHardeningNeeded` and `ConfigurationAndSWHardeningNeeded`.
And update test case data file (v2) to reflect the change.
Due to recent sgx update, `UpToDate` tcb would be marked as `SWHardeningNeeded`. So we set status `SWHardeningNeeded` as `up_to_date` for now to make sure services are not affected.