### PR TITLE
Test public headers against C99 standard

### DIFF
--- a/host/sgx/enclave.h
+++ b/host/sgx/enclave.h
@@ -90,7 +90,7 @@ oe_thread_binding_t* oe_get_thread_binding(void);
  *  This structure must be kept in sync with the defines in
  *  debugger/pythonExtension/gdb_sgx_plugin.py.
  */
-struct _oe_enclave
+typedef struct _oe_enclave
 {
     /* A "magic number" to validate structure */
     uint64_t magic;
@@ -130,7 +130,7 @@ struct _oe_enclave
 
     /* Manager for switchless calls */
     oe_switchless_call_manager_t* switchless_manager;
-};
+} oe_enclave_t;
 
 /* Get the event for the given TCS */
 EnclaveEvent* GetEnclaveEvent(oe_enclave_t* enclave, uint64_t tcs);

--- a/include/openenclave/corelibc/bits/types.h
+++ b/include/openenclave/corelibc/bits/types.h
@@ -6,7 +6,6 @@
 
 #include <openenclave/bits/types.h>
 
-typedef int64_t oe_intptr_t;
 typedef uint32_t oe_mode_t;
 typedef int64_t oe_off_t;
 typedef uint64_t oe_ino_t;
@@ -17,8 +16,6 @@ typedef int oe_pid_t;
 typedef uint64_t oe_nlink_t;
 typedef int64_t oe_blksize_t;
 typedef int64_t oe_blkcnt_t;
-typedef int64_t oe_time_t;
-typedef int64_t oe_suseconds_t;
 typedef uint32_t oe_socklen_t;
 typedef uint16_t oe_sa_family_t;
 typedef uint16_t oe_in_port_t;
@@ -28,7 +25,6 @@ struct oe_dirent;
 
 #if defined(OE_NEED_STDC_NAMES)
 
-typedef oe_intptr_t intptr_t;
 typedef oe_mode_t mode_t;
 typedef oe_off_t off_t;
 typedef oe_ino_t ino_t;
@@ -39,8 +35,6 @@ typedef oe_pid_t pid_t;
 typedef oe_nlink_t nlink_t;
 typedef oe_blksize_t blksize_t;
 typedef oe_blkcnt_t blkcnt_t;
-typedef oe_time_t time_t;
-typedef oe_suseconds_t suseconds_t;
 typedef oe_socklen_t socklen_t;
 typedef oe_sa_family_t sa_family_t;
 typedef oe_in_port_t in_port_t;

--- a/include/openenclave/internal/crypto/crl.h
+++ b/include/openenclave/internal/crypto/crl.h
@@ -16,8 +16,6 @@ typedef struct _oe_crl
     uint64_t impl[4];
 } oe_crl_t;
 
