### PR TITLE
Add Windows cross-compilation test to daily build

### DIFF
--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -123,9 +123,11 @@ try{
       }
     } else {
       stage("PR Testing") {
-        parallel "Win2016 Sim Release Cross Compile LVI " :                 { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
+        parallel "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build LVI" : { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow') },
+                 "Win2016 Sim Release Cross Compile LVI " :                 { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
                  "Win2016 Debug Cross Compile DCAP LVI" :                   { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
                  "Win2016 Release Cross Compile DCAP LVI" :                 { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow', '0', 'ON') }
+                 //"Win2019 Ubuntu1804 clang-7 Release Linux-Elf-build LVI" : { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow') },
                  //"Win2019 Sim Release Cross Compile LVI " :                 { windowsCrossCompile('acc-win2019', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
                  //"Win2019 Debug Cross Compile DCAP LVI" :                   { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
                  //"Win2019 Release Cross Compile DCAP LVI" :                 { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow', '0', 'ON') }


### PR DESCRIPTION
This PR brings back the test of Windows cross-compilation to the daily build; i.e., building enclave binaries in a linux container and testing the binaries on the Windows host.
This allows the daily build to catch bugs that cause such workflow to fail.

Note that the PR only adds two of the configurations, which should be sufficient to test the workflow. The full list of configurations is tested by nightly build.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>