### PR TITLE
Remove redundant testing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Azure
 [![Nightly Libcxx Testing Status](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/buildStatus/icon?job=OpenEnclave-libcxx-tests&subject=Azure%20libcxx%20testing)](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave-libcxx-tests/)
 [![Build Status](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/pipelines/job/Azure-Linux-Badge/badge/icon?subject=Azure-Linux)](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/pipelines/job/Azure-Linux-Badge/)
 [![Packages Build Status](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/buildStatus/icon?job=OpenEnclave-nightly-packages&subject=Azure%20Package%20build)](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave-nightly-packages/)
-[![Packages Testing Status](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/buildStatus/icon?job=OpenEnclave-nightly-packages-testing&subject=Azure%20Package%20Testing)](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave-nightly-packages-testing/)
 
 
 Introduction


### PR DESCRIPTION
The current packaging regression testing has been augmented to include the testing of the installation candidates. This renders the "Nightly Package Testing" badge redundant and should be removed.