### PR TITLE
Change ADD_LVI_MITIGATION from oneValueArgs to options

### DIFF
--- a/cmake/add_enclave.cmake
+++ b/cmake/add_enclave.cmake
@@ -9,7 +9,7 @@
 #  add_enclave(<TARGET target>
 #              [<UUID uuid>]
 #              [CXX]
-#              [ADD_LVI_MITIGATION ON/OFF]
+#              [ADD_LVI_MITIGATION]
 #              <SOURCES sources>
 #              [<CONFIG config>]
 #              [<KEY key>])
@@ -46,8 +46,8 @@
 # default custom target.
 # TODO: (3) Validate arguments into this function
 macro(add_enclave)
-  set(options CXX)
-  set(oneValueArgs TARGET UUID CONFIG KEY SIGNING_ENGINE ENGINE_LOAD_PATH ENGINE_KEY_ID ADD_LVI_MITIGATION)
+  set(options CXX ADD_LVI_MITIGATION)
+  set(oneValueArgs TARGET UUID CONFIG KEY SIGNING_ENGINE ENGINE_LOAD_PATH ENGINE_KEY_ID)
   set(multiValueArgs SOURCES)
   cmake_parse_arguments(ENCLAVE
     "${options}"

--- a/tests/libc/enc/CMakeLists.txt
+++ b/tests/libc/enc/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 add_enclave(TARGET libc_enc UUID d7fe296a-24e9-46d1-aa78-9c7395082a41
     # Building the enclave by default when enabling LVI mitigation to
     # test linking against LVI-mitigated libraries.
-    ADD_LVI_MITIGATION ON
+    ADD_LVI_MITIGATION
     SOURCES
     enc.c
     ${test_dependencies}

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -54,7 +54,7 @@ function(add_libcxx_test_enc NAME CXXFILE)
     add_enclave(TARGET libcxxtest-${NAME}_enc UUID 486dcdcc-f0c6-4bdd-91e0-c7566794f899 CXX
         # Building the enclave by default when enabling LVI mitigation to
         # test linking against LVI-mitigated libraries.
-        ADD_LVI_MITIGATION ON
+        ADD_LVI_MITIGATION
         SOURCES
         main.cpp libcxx_t.c)
 

--- a/tests/mbed/enc/CMakeLists.txt
+++ b/tests/mbed/enc/CMakeLists.txt
@@ -48,7 +48,7 @@ function(add_mbed_test_enclave NAME)
   add_enclave(TARGET mbedtest_suite_${NAME} UUID 0e405a1d-dd06-49a4-9d46-3f02440cbf0a
     # Building the enclave by default when enabling LVI mitigation to
     # test linking against LVI-mitigated libraries.
-    ADD_LVI_MITIGATION ON
+    ADD_LVI_MITIGATION
     SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/test_suite_${NAME}.c
     enc.c


### PR DESCRIPTION
Since `ADD_LVI_MITIGATION`, an argument in the `add_enclave` cmake function, can only be `ON` or `OFF`, and the default value is `OFF`.  Making the argument as options (similar to `CXX`) is more appropriate.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>