### PR TITLE
Document the compiler support on the libcxx test

### DIFF
--- a/docs/LibcxxSupport.md
+++ b/docs/LibcxxSupport.md
@@ -6,6 +6,8 @@ Open Enclave uses a a version of the [LLVM libc++](https://libcxx.llvm.org/) lib
     - Others, such as thread creation, are simply not supported in the the enclave runtime.
 - Equivalent standard C library functions that are not supported, as documented in [LibcSupport.md](LibcSupport.md)
 
+For more details on the libcxx testing in Open Enclave, refer to this [document](/tests/libcxx/README.md).
+
 ## Concepts Library
 Header | Supported | Comments |
 :---:|:---:|:---|

--- a/tests/libcxx/README.md
+++ b/tests/libcxx/README.md
@@ -8,6 +8,8 @@ directory for each unit test found in tests.supported.
 The unit tests are partitioned into three files:
 
 * tests.supported -- unit tests that work
+* tests.supported.cxx17 -- unit tests of C++17 features that work (compiled with std=c++17)
+* tests.supported.default -- subset of working tests ran by daily build
 * tests.broken -- unit tests that are broken
 * tests.unsupported -- unit tests that are not supported
 
@@ -21,6 +23,3 @@ As tests are fixed, they should be moved from tests.broken to tests.supported.
 
 As tests are determined to be unsupportable, they should be moved from
 tests.broken to tests.unsupported.
-
-
-

--- a/tests/libcxx/README.md
+++ b/tests/libcxx/README.md
@@ -13,6 +13,18 @@ The unit tests are partitioned into three files:
 * tests.broken -- unit tests that are broken
 * tests.unsupported -- unit tests that are not supported
 
+The tests are currently ran with the following configurations.
+
+| Compiler    | Environment          | Test set |
+|-------------|----------------------|----------|
+| gcc 5.4.0   | Ubuntu 16.04         | Full     |
+| gcc 7.5.0   | Ubuntu 18.04         | Full     |
+| gcc 8.3.1   | Red Hat 8            | Default  |
+| clang 7.1.0 | Ubuntu 16.04 & 18.04 | Full     |
+| clang 8.0.1 | Red Hat 8            | Default  |
+
+*Note*: For compatibility, some test cases are disabled on certain versions of compilers via [CMakeLists.txt](CMakeLists.txt).
+
 To run all the tests, type the following command:
 
 ```


### PR DESCRIPTION
This PR documents the compiler support on the libcxx test  based on the status of current CI/CD.

Fixes #1516 