### PR TITLE
Add host_verify sample to host_verify lib

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -26,7 +26,8 @@ if (BUILD_ENCLAVES)
 endif ()
 
 install(DIRECTORY host_verify
-	DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples)
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples
+        COMPONENT OEHOSTVERIFY)
 
 if (WIN32)
   install(FILES README_Windows.md


### PR DESCRIPTION
Modify a cmake file so that cpack adds the latest host_verify sample to the open-enclave-hostverify library.

Fix #2512.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>