### PR TITLE
Update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ------------
 
 ### Added
+- Complete support for inttypes.h and stdlib.h in oelibc. See docs/LibcSupport.md for more details.
 - Support for Simulation Mode on Windows. Simulation mode only runs on systems with SGX enabled.
 - Support `transition_using_threads` EDL attribute for ecalls in oeedger8r.
   OE SDK now supports both switchless OCALLs and ECALLs.
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are intended to be used by generated code and are not part of the OE public
   API surface.
 - Support for Windows Server 2019.
+- Experimental support for RHEL8.
 - Preview versions of VSCode and Visual Studio Extensions for OE are now part of the github repo.
 - Experimental support for enclave file system APIs on Windows host.
 - oelibcxx now supports up to `std=c++17`. Please see docs/LibcxxSupport.md for more details.
@@ -29,11 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   OCalls and ECalls into OE libraries as before. If it is set to off, each enclave
   application must import the ECalls/OCalls it needs into its own EDL file from
   `{OE_INSTALL_PATH}/include/openenclave/edl`.
+- Experimental support for snmalloc. To use snmalloc, build the SDK from source using -DUSE_SNMALLOC=ON.
 
 ### Changed
 - Moved `oe_asymmetric_key_type_t`, `oe_asymmetric_key_format_t`, and
   `oe_asymmetric_key_params_t` to `bits/asym_keys.h` from `bits/types.h`.
-- Update OE SDK on Windows to depend on OpenSSL version 1.1.1f.
 - Windows host libraries in the Open Enclave NuGet package have been compiled with /WX /W3 enabled.
 - Attestation plugin APIs in include/openenclave/attestation/plugin.h are marked experimental.
 

--- a/docs/GettingStartedDocs/Contributors/ExperimentalSupportRHEL8.md
+++ b/docs/GettingStartedDocs/Contributors/ExperimentalSupportRHEL8.md
@@ -1,14 +1,23 @@
-# Getting Started with Open Enclave in SGX1-FLC mode
+# Experimental - Getting Started with Open Enclave on RHEL8
 
 ## Platform requirements
 
-- Ubuntu 16.04-LTS 64-bits or Ubuntu 18.04-LTS 64-bits.
-- For RHEL8 support, please see [ExperimentalSupportRHEL8.md](ExperimentalSupportRHEL8.md).
-- SGX1 capable system with Flexible Launch Control support. Most likely this will be an Intel Coffeelake system.
+- RHEL8
+- A machine with an Intel processor.
+
+Please refer to [SGXSupportLevel.md](/docs/GettingStartedDocs/SGXSupportLevel.md) to determine the SGX support level for your target system. If your system does not have SGX1 or SGX1+FLC support, you can use the simulation mode.
+
+Note: Attestation is not supported on RHEL8.
 
 ## Clone Open Enclave SDK repo from GitHub
 
-Use the following command to download the source code.
+Install git.
+
+```bash
+sudo yum install git
+```
+
+Use the following command to download the source code (make sure `git` is installed before doing this):
 
 ```bash
 git clone https://github.com/openenclave/openenclave.git
@@ -19,80 +28,59 @@ This creates a source tree under the directory called openenclave.
 ## Install project requirements
 
 First, change directory into the openenclave repository:
+
 ```bash
 cd openenclave
 ```
 
 Ansible is required to install the project requirements. If not already installed, you can install it by running:
+
 ```bash
 sudo scripts/ansible/install-ansible.sh
 ```
 
-If you are running in an Azure Confidential Compute (ACC) VM and would like to use the attestation features, you should also run the following command from the root of the source tree:
+Install the prerequisites.
 
 ```bash
-ansible-playbook scripts/ansible/oe-contributors-acc-setup.yml
+ansible-playbook scripts/ansible/oe-contributors-setup-sgx1.yml
 ```
-
-If you are not running in an ACC VM, you should instead run:
-
-```bash
-ansible-playbook scripts/ansible/oe-contributors-setup.yml
-```
-
-To support LVI mitigation, the command creates
-`/usr/local/lvi-mitigation/bin` that includes the dependencies.
-
-NOTE: The Ansible playbook commands from above will try and execute tasks with `sudo` rights. Make sure that the user running the playbooks has `sudo` rights, and if it uses a `sudo` password add the following extra parameter `--ask-become-pass`.
 
 ## Build
 
-To build, first create a build directory ("build" in the example below) and change directory into it.
+To build first create a build directory ("build/" in the example below) and change into it.
 
 ```bash
