### PR TITLE
v2 collateral verify changes

### DIFF
--- a/common/sgx/collateral.c
+++ b/common/sgx/collateral.c
@@ -340,6 +340,28 @@ oe_result_t oe_validate_revocation_list(
         "Failed to parse TCB info or Platform TCB is not up-to-date. %s",
         oe_result_str(result));
 
+    if (memcmp(
+            parsed_extension_info.fmspc,
+            parsed_tcb_info.fmspc,
+            sizeof(parsed_extension_info.fmspc)) != 0)
+    {
+        OE_RAISE_MSG(
+            OE_VERIFY_FAILED,
+            "Failed to verify fmspc in TCB. %s",
+            oe_result_str(result));
+    }
+
+    if (memcmp(
+            parsed_extension_info.pce_id,
+            parsed_tcb_info.pceid,
+            sizeof(parsed_extension_info.pce_id)) != 0)
+    {
+        OE_RAISE_MSG(
+            OE_VERIFY_FAILED,
+            "Failed to verify pceid in TCB. %s",
+            oe_result_str(result));
+    }
+
     OE_CHECK_MSG(
         oe_verify_ecdsa256_signature(
             parsed_tcb_info.tcb_info_start,

--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -595,6 +595,14 @@ static oe_result_t _read_tcb_info(
         OE_TRACE_VERBOSE("V2: Reading tcbType");
         OE_CHECK(_read_property_name_and_colon("tcbType", itr, end));
         OE_CHECK(_read_integer(itr, end, &value));
+
+        // HW representation of CPUSVN for a given FMSPC is not architecturally
+        // defined to provide designers more flexibility. SW needs "tcbType" to
+        // determine how to decompose the CPUSVN. Each FMSPC has its own
+        // tcbType. For now, there is only one tcbType(0) has been defined.
+        if (value != 0)
+            OE_RAISE_MSG(
+                OE_JSON_INFO_PARSE_ERROR, "Unsupported tcbType(%d).", value);
         parsed_info->tcb_type = (uint32_t)value;
         OE_CHECK(_read(',', itr, end));
 

--- a/tests/report/data_v2/tcbInfoNegativeTcbType.json
+++ b/tests/report/data_v2/tcbInfoNegativeTcbType.json
@@ -1,0 +1,174 @@
+{
+  "tcbInfo": {
+    "version": 2,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 1,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":8
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":7
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"SWHardeningNeeded"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"ConfigurationAndSWHardeningNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/host/tcbinfo.cpp
+++ b/tests/report/host/tcbinfo.cpp
@@ -442,6 +442,8 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         "./data_v2/tcbInfoNegativeIntegerOverflow.json",
         "./data_v2/tcbInfoNegativeIntegerWithSign.json",
         "./data_v2/tcbInfoNegativeFloat.json",
+        // TcbType != 0.
+        "./data_v2/tcbInfoNegativeTcbType.json",
     };
 
     for (size_t i = 0; i < sizeof(negative_files) / sizeof(negative_files[0]);


### PR DESCRIPTION
Intel SGX released v2 attestation and multiple APIs were affected and need updates.
Parsing updates had been done in #2293. This pr is to handle validation updates.
Summary of validation changes are:
v1 Bug fix.
    - Verify `pceid` field matches the one in the PCK Cert.
    - Verify `fmspc` field matches the one in the PCK Cert.
v2:
    - Validate `tcbType` has a value of 0. Intel use `tcbType` to guide SW how to decompose the CPUSVN. Each FMSPc has its own tcbType. For now, there is only one tcbType(0) has been defined.
    - Validate `tcbEvaluationDataNumber` in tcbInfo and qeIdentity. `tcbEvaluationDataNumber` is defined as a monotonically increasing number to reflect the freshness of the collaterals. So `tcbEvaluationDataNumber` should always greater or equals to the `tcbEvaluationDataNumber` the enclave has seen. For now, intel didn't validate this value but just return it as a part of supplemental data.
This PR fixed v1 bugs and validated tcbType for now.