### PR TITLE
Add to getting started doc possibility of SGX driver being preinstalled

### DIFF
--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
@@ -23,6 +23,16 @@ wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add 
 ```
 
 ### 2. Install the Intel SGX DCAP Driver
+Some versions of Ubuntu come with the SGX driver already installed. You can check
+by running with the following:
+
+```
+$ dmesg | grep -i sgx
+[  106.775199] sgx: intel_sgx: Intel SGX DCAP Driver {version}
+```
+
+If the output of the above is blank, you should proceed with installing the driver:
+
 ```bash
 sudo apt update
 sudo apt -y install dkms

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
@@ -23,6 +23,16 @@ wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add 
 ```
 
 ### 2. Install the Intel SGX DCAP Driver
+Some versions of Ubuntu come with the SGX driver already installed. You can check
+by running with the following:
+
+```
+$ dmesg | grep -i sgx
+[  106.775199] sgx: intel_sgx: Intel SGX DCAP Driver {version}
+```
+
+If the output of the above is blank, you should proceed with installing the driver:
+
 ```bash
 sudo apt update
 sudo apt -y install dkms


### PR DESCRIPTION
In the Azure Ubuntu kernel, the SGX driver is pre-installed. Add a note to the getting started docs about this possibility and how to check if it is installed.