### PR TITLE
Infra fixes

### DIFF
--- a/.jenkins/infrastructure/provision/run-sysprep.ps1
+++ b/.jenkins/infrastructure/provision/run-sysprep.ps1
@@ -4,7 +4,6 @@
 $ErrorActionPreference = "Stop"
 
 while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }
-while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Running') { Start-Sleep -s 5 }
 while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }
 
 & $env:SystemRoot\System32\Sysprep\Sysprep.exe /oobe /generalize /quiet /quit

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -602,6 +602,11 @@ function Install-DCAP-Dependencies {
                 }
                 Write-Output $install
             }
+            elseif (($LaunchConfiguration -eq "SGX1FLC-NoDriver") -and (${OS_VERSION} -eq "WinServer2016"))
+            {
+                 Write-Output "Copying Intel_SGX_DCAP dll files into $($env:SystemRoot)\system32"
+                 Copy-item -Path $PACKAGES_DIRECTORY\Intel_SGX_DCAP\$driver\drivers\*\*.dll $env:SystemRoot\system32\
+            }
         }
     }
 
@@ -645,7 +650,7 @@ function Install-DCAP-Dependencies {
         Throw "Failed to install nuget EnclaveCommonAPI"
     }
 
-    if (($LaunchConfiguration -eq "SGX1FLC") -or (${OS_VERSION} -eq "WinServer2019"))
+    if (($LaunchConfiguration -eq "SGX1FLC") -or (${OS_VERSION} -eq "WinServer2016"))
     {
         # Please refer to Intel's Windows DCAP documentation for this registry setting: https://download.01.org/intel-sgx/dcap-1.2/windows/docs/Intel_SGX_DCAP_Windows_SW_Installation_Guide.pdf
         New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\sgx_lc_msr\Parameters" -Name "SGX_Launch_Config_Optin" -Value 1 -PropertyType DWORD -Force


### PR DESCRIPTION
- Sysprep script is failing with the following error:
`"Get-Service : Cannot find any service with service name 'WindowsAzureTelemetryService'"`
Thus, we remove this condition before running Sysprep

- Update Windows install script to copy SGX Dlls to System32 folder for Windows Server 2016 nonSGX 