### PR TITLE
Dynamically load Intel SGX Enclave Common shared library

### DIFF
--- a/3rdparty/intel/sgx_enclave_common.h
+++ b/3rdparty/intel/sgx_enclave_common.h
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2011-2018 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+
+
+#ifndef _SGX_ENCLAVE_COMMON_H_
+#define _SGX_ENCLAVE_COMMON_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#ifdef _MSC_VER
+#include <sal.h>
+#include <Windows.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _MSC_VER
+/* The following macros are MSVC only */
+#define COMM_API     cdecl
+#define COMM_IN      _In_
+#define COMM_IN_OPT  _In_opt_
+#define COMM_OUT     _Out_
+#define COMM_OUT_OPT _Out_opt_
+#define COMM_IN_OUT  _Inout_
+#else
+/* The following macros are for GCC only */
+#define COMM_API
+#define COMM_IN
+#define COMM_IN_OPT
+#define COMM_OUT
+#define COMM_OUT_OPT
+#define COMM_IN_OUT
+#endif
+
+#ifndef ENCLAVE_TYPE_SGX
+#define ENCLAVE_TYPE_SGX            0x00000001    /* An enclave for the Intel Software Guard Extensions (SGX) architecture version 1. */
+#endif
+#ifndef ENCLAVE_TYPE_SGX2
+#define ENCLAVE_TYPE_SGX2           0x00000002    /* An enclave for the Intel Software Guard Extensions (SGX) architecture version 2. */
+#endif
+#define ENCLAVE_TYPE_SGX1 ENCLAVE_TYPE_SGX
+
+#define ENCLAVE_MK_ERROR(x)              (0x00000000|(x))
+
+typedef enum
+{
+    ENCLAVE_ERROR_SUCCESS                   = ENCLAVE_MK_ERROR(0x0000),      /* No error. */
+    ENCLAVE_NOT_SUPPORTED                   = ENCLAVE_MK_ERROR(0x0001),      /* Enclave type not supported, Intel® SGX is not supported, the Intel® SGX device is not present, or the AESM Service is not running. */
+    ENCLAVE_INVALID_SIG_STRUCT              = ENCLAVE_MK_ERROR(0x0002),      /* SGX - SIGSTRUCT contains an invalid value. */
+    ENCLAVE_INVALID_SIGNATURE               = ENCLAVE_MK_ERROR(0x0003),      /* SGX – Invalid Signature or SIGSTRUCT. */
+    ENCLAVE_INVALID_ATTRIBUTE               = ENCLAVE_MK_ERROR(0x0004),      /* SGX - Invalid SECS Attribute. */
+    ENCLAVE_INVALID_MEASUREMENT             = ENCLAVE_MK_ERROR(0x0005),      /* SGX - Invalid measurement. */
+    ENCLAVE_NOT_AUTHORIZED                  = ENCLAVE_MK_ERROR(0x0006),      /* Enclave not authorized to run. */
+    ENCLAVE_INVALID_ENCLAVE                 = ENCLAVE_MK_ERROR(0x0007),      /* Address is not a valid enclave. */
+    ENCLAVE_LOST                            = ENCLAVE_MK_ERROR(0x0008),      /* SGX - Enclave is lost (likely due to a power event). */
+    ENCLAVE_INVALID_PARAMETER               = ENCLAVE_MK_ERROR(0x0009),      /* Invalid Parameter (unspecified) - may be due to type length/format. */
+    ENCLAVE_OUT_OF_MEMORY                   = ENCLAVE_MK_ERROR(0x000a),      /* Out of memory. May be a result of allocation failure in the API or internal function calls. */
+    ENCLAVE_DEVICE_NO_RESOURCES             = ENCLAVE_MK_ERROR(0x000b),      /* Out of EPC Memory. */
+    ENCLAVE_ALREADY_INITIALIZED             = ENCLAVE_MK_ERROR(0x000c),      /* Enclave has already been initialized. */
+    ENCLAVE_INVALID_ADDRESS                 = ENCLAVE_MK_ERROR(0x000d),      /* Address is not within a valid enclave. Address has already been committed. */
+    ENCLAVE_RETRY                           = ENCLAVE_MK_ERROR(0x000e),      /* Please retry the operation - there was an unmasked event in EINIT. */
+    ENCLAVE_INVALID_SIZE                    = ENCLAVE_MK_ERROR(0x000f),      /* An invalid size was entered. */
+    ENCLAVE_NOT_INITIALIZED                 = ENCLAVE_MK_ERROR(0x0010),      /* The enclave is not initialized - the operation requires that the enclave be initialized. */
+    ENCLAVE_SERVICE_TIMEOUT                 = ENCLAVE_MK_ERROR(0x0011),      /* The launch service timed out when attempting to obtain a launch token.  Check to ensure that the AESM service is running and accessible. */
+    ENCLAVE_UNEXPECTED                      = ENCLAVE_MK_ERROR(0x1001),      /* Unexpected error. */
+} enclave_error_t;
+
+typedef enum
+{
+    ENCLAVE_PAGE_READ           = 1 << 0,      /* Enables read access to the committed region of pages. */
+    ENCLAVE_PAGE_WRITE          = 1 << 1,      /* Enables write access to the committed region of pages. */
+    ENCLAVE_PAGE_EXECUTE        = 1 << 2,      /* Enables execute access to the committed region of pages. */
+    ENCLAVE_PAGE_THREAD_CONTROL = 1 << 8,      /* The page contains a thread control structure. */
+    ENCLAVE_PAGE_UNVALIDATED    = 1 << 12,     /* The page contents that you supply are excluded from measurement and content validation. */
+} enclave_page_properties_t;
+
+typedef enum 
+{
+    ENCLAVE_LAUNCH_TOKEN = 0x1,
+} enclave_info_type_t;
+
+#define SECS_SIZE 4096
+#define SIGSTRUCT_SIZE 1808
+
+typedef struct enclave_create_sgx_t 
+{
+    uint8_t secs[SECS_SIZE];
+} enclave_create_sgx_t;
+
+typedef struct enclave_init_sgx_t 
+{
+    uint8_t sigstruct[SIGSTRUCT_SIZE];
+} enclave_init_sgx_t;
+
+/* enclave_create()
+ * Parameters:
+ *      base_address [in, optional] - An optional preferred base address for the enclave.
+ *      virtual_size [in] - The virtual address range of the enclave in bytes.
+ *      initial_commit[in] - The amount of physical memory to reserve for the initial load of the enclave in bytes.
+ *      type [in] - The architecture type of the enclave that you want to create.
+ *      info [in] - A pointer to the architecture-specific information to use to create the enclave.
+ *      info_size [in] - The length of the structure that the info parameter points to, in bytes.
+ *      enclave_error [out, optional] - An optional pointer to a variable that receives an enclave error code.
+ * Return Value:
+ *      If the function succeeds, the return value is the base address of the created enclave.
+ *      If the function fails, the return value is NULL. The extended error information will be in the enclave_error parameter if used.
+*/
+void* COMM_API enclave_create
+(
+    COMM_IN_OPT  void*        base_address,
+    COMM_IN      size_t       virtual_size,
+    COMM_IN      size_t       initial_commit,
+    COMM_IN      uint32_t     type,
+    COMM_IN      const void*  info,
+    COMM_IN      size_t       info_size,
+    COMM_OUT_OPT uint32_t*    enclave_error 
+);
+
+/* enclave_load_data()
+ * Parameters:
+ *      target_address [in] - The address in the enclave where you want to load the data.
+ *      target_size [in] - The size of the range that you want to load in the enclave, in bytes. 
+ *      source_buffer [in, optional] - An optional pointer to the data you want to load into the enclave.
+ *      data_properties [in] - The properties of the pages you want to add to the enclave.
+ *      enclave_error [out, optional] - An optional pointer to a variable that receives an enclave error code.
+ * Return Value:
+ *      The return value is the number of bytes that was loaded into the enclave.
+ *      If the number is different than target_size parameter an error occurred. The extended error information will be in the enclave_error parameter if used.
+*/
+size_t COMM_API enclave_load_data
+(
+    COMM_IN      void*        target_address,
+    COMM_IN      size_t       target_size,
+    COMM_IN_OPT  const void*  source_buffer,
+    COMM_IN      uint32_t     data_properties,
+    COMM_OUT_OPT uint32_t*    enclave_error 
+);
+
+/* enclave_initialize()
+ * Parameters:
+ *      base_address [in] - The enclave base address as returned from the enclave_create API.
+ *      info [in] - A pointer to the architecture-specific information to use to initialize the enclave. 
+ *      info_size [in] - The length of the structure that the info parameter points to, in bytes.
+ *      enclave_error [out, optional] - An optional pointer to a variable that receives an enclave error code.
+ * Return Value:
+ *      non-zero - The function succeeds.
+ *      zero - The function fails and the extended error information will be in the enclave_error parameter if used.
+*/
+bool COMM_API enclave_initialize
+(
+    COMM_IN      void*        base_address,
+    COMM_IN      const void*  info,
+    COMM_IN      size_t       info_size,
+    COMM_OUT_OPT uint32_t*    enclave_error 
+);
+
+/* enclave_delete()
+ * Parameters:
+ *      base_address [in] - The enclave base address as returned from the enclave_create API.
+ *      enclave_error [out, optional] - An optional pointer to a variable that receives an enclave error code.
+ * Return Value:
+ *      non-zero - The function succeeds.
+ *      zero - The function fails and the extended error information will be in the enclave_error parameter if used.
+*/
+bool COMM_API enclave_delete
+(
+    COMM_IN      void*        base_address,
+    COMM_OUT_OPT uint32_t*    enclave_error 
+);
+
+/* enclave_get_information()
+ * Parameters:
+ *      base_address [in] - The enclave base address as returned from the enclave_create API.
+ *      info_type[in] - Identifies the type of information requested. initialized.
+ *      output_info[out] - Pointer to information returned by the API
+ *      output_info_size[in, out] - Size of the output_info buffer, in bytes.  If the API succeeds, then this will return the number of bytes returned in output_info.  If the API fails with, ENCLAVE_INVALID_SIZE, then this will return the required size
+ *      enclave_error [out, optional] - An optional pointer to a variable that receives an enclave error code. 
+ * Return Value:
+ *      non-zero - The function succeeds.
+ *      zero - The function fails and the extended error information will be in the enclave_error parameter if used.
+ */
+bool COMM_API enclave_get_information
+(
+    COMM_IN void* base_address,
+    COMM_IN uint32_t info_type,
+    COMM_OUT void* output_info,
+    COMM_IN_OPT size_t* output_info_size,
+    COMM_OUT_OPT uint32_t* enclave_error
+);
+
+/* enclave_set_information
+ * Parameters:
+ *      base_address [in] - The enclave base address as returned from the enclave_create API.
+ *      info_type[in] - Identifies the type of information requested. not been initialized.
+ *      input_info[in] - Pointer to information provided to the API
+ *      input_info_size[in] - Size of the information, in bytes, provided in input_info from the API.
+ *      enclave_error [out, optional] - An optional pointer to a variable that receives an enclave error code. 
+ * Return Value:
+ *      non-zero - The function succeeds.
+ *      zero - The function fails and the extended error information will be in the enclave_error parameter if used.
+ */
+bool COMM_API enclave_set_information
+(
+    COMM_IN void* base_address,
+    COMM_IN uint32_t info_type,
+    COMM_IN void* input_info,
+    COMM_IN size_t input_info_size,
+    COMM_OUT_OPT uint32_t* enclave_error
+);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -172,6 +172,7 @@ if (UNIX)
     crypto/openssl/key.c
     crypto/openssl/rsa.c
     crypto/openssl/sha.c
