### PR TITLE
Enable the memory test on Windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,9 @@ endif()
 if (UNIX OR ADD_WINDOWS_ENCLAVE_TESTS OR USE_CLANGW)
     if (OE_SGX)
         if (BUILD_ENCLAVES)
+            # Disable the memory test for the scenario of building the enclave in Linux and running
+            # it on Windows because of the mismatch on the enclave heap size configuration.
+            add_subdirectory(memory)
             add_subdirectory(tls_e2e)
         endif()
 
@@ -94,12 +97,10 @@ add_subdirectory(pingpong)
 add_subdirectory(pingpong-shared)
 endif()
 
-# Windows test Broken Post #632 issue
 if ( UNIX )
     if (OE_SGX)
         add_subdirectory(child_process)
         add_subdirectory(cmake_name_conflict)
-        add_subdirectory(memory)
     endif()
 add_subdirectory(libc)
 endif()

--- a/tests/memory/README.md
+++ b/tests/memory/README.md
@@ -1,4 +1,3 @@
-
 This directory tests enclave memory management with the following tests:
   - Checking that basic uses of malloc and free work.
   - Checking that malloc returns pointers within the enclave boundary.

--- a/tests/memory/enc/CMakeLists.txt
+++ b/tests/memory/enc/CMakeLists.txt
@@ -16,5 +16,9 @@ add_enclave(TARGET memory_enc UUID 719ff522-610b-43bd-9991-c4d52a91a7e1
   stress.c
   memory_t.c)
 
+if (WIN32)
+    enclave_compile_definitions(memory_enc PRIVATE NO_PAGING_SUPPORT)
+endif ()
+
 enclave_include_directories(memory_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 enclave_link_libraries(memory_enc oelibc)

--- a/tests/memory/enc/enc.c
+++ b/tests/memory/enc/enc.c
@@ -5,9 +5,14 @@
 #include <openenclave/enclave.h>
 
 OE_SET_ENCLAVE_SGX(
-    1234,   /* ProductID */
-    5678,   /* SecurityVersion */
-    true,   /* AllowDebug */
+    1234,                /* ProductID */
+    5678,                /* SecurityVersion */
+    true,                /* AllowDebug */
+#ifdef NO_PAGING_SUPPORT /* Set smaller heap for systems without paging \
+                            support. */
+    2560,                /* HeapPageCount */
+#else
     131072, /* HeapPageCount */
-    512,    /* StackPageCount */
-    4);     /* TCSCount */
+#endif
+    32, /* StackPageCount */
+    4); /* TCSCount */

--- a/tests/memory/host/host.cpp
+++ b/tests/memory/host/host.cpp
@@ -79,10 +79,15 @@ static void _malloc_boundary_test(oe_enclave_t* enclave, uint32_t flags)
     for (int i = 0; i < BUFSIZE; i++)
         heapbuf[i] = 2;
 
-    buffer host_stack = {.buf = stackbuf, .size = sizeof(stackbuf)};
-    buffer host_heap = {.buf = heapbuf, .size = BUFSIZE};
+    buffer host_stack;
+    buffer host_heap;
     buffer enclave_memory;
     buffer enclave_host_memory;
+
+    host_stack.buf = stackbuf;
+    host_stack.size = sizeof(stackbuf);
+    host_heap.buf = heapbuf;
+    host_heap.size = BUFSIZE;
 
     OE_TEST(
         test_between_enclave_boundaries(


### PR DESCRIPTION
This PR enables the memory test on Windows. More detail of the PR is as follows.
- Set smaller heap size (~10MB) on Windows to accommodate to its lack support of paging.
- Update the logic to respect the size of the heap.
- Update the available heap in the enclave: subtracting the amount of heap used by the OE (obtained from manual tests) from the total heap size.

Fixes #2397

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>