### PR TITLE
Pre-allocating memory for quote verification collaterals before an ocall

### DIFF
--- a/common/sgx/collateral.h
+++ b/common/sgx/collateral.h
@@ -66,6 +66,16 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
 void oe_free_sgx_quote_verification_collateral_args(
     oe_get_sgx_quote_verification_collateral_args_t* args);
 
+/**
+ * Pre-allocate memory for the resources that get passed into the 
+ * oe_get_quote_verification_collateral_ocall. To avoid extra passes needed
+ * to take care of OE_BUFFER_TOO_SMALL failures.
+ *
+ * @param[in] args The quote verification collateral.
+ */
+void oe_prealloc_quote_verification_collateral_args(
+    oe_get_sgx_quote_verification_collateral_args_t* buf);
+
 OE_EXTERNC_END
 
 #endif // _OE_COMMON_REVOCATION_H

--- a/common/sgx/collateral.h
+++ b/common/sgx/collateral.h
@@ -66,16 +66,6 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
 void oe_free_sgx_quote_verification_collateral_args(
     oe_get_sgx_quote_verification_collateral_args_t* args);
 
-/**
- * Pre-allocate memory for the resources that get passed into the 
- * oe_get_quote_verification_collateral_ocall. To avoid extra passes needed
- * to take care of OE_BUFFER_TOO_SMALL failures.
- *
- * @param[in] args The quote verification collateral.
- */
-void oe_prealloc_quote_verification_collateral_args(
-    oe_get_sgx_quote_verification_collateral_args_t* buf);
-
 OE_EXTERNC_END
 
 #endif // _OE_COMMON_REVOCATION_H