-mkdir build
-cd build
+mkdir build/
+cd build/
 ```
 
-Then run `cmake` to configure the build and generate the Makefiles, and then build by running `make` or 'ninja' depending:
+Then run `cmake` to configure the build and generate the make files and build:
 
 ```bash
-cmake -G "Unix Makefiles" ..
+cmake -DHAS_QUOTE_PROVIDER=OFF ..
 make
+ctest
 ```
-or
-```bash
-cmake -G "Ninja" ..
-ninja
-```
-
-To build with LVI mitigation, run
-
-```bash
-cmake -G "Ninja" .. \
--DLVI_MITIGATION=ControlFlow \
--DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin
-ninja
-```
-
-Refer to [Advanced Build Information](AdvancedBuildInfo.md) and
-[LVI Mitigation](AdvancedBuildInfo.md#lvi-mitigation) documentation for further information.
 
 ## Run unit tests
 
 After building, run all unit test cases using `ctest` to confirm the SDK is built and working as expected.
 
-Run the following command from the build directory:
+Run the following command from the build directory if your system supports SGX1 or SGX1+FLC:
 
 ```bash
 ctest
 ```
 
+If your system does not have SGX support, run the following:
+
+```bash
+OE_SIMULATION=1 ctest
+```
+
 You will see test logs similar to the following:
 
 ```bash
-~/openenclave/build$  ctest
-
 Test project /home/youradminusername/openenclave/build
       Start   1: tests/aesm
 1/123 Test   #1: tests/aesm ...............................................................................................................   Passed    0.98 sec
@@ -120,8 +108,8 @@ For more information refer to the [Advanced Test Info](AdvancedTestInfo.md) docu
 
 ## Install
 
-Follow the instructions in the [Install Info](LinuxInstallInfo.md) document to install the Open Enclave SDK built above.
+ Follow the instructions in the [Install Info](LinuxInstallInfo.md) document to install the Open Enclave SDK built above.
 
 ## Build and run samples
 
-To build and run the samples, please look [here](/samples/README_Linux.md).
+To build and run the samples, please look at [README_Linux.md](/samples/README_Linux.md).

--- a/docs/GettingStartedDocs/Contributors/LinuxInstallInfo.md
+++ b/docs/GettingStartedDocs/Contributors/LinuxInstallInfo.md
@@ -49,13 +49,13 @@ make install DESTDIR=foo
 
 If you also specified a `CMAKE_INSTALL_PREFIX`, this would install the SDK to
 
-```
+```bash
 /foo/opt/openenclave
 ```
 
-## Create a redistributable SDK package
+## Create a redistributable Debian package
 
-To create a redistributable package (e.g. deb, rpm), use `cpack`. Specify
+To create a redistributable Debian package, use `cpack`. Specify
 the final installation prefix to cmake using the `CMAKE_INSTALL_PREFIX` variable
 as above. For example, to create a Debian package that will install the SDK to
 /opt/openenclave, run the following from your build subfolder:
@@ -63,6 +63,18 @@ as above. For example, to create a Debian package that will install the SDK to
 ```bash
 cmake -DCMAKE_INSTALL_PREFIX=/opt/openenclave ..
 cpack -G DEB
