### PR TITLE
Add description for NuGet host verification library

### DIFF
--- a/cmake/HostVerifyNuGetDescription.txt
+++ b/cmake/HostVerifyNuGetDescription.txt
@@ -1,0 +1,6 @@
+Open Enclave Host-Side Verification Library is an SDK for building applications
+in order to perform host-side enclave verification in C and C++.
+
+Host-side enclave verification means that a non-enclave application is trying to
+authenticate an enclave's hardware and software settings so that the application
+can determine whether or not to trust the enclave.

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -31,4 +31,9 @@ set(CPACK_NUGET_PACKAGE_AUTHORS "Open Enclave SDK Contributors")
 set(CPACK_NUGET_PACKAGE_VERSION ${OE_VERSION})
 set(CPACK_NUGET_PACKAGE_LICENSEURL "https://github.com/openenclave/openenclave/blob/master/LICENSE")
 
+# CPack variables for Nuget packages for the host-side verification library
+file(READ "${PROJECT_SOURCE_DIR}/cmake/HostVerifyNuGetDescription.txt" CPACK_NUGET_OEHOSTVERIFY_PACKAGE_DESCRIPTION_FILE)
+set(CPACK_NUGET_OEHOSTVERIFY_PACKAGE_DESCRIPTION ${CPACK_NUGET_OEHOSTVERIFY_PACKAGE_DESCRIPTION_FILE})
+set(CPACK_NUGET_OEHOSTVERIFY_PACKAGE_DESCRIPTION_SUMMARY "Open Enclave Report Verification Host Library")
+
 include(CPack)

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -58,6 +58,7 @@ docs/*
 3rdparty/optee/optee_os
 3rdparty/snmalloc
 cmake/NuGetDescription.txt
+cmake/HostVerifyNuGetDescription.txt
 devex/vscode-extension/.vscodeignore
 devex/vscode-extension/assets/devkit/devdata.tar.gz
 devex/vscode-extension/assets/edgeSolutionTemplateFolder/modules/\[\[project-name\]\]/Dockerfile.aarch64-qemu


### PR DESCRIPTION
Add summary and description for the nuget package for the open-enclave-hostverify library.

Unable to find an attribute for a component's description file, I add a simple description of the library in the component's description field.

Fix #2548.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>