### PR TITLE
Experimental: Use platform's ocaml to build oeedger8r

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,11 @@ if (NOT USE_SNMALLOC)
   set(USE_DLMALLOC true)
 endif ()
 
+# Support building oeedger8r without esy. Some systems have problems with esy.
+# Ocaml has good Linux support and on most platforms, it is easy to obtain ocaml
+# via the package manager. Note: This is how oeedger8r was built originally.
+option(USE_PLATFORM_OCAML "[EXPERIMENTAL] Build oeedger8r using platform's ocaml. If this is not set, esy is required." OFF)
+
 option(COMPILE_SYSTEM_EDL "Build system ecalls and ocalls into OE libraries. If not set, they must be included by application EDL to use." ON)
 
 option(BUILD_TESTS "Build OE tests" ON)

--- a/tools/oeedger8r/CMakeLists.txt
+++ b/tools/oeedger8r/CMakeLists.txt
@@ -7,21 +7,87 @@
 # the location of the input file.
 
 find_program(ESY esy)
-if (NOT ESY)
-  message(FATAL_ERROR "Please check your esy installation")
-endif ()
+if (NOT ESY AND NOT USE_PLATFORM_OCAML)
+  message(FATAL_ERROR "Please check your esy installation.\n")
 
-# An artifact of using `esy` is that the generated binary is always
-# `main.exe` regardless of platform. We rename it for installation in
-# the package.
-set(BINARY ${CMAKE_CURRENT_BINARY_DIR}/_build/default/src/main.exe)
-add_custom_command(
-  OUTPUT ${BINARY}
-  # NOTE: We copy only the files we need to build in order to allow
-  # for developers to build in the source tree (as this is easier for
-  # testing changes and new packages and formatting etc.). We cannot
-  # just copy the entire folder as CMake crashes with the
-  # `node_modules`.
+elseif (NOT ESY) # USE_PLATFORM_OCAML
+  # Use ocaml compilers if available.
+  # Use ocaml compilers if available
+  find_program(OCAMLLEX ocamllex)
+  find_program(OCAMLYACC ocamlyacc)
+  find_program(OCAMLOPT ocamlopt)
+  if ((NOT OCAMLLEX) OR (NOT OCAMLYACC) OR (NOT OCAMLOPT))
+     message(FATAL_ERROR "ocamllex, ocamlyacc or ocamlopt not found.\n"
+                         "Install ocaml via your platform's package manager.")
+  endif ()
+
+  # Generate Lexer.
+  add_custom_command(
+    OUTPUT Lexer.ml
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/intel/Lexer.mll ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ocamllex Lexer.mll
+    DEPENDS intel/Lexer.mll)
+
+  # Generate Parser.
+  add_custom_command(
+    OUTPUT Parser.ml Parser.mli
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/intel/Parser.mly ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ocamlyacc Parser.mly
+    DEPENDS intel/Parser.mly)
+
+  # Compile
+  set(BINARY  ${CMAKE_CURRENT_BINARY_DIR}/oeedger8r_main)
+  add_custom_command(
+    OUTPUT ${BINARY}
+    COMMAND mkdir -p Intel
+    COMMAND ocamlopt -c -bin-annot -I . -for-pack Intel -o Ast.cmx          ${CMAKE_CURRENT_SOURCE_DIR}/intel/Ast.ml
+    COMMAND ocamlopt -c -bin-annot -I . -for-pack Intel -o Util.cmx         ${CMAKE_CURRENT_SOURCE_DIR}/intel/Util.ml
+    COMMAND ocamlopt -c -bin-annot -I . -for-pack Intel -o SimpleStack.cmx  ${CMAKE_CURRENT_SOURCE_DIR}/intel/SimpleStack.ml
+    COMMAND ocamlopt -c -bin-annot -I . -for-pack Intel -o Plugin.cmx       ${CMAKE_CURRENT_SOURCE_DIR}/intel/Plugin.ml
+    COMMAND ocamlopt -c -bin-annot -I . -for-pack Intel -o Preprocessor.cmx ${CMAKE_CURRENT_SOURCE_DIR}/intel/Preprocessor.ml
+    COMMAND ocamlopt -c -bin-annot -I . -for-pack Intel -o Parser.cmi       ${CMAKE_CURRENT_BINARY_DIR}/Parser.mli
+    COMMAND ocamlopt -c -bin-annot -I . -for-pack Intel -o Parser.oocmxl       ${CMAKE_CURRENT_BINARY_DIR}/Parser.ml
+    COMMAND ocamlopt -c -bin-annot -I . -for-pack Intel -o Lexer.cmx        ${CMAKE_CURRENT_BINARY_DIR}/Lexer.ml
+    COMMAND ocamlopt -c -bin-annot -I . -for-pack Intel -o CodeGen.cmx      ${CMAKE_CURRENT_SOURCE_DIR}/intel/CodeGen.ml
+    COMMAND ocamlopt -pack -o Intel.cmx Ast.cmx Util.cmx SimpleStack.cmx Plugin.cmx
+                     Preprocessor.cmx Parser.cmx Lexer.cmx CodeGen.cmx
+    COMMAND ocamlopt -c -bin-annot -I . -o Common.cmi      ${CMAKE_CURRENT_SOURCE_DIR}/src/Common.mli
+    COMMAND ocamlopt -c -bin-annot -I . -o Common.cmx      ${CMAKE_CURRENT_SOURCE_DIR}/src/Common.ml
+    COMMAND ocamlopt -c -bin-annot -I . -o Headers.cmi      ${CMAKE_CURRENT_SOURCE_DIR}/src/Headers.mli
+    COMMAND ocamlopt -c -bin-annot -I . -o Headers.cmx      ${CMAKE_CURRENT_SOURCE_DIR}/src/Headers.ml
+    COMMAND ocamlopt -c -bin-annot -I . -o Sources.cmi      ${CMAKE_CURRENT_SOURCE_DIR}/src/Sources.mli
+    COMMAND ocamlopt -c -bin-annot -I . -o Sources.cmx      ${CMAKE_CURRENT_SOURCE_DIR}/src/Sources.ml
+    COMMAND ocamlopt -c -bin-annot -I . -o Emitter.cmx     ${CMAKE_CURRENT_SOURCE_DIR}/src/Emitter.ml
+    COMMAND ocamlopt -c -bin-annot -I . -o main.cmx        ${CMAKE_CURRENT_SOURCE_DIR}/src/main.ml
+    COMMAND ocamlopt str.cmxa unix.cmxa Intel.cmx Common.cmx Headers.cmx Sources.cmx Emitter.cmx main.cmx -o ${BINARY}
+
+    # Add dependency to generated Lexer and Parser, and all of the sources.
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Lexer.ml
+            ${CMAKE_CURRENT_BINARY_DIR}/Parser.ml
+            ${CMAKE_CURRENT_BINARY_DIR}/Parser.mli
+            src/Emitter.ml
+            src/main.ml
+            intel/Ast.ml
+            intel/CodeGen.ml
+            intel/Edger8r.ml
+            intel/Plugin.ml
+            intel/Preprocessor.ml
+            intel/SimpleStack.ml
+            intel/Util.ml)
+
+  #add_custom_target(oeedger8r DEPENDS ${BINARY})
+else()
+  # An artifact of using `esy` is that the generated binary is always
+  # `main.exe` regardless of platform. We rename it for installation in
+  # the package.
+  set(BINARY ${CMAKE_CURRENT_BINARY_DIR}/_build/default/src/main.exe)
+  add_custom_command(
+    OUTPUT ${BINARY}
+    # NOTE: We copy only the files we need to build in order to allow
+    # for developers to build in the source tree (as this is easier for
+    # testing changes and new packages and formatting etc.). We cannot
+    # just copy the entire folder as CMake crashes with the
+    # `node_modules`.
   COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/esy.lock ${CMAKE_CURRENT_BINARY_DIR}/esy.lock
   COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/intel ${CMAKE_CURRENT_BINARY_DIR}/intel
   COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR}/src
@@ -43,6 +109,7 @@ add_custom_command(
           intel/Preprocessor.ml
           intel/SimpleStack.ml
           intel/Util.ml)
+endif ()
 
 # The names here are important because the output file must be named
 # `oeedger8r`, and our targets must not clash with that.

--- a/tools/oeedger8r/CMakeLists.txt
+++ b/tools/oeedger8r/CMakeLists.txt
@@ -6,11 +6,7 @@
 # do not emit to the current working directory, they always emit to
 # the location of the input file.
 
-find_program(ESY esy)
-if (NOT ESY AND NOT USE_PLATFORM_OCAML)
-  message(FATAL_ERROR "Please check your esy installation.\n")
-
-elseif (NOT ESY) # USE_PLATFORM_OCAML
+if (USE_PLATFORM_OCAML)
   # Use ocaml compilers if available.
   # Use ocaml compilers if available
   find_program(OCAMLLEX ocamllex)
@@ -77,6 +73,11 @@ elseif (NOT ESY) # USE_PLATFORM_OCAML
 
   #add_custom_target(oeedger8r DEPENDS ${BINARY})
 else()
+  find_program(ESY esy)
+  if (NOT ESY)
+    message(FATAL_ERROR "Please check your esy installation.\n")
+  endif()
+
   # An artifact of using `esy` is that the generated binary is always
   # `main.exe` regardless of platform. We rename it for installation in
   # the package.

--- a/tools/oeedger8r/src/Common.ml
+++ b/tools/oeedger8r/src/Common.ml
@@ -41,16 +41,6 @@ let get_parameter_str (p : pdecl) =
 
 (** ----- End code borrowed and tweaked from {!CodeGen.ml} ----- *)
 
-(* Helper to map and filter out None at the same time. *)
-let filter_map f l =
-  let rec apply = function
-    | hd::tl -> (match f hd with
-                | Some v -> v ::(apply tl)
-                | None -> apply tl)
-    | [] -> []
- in apply l
-
-
 (* Helper to flatten and map at the same time. *)
 let flatten_map f l = List.flatten (List.map f l)
 

--- a/tools/oeedger8r/src/Common.ml
+++ b/tools/oeedger8r/src/Common.ml
@@ -42,7 +42,14 @@ let get_parameter_str (p : pdecl) =
 (** ----- End code borrowed and tweaked from {!CodeGen.ml} ----- *)
 
 (* Helper to map and filter out None at the same time. *)
-let filter_map f l = List.of_seq (Seq.filter_map f (List.to_seq l))
+let filter_map f l =
+  let rec apply = function
+    | hd::tl -> (match f hd with
+                | Some v -> v ::(apply tl)
+                | None -> apply tl)
+    | [] -> []
+ in apply l
+
 
 (* Helper to flatten and map at the same time. *)
 let flatten_map f l = List.flatten (List.map f l)

--- a/tools/oeedger8r/src/Common.mli
+++ b/tools/oeedger8r/src/Common.mli
@@ -7,8 +7,6 @@ val get_array_dims : int list -> string
 
 val get_parameter_str : Intel.Ast.pdecl -> string
 
-val filter_map : ('a -> 'b option) -> 'a list -> 'b list
-
 val flatten_map : ('a -> 'b list) -> 'a list -> 'b list
 
 val flatten_map2 : ('a -> 'b -> 'c list) -> 'a list -> 'b list -> 'c list

--- a/tools/oeedger8r/src/Emitter.ml
+++ b/tools/oeedger8r/src/Emitter.ml
@@ -68,25 +68,25 @@ let warn_signed_size_or_count_types (fd : func_decl) =
   in
   (* Get the names of all size and count parameters for the function [fd]. *)
   let size_params =
-    filter_map
-      (fun (ptype, _) ->
+    List.fold_left
+      (fun names (ptype, _) ->
         (* The size may be either a [count] or [size], and then
            either a number or string. We are interested in the
            strings, as they indicate named [size] or [count]
            parameters. *)
-        let param_name { ps_size; ps_count } =
+        let prepend_param_name { ps_size; ps_count } =
           match (ps_size, ps_count) with
           (* [s] is the name of the parameter as a string. *)
-          | None, Some (AString s) | Some (AString s), None -> Some s
+          | None, Some (AString s) | Some (AString s), None -> s :: names
           (* TODO: Check for [Some (ANumber n)] that [n < 1] *)
-          | _ -> None
+          | _ -> names
         in
         (* Only variables that are pointers where [chkptr] is true may
            have size parameters. *)
         match ptype with
-        | PTPtr (_, a) when a.pa_chkptr -> param_name a.pa_size
-        | _ -> None)
-      fd.plist
+        | PTPtr (_, a) when a.pa_chkptr -> prepend_param_name a.pa_size
+        | _ -> names)
+      [] fd.plist
   in
   (* Print warnings for size parameters that are [Signed]. *)
   List.iter


### PR DESCRIPTION
Problem: We use esy to build oeedger8r. Esy builds the ocaml compiler locally, and then uses that
to build oeedger8r. We have tested only specific versions of nodejs (10.x) and esy (0.5.8).
On a new machine, it is easy to end up with a broken build of oeedger8r.

Solution:
USE_PLATFORM_OCAML flag provides a way to build oeedge8r, as it used to be built, using the
platform's ocaml compiler. It is easy to install ocaml compilers via a platform's package
manager since ocaml has good linux support. `sudo apt install ocaml`

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>