### PR TITLE
Change OE_TRACE_ERROR to OE_TRACE_WARNING when non-standard API is not available

### DIFF
--- a/host/sgx/linux/sgxquoteproviderloader.c
+++ b/host/sgx/linux/sgxquoteproviderloader.c
@@ -41,8 +41,9 @@ void oe_load_quote_provider()
             }
             else
             {
-                OE_TRACE_INFO("sgxquoteprovider: sgx_ql_set_logging_function "
-                              "not found\n");
+                OE_TRACE_WARNING(
+                    "sgxquoteprovider: sgx_ql_set_logging_function "
+                    "not found\n");
             }
 
             provider.get_sgx_quote_verification_collateral = dlsym(

--- a/host/sgx/linux/sgxquoteproviderloader.c
+++ b/host/sgx/linux/sgxquoteproviderloader.c
@@ -41,8 +41,8 @@ void oe_load_quote_provider()
             }
             else
             {
-                OE_TRACE_ERROR("sgxquoteprovider: sgx_ql_set_logging_function "
-                               "not found\n");
+                OE_TRACE_INFO("sgxquoteprovider: sgx_ql_set_logging_function "
+                              "not found\n");
             }
 
             provider.get_sgx_quote_verification_collateral = dlsym(

--- a/host/sgx/windows/sgxquoteproviderloader.c
+++ b/host/sgx/windows/sgxquoteproviderloader.c
@@ -40,8 +40,9 @@ void oe_load_quote_provider()
             }
             else
             {
-                OE_TRACE_ERROR("sgxquoteprovider: sgx_ql_set_logging_function "
-                               "not found\n");
+                OE_TRACE_WARNING(
+                    "sgxquoteprovider: sgx_ql_set_logging_function "
+                    "not found\n");
             }
 
             provider.get_sgx_quote_verification_collateral =


### PR DESCRIPTION
Function sgx_ql_set_logging_function is an Azure DCAP client specific API, which is not defined in Intel DCAP standard spec. To enable OE to be used in non-ACC environments, a warning, instead of an error, is given when this non-standard API is not available.