--- a/enclave/sgx/collateralinfo.c
+++ b/enclave/sgx/collateralinfo.c
@@ -13,6 +13,40 @@
 #include "platform_t.h"
 
 /**
+ * Update these default size values as needed.
+ * These represent the default buffer sizes that can store their
+ * corresponding quote_verification_collateral_args completely.
+ * Last updated as per arg-sizes observered as of May 2020.
+ */
+#define TCBINFO_DEFAULT_SIZE 5000
+#define PCK_CRL_DEFAULT_SIZE 600
+#define QE_IDENTITY_DEFAULT_SIZE 1500
+#define ROOT_CA_CRL_DEFAULT_SIZE 600
+#define ALL_ISSUER_CHAIN_DEFAULT_SIZE 3000
+
+/**
+ * Pre-allocate memory for the resources that get passed into the
+ * oe_get_quote_verification_collateral_ocall. To avoid extra passes
+ * needed to take care of OE_BUFFER_TOO_SMALL failures.
+ *
+ * @param[in] buf The quote verification collateral.
+ * [in] def_sizes The default quote verification collateral sizes.
+ */
+void oe_prealloc_quote_verification_collateral_args(
+    oe_get_sgx_quote_verification_collateral_args_t* buf,
+    oe_get_sgx_quote_verification_collateral_args_t* default_sizes);
+
+/**
+ * This function is called to update the default collateral arg sizes.
+ *
+ * @param[in] default_sizes The default quote verification collateral sizes.
+ * [in] src_args The quote verification collateral.
+ */
+void oe_update_default_collateral_arg_sizes(
+    oe_get_sgx_quote_verification_collateral_args_t* src_args,
+    oe_get_sgx_quote_verification_collateral_args_t* default_sizes);
+
+/**
  * Call into host to fetch collateral information.
  */
 oe_result_t oe_get_sgx_quote_verification_collateral(
@@ -21,6 +55,29 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
     oe_result_t result = OE_FAILURE;
     oe_get_sgx_quote_verification_collateral_args_t in = {0};
     oe_get_sgx_quote_verification_collateral_args_t out = {0};
+
+    /**
+     * This variable is used to store default collateral arg sizes.
+     */
+    static oe_get_sgx_quote_verification_collateral_args_t default_arg_size = {
+        0,
+        {0},
+        0,
+        TCBINFO_DEFAULT_SIZE,
+        0,
+        ALL_ISSUER_CHAIN_DEFAULT_SIZE,
+        0,
+        PCK_CRL_DEFAULT_SIZE,
+        0,
+        ALL_ISSUER_CHAIN_DEFAULT_SIZE,
+        0,
+        ROOT_CA_CRL_DEFAULT_SIZE,
+        0,
+        QE_IDENTITY_DEFAULT_SIZE,
+        0,
+        ALL_ISSUER_CHAIN_DEFAULT_SIZE,
+        0};
+
     uint32_t retval;
 
     if (!args)
@@ -28,11 +85,11 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
 
     /* fmspc */
     memcpy(in.fmspc, args->fmspc, sizeof(in.fmspc));
+    oe_prealloc_quote_verification_collateral_args(&in, &default_arg_size);
 
     for (;;)
     {
         memcpy(&out, &in, sizeof(out));
-        oe_prealloc_quote_verification_collateral_args(&out);
 
         if (oe_get_quote_verification_collateral_ocall(
                 &retval,
@@ -154,6 +211,7 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
 
     OE_CHECK((oe_result_t)retval);
 
+    oe_update_default_collateral_arg_sizes(&out, &default_arg_size);
     *args = out;
     memset(&out, 0, sizeof(out));
     result = OE_OK;
@@ -171,120 +229,127 @@ done:
 }
 
 void oe_prealloc_quote_verification_collateral_args(
-oe_get_sgx_quote_verification_collateral_args_t* buf)
+    oe_get_sgx_quote_verification_collateral_args_t* buf,
+    oe_get_sgx_quote_verification_collateral_args_t* default_sizes)
 {
-    /*These numbers are just estimates of buffer sizes*/
-    size_t prealloc_tcb_info_size = 5000;
-    size_t prealloc_tcb_info_issuer_chain_size = 3000;
-    size_t prealloc_pck_crl_size = 600;
-    size_t prealloc_root_ca_crl_size = 600;
-    size_t prealloc_pck_crl_issuer_chain_size = 3000;
-    size_t prealloc_qe_identity_issuer_chain_size = 3000;
-    size_t prealloc_qe_identity_size = 700;
-    if(!buf->tcb_info_size)
+    /* Allocate estimated buffers for quote_verification_collateral_args */
+
+    buf->tcb_info = (uint8_t*)calloc(1, default_sizes->tcb_info_size);
+
+    if (buf->tcb_info)
     {
-        buf->tcb_info = (uint8_t *)malloc(prealloc_tcb_info_size);
-        if(buf->tcb_info != NULL)
-        {
-            buf->tcb_info_size = prealloc_tcb_info_size;
-            memset(buf->tcb_info,0, buf->tcb_info_size);   
-        }
-        else
-        {
-            goto cleanup;
-        }        
+        buf->tcb_info_size = default_sizes->tcb_info_size;
+    }
+    else
+    {
+        goto done;
     }
 
-    if(!buf->tcb_info_issuer_chain_size)
+    buf->tcb_info_issuer_chain =
+        (uint8_t*)calloc(1, default_sizes->tcb_info_issuer_chain_size);
+
+    if (buf->tcb_info_issuer_chain)
     {
-        buf->tcb_info_issuer_chain = (uint8_t *)malloc(prealloc_tcb_info_size);
-        if(buf->tcb_info != NULL)
-        {
-            buf->tcb_info_issuer_chain_size = prealloc_tcb_info_issuer_chain_size;
-            memset(buf->tcb_info_issuer_chain,0, buf->tcb_info_issuer_chain_size);    
-        }
-        else
-        {
-            goto cleanup;
-        }
+        buf->tcb_info_issuer_chain_size =
+            default_sizes->tcb_info_issuer_chain_size;
+    }
+    else
+    {
+        goto done;
     }
 
-    if(!buf->pck_crl_size)
+    buf->pck_crl = (uint8_t*)calloc(1, default_sizes->pck_crl_size);
+
+    if (buf->pck_crl)
     {
-        buf->pck_crl = (uint8_t *)malloc(prealloc_pck_crl_size);
-        if(buf->pck_crl != NULL)
-        {
-            buf->pck_crl_size = prealloc_pck_crl_size;
-            memset(buf->pck_crl,0, buf->pck_crl_size);
-        }
-        else
-        {
-            goto cleanup;
-        }
+        buf->pck_crl_size = default_sizes->pck_crl_size;
+    }
+    else
+    {
+        goto done;
     }
 
-    if(!buf->root_ca_crl_size)
+    buf->root_ca_crl = (uint8_t*)calloc(1, default_sizes->root_ca_crl_size);
+
+    if (buf->root_ca_crl)
     {
-        buf->root_ca_crl = (uint8_t *)malloc(prealloc_root_ca_crl_size);
-        if(buf->root_ca_crl != NULL)
-        {
-            buf->root_ca_crl_size = prealloc_root_ca_crl_size;
-            memset(buf->root_ca_crl,0, buf->root_ca_crl_size);
-        }
-        else
-        {
-            goto cleanup;
-        }
+        buf->root_ca_crl_size = default_sizes->root_ca_crl_size;
+    }
+    else
+    {
+        goto done;
     }
 
-    if(!buf->pck_crl_issuer_chain_size)
+    buf->pck_crl_issuer_chain =
+        (uint8_t*)calloc(1, default_sizes->pck_crl_issuer_chain_size);
+
+    if (buf->pck_crl_issuer_chain)
     {
-        buf->pck_crl_issuer_chain = (uint8_t *)malloc(prealloc_pck_crl_issuer_chain_size);
-        if(buf->pck_crl_issuer_chain != NULL)
-        {
-            buf->pck_crl_issuer_chain_size = 
-            prealloc_pck_crl_issuer_chain_size;
-            memset(buf->pck_crl_issuer_chain,0, buf->pck_crl_issuer_chain_size
-            );
-        }
-        else
-        {
-            goto cleanup;
-        }
+        buf->pck_crl_issuer_chain_size =
+            default_sizes->pck_crl_issuer_chain_size;
+    }
+    else
+    {
+        goto done;
     }
 
-    if(!buf->qe_identity_size)
-    {   
-        buf->qe_identity = (uint8_t *)malloc(prealloc_qe_identity_size);
-        if(buf->qe_identity != NULL)
-        {
-            buf->qe_identity_size = prealloc_qe_identity_size;
-            memset(buf->qe_identity,0, buf->qe_identity_size);
-        }
-        else
-        {
-            goto cleanup;
-        }
-    }   
+    buf->qe_identity = (uint8_t*)calloc(1, default_sizes->qe_identity_size);
 
-    if(!buf->qe_identity_issuer_chain_size)
+    if (buf->qe_identity)
     {
-        buf->qe_identity_issuer_chain = (uint8_t *)malloc(prealloc_qe_identity_issuer_chain_size);
-        if(buf->qe_identity_issuer_chain != NULL)
-        {
-            buf->qe_identity_issuer_chain_size = prealloc_qe_identity_issuer_chain_size;
-            memset(buf->qe_identity_issuer_chain,0, buf->qe_identity_issuer_chain_size);
-        }
-        else
-        {
-            goto cleanup;
-        }
+        buf->qe_identity_size = default_sizes->qe_identity_size;
+    }
+    else
+    {
+        goto done;
+    }
+
+    buf->qe_identity_issuer_chain =
+        (uint8_t*)calloc(1, default_sizes->qe_identity_issuer_chain_size);
+
+    if (buf->qe_identity_issuer_chain)
+    {
+        buf->qe_identity_issuer_chain_size =
+            default_sizes->qe_identity_issuer_chain_size;
+    }
+    else
+    {
+        goto done;
     }
     return;
-cleanup:
-            oe_free_sgx_quote_verification_collateral_args(buf);
-            return;
-    
+done:
+    /*if any of the args remain unallocated, clear all values*/
+    oe_free_sgx_quote_verification_collateral_args(buf);
+    buf->qe_identity_issuer_chain_size = 0;
+    buf->qe_identity_size = 0;
+    buf->pck_crl_issuer_chain_size = 0;
+    buf->pck_crl_size = 0;
+    buf->tcb_info_size = 0;
+    buf->tcb_info_issuer_chain_size = 0;
+    buf->root_ca_crl_size = 0;
+    return;
+}
+
+void oe_update_default_collateral_arg_sizes(
+    oe_get_sgx_quote_verification_collateral_args_t* src_args,
+    oe_get_sgx_quote_verification_collateral_args_t* default_sizes)
+{
+    /**
+     * Update the default sizes after the actual collateral
+     * arg sizes have been retrieved
+     * */
+
+    default_sizes->tcb_info_size = src_args->tcb_info_size;
+    default_sizes->tcb_info_issuer_chain_size =
+        src_args->tcb_info_issuer_chain_size;
+    default_sizes->root_ca_crl_size = src_args->root_ca_crl_size;
+    default_sizes->pck_crl_size = src_args->pck_crl_size;
+    default_sizes->pck_crl_issuer_chain_size =
+        src_args->pck_crl_issuer_chain_size;
+    default_sizes->qe_identity_size = src_args->qe_identity_size;
+    default_sizes->qe_identity_issuer_chain_size =
+        src_args->qe_identity_issuer_chain_size;
+    return;
 }
 
 void oe_free_sgx_quote_verification_collateral_args(

--- a/enclave/sgx/collateralinfo.c
+++ b/enclave/sgx/collateralinfo.c
@@ -32,6 +32,7 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
     for (;;)
     {
         memcpy(&out, &in, sizeof(out));
+        oe_prealloc_quote_verification_collateral_args(&out);
 
         if (oe_get_quote_verification_collateral_ocall(
                 &retval,
@@ -167,6 +168,123 @@ done:
     }
 
     return result;
+}
+
+void oe_prealloc_quote_verification_collateral_args(
+oe_get_sgx_quote_verification_collateral_args_t* buf)
+{
+    /*These numbers are just estimates of buffer sizes*/
+    size_t prealloc_tcb_info_size = 5000;
+    size_t prealloc_tcb_info_issuer_chain_size = 3000;
+    size_t prealloc_pck_crl_size = 600;
+    size_t prealloc_root_ca_crl_size = 600;
+    size_t prealloc_pck_crl_issuer_chain_size = 3000;
+    size_t prealloc_qe_identity_issuer_chain_size = 3000;
+    size_t prealloc_qe_identity_size = 700;
+    if(!buf->tcb_info_size)
+    {
+        buf->tcb_info = (uint8_t *)malloc(prealloc_tcb_info_size);
+        if(buf->tcb_info != NULL)
+        {
+            buf->tcb_info_size = prealloc_tcb_info_size;
+            memset(buf->tcb_info,0, buf->tcb_info_size);   
+        }
+        else
+        {
+            goto cleanup;
+        }        
+    }
+
+    if(!buf->tcb_info_issuer_chain_size)
+    {
+        buf->tcb_info_issuer_chain = (uint8_t *)malloc(prealloc_tcb_info_size);
+        if(buf->tcb_info != NULL)
+        {
+            buf->tcb_info_issuer_chain_size = prealloc_tcb_info_issuer_chain_size;
+            memset(buf->tcb_info_issuer_chain,0, buf->tcb_info_issuer_chain_size);    
+        }
+        else
+        {
+            goto cleanup;
+        }
+    }
+
+    if(!buf->pck_crl_size)
+    {
+        buf->pck_crl = (uint8_t *)malloc(prealloc_pck_crl_size);
+        if(buf->pck_crl != NULL)
+        {
+            buf->pck_crl_size = prealloc_pck_crl_size;
+            memset(buf->pck_crl,0, buf->pck_crl_size);
+        }
+        else
+        {
+            goto cleanup;
+        }
+    }
+
+    if(!buf->root_ca_crl_size)
+    {
+        buf->root_ca_crl = (uint8_t *)malloc(prealloc_root_ca_crl_size);
+        if(buf->root_ca_crl != NULL)
+        {
+            buf->root_ca_crl_size = prealloc_root_ca_crl_size;
+            memset(buf->root_ca_crl,0, buf->root_ca_crl_size);
+        }
+        else
+        {
+            goto cleanup;
+        }
+    }
+
+    if(!buf->pck_crl_issuer_chain_size)
+    {
+        buf->pck_crl_issuer_chain = (uint8_t *)malloc(prealloc_pck_crl_issuer_chain_size);
+        if(buf->pck_crl_issuer_chain != NULL)
+        {
+            buf->pck_crl_issuer_chain_size = 
+            prealloc_pck_crl_issuer_chain_size;
+            memset(buf->pck_crl_issuer_chain,0, buf->pck_crl_issuer_chain_size
+            );
+        }
+        else
+        {
+            goto cleanup;
+        }
+    }
+
+    if(!buf->qe_identity_size)
+    {   
+        buf->qe_identity = (uint8_t *)malloc(prealloc_qe_identity_size);
+        if(buf->qe_identity != NULL)
+        {
+            buf->qe_identity_size = prealloc_qe_identity_size;
+            memset(buf->qe_identity,0, buf->qe_identity_size);
+        }
+        else
+        {
+            goto cleanup;
+        }
+    }   
+
+    if(!buf->qe_identity_issuer_chain_size)
+    {
+        buf->qe_identity_issuer_chain = (uint8_t *)malloc(prealloc_qe_identity_issuer_chain_size);
+        if(buf->qe_identity_issuer_chain != NULL)
+        {
+            buf->qe_identity_issuer_chain_size = prealloc_qe_identity_issuer_chain_size;
+            memset(buf->qe_identity_issuer_chain,0, buf->qe_identity_issuer_chain_size);
+        }
+        else
+        {
+            goto cleanup;
+        }
+    }
+    return;
+cleanup:
+            oe_free_sgx_quote_verification_collateral_args(buf);
+            return;
+    
 }
 
 void oe_free_sgx_quote_verification_collateral_args(


### PR DESCRIPTION
Issue: Update oe_get_sgx_quote_verification_collateral to preallocate buffers to avoid double calls. #2049
Fix: 1. Added a list of pre-estimated memory sizes for each arguments passed into the oe_get_quote_verification_collateral_ocall().
2. Allocate the above estimated memory-buffers to each of the arguments before passing them on to the ocall.