### PR TITLE
Fix format-code string -> array bugs

### DIFF
--- a/scripts/format-code
+++ b/scripts/format-code
@@ -53,7 +53,8 @@ do
         ;;
 
     -s | --staged)
-        userFiles="$(git diff --cached --name-only --diff-filter=ACMR)"
+        # Split into array
+        mapfile -t userFiles <<< "$(git diff --cached --name-only --diff-filter=ACMR)"
         ;;
 
     --exclude-dirs=*)
@@ -65,7 +66,7 @@ do
         ;;
 
     --files=*)
-        userFiles="${opt#*=}"
+        read -ra userFiles <<< "${opt#*=}"
         ;;
     *)
         echo "$0: unknown option:  $opt"
@@ -246,17 +247,16 @@ fi
 
 get_file_list()
 {
-    if [[ -z ${userFiles} ]]; then
+    if [[ -z "${userFiles[*]}" ]]; then
         mapfile -t file_list < <(eval "$findargs")
         if [[ ${#file_list[@]} -eq 0 ]]; then
             echo "No files were found to format!"
             exit 1
         fi
     else
-        log_verbose "Using user files: ${userFiles}"
-        mapfile -t user_file_list <<< "${userFiles}"
+        log_verbose "Using user files: ${userFiles[*]}"
         file_list=()
-        for file in "${user_file_list[@]}"; do
+        for file in "${userFiles[@]}"; do
             for ext in "${includeExts[@]}"; do
                 if [[ ${file##*\.} == "$ext" ]]; then
                     file_list+=( "$file" )


### PR DESCRIPTION
Some ugly bash behavior causes bugs in how files are parsed into arrays in the format-code script. Clean these up to ensure the --staged and --files options work properly.