### PR TITLE
Retain ECALL worker thread's tcs binding.

### DIFF
--- a/edl/sgx/switchless.edl
+++ b/edl/sgx/switchless.edl
@@ -32,5 +32,9 @@ enclave
         // Wake up a host switchless ocall worker thread.
         void oe_sgx_wake_switchless_worker_ocall(
             [user_check] struct _host_worker_context* context);
+
+        // Call into the host to sleep.
+        void oe_sgx_sleep_switchless_worker_ocall(
+            [user_check] struct _enclave_worker_context* context);
     };
 };

--- a/enclave/core/sgx/switchlesscalls.c
+++ b/enclave/core/sgx/switchlesscalls.c
@@ -248,7 +248,9 @@ void oe_sgx_switchless_enclave_worker_thread_ecall(
                 // Reset spin count and return to host to sleep.
                 context->total_spin_count += context->spin_count;
                 context->spin_count = 0;
-                break;
+
+                // Make an ocall to sleep until messages arrive.
+                oe_sgx_sleep_switchless_worker_ocall(context);
             }
 
             // In Release builds, the following pause has been observed to be

--- a/host/sgx/switchless.c
+++ b/host/sgx/switchless.c
@@ -70,6 +70,12 @@ static void* _switchless_ocall_worker(void* arg)
     return NULL;
 }
 
+void oe_sgx_sleep_switchless_worker_ocall(oe_enclave_worker_context_t* context)
+{
+    // Wait for messages.
+    oe_enclave_worker_wait(context);
+}
+
 /*
 ** The thread function that handles switchless ecalls
 **
@@ -78,20 +84,13 @@ static void* _switchless_ecall_worker(void* arg)
 {
     oe_enclave_worker_context_t* context = (oe_enclave_worker_context_t*)arg;
 
-    // Loop until stop has been requested.
-    while (!context->is_stopping)
+    // Enter enclave to process ecall messages.
+    if (oe_sgx_switchless_enclave_worker_thread_ecall(
+            context->enclave, context) != OE_OK)
     {
-        // Wait for event to start executing.
-        oe_enclave_worker_wait(context);
-
-        // Enter enclave to process ecall messages.
-        if (oe_sgx_switchless_enclave_worker_thread_ecall(
-                context->enclave, context) != OE_OK)
-        {
-            OE_TRACE_ERROR("Switchless enclave worker thread failed\n");
-            break;
-        }
+        OE_TRACE_ERROR("Switchless enclave worker thread failed\n");
     }
+
     return NULL;
 }
 


### PR DESCRIPTION
Instead of returning when spin count threshold has been reached,
make an ocall to sleep in the host.
This ensures that the tcs is still bound to the host thread.
When the messages arrive, the worker thread can go back into the
enclave in the same tcs.
Without retaining the tcs binding, there may not be a tcs available
for the worker thread to go back into the enclave.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>