### PR TITLE
Fix bug in the local_attestation sample

### DIFF
--- a/samples/local_attestation/enclave_a/Makefile
+++ b/samples/local_attestation/enclave_a/Makefile
@@ -33,7 +33,7 @@ genkey: public.pem
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../localattestation.edl --trusted --trusted-dir ../common
-	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I. -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
 	$(CC) -g -c $(CFLAGS) $(CINCLUDES) -I.. -DOE_API_VERSION=2 ../common/localattestation_t.c
 	$(CXX) -o enclave_a attestation.o crypto.o ecalls.o dispatcher.o localattestation_t.o $(LDFLAGS)
 

--- a/samples/local_attestation/enclave_a/ecalls.cpp
+++ b/samples/local_attestation/enclave_a/ecalls.cpp
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 #include <common/dispatcher.h>
 #include <common/localattestation_t.h>
+#include <enclave_b_pubkey.h>
 #include <openenclave/enclave.h>
-#include "enclave_b_pubkey.h"
 
 // For this purpose of this example: demonstrating how to do attestation
 // g_enclave_secret_data is hardcoded as part of the enclave. In this sample,

--- a/samples/local_attestation/enclave_b/Makefile
+++ b/samples/local_attestation/enclave_b/Makefile
@@ -33,7 +33,7 @@ genkey: public.pem
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../localattestation.edl --trusted --trusted-dir ../common
-	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I. -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
 	$(CC) -g -c $(CFLAGS) $(CINCLUDES) -I.. -DOE_API_VERSION=2 ../common/localattestation_t.c
 	$(CXX) -o enclave_b attestation.o crypto.o ecalls.o dispatcher.o localattestation_t.o $(LDFLAGS)
 

--- a/samples/local_attestation/enclave_b/ecalls.cpp
+++ b/samples/local_attestation/enclave_b/ecalls.cpp
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 #include <common/dispatcher.h>
 #include <common/localattestation_t.h>
+#include <enclave_a_pubkey.h>
 #include <openenclave/enclave.h>
-#include "enclave_a_pubkey.h"
 
 // For this purpose of this example: demonstrating how to do attestation
 // g_enclave_secret_data is hardcoded as part of the enclave. In this sample,


### PR DESCRIPTION
This PR fixes the bug in the local_attestation sample that causes the failure of building & running with cmake after using make.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>