+```
+
+## Create a redistributable RPM package
+
+To create a redistributable RPM package, use `cpack`. Specify
+the final installation prefix to cmake using the `CMAKE_INSTALL_PREFIX` variable
+as above. For example, to create a Debian package that will install the SDK to
+/opt/openenclave, run the following from your build subfolder:
+
+```bash
+cmake -DCMAKE_INSTALL_PREFIX=/opt/openenclave ..
+cpack -G PRM
 ```
 
 ## Create the host-only report verification package

--- a/docs/GettingStartedDocs/Contributors/LinuxSamples.md
+++ b/docs/GettingStartedDocs/Contributors/LinuxSamples.md
@@ -1,0 +1,11 @@
+# Installing SDK and using samples
+Assuming you install the SDK as below (also described in the [basic install section](LinuxInstallInfo.md#basic-install-on-Linux))
+
+```bash
+cmake -DCMAKE_INSTALL_PREFIX=~/openenclave ..
+make install
+```
+
+Open Enclave samples can be found in ~/openenclave/share/openenclave/samples
+
+See [Open Enclave samples](/samples/README.md) for details.

--- a/docs/GettingStartedDocs/Contributors/SGX1GettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/SGX1GettingStarted.md
@@ -2,9 +2,8 @@
 
 ## Platform requirements
 
-- Ubuntu 16.04-LTS 64-bits
-- Ubuntu 18.04-LTS 64-bits
-- Red Hat Enterprise Linux 8 64-bits
+- Ubuntu 16.04-LTS 64-bits or Ubuntu 18.04-LTS 64-bits
+- For RHEL8 support, please see [ExperimentalSupportRHEL8.md](ExperimentalSupportRHEL8.md).
 - SGX1 capable system. Most likely this will be an Intel SkyLake or Intel KabyLake system
 
 ## Clone Open Enclave SDK repo from GitHub

--- a/docs/GettingStartedDocs/Contributors/SimulatorGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/SimulatorGettingStarted.md
@@ -2,7 +2,9 @@
 
 ## Platform requirement
 
-- Ubuntu 16.04-LTS 64-bits
+- Ubuntu 16.04-LTS 64-bits or Ubuntu 18.04-LTS 64-bits
+- A machine with an Intel processor
+- For RHEL8 support, please see [ExperimentalSupportRHEL8.md](ExperimentalSupportRHEL8.md).
 
 ## Clone Open Enclave SDK repo from GitHub
 
@@ -18,6 +20,7 @@ This creates a source tree under the directory called openenclave.
 ## Install project prerequisites
 
 Ansible is required to install the project prerequisites. You can install it by running:
+
 ```bash
 sudo ./scripts/ansible/install-ansible.sh
 ```
@@ -25,8 +28,7 @@ sudo ./scripts/ansible/install-ansible.sh
 To install all the Open Enclave prerequisites you can execute the `environment-setup.yml` tasks from `linux/openenclave` Ansible role:
 
 ```bash
-cd scripts/ansible
-ansible localhost -m import_role -a "name=linux/openenclave tasks_from=environment-setup.yml" --become --ask-become-pass
+ansible-playbook scripts/ansible/oe-contributors-setup.yml
 ```
 
 ## Build

--- a/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
@@ -18,6 +18,7 @@
 - [Clang/LLVM for Windows 64-bit](http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe)
 - [Python 3](https://www.python.org/downloads/windows/)
 - [ShellCheck](https://oejenkins.blob.core.windows.net/oejenkins/shellcheck-v0.7.0.zip)
+- [OpenSSL 1.1.1](https://slproweb.com/products/Win32OpenSSL.html)
 
 ## Prerequisites specific to SGX support on your system
 
@@ -43,14 +44,7 @@ C:\Program Files\Git\bin\bash.exe
 ```
 
 Tools available in the Git bash environment are also used for test and sample
-builds. For example, OpenSSL is used to generate test certificates, so it is
-also useful to have the `Git\mingw64\bin` folder added to PATH. This can be checked
-from the command prompt as well:
-
-```cmd
-C:\>where openssl
-C:\Program Files\Git\mingw64\bin\openssl.exe
-```
+builds. It is also useful to have the `Git\mingw64\bin` folder added to PATH.
 
 ## Clang
 
