### PR TITLE
Add option to format-code to only format staged changes

### DIFF
--- a/scripts/format-code
+++ b/scripts/format-code
@@ -51,6 +51,10 @@ do
     -w | --whatif)
         whatif=1
         ;;
+    -s | --staged)
+        # Only format files which are staged to be committed
+        userFiles="$(git diff --cached --name-only --diff-filter=ACMR)"
+        ;;
 
     --exclude-dirs=*)
         userExcludeDirs="${opt#*=}"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -39,7 +39,7 @@ scripts=$(git rev-parse --show-toplevel)/scripts
 
 # shellcheck disable=SC2154
 if ! "$scripts/format-code" --quiet --whatif --files="${files[*]}"; then
-    exit_ "Commit failed: please run './scripts/format-code' to fix the formatting"
+    exit_ "Commit failed: please run './scripts/format-code --staged' to fix the formatting"
 fi
 
 if ! "$scripts/check-license" "${files[@]}"; then


### PR DESCRIPTION
The git pre-commit hook only checks staged files, but then we advise people in the error message to run format-code on every file in the repo when this is not really necessary. Add a `--staged` flag to format code and suggest that people use that in the pre-commit hook error message.