### PR TITLE
Fix the thread event and wait/wake functions

### DIFF
--- a/host/sgx/enclave.h
+++ b/host/sgx/enclave.h
@@ -21,11 +21,7 @@
 
 typedef struct _enclave_event
 {
-#if defined(__linux__)
-    uint32_t value;
-#elif defined(_WIN32)
-    HANDLE handle;
-#endif
+    volatile uint32_t lock;
 } EnclaveEvent;
 
 #define ENCLAVE_MAGIC 0x20dc98463a5ad8b8


### PR DESCRIPTION
1. On Windows, replace WaitForSingleObject() with WaitOnAddress(), unify EnclaveEvent struct as on Linux.
Fixes #85

2. Let wake thread holds until wait thread starts.
There is a possible catch that if HandleThreadWake() is execute earlier than
HandleThreadWait(), HandleThreadWait() will miss the wake signal then
hang there forever. To avoid such situation HandleThreadWake() must
wait until HandleThreadWait() starts.
partially fix #2920
