### PR TITLE
Fix tcs exhaustion test to predictably terminate

### DIFF
--- a/tests/thread/enc/enc.cpp
+++ b/tests/thread/enc/enc.cpp
@@ -275,25 +275,13 @@ void enc_lock_and_unlock_mutexes(const char* mutex_ids)
 // test_tcs_exhaustion
 static std::atomic<size_t> g_tcs_used_thread_count(0);
 
-// this ecall increments a counter (tcs_used_thread_count) and waits for the
-// total thread count to reach the test count (tcs_req_count)
-void enc_test_tcs_exhaustion(const size_t tcs_req_count)
+// this ecall increments a counter (tcs_used_thread_count)
+void enc_test_tcs_exhaustion()
 {
     ++g_tcs_used_thread_count;
 
-    // the local tcs_out_thread_count is a local copy of a value maintained on
-    // the host
-    size_t tcs_out_thread_count = 0;
-    // host_tcs_out_thread_count retrieves the value from the host
-    OE_TEST(host_tcs_out_thread_count(&tcs_out_thread_count) == OE_OK);
-
-    // wait until the thread counts total has reached the total requested
-    // thread count
-    while (g_tcs_used_thread_count + tcs_out_thread_count < tcs_req_count)
-    {
-        // retrieve tcs_out_thread_count from the host
-        OE_TEST(host_tcs_out_thread_count(&tcs_out_thread_count) == OE_OK);
-    }
+    // Wait in the host until desired tcs exhaustion has been reached.
+    OE_TEST(host_wait() == OE_OK);
 }
 
 size_t enc_tcs_used_thread_count()

--- a/tests/thread/host/host.cpp
+++ b/tests/thread/host/host.cpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -217,15 +218,19 @@ void test_errno_multi_threads_diffenclave(
 
 // test_tcs_exhaustion
 static std::atomic<size_t> g_tcs_out_thread_count(0);
+static std::mutex g_tcs_mutex;
+static std::condition_variable g_tcs_cv;
 
 // this is the test_tcs worker thread
-void* tcs_thread(oe_enclave_t* enclave, size_t tcs_req_count)
+void* tcs_thread(oe_enclave_t* enclave, size_t expected_out_of_threads)
 {
-    oe_result_t result = enc_test_tcs_exhaustion(enclave, tcs_req_count);
+    oe_result_t result = enc_test_tcs_exhaustion(enclave);
     if (result == OE_OUT_OF_THREADS)
     {
-        // increment g_tcs_out_thread_count when thread exhaustion is reached
-        ++g_tcs_out_thread_count;
+        // Increment tcs count. Resume threads if expected tcs exhaustion
+        // failures have been reached.
+        if (++g_tcs_out_thread_count == expected_out_of_threads)
+            g_tcs_cv.notify_all();
     }
     else
     {
@@ -241,20 +246,20 @@ void* tcs_thread(oe_enclave_t* enclave, size_t tcs_req_count)
 //   - successful ecalls increment a counter (tcs_used_thread_count) and wait
 //     for the total thread count to reach the test count (tcs_req_count)
 //   - unsuccessful ecalls increment a counter (tcs_out_thread_count)
-// tcs_used_thread_count is maintained in the enclave
-// tcs_out_thread_count is maintained in the host
 void test_tcs_exhaustion(oe_enclave_t* enclave)
 {
     std::vector<std::thread> threads;
     // Set the test_tcs_count to a value greater than the enclave TCSCount
     const size_t test_tcs_req_count = enclave->num_bindings * 2;
+    const size_t expected_out_of_threads = enclave->num_bindings;
     printf(
         "test_tcs_exhaustion - Number of TCS bindings in enclave=%zu\n",
         enclave->num_bindings);
 
     for (size_t i = 0; i < test_tcs_req_count; i++)
     {
-        threads.push_back(std::thread(tcs_thread, enclave, test_tcs_req_count));
+        threads.push_back(
+            std::thread(tcs_thread, enclave, expected_out_of_threads));
     }
 
     for (size_t i = 0; i < test_tcs_req_count; i++)
@@ -262,32 +267,27 @@ void test_tcs_exhaustion(oe_enclave_t* enclave)
         threads[i].join();
     }
 
-    // the local tcs_used_thread_count is a local copy of a value maintained on
-    // the enclave
     size_t tcs_used_thread_count = 0;
-    // enc_tcs_used_thread_count retrieves the value from the enclave
     OE_TEST(
         enc_tcs_used_thread_count(enclave, &tcs_used_thread_count) == OE_OK);
 
     printf(
         "test_tcs_exhaustion: tcs_count=%zu; num_threads=%zu; "
-        "num_out_threads=%zu\n",
-        test_tcs_req_count,
+        "num_out_of_tcs=%zu\n",
         tcs_used_thread_count,
+        test_tcs_req_count,
         g_tcs_out_thread_count.load());
 
-    // Crux of the test is to get OE_OUT_OF_THREADS i.e. to exhaust the TCSes
-    OE_TEST(g_tcs_out_thread_count > 0);
-    // Verifying that everything adds up fine
-    OE_TEST(
-        tcs_used_thread_count + g_tcs_out_thread_count == test_tcs_req_count);
-    // Sanity test that we are not reusing the bindings
+    // Assert that expected thread exhaustion failures have been reached.
+    OE_TEST(g_tcs_out_thread_count == expected_out_of_threads);
     OE_TEST(tcs_used_thread_count <= enclave->num_bindings);
 }
 
-size_t host_tcs_out_thread_count()
+void host_wait()
 {
-    return g_tcs_out_thread_count;
+    // Wait until explicitly notified.
+    std::unique_lock<std::mutex> lock(g_tcs_mutex);
+    g_tcs_cv.wait(lock);
 }
 
 int main(int argc, const char* argv[])

--- a/tests/thread/thread.edl
+++ b/tests/thread/thread.edl
@@ -25,8 +25,7 @@ enclave {
         public void enc_lock_and_unlock_mutexes(
             [in, string] const char* mutex_ids);
 
-        public void enc_test_tcs_exhaustion(
-            size_t tcs_req_count);
+        public void enc_test_tcs_exhaustion();
 
         public size_t enc_tcs_used_thread_count();
 
@@ -55,6 +54,6 @@ enclave {
         void host_usleep(
             size_t microseconds);
 
-        size_t host_tcs_out_thread_count();
+        void host_wait();
     };
 };


### PR DESCRIPTION
Previously each thread would keep making ocalls to check if it can exit.
This could cause the thread to hog the CPU, preventing other threads
from making progress so that the termination condition for the test
is reached.

Wait on a condition variable instead. This allows other threads to run.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>