### PR TITLE
Fix the print test on cross-compilation configurations

### DIFF
--- a/tests/print/CMakeLists.txt
+++ b/tests/print/CMakeLists.txt
@@ -5,21 +5,23 @@ add_subdirectory(host)
 
 if (BUILD_ENCLAVES)
     add_subdirectory(enc)
-
-    #note: this is Linux-specific
-    if (WIN32)
-        set(RESULTDIR ${CMAKE_CURRENT_SOURCE_DIR}/results/windows)
-    else()
-        set(RESULTDIR ${CMAKE_CURRENT_SOURCE_DIR}/results/others)
-    endif()
-
-    add_test(NAME tests/print
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMAND sh -c "OE_LOG_LEVEL=NONE host/print_host ./enc/print_enc >testout.stdout 2>testout.stderr &&
-            diff ${RESULTDIR}/printhost.stdout testout.stdout &&
-            diff ${RESULTDIR}/printhost.stderr testout.stderr"
-        )
-else()
-
-    add_enclave_test(tests/print print_host print_enc)
 endif()
+
+# Both host-side stderr and stdout behave differently in Windows and Linux.
+# Therefore, using corresponding oracle files for the test based on the type of OS.
+if (WIN32)
+    set(RESULTDIR ${CMAKE_CURRENT_SOURCE_DIR}/results/windows)
+else()
+    set(RESULTDIR ${CMAKE_CURRENT_SOURCE_DIR}/results/others)
+endif()
+
+# Use add_enclave_test to ensure the enclave binaries are copied from the pre-built directory
+# when ADD_WINDOWS_ENCLAVE_TESTS is ON and BUILD_ENCLAVES is OFF.
+add_enclave_test(tests/print print_host print_enc)
+
+add_test(NAME tests/print-diff
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${OE_BASH} -c "OE_LOG_LEVEL=NONE host/print_host ./enc/print_enc >testout.stdout 2>testout.stderr &&
+        diff ${RESULTDIR}/printhost.stdout testout.stdout &&
+        diff ${RESULTDIR}/printhost.stderr testout.stderr"
+)


### PR DESCRIPTION
The print test does not correctly run on cross-compilation configurations (i.e., when `ADD_WINDOWS_ENCLAVE_TESTS=ON` and ` BUILD_ENCLAVES = OFF`).

This PR fixes the issue by explicitly adding `add_enclave_test`, which handles the test run with cross-compilation configurations, before the actual test (i.e., comparing the output of the test against the oracle output).

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>