### PR TITLE
Update docs of installation OE on windows

### DIFF
--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
@@ -17,18 +17,27 @@ C:\Intel SGX PSW for Windows v2.7.101.2\PSW_EXE_RS2_and_before\Intel(R)_SGX_Wind
 
 Note that this is optional since you can choose an alternate implementation of the DCAP client or create your own.
 The Azure DCAP client for Windows is necessary if you would like to perform enclave attestation on a Azure Confidential Computing VM. It is available from [nuget.org](https://www.nuget.org/packages/Microsoft.Azure.DCAP/) and can be installed directly via command below.
-This example assumes that `C:\oe_prereqs` is where you would like the prerequisites to be installed.
 
 ```cmd
 nuget.exe install Microsoft.Azure.DCAP -ExcludeVersion -Version 1.3.0 -OutputDirectory C:\oe_prereqs
 ```
 This example assumes you would like to install the package to `C:\oe_prereqs`.
 
-##### [Intel Data Center Attestation Primitives (DCAP) Libraries v1.6](http://registrationcenter-download.intel.com/akdlm/irc_nas/16620/Intel%20SGX%20DCAP%20for%20Windows%20v1.6.100.2.exe)
+## [Intel Data Center Attestation Primitives (DCAP) Libraries v1.6](http://registrationcenter-download.intel.com/akdlm/irc_nas/16620/Intel%20SGX%20DCAP%20for%20Windows%20v1.6.100.2.exe)
 After unpacking the self-extracting ZIP executable, you can refer to the *Intel SGX DCAP Windows SW Installation Guide.pdf*
 for more details on how to install the contents of the package.
 
 The following summary will assume that the contents were extracted to `C:\Intel SGX DCAP for Windows v1.6.100.2`:
+
+### Install the Intel DCAP nuget packages
+The standalone `nuget.exe` [CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) can be used to do this from the command prompt:
+
+```cmd
+nuget.exe install DCAP_Components -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.6.100.2\nuget" -OutputDirectory c:\oe_prereqs
+nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.6.100.2\nuget" -OutputDirectory c:\oe_prereqs
+```
+
+### Install the Intel DCAP driver
 
 1. Unzip the required drivers from the extracted subfolders:
     - For Windows Server 2016
@@ -52,13 +61,8 @@ The following summary will assume that the contents were extracted to `C:\Intel 
     - `devcon.exe` from the [Windows Driver Kit for Windows 10](https://go.microsoft.com/fwlink/?linkid=2026156)
       can be used to install the drivers from an elevated command prompt:
       ```cmd
-      devcon.exe install LC_driver\drivers\b361e4d8-bc01-43fc-b8a6-8d101e659ed1\sgx_base_dev.inf root\SgxLCDevice
-      devcon.exe install DCAP_INF\drivers\226fdf07-49d3-46aa-a0ce-f21b6d4a05cf\sgx_dcap_dev.inf root\SgxLCDevice_DCAP
+      devcon.exe install LC_driver\drivers\8e78fd6b-efeb-4952-ab0d-945e61c164ba\sgx_base_dev.inf root\SgxLCDevice
+      devcon.exe install DCAP_INF\drivers\08cc8440-9f38-4635-9685-cdbf476666fa\sgx_dcap_dev.inf root\SgxLCDevice_DCAP
       ```
+    - The hash values in the paths may be different from the above commands, please update them accordingly.
     - Note that `devcon.exe` is usually installed to `C:\Program Files (x86)\Windows Kits\10\tools\x64` which is not in the PATH environment variable by default.
-4. Install the DCAP nuget packages:
-    - The standalone `nuget.exe` [CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) can be used to do this from the command prompt:
-      ```cmd
-      nuget.exe install DCAP_Components -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.6.100.2\nuget" -OutputDirectory c:\oe_prereqs
-      nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.6.100.2\nuget" -OutputDirectory c:\oe_prereqs
-      ```

--- a/docs/GettingStartedDocs/install_oe_sdk-Windows.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Windows.md
@@ -58,7 +58,7 @@ C:\Program Files\LLVM\bin\ld.lld.exe
 
 ### SGX1 with Flexible Launch Control (FLC) Prerequisites
 
-Instructions to install Intel's PSW, Intel's Data Center Attestation Primitives and related dependencies can be found [here](Contributors/WindowsManualSGX1FLCDCAPPrereqs.md).
+Instructions to install Intel's PSW, Intel's Data Center Attestation Primitives, and related dependencies can be found [here](Contributors/WindowsManualSGX1FLCDCAPPrereqs.md).
 
 ## Download and install the Open Enclave SDK NuGet Package
 
@@ -69,6 +69,16 @@ Download the required Windows NuGet Package from [here](https://github.com/opene
 ```
 
 Note: If it is an RC package, append `-pre` to the command above.
+
+After the installation, the Open Enclave SDK will be placed in the path `C:\oe\open-enclave\openenclave`.
+Use the following command to copy the SDK to `C:\openenclave`.
+
+```cmd
+xcopy /E  C:\oe\open-enclave\openenclave C:\openenclave\
+```
+
+The rest of the documentation assumes `C:\openenclave` as the default installation path of the SDK.
+
 
 ## Verify the Open Enclave SDK installation
 


### PR DESCRIPTION
This PR updates the documentation as follows.
- `WindowsManualSGX1FLCDCAPPrereqs.md`.
  - Fixing the indent --- Intel DCAP should not the sub-section of  Azure DCAP Windows
  - Re-organize---separating the nuget and driver installation

Update the installation path. The current behavior of installation via the nuget package is that if specifying the installation path to `C:\oe`, the corresponding path to the openenclave would be `C:\oe\open-enclave\openenclave`.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>