### PR TITLE
Restore libsgx-urts install

### DIFF
--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
@@ -14,6 +14,7 @@ intel_sgx_packages:
 intel_dcap_packages:
   - "libsgx-dcap-ql"
   - "libsgx-dcap-ql-dev"
+  - "libsgx-urts"
 
 packages_validation_distribution_files:
   - "/usr/lib/x86_64-linux-gnu/libsgx_enclave_common.so"


### PR DESCRIPTION
This reverts part of #2825. That change removed `libsgx-urts` from the list of required Intel SGX packages. However, this package is still transitively required by `libsgx-pce-logic` in order to build Open Enclave successfully. For example if `urts` is still on version 2.8 while the others have updated to 2.9, we get the following error:

```
Linking C executable tests/mem/mem
FAILED: tests/mem/mem 
: && /usr/bin/clang-7 -O2 -g -DNDEBUG   tests/mem/CMakeFiles/mem.dir/main.c.o  -o tests/mem/mem  output/lib/openenclave/host/liboehost.a /usr/lib/x86_64-linux-gnu/libcrypto.so /usr/lib/x86_64-linux-gnu/libdl.so -lpthread /usr/lib/x86_64-linux-gnu/libsgx_enclave_common.so /usr/lib/x86_64-linux-gnu/libsgx_dcap_ql.so -Wl,-z,noexecstack && :
//usr/lib/x86_64-linux-gnu/libsgx_pce_logic.so: undefined reference to `sgx_get_metadata'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

This may not be a complete fix (do we need the same thing in the redhat packages? We didn't have one previously...), but it should be sufficient to fix ansible-configured Ubuntu machines.