@@ -101,3 +95,7 @@ Python 3 is used as part of the mbedtls tests.
 
 Download the [ShellCheck zip](https://oejenkins.blob.core.windows.net/oejenkins/shellcheck-v0.7.0.zip).
 Inside it there is a shellcheck-v0.7.0.exe which must be copied to a directory in your PATH and renamed to shellcheck.exe.
+
+## OpenSSL
+
+Download and install the latest [Win64 OpenSSL 1.1.1](https://slproweb.com/products/Win32OpenSSL.html). Do not choose the light version; for example, use Win64OpenSSL-1_1_1g.exe, not Win64OpenSSL_Light-1_1_1g.exe.

--- a/docs/GettingStartedDocs/Contributors/building_oe_sdk.md
+++ b/docs/GettingStartedDocs/Contributors/building_oe_sdk.md
@@ -33,22 +33,25 @@ Please refer to the following [documentation](/docs/GettingStartedDocs/SGXSuppor
 
    On Linux, if your target system does not have any SGX hardware support, you may want to choose simulation.
 
-   On Windows, Open Enclave SDK does not support simulation mode.
+   On Windows, Open Enclave SDK supports simulation mode but only on systems with SGX1 or SGX1+FLC support.
 
 #### 3. Build, install and run
 
    Choose an operating mode that is compatible with the SGX support level of your target system.
    The links below contain instructions on how to set up Open Enclave SDK environment for a given mode.
 
-On Linux:
-  - [Setup Open Enclave SDK for SGX1+FLC](SGX1FLCGettingStarted.md)
-  - [Setup Open Enclave SDK for SGX1](SGX1GettingStarted.md)
-  - [Setup Open Enclave SDK for simulation mode](SimulatorGettingStarted.md)
+On Ubuntu 1604 or Ubuntu 1804
+  - [Set up Open Enclave SDK for SGX1+FLC](SGX1FLCGettingStarted.md)
+  - [Set up Open Enclave SDK for SGX1](SGX1GettingStarted.md)
+  - [Set up Open Enclave SDK for simulation mode](SimulatorGettingStarted.md)
 
-On Windows:
+On RHEL8
+ - [Set up Open Enclave SDK on RHEL8](ExperimentalSupportRHEL8.md)
+
+On Windows
  - [Set up Open Enclave SDK for SGX1+FLC](WindowsSGX1FLCGettingStarted.md)
  - [Set up Open Enclave SDK for SGX1](WindowsSGX1GettingStarted.md)
- - Simulation mode is not supported on Windows
+ - Simulation mode is supported on Windows but only on systems that have SGX1 or SGX1+FLC support.
 
 ## Samples
 

--- a/docs/GettingStartedDocs/Debugging.md
+++ b/docs/GettingStartedDocs/Debugging.md
@@ -3,6 +3,11 @@
 For debugging enclaves on Windows using Visual Studio Code see [Windows_vscode.md](./Windows_vscode.md).
 
 For debugging enclaves on Windows using WinDbg Preview see [Windows_windbg.md](./Windows_windbg.md).
+For debugging enclaves on Linux using Visual Studio Code see [Linux_vscode.md](./Linux_vscode.md).
+For debugging enclaves on Windows using Visual Studio see [VisualStudioWindows.md](./VisualStudioWindows.md).
+For debugging enclaves on Linux using Visual Studio see [VisualStudioLinux.md](./VisualStudioLinux.md).
+
+## Using oegdb on Linux
 
 While you can use GDB to debug the host of the enclave app like any other normal process,
 you won’t be able to debug into the enclave’s execution state or memory. To enable that,

--- a/docs/GettingStartedDocs/install_oe_sdk-Simulation.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Simulation.md
@@ -1,20 +1,22 @@
 # Install the Open Enclave SDK (non-SGX Ubuntu 16.04/18.04)
 
 ## Considerations
-The Open Enclave SDK can be installed on non-SGX Ubuntu 16.04 and 18.04 systems. It can also be used in simulation mode, although some features may not work. Specifically these features are not supported when running in simulation mode:
+The Open Enclave SDK can be installed on non-SGX Ubuntu 16.04 and 18.04 systems. Ensure your machine has an Intel processor. It can also be used in simulation mode, although some features may not work. Specifically these features are not supported when running in simulation mode:
 - Enclave signing and measurement
 - Data Sealing
 - Attestation (both remote and local)
 - Signal handling (specifically: the oe_add_vectored_exception_handler and oe_remove_vectored_exception_handler APIs)
 
-Only two of the samples provided in the Open Enclave SDK will function in simulation mode:
+Only three of the samples provided in the Open Enclave SDK will function in simulation mode:
 - helloworld
 - file-encryptor
+- switchless
 
 Note that enclaves that are run in simulation mode are not protected by a trusted execution environment. Therefore, simulation mode should only be used for prototype scenarios and validating ocall/ecalls.
 Also note that simulation mode is subject to being fundamentally changed or removed in the future.
 
 ## How to install and use the SDK for Simulation mode
+
 Follow one of the docs below for your platform, _and skip the driver installation step (step #2)_:
 - [Ubuntu 16.04](install_oe_sdk-Ubuntu_16.04.md)
 - [Ubuntu 18.04](install_oe_sdk-Ubuntu_18.04.md)

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
@@ -8,9 +8,10 @@
     - You can acquire a VM with the required features from [Azure Confidential Compute](https://azure.microsoft.com/en-us/solutions/confidential-compute/).
     - If you are setting up your own device, [check if your existing device supports SGX with FLC](/docs/GettingStartedDocs/Contributors/building_oe_sdk.md#1-determine-the-sgx-support-level-on-your-developmenttarget-system).
         - If your device only supports SGX without FLC, you will need to [clone and build OE SDK](/docs/GettingStartedDocs/Contributors/SGX1GettingStarted.md) for that configuration.
-        - If your device does not support SGX, follow the [instructions for simulation mode](/docs/GettingStartedDocs/install_oe_sdk-Simulation.md).
+        - If your device does not support SGX, follow the [instructions for simulation mode](/docs/GettingStartedDocs/install_oe_sdk-Simulation.md). Please see [instructions for determining SGX support](/docs/GettingStartedDocs/SGXSupportLevel.md) on the machine you are using.
 
 ### 1. Configure the Intel and Microsoft APT Repositories
+
 ```bash
 echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu xenial main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
@@ -23,6 +24,7 @@ wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add 
 ```
 
 ### 2. Install the Intel SGX DCAP Driver
+<<<<<<< HEAD
 Some versions of Ubuntu come with the SGX driver already installed. You can check
 by running with the following:
 
@@ -46,6 +48,7 @@ sudo ./sgx_linux_x64_driver.bin
 > if a more recent SGX DCAP driver exists.
 
 ### 3. Install the Intel and Open Enclave packages and dependencies
+
 ```bash
 sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf9v5 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave
 ```
@@ -55,9 +58,11 @@ sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-
 > implementation for using Intel DCAP outside the Azure environment is coming soon.
 
 If you wish to use the Ninja build system rather than make, also install
+
 ```bash
 sudo apt -y install ninja-build
 ```
+
 If you wish to make use of the Open Enclave CMake package, please install CMake and [follow the instructions here](/cmake/sdk_cmake_targets_readme.md).
 
 ### 4. Verify the Open Enclave SDK install

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
@@ -8,7 +8,7 @@
     - You can acquire a VM with the required features from [Azure Confidential Compute](https://azure.microsoft.com/en-us/solutions/confidential-compute/).
     - If you are setting up your own device, [check if your existing device supports SGX with FLC](/docs/GettingStartedDocs/Contributors/building_oe_sdk.md#1-determine-the-sgx-support-level-on-your-developmenttarget-system).
         - If your device only supports SGX without FLC, you will need to [clone and build OE SDK](/docs/GettingStartedDocs/Contributors/SGX1GettingStarted.md) for that configuration.
-        - If your device does not support SGX, follow the [instructions for simulation mode](/docs/GettingStartedDocs/install_oe_sdk-Simulation.md).
+        - If your device does not support SGX, follow the [instructions for simulation mode](/docs/GettingStartedDocs/install_oe_sdk-Simulation.md). Please see [instructions for determining SGX support](/docs/GettingStartedDocs/SGXSupportLevel.md) on the machine you are using.
 
 ### 1. Configure the Intel and Microsoft APT Repositories
 ```bash

--- a/samples/README_Linux.md
+++ b/samples/README_Linux.md
@@ -128,7 +128,7 @@ The following samples demonstrate how to develop enclave applications using OE A
 
 #### [Data-Sealing](data-sealing/README.md)
 
-- Introduce OE sealing and unsealing features 
+- Introduce OE sealing and unsealing features
 - Demonstrate how to use OE sealing APIs
 - Explore two supported seal polices
   - OE_SEAL_POLICY_UNIQUE

--- a/samples/file-encryptor/README.md
+++ b/samples/file-encryptor/README.md
@@ -152,3 +152,13 @@ cd file-encryptor
 make build
 make run
 ```
+
+#### Note
+
+Fileencryptor sample can run under OE simulation mode.
+
+To run the sample in simulation mode from the command like, use the following:
+
+```bash
+./host/file-encryptor_host ./enclave/enclave.signed --simulate
+```

--- a/samples/switchless/README.md
+++ b/samples/switchless/README.md
@@ -233,6 +233,7 @@ cd switchless
 make build
 make run
 ```
+
 #### Note
 
 switchless sample can run under Open Enclave simulation mode.


### PR DESCRIPTION
Signed-off-by: Radhika Jandhyala <radhikaj@microsoft.com>

Add experimental support for RHEL8
Fix docs for simulation mode on Linux and Windows.
On Linux,  on a non SGX VM it is possible to build SDK from source and also install the SDK package and run samples in simulation mode.
On Windows, you need an SGX1 or an SGX1+FLC machine to use simulation mode.
Have updated docs to say "Use a machine with an intel processor"