### PR TITLE
Fix typos in error messages

### DIFF
--- a/common/sgx/quote.c
+++ b/common/sgx/quote.c
@@ -529,7 +529,7 @@ oe_result_t oe_verify_quote_with_sgx_endorsements(
     oe_datetime_log("Validation datetime: ", &validation_time);
     if (oe_datetime_compare(&validation_time, &validity_from) < 0)
     {
-        oe_datetime_log("Latests valid datetime: ", &validity_from);
+        oe_datetime_log("Latest valid datetime: ", &validity_from);
         OE_RAISE_MSG(
             OE_VERIFY_FAILED_TO_FIND_VALIDITY_PERIOD,
             "Time to validate quote is earlier than the "
@@ -541,7 +541,7 @@ oe_result_t oe_verify_quote_with_sgx_endorsements(
         oe_datetime_log("Earliest expiration datetime: ", &validity_until);
         OE_RAISE_MSG(
             OE_VERIFY_FAILED_TO_FIND_VALIDITY_PERIOD,
-            "Time to validate quoteis later than the "
+            "Time to validate quote is later than the "
             "earliest 'valid to' value.",
             NULL);
     }

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -539,19 +539,19 @@ oe_result_t oe_sgx_validate_enclave_properties(
         if (field_name)
             *field_name = "config.product_id";
         OE_TRACE_ERROR(
-            "oe_sgx_is_valid_product_id failed: num_tcs = %x\n",
+            "oe_sgx_is_valid_product_id failed: product_id = %x\n",
             properties->config.product_id);
         result = OE_FAILURE;
         goto done;
     }
 
-    if (!oe_sgx_is_valid_security_version(properties->config.product_id))
+    if (!oe_sgx_is_valid_security_version(properties->config.security_version))
     {
         if (field_name)
             *field_name = "config.security_version";
         OE_TRACE_ERROR(
             "oe_sgx_is_valid_security_version failed: security_version = %x\n",
-            properties->config.product_id);
+            properties->config.security_version);
         result = OE_FAILURE;
         goto done;
     }


### PR DESCRIPTION
While investigating unrelated issues, I noticed a few copy-paste errors during validation and typos in the resulting messages. This fixes those.