+    linux/dynload.c
     linux/hostthread.c)
 
   list(APPEND PLATFORM_SDK_ONLY_SRC
@@ -192,6 +193,7 @@ elseif (WIN32)
     crypto/bcrypt/sha.c
     crypto/bcrypt/pem.c
     crypto/bcrypt/util.c
+    windows/dynload.c
     windows/hostthread.c)
 
   list(APPEND PLATFORM_SDK_ONLY_SRC
@@ -260,6 +262,7 @@ if (OE_SGX)
     sgx/quote.c
     sgx/registers.c
     sgx/report.c
+    sgx/sgx_enclave_common.c
     sgx/sgxload.c
     sgx/sgxmeasure.c
     sgx/sgxquote.c
@@ -446,29 +449,13 @@ endif ()
 target_include_directories(oehost PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 if (OE_SGX)
-  # Always link with the EnclaveCommonAPI
-  if (WIN32)
-    set(LIBPATHS ${NUGET_PACKAGE_PATH}/EnclaveCommonAPI/lib/native/x64-Release)
-    set(INCPATHS "${NUGET_PACKAGE_PATH}/EnclaveCommonAPI/Header Files")
-  endif ()
+  # For sgx_enclave_common.h.
+  target_include_directories(oehost PRIVATE
+    ${CMAKE_SOURCE_DIR}/3rdparty/intel)
+
   if (NOT LIBPATHS)
     set(LIBPATHS "/usr")
   endif ()
-  find_library(LIBSGX_COMMON NAMES sgx_enclave_common HINTS ${LIBPATHS})
-  if (NOT LIBSGX_COMMON)
-    message(FATAL_ERROR "Intel SGX EnclaveCommonAPI library not found, aborting!")
-  endif ()
-  add_library(sgx_enclave_common SHARED IMPORTED)
-  if (WIN32)
-     set_target_properties(sgx_enclave_common PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${INCPATHS}"
-        IMPORTED_LOCATION $ENV{WINDIR}/System32
-        IMPORTED_IMPLIB ${LIBSGX_COMMON})
-  elseif (UNIX)
-    set_target_properties(sgx_enclave_common PROPERTIES IMPORTED_LOCATION ${LIBSGX_COMMON})
-  endif ()
-  target_link_libraries(oehost PUBLIC $<BUILD_INTERFACE:sgx_enclave_common>)
-
   # Optionally link in DCAP library
   if (HAS_QUOTE_PROVIDER)
     if (WIN32)

--- a/host/dynload.h
+++ b/host/dynload.h
@@ -1,0 +1,17 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_HOST_DYNLOAD_H
+#define _OE_HOST_DYNLOAD_H
+
+#include <openenclave/bits/defs.h>
+
+OE_EXTERNC_BEGIN
+
+void* oe_shared_library_load(const char* name);
+void oe_shared_library_unload(void* handle);
+void* oe_shared_library_lookup(void* handle, const char* function);
+
+OE_EXTERNC_END
+
+#endif /* _OE_HOST_DUPENV_H */

--- a/host/linux/dynload.c
+++ b/host/linux/dynload.c
@@ -1,0 +1,20 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "../dynload.h"
+#include <dlfcn.h>
+
+void* oe_shared_library_load(const char* name)
+{
+    return dlopen(name, RTLD_LAZY | RTLD_LOCAL);
+}
+
+void oe_shared_library_unload(void* handle)
+{
+    dlclose(handle);
+}
+
+void* oe_shared_library_lookup(void* handle, const char* function)
+{
+    return dlsym(handle, function);
+}

--- a/host/sgx/sgx_enclave_common.c
+++ b/host/sgx/sgx_enclave_common.c
@@ -1,0 +1,214 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "sgx_enclave_common.h"
+#include <openenclave/internal/trace.h>
+#include <stdlib.h>
+#include "../dynload.h"
+#include "../hostthread.h"
+
+/****** Pointers to functions in libsgx_enclave_common.so **************/
+static void* COMM_API (*_enclave_create)(
+    COMM_IN_OPT void* base_address,
+    COMM_IN size_t virtual_size,
+    COMM_IN size_t initial_commit,
+    COMM_IN uint32_t type,
+    COMM_IN const void* info,
+    COMM_IN size_t info_size,
+    COMM_OUT_OPT uint32_t* enclave_error);
+
+static size_t COMM_API (*_enclave_load_data)(
+    COMM_IN void* target_address,
+    COMM_IN size_t target_size,
+    COMM_IN_OPT const void* source_buffer,
+    COMM_IN uint32_t data_properties,
+    COMM_OUT_OPT uint32_t* enclave_error);
+
+bool COMM_API (*_enclave_initialize)(
+    COMM_IN void* base_address,
+    COMM_IN const void* info,
+    COMM_IN size_t info_size,
+    COMM_OUT_OPT uint32_t* enclave_error);
+
+bool COMM_API (*_enclave_delete)(
+    COMM_IN void* base_address,
+    COMM_OUT_OPT uint32_t* enclave_error);
+
+static bool COMM_API (*_enclave_set_information)(
+    COMM_IN void* base_address,
+    COMM_IN uint32_t info_type,
+    COMM_IN void* input_info,
+    COMM_IN size_t input_info_size,
+    COMM_OUT_OPT uint32_t* enclave_error);
+
+/****** Dynamic loading of libsgx_enclave_common.so/.dll **************/
+static void* _module;
+
+static void _unload_libsgx_enclave_common(void)
+{
+    if (_module)
+        oe_shared_library_unload(_module);
+}
+
+static void _load_libsgx_enclave_common_impl(void)
+{
+    oe_result_t result = OE_FAILURE;
+    void* module = _module;
+    if (!module)
+    {
+#if _WIN32
+        const char* library_name = "sgx_enclave_common.dll";
+#else
+        const char* library_name = "libsgx_enclave_common.so";
+#endif
+        OE_TRACE_INFO("Loading %s\n", library_name);
+        module = oe_shared_library_load(library_name);
+        if (module)
+        {
+            *(void**)&_enclave_create =
+                oe_shared_library_lookup(module, "enclave_create");
+            if (!_enclave_create)
+            {
+                OE_TRACE_ERROR("enclave_create function not found.\n");
+                goto done;
+            }
+
+            *(void**)&_enclave_load_data =
+                oe_shared_library_lookup(module, "enclave_load_data");
+            if (!_enclave_load_data)
+            {
+                OE_TRACE_ERROR("enclave_load_data function not found.\n");
+                goto done;
+            }
+
+            *(void**)&_enclave_initialize =
+                oe_shared_library_lookup(module, "enclave_initialize");
+            if (!_enclave_initialize)
+            {
+                OE_TRACE_ERROR("enclave_initialize function not found.\n");
+                goto done;
+            }
+
+            *(void**)&_enclave_delete =
+                oe_shared_library_lookup(module, "enclave_delete");
+            if (!_enclave_delete)
+            {
+                OE_TRACE_ERROR("enclave_delete function not found.\n");
+                goto done;
+            }
+
+            *(void**)&_enclave_set_information =
+                oe_shared_library_lookup(module, "enclave_set_information");
+            if (!_enclave_set_information)
+            {
+                OE_TRACE_ERROR("enclave_set_information function not found.\n");
+                goto done;
+            }
+
+            _module = module;
+            atexit(_unload_libsgx_enclave_common);
+            result = OE_OK;
+            OE_TRACE_INFO("Loaded %s\n", library_name);
+        }
+    }
+
+done:
+    if (result != OE_OK)
+    {
+        if (module)
+            oe_shared_library_unload(module);
+    }
+}
+
+static bool _load_libsgx_enclave_common(void)
+{
+    static oe_once_type _once;
+    oe_once(&_once, _load_libsgx_enclave_common_impl);
+    return (_module != NULL);
+}
+
+/****** Wrappers for functions in libsgx_enclave_common.so **************/
+void* COMM_API enclave_create(
+    COMM_IN_OPT void* base_address,
+    COMM_IN size_t virtual_size,
+    COMM_IN size_t initial_commit,
+    COMM_IN uint32_t type,
+    COMM_IN const void* info,
+    COMM_IN size_t info_size,
+    COMM_OUT_OPT uint32_t* enclave_error)
+{
+    if (!_load_libsgx_enclave_common())
+    {
+        *enclave_error = ENCLAVE_NOT_SUPPORTED;
+        return NULL;
+    }
+    return _enclave_create(
+        base_address,
+        virtual_size,
+        initial_commit,
+        type,
+        info,
+        info_size,
+        enclave_error);
+}
+
+size_t COMM_API enclave_load_data(
+    COMM_IN void* target_address,
+    COMM_IN size_t target_size,
+    COMM_IN_OPT const void* source_buffer,
+    COMM_IN uint32_t data_properties,
+    COMM_OUT_OPT uint32_t* enclave_error)
+{
+    if (!_load_libsgx_enclave_common())
+    {
+        *enclave_error = ENCLAVE_NOT_SUPPORTED;
+        return 0;
+    }
+    return _enclave_load_data(
+        target_address,
+        target_size,
+        source_buffer,
+        data_properties,
+        enclave_error);
+}
+
+bool COMM_API enclave_initialize(
+    COMM_IN void* base_address,
+    COMM_IN const void* info,
+    COMM_IN size_t info_size,
+    COMM_OUT_OPT uint32_t* enclave_error)
+{
+    if (!_load_libsgx_enclave_common())
+    {
+        *enclave_error = ENCLAVE_NOT_SUPPORTED;
+        return false;
+    }
+    return _enclave_initialize(base_address, info, info_size, enclave_error);
+}
+
+bool COMM_API
+enclave_delete(COMM_IN void* base_address, COMM_OUT_OPT uint32_t* enclave_error)
+{
+    if (!_load_libsgx_enclave_common())
+    {
+        *enclave_error = ENCLAVE_NOT_SUPPORTED;
+        return false;
+    }
+    return _enclave_delete(base_address, enclave_error);
+}
+
+bool COMM_API enclave_set_information(
+    COMM_IN void* base_address,
+    COMM_IN uint32_t info_type,
+    COMM_IN void* input_info,
+    COMM_IN size_t input_info_size,
+    COMM_OUT_OPT uint32_t* enclave_error)
+{
+    if (!_load_libsgx_enclave_common())
+    {
+        *enclave_error = ENCLAVE_NOT_SUPPORTED;
+        return false;
+    }
+    return _enclave_set_information(
+        base_address, info_type, input_info, input_info_size, enclave_error);
+}

--- a/host/windows/dynload.c
+++ b/host/windows/dynload.c
@@ -1,0 +1,20 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "../dynload.h"
+#include <Windows.h>
+
+void* oe_shared_library_load(const char* name)
+{
+    return (void*)LoadLibraryEx(name, NULL, 0);
+}
+
+void oe_shared_library_unload(void* handle)
+{
+    FreeLibrary((HANDLE)handle);
+}
+
+void* oe_shared_library_lookup(void* handle, const char* function)
+{
+    return (void*)GetProcAddress((HANDLE)handle, function);
+}

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -30,6 +30,7 @@ tests/mbed/tests\..*$
 
 # Directories
 3rdparty/dlmalloc/dlmalloc/.*
+3rdparty/intel/.*
 3rdparty/libcxx/libcxx/.*
 3rdparty/libcxxrt/libcxxrt/.*
 3rdparty/libunwind/libunwind/.*


### PR DESCRIPTION
This eliminates that the host application had on Intel SGX Enclave Common Library.

This PR would allow the SDK to be built without the library being present in the
build system. Additionally, it will help make simulation mode work on non-sgx systems.

This based on the same approach we do for the DCAP Quote Provider shared library.
(libdcap_quoteprove.so). See host/sgx/linux/sgxquoteproviderloader.c.

We keep copy of sgx_enclave_common.h in 3rdparty/intel. This describes the
contract between OE SDK and the sgx_enclave_common shared library.

The shared library is lazily loaded via a oe_once function.
Necessary functions are looked up and cached.

NTH:
libsgx_enclave_common.so can provide a version information that the OE SDK
can use to determine if the library conforms to the contract at the time
the SDK was built.

Testing:
1) The existing CI tests will automatically lockdown the case where
   the library exists.
2) We need tests for
   - Case when the library is not present
   - Case when the library is present, but does not have all the
     functions.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>