### PR TITLE
Disable errno thread tests

### DIFF
--- a/tests/thread/README.md
+++ b/tests/thread/README.md
@@ -9,14 +9,16 @@ Test various OE synchronization primitives:
 
 - **oe_cond_t**
   1. *TestCond* : Tests basic condition variable use.
-  1. *TestThreadWakeWait* : Tests internal _ThreadWakeWait function.
-  1. *TestCondBroadcast* : Tests oe_cond_broadcast function in a tight-loop to assert that all waiting threads are woken.
+  1. *TestThreadWakeWait* : Tests internal `_ThreadWakeWait` function.
+  1. *TestCondBroadcast* : Tests `oe_cond_broadcast` function in a tight-loop to assert that all waiting threads are woken.
 
 
   **oe_rwlock_t**
   1. *TestReadersWriterLock* : Tests readers-writer lock invariants by launching multiple reader and writer threads racing against each other. Asserts that multiple/all readers can be simultaneously active, only one writer is active,  readers and writers are never simultaneously active.
 
   **oe_spinlock_t**
+  DISABLED: These tests are disabled due to an open investigation into
+  deadlock in the oethread/pthread tests.
   1. *TestErrnoMultiThreadsSameenclave* : Tests errno can be set correctly in multi-threads for same enclaves.
   2. *TestErrnoMultiThreadsDiffenclave* : Tests errno can be set correctly in multi-threads for different enclaves.
 

--- a/tests/thread/host/host.cpp
+++ b/tests/thread/host/host.cpp
@@ -294,7 +294,7 @@ int main(int argc, const char* argv[])
 {
     oe_result_t result;
     oe_enclave_t* enclave = NULL;
-    oe_enclave_t* enclave2 = NULL;
+    // oe_enclave_t* enclave2 = NULL;
 
     if (argc != 2)
     {
@@ -325,6 +325,7 @@ int main(int argc, const char* argv[])
 
     test_tcs_exhaustion(enclave);
 
+    /*
     test_errno_multi_threads_sameenclave(enclave);
 
     result = oe_create_thread_enclave(
@@ -335,9 +336,10 @@ int main(int argc, const char* argv[])
     }
 
     test_errno_multi_threads_diffenclave(enclave, enclave2);
+    Add to following if: (result = oe_terminate_enclave(enclave2)) != OE_OK
+    */
 
-    if ((result = oe_terminate_enclave(enclave)) != OE_OK ||
-        (result = oe_terminate_enclave(enclave2)) != OE_OK)
+    if ((result = oe_terminate_enclave(enclave)) != OE_OK)
     {
         oe_put_err("oe_terminate_enclave(): result=%u", result);
     }


### PR DESCRIPTION
Since the new errno oethread and pthread tests were added, we have seen multiple timeouts in CI. Disable these tests until the issue can be root-caused.