### PR TITLE
Fix the logic of detecting compilers when LVI mitigation is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if (UNIX AND LVI_MITIGATION MATCHES ControlFlow)
     message(FATAL_ERROR "LVI_MITIGATION_BINDIR is not specified.")
   endif ()
   include(configure_lvi_mitigation_build)
-  configure_lvi_mitigation_build(${LVI_MITIGATION_BINDIR})
+  configure_lvi_mitigation_build(BINDIR ${LVI_MITIGATION_BINDIR})
 endif ()
 
 project(

--- a/cmake/configure_lvi_mitigation_build.cmake
+++ b/cmake/configure_lvi_mitigation_build.cmake
@@ -1,25 +1,92 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Adopt customized compiler wrappers for LVI mitigation.
-function (configure_lvi_mitigation_build LVI_MITIGATION_BINDIR)
-  if (NOT EXISTS "${LVI_MITIGATION_BINDIR}")
-    message(FATAL_ERROR "${LVI_MITIGATION_BINDIR} does not exist.")
+macro (detect_compiler BINDIR CC)
+  set(GCC gcc)
+  set(CLANG clang)
+  if (${CC} STREQUAL CXX)
+    set(GCC g++)
+    set(CLANG clang++)
   endif ()
-  # Perfer clang over gcc.
-  if (EXISTS "${LVI_MITIGATION_BINDIR}/clang-7")
+
+  # Set the COMPILER as the variable name (either C_COMPILER or CXX_COMPILER).
+  set(COMPILER "${CC}_COMPILER")
+
+  # Use the second level of unwrapping on COMPILER to get the compiler name.
+  # If the default compiler is found, return.
+  if (EXISTS "${BINDIR}/${${COMPILER}}")
+    return()
+  endif ()
+
+  if (NOT OE_IN_PACKAGE)
+    # Build OE. Fallback to gcc/g++.
+    set(${COMPILER} ${GCC})
+  else ()
+    # Build enclave applications. Try to search newer versions of clang/clang++.
+    # Be consistent to the logic implemented by samples/config.mk.
+    foreach (VERSION 9 8 7)
+      set(CLANG_VERSION "")
+      if (EXISTS "${BINDIR}/${${COMPILER}}-${VERSION}")
+        set(CLANG_VERSION ${VERSION})
+        break()
+      endif ()
+    endforeach ()
+    # Set the compiler if a version of clang/clang++ is found.
+    if (CLANG_VERSION)
+      set(${COMPILER} ${CLANG}-${CLANG_VERSION})
+    else ()
+      set(${COMPILER} ${GCC})
+    endif ()
+  endif ()
+endmacro ()
+
+# Adopt customized compiler wrappers for LVI mitigation.
+function (configure_lvi_mitigation_build)
+  cmake_parse_arguments(OE "IN_PACKAGE" "BINDIR" "" ${ARGN})
+
+  if (NOT EXISTS "${OE_BINDIR}")
+    message(FATAL_ERROR "${OE_BINDIR} does not exist.")
+  endif ()
+
+  if (NOT OE_IN_PACKAGE)
+    # Default to clang-7 when building SDK.
+    set(C_COMPILER clang-7)
+    set(CXX_COMPILER clang++-7)
+  else ()
+    # Default to clang when building enclave applications.
+    set(C_COMPILER clang)
+    set(CXX_COMPILER clang++)
+  endif ()
+
+  # Overwrite the default C compiler if CC is explicitly specified.
+  # Otherwise, select the compiler based on the detection logic.
+  if (DEFINED ENV{CC})
+    set(C_COMPILER $ENV{CC})
+  else ()
+    detect_compiler(${OE_BINDIR} C)
+  endif ()
+
+  if (EXISTS "${OE_BINDIR}/${C_COMPILER}")
     set(CMAKE_C_COMPILER
-        ${LVI_MITIGATION_BINDIR}/clang-7
-        PARENT_SCOPE)
-    set(CMAKE_CXX_COMPILER
-        ${LVI_MITIGATION_BINDIR}/clang++-7
+        ${OE_BINDIR}/${C_COMPILER}
         PARENT_SCOPE)
   else ()
-    set(CMAKE_C_COMPILER
-        ${LVI_MITIGATION_BINDIR}/gcc
-        PARENT_SCOPE)
+    message(FATAL_ERROR "-- ${C_COMPILER} is not found.")
+  endif ()
+
+  # Overwrite the default C++ compiler if CXX is explicitly specified.
+  # Otherwise, select the compiler based on the detection logic.
+  if (DEFINED ENV{CXX})
+    set(CXX_COMPILER $ENV{CXX})
+  else ()
+    detect_compiler(${OE_BINDIR} CXX)
+  endif ()
+
+  if (EXISTS "${OE_BINDIR}/${CXX_COMPILER}")
     set(CMAKE_CXX_COMPILER
-        ${LVI_MITIGATION_BINDIR}/g++
+        ${OE_BINDIR}/${CXX_COMPILER}
         PARENT_SCOPE)
+  else ()
+    message(FATAL_ERROR "-- ${CXX_COMPILER} is not supported.")
   endif ()
 endfunction ()

--- a/cmake/openenclave-lvi-mitigation-config.cmake.in
+++ b/cmake/openenclave-lvi-mitigation-config.cmake.in
@@ -16,7 +16,7 @@ if (OE_LVI_MITIGATION MATCHES ControlFlow)
     endif()
     include("${CMAKE_CURRENT_LIST_DIR}/configure_lvi_mitigation_build.cmake")
     # Pick up the customized compilation toolchain based on the specified path.
-    configure_lvi_mitigation_build(${LVI_MITIGATION_BINDIR})
+    configure_lvi_mitigation_build(BINDIR ${LVI_MITIGATION_BINDIR} IN_PACKAGE)
   endif()
   include("${CMAKE_CURRENT_LIST_DIR}/apply_lvi_mitigation.cmake")
 else()


### PR DESCRIPTION
This PR fixes the logic of detecting compilers when LVI mitigation is enabled. That is, the old logic always picks `clang-7` (if installed) regardless the environment variable `CC` is set to `gcc`. 
- Fixes #2930

This fix also allows users to specify the version of clang (other than the default version 7) when building the helloworld sample with LVI mitigation.
- Fixes #2670 

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>