### PR TITLE
Create event objects after enclave struct init

### DIFF
--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -753,6 +753,19 @@ oe_result_t oe_create_enclave(
     if (!(enclave = (oe_enclave_t*)calloc(1, sizeof(oe_enclave_t))))
         OE_RAISE(OE_OUT_OF_MEMORY);
 
+    /* Initialize the context parameter and any driver handles */
+    OE_CHECK(oe_sgx_initialize_load_context(
+        &context, OE_SGX_LOAD_TYPE_CREATE, flags));
+
+    /* Build the enclave */
+    OE_CHECK(oe_sgx_build_enclave(&context, enclave_path, NULL, enclave));
+
+    /* Push the new created enclave to the global list. */
+    if (oe_push_enclave_instance(enclave) != 0)
+    {
+        OE_RAISE(OE_FAILURE);
+    }
+
 #if defined(_WIN32)
     /* Create Windows events for each TCS binding. Enclaves use
      * this event when calling into the host to handle waits/wakes
@@ -775,19 +788,6 @@ oe_result_t oe_create_enclave(
     }
 
 #endif
-
-    /* Initialize the context parameter and any driver handles */
-    OE_CHECK(oe_sgx_initialize_load_context(
-        &context, OE_SGX_LOAD_TYPE_CREATE, flags));
-
-    /* Build the enclave */
-    OE_CHECK(oe_sgx_build_enclave(&context, enclave_path, NULL, enclave));
-
-    /* Push the new created enclave to the global list. */
-    if (oe_push_enclave_instance(enclave) != 0)
-    {
-        OE_RAISE(OE_FAILURE);
-    }
 
     // Create debugging structures only for debug enclaves.
     if (enclave->debug)


### PR DESCRIPTION
Previously we did:

```c
    /* Allocate and zero-fill the enclave structure */
    if (!(enclave = (oe_enclave_t*)calloc(1, sizeof(oe_enclave_t))))
        OE_RAISE(OE_OUT_OF_MEMORY);

    for (size_t i = 0; i < enclave->num_bindings; i++)  <- num_bindings is zero due to calloc
    {
      …
   }
```

In all likelihood, we weren't creating event objects on Windows.