### PR TITLE
Fix bugs in format-code scripts

### DIFF
--- a/scripts/format-code
+++ b/scripts/format-code
@@ -51,8 +51,8 @@ do
     -w | --whatif)
         whatif=1
         ;;
+
     -s | --staged)
-        # Only format files which are staged to be committed
         userFiles="$(git diff --cached --name-only --diff-filter=ACMR)"
         ;;
 
@@ -87,12 +87,13 @@ OVERVIEW:
 
 Formats all C/C++ source files based on the .clang-format rules
 
-    $ format-code [-h] [-v] [-w] [--exclude-dirs="..."] [--include-exts="..."] [--files="..."]
+    $ format-code [-h] [-q] [-s] [-v] [-w] [--exclude-dirs="..."] [--include-exts="..."] [--files="..."]
 
 OPTIONS:
     -h, --help              Print this help message.
+    -q, --quiet             Display only clang-format output and errors.
+    -s, --staged            Only format files which are staged to be committed.
     -v, --verbose           Display verbose output.
-    -v, --quiet             Display only clang-format output and errors.
     -w, --whatif            Run the script without actually modifying the files
                             and display the diff of expected changes, if any.
     --exclude-dirs          Subdirectories to exclude. If unspecified, then
@@ -193,10 +194,10 @@ get_find_args()
     local defaultIncludeExts='h c cpp'
 
     if [[ -z ${userExcludeDirs} ]]; then
-        local excludeDirs=( ${defaultExcludeDirs} )
+        read -r -a excludeDirs <<< "${defaultExcludeDirs}"
     else
         log_verbose "Using user directory exclusions: ${userExcludeDirs}"
-        local excludeDirs=( ${userExcludeDirs} )
+        read -r -a excludeDirs <<< "${userExcludeDirs}"
     fi
 
     for exc in "${excludeDirs[@]}"
@@ -206,10 +207,10 @@ get_find_args()
 
     if [[ -z ${userIncludeExts} ]]; then
         # not local as this is used in get_file_list() too
-        includeExts=( ${defaultIncludeExts} )
+        read -r -a includeExts <<< "${defaultIncludeExts}"
     else
         log_verbose "Using user extension inclusions: ${userIncludeExts}"
-        includeExts=( ${userIncludeExts} )
+        read -r -a includeExts <<< "${userIncludeExts}"
     fi
 
     findargs="${findargs} \("
@@ -253,7 +254,7 @@ get_file_list()
         fi
     else
         log_verbose "Using user files: ${userFiles}"
-        local user_file_list=( ${userFiles} )
+        mapfile -t user_file_list <<< "${userFiles}"
         file_list=()
         for file in "${user_file_list[@]}"; do
             for ext in "${includeExts[@]}"; do
@@ -299,4 +300,4 @@ done
 log_whatif "${filecount} files processed, ${changecount} changed."
 
 # If files are being edited, this count is zero so we exit with success.
-exit $changecount
+exit "$changecount"


### PR DESCRIPTION
1) fix shellcheck complaints ([SC2086](https://github.com/koalaman/shellcheck/wiki/Sc2086) and [SC2206](https://github.com/koalaman/shellcheck/wiki/Sc2206)) on the bash script
2) add --staged support to powershell script (PR #2883 only touched the bash script not the powershell script)
3) make powershell script default to non-verbose to match bash script
4) fix single-dash args to powershell script.  Fallthrough doesn't work the way the old script expected, as noted in the stackoverflow thread referenced in a new comment
5) fix bugs in the powershell script that caused it to never find any files to process
6) fix panic in powershell script when trying to report a version mismatch
7) fix typos in the Usage output

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>