### PR TITLE
Ignore MSVC-compatible clang flags in clangw

### DIFF
--- a/scripts/clangw
+++ b/scripts/clangw
@@ -49,6 +49,14 @@ function call_clang {
         [ "$a" == "/W4" ]           && continue
         [ "$a" == "/WX" ]           && continue
 
+        # Ignore specific clang flags for the MSVC compatibility.
+        # See http://clang.llvm.org/docs/UsersManual.html#microsoft-extensions for more detail.
+        [ "$a" == "-fms-compatibility" ]            && continue
+        [ "$a" == "-fms-extension" ]                && continue
+        [ "$a" == "-fdelayed-template-parsing" ]    && continue
+        # Use regex to match the value-passing flag.
+        [[ "$a" =~ "-fms-compatibility-version=" ]] && continue
+
         # Ignore warnings for specific error codes
         if [[ "$a" =~ /[wW][dD][0-9]* ]]; then
             continue
@@ -88,6 +96,7 @@ function call_clang {
 
     # Call clang with the transformed arguments arguments
     if [ $linking ]; then
+        # shellcheck disable=SC2230
         clang -target x86_64-pc-linux ${args[@]} -o "$output" -fuse-ld="`which ld.lld`"
     else
         # Check if the LVI mitigation is enabled.


### PR DESCRIPTION
This PR updates the clangw script to ignore specific flags for MSVC compatibility, which would otherwise cause the compilation to fail (e.g., suppressing the `-target x86_64-pc-linux` flag) or other unwanted effects. Refer to the [clang docs](http://clang.llvm.org/docs/UsersManual.html#microsoft-extensions) for the list of the flags.

Fixes #2857 

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>