### PR TITLE
Don't copy sgx DLLs to system32 on Windows Server 2019

### DIFF
--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -583,11 +583,6 @@ function Install-DCAP-Dependencies {
                 }
                 Write-Output $install
             }
-            elseif ($LaunchConfiguration -eq "SGX1FLC-NoDriver")
-            {
-                Write-Output "Copying Intel_SGX_DCAP dll files into $($env:SystemRoot)\system32"
-                Copy-item -Path $PACKAGES_DIRECTORY\Intel_SGX_DCAP\$driver\drivers\*\*.dll $env:SystemRoot\system32\
-            }
         }
     }
 


### PR DESCRIPTION
Windows Server 2019 installs the SGX system libraries via Windows Update/Device Manager. Do not overwrite these system32 DLLs in the installprereqs script.