-typedef struct _oe_crl oe_crl_t;
-
 /**
  * Read a certificate revocation list (CRL) from DER format.
  *

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ if (UNIX OR ADD_WINDOWS_ENCLAVE_TESTS OR USE_CLANGW)
         add_subdirectory(stack_smashing_protector)
     endif()
 
+add_subdirectory(c99_compliant)
 add_subdirectory(create-errors)
 add_subdirectory(crypto)
 add_subdirectory(hexdump)

--- a/tests/c99_compliant/CMakeLists.txt
+++ b/tests/c99_compliant/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+	add_subdirectory(enc)
+endif()
+
+add_enclave_test(tests/c99_compliant c99_compliant_host c99_compliant_enc)

--- a/tests/c99_compliant/c99_compliant.edl
+++ b/tests/c99_compliant/c99_compliant.edl
@@ -1,0 +1,8 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+        public int enc_c99_compliant();
+    };
+};

--- a/tests/c99_compliant/enc/CMakeLists.txt
+++ b/tests/c99_compliant/enc/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set (EDL_FILE ../c99_compliant.edl)
+
+add_custom_command(
+    OUTPUT c99_compliant_t.h c99_compliant_t.c
+    DEPENDS ${EDL_FILE} edger8r
+    COMMAND edger8r --trusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(TARGET c99_compliant_enc UUID b843807a-e05c-423c-bcfb-1062cadb482f SOURCES enc.c ${CMAKE_CURRENT_BINARY_DIR}/c99_compliant_t.c)
+
+set_enclave_property(TARGET c99_compliant_enc PROPERTY C_STANDARD 99)
+
+enclave_include_directories(c99_compliant_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+enclave_link_libraries(c99_compliant_enc oelibc)

--- a/tests/c99_compliant/enc/enc.c
+++ b/tests/c99_compliant/enc/enc.c
@@ -1,0 +1,63 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+// Published headers under the include directory.
+#include <openenclave/attestation/plugin.h>
+#include <openenclave/attestation/sgx/attester.h>
+#include <openenclave/attestation/sgx/verifier.h>
+#include <openenclave/bits/attestation.h>
+#include <openenclave/bits/defs.h>
+#include <openenclave/bits/edl/syscall_types.h>
+#include <openenclave/bits/exception.h>
+#include <openenclave/bits/fs.h>
+#include <openenclave/bits/module.h>
+#include <openenclave/bits/properties.h> // Implicitly test sgxproperties.h and opteeproperties.h.
+#include <openenclave/bits/report.h>
+#include <openenclave/bits/result.h>
+#if __x86_64__ || _M_X64
+#include <openenclave/bits/sgx/epid.h>
+#include <openenclave/bits/sgx/sgxtypes.h>
+#endif
+#include <openenclave/bits/types.h>
+#include <openenclave/corelibc/bits/defs.h>
+#include <openenclave/corelibc/errno.h>
+#include <openenclave/corelibc/limits.h>
+#include <openenclave/corelibc/stdlib.h>
+#include <openenclave/corelibc/string.h>
+#include <openenclave/corelibc/wchar.h>
+#include <openenclave/edger8r/common.h>
+#include <openenclave/edger8r/enclave.h>
+#include <openenclave/enclave.h>
+
+// Oeedger8r-generated headers.
+#include <openenclave/bits/asym_keys.h>
+#include <openenclave/bits/time.h>
+
+int enc_c99_compliant()
+{
+    return 0;
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* AllowDebug */
+    256,  /* HeapPageCount */
+    256,  /* StackPageCount */
+    2);   /* TCSCount */
+
+#define TA_UUID                                            \
+    { /* b843807a-e05c-423c-bcfb-1062cadb482f */           \
+        0xb843807a, 0xe05c, 0x423c,                        \
+        {                                                  \
+            0xbc, 0xfb, 0x10, 0x62, 0xca, 0xdb, 0x48, 0x2f \
+        }                                                  \
+    }
+
+OE_SET_ENCLAVE_OPTEE(
+    TA_UUID,
+    1 * 1024 * 1024,
+    12 * 1024,
+    TA_FLAG_EXEC_DDR,
+    "1.0.0",
+    "C99-compliant test")

--- a/tests/c99_compliant/host/CMakeLists.txt
+++ b/tests/c99_compliant/host/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set (EDL_FILE ../c99_compliant.edl)
+
+add_custom_command(
+    OUTPUT c99_compliant_u.h c99_compliant_u.c
+    DEPENDS ${EDL_FILE} edger8r
+    COMMAND edger8r --untrusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(c99_compliant_host host.c c99_compliant_u.c)
+
+target_include_directories(c99_compliant_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(c99_compliant_host oehostapp)

--- a/tests/c99_compliant/host/host.c
+++ b/tests/c99_compliant/host/host.c
@@ -1,0 +1,46 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <limits.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "c99_compliant_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    if ((result = oe_create_c99_compliant_enclave(
+             argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    int return_val;
+
+    result = enc_c99_compliant(enclave, &return_val);
+
+    if (result != OE_OK)
+        oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+    if (return_val != 0)
+        oe_put_err("ECALL failed args.result=%d", return_val);
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (c99_compliant)\n");
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds a test that compiles all the public headers (3rd party ones are not included) against C99 standard (using `std=gnu99`). Any violation should cause compile-time errors.

Also, cleaning up code that are unnecessary / inconsistent as follows.
* `host/sgx/enclave.h`
   - `typedef` the `struct _oe_enclave` as `oe_enclave_t` because it's used in the following `GetEnclaveEvent` function.
* `include/openenclave/corelibc/bits/types.h `
   - Remove `intptr_t`, `time_t`, and `suseconds_t`, which are already defined in `openenclave/bits/types.h`
* `include/openenclave/internal/crypto/crl.h`
   - Remove a redundant `typedef`

Fixes #2376 #2486