### PR TITLE
Support code coverage tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,4 @@
 	path = 3rdparty/libgcov/compiler-rt
 	url = https://github.com/llvm-mirror/compiler-rt
 	branch = release_70
+	ignore = all

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,7 @@
 [submodule "tools/oeedger8r-cpp"]
 	path = tools/oeedger8r-cpp
 	url = https://github.com/openenclave/oeedger8r-cpp
+[submodule "3rdparty/libgcov/compiler-rt"]
+	path = 3rdparty/libgcov/compiler-rt
+	url = https://github.com/llvm-mirror/compiler-rt
+	branch = release_70

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -20,6 +20,46 @@ AGENTS_LABELS = [
     "acc-rhel-8-vanilla":       env.RHEL_8_VANILLA_CUSTOM_LABEL ?: "vanilla-rhel-8"
 ]
 
+def ACCCodeCoverageTest(String label, String compiler, String build_type) {
+    stage("${label} ${compiler} ${build_type} Code Coverage") {
+        node("${label}") {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def task = """
+                           cmake ${WORKSPACE}                                           \
+                               -G Ninja                                                 \
+                               -DCODE_COVERAGE=ON                                       \
+                               -DUSE_DEBUG_MALLOC=OFF                                   \
+                               -DCMAKE_BUILD_TYPE=${build_type}                         \
+                               -Wdev
+                           ninja -v
+                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
+                           ninja code_coverage
+                           """
+                oe.Run(compiler, task)
+
+                // Publish the report via Cobertura Plugin.
+                cobertura coberturaReportFile: 'build/coverage/coverage.xml'
+
+                // Publish the result to the PR(s) via GitHub Coverage reporter Plugin.
+                // Workaround to obtain the PR id(s) as Bors does not us to grab them reliably.
+                def log = sh (script: "git log -1 | grep -Po '(Try #\\K|Merge #\\K)[^:]*'", returnStdout: true).trim()
+                def id_list = log.split(' #')
+                id_list.each {
+                    echo "PR ID: ${it}, REPOSITORY_NAME: ${REPOSITORY_NAME}"
+                    withEnv(["CHANGE_URL=https://github.com/${REPOSITORY_NAME}/pull/${it}"]) {
+                        publishCoverageGithub(filepath:'build/coverage/coverage.xml',
+                                              coverageXmlType: 'cobertura',
+                                              comparisonOption: [ value: 'optionFixedCoverage', fixedCoverage: '0.60' ],
+                                              coverageRateType: 'Line')
+                    }
+                }
+            }
+        }
+    }
+}
+
 def ACCTest(String label, String compiler, String build_type, List extra_cmake_args = [], List test_env = [], boolean fresh_install = false) {
     stage("${label} ${compiler} ${build_type}, extra_cmake_args: ${extra_cmake_args}, test_env: ${test_env}${fresh_install ? ", e2e" : ""}") {
         node(label) {
@@ -320,6 +360,7 @@ try{
                 "ACC1804 clang-7 Release LVI FULL Tests": { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
                 "ACC1804 gcc Debug LVI":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
                 "ACC1804 gcc Release LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 Code Coverage Test" :            { ACCCodeCoverageTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug') },
 
                 "ACC1604 clang-7 Debug LVI e2e":          { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04-vanilla"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) },
                 "ACC1604 gcc Release LVI e2e":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04-vanilla"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) },

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -20,6 +20,10 @@ if (OE_SGX AND COMPILER_SUPPORTS_SNMALLOC)
   add_subdirectory(snmalloc)
 endif ()
 
+if (CODE_COVERAGE OR BUILD_LIBGCOV)
+  add_subdirectory(libgcov)
+endif ()
+
 if (OE_TRUSTZONE)
   # EL: (ARM) Exception Level
   # GP: GlobalPlatform

--- a/3rdparty/libgcov/CMakeLists.txt
+++ b/3rdparty/libgcov/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+check_submodule_not_empty(compiler-rt)
+
+apply_patches(patches compiler-rt)
+
+add_enclave_library(
+  gcov
+  STATIC
+  # Only the following three files are required to support GCOV-based code coverage analysis.
+  compiler-rt/lib/profile/GCDAProfiling.c
+  compiler-rt/lib/profile/InstrProfiling.c
+  compiler-rt/lib/profile/InstrProfilingUtil.c)
+
+maybe_build_using_clangw(gcov)
+
+enclave_compile_options(gcov PRIVATE -Wno-error)
+
+enclave_link_libraries(gcov PRIVATE oelibc oehostfs)
+
+enclave_include_directories(gcov PRIVATE src)
+
+install_enclaves(
+  TARGETS
+  gcov
+  EXPORT
+  openenclave-targets
+  ARCHIVE
+  DESTINATION
+  ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/3rdparty/libgcov/README.md
+++ b/3rdparty/libgcov/README.md
@@ -1,0 +1,13 @@
+# libgcov
+
+The source is based on the profile library as part of [LLVM compiler-rt libraries](http://compiler-rt.llvm.org/).
+The current version is based on the release_70 branch (clang-7).
+
+## Modifications
+
+The following changes are made to the source to accommodate TEEs (see patches/ for more detail):
+- Initialize the `hostfs` during the GCOV initialization (`llvm_gcov_init()`).
+  - Ensure that the following filesystem operations work correctly.
+- Replace `mmap` and `ummap` (in `map_file()` and `unmap_file()`)
+  - `mmap` is not supported by OE. Use `fread()` instead.
+  - Alternatively, OE can support `mmap` only for code coverage testing (if there is a performance gap). Note that `mmap` implies using the host memory.

--- a/3rdparty/libgcov/patches/GCDAProfiling.c.patch
+++ b/3rdparty/libgcov/patches/GCDAProfiling.c.patch
@@ -1,0 +1,91 @@
+diff --git a/3rdparty/libgcov/compiler-rt/lib/profile/GCDAProfiling.c b/3rdparty/libgcov/compiler-rt/lib/profile/GCDAProfiling.c
+index cbca36551..3c42b1008 100644
+--- a/3rdparty/libgcov/compiler-rt/lib/profile/GCDAProfiling.c
++++ b/3rdparty/libgcov/compiler-rt/lib/profile/GCDAProfiling.c
+@@ -33,6 +33,7 @@
+ #else
+ #include <sys/mman.h>
+ #include <sys/file.h>
++#include <sys/mount.h>
+ #endif
+ 
+ #if defined(__FreeBSD__) && defined(__i386__)
+@@ -58,6 +59,11 @@ typedef unsigned int uint32_t;
+ typedef unsigned long long uint64_t;
+ #endif
+ 
++/* Beginning of the OE modfication */
++#include "openenclave/bits/module.h"
++#include "openenclave/bits/fs.h"
++/* End of the OE modification */
++
+ #include "InstrProfiling.h"
+ #include "InstrProfilingUtil.h"
+ 
+@@ -255,28 +261,42 @@ static int map_file() {
+   if (file_size == 0)
+     return -1;
+ 
++#if defined(COMPILER_RT_HAS_MMAP)
+   write_buffer = mmap(0, file_size, PROT_READ | PROT_WRITE,
+                       MAP_FILE | MAP_SHARED, fd, 0);
++#endif
++
++  write_buffer = malloc(file_size);
+   if (write_buffer == (void *)-1) {
+     int errnum = errno;
+     fprintf(stderr, "profiling: %s: cannot map: %s\n", filename,
+             strerror(errnum));
+     return -1;
+   }
++  fseek(output_file, 0L, SEEK_SET);
++  fread(write_buffer, file_size, 1, output_file);
+   return 0;
+ }
+ 
+ static void unmap_file() {
++#if defined(COMPILER_RT_HAS_MSYNC)
+   if (msync(write_buffer, file_size, MS_SYNC) == -1) {
+     int errnum = errno;
+     fprintf(stderr, "profiling: %s: cannot msync: %s\n", filename,
+             strerror(errnum));
+   }
++#endif
++
++  fseek(output_file, 0L, SEEK_SET);
++  fwrite(write_buffer, file_size, 1, output_file);
+ 
+   /* We explicitly ignore errors from unmapping because at this point the data
+    * is written and we don't care.
+    */
++#if defined(COMPILER_RT_HAS_MUNMAP)
+   (void)munmap(write_buffer, file_size);
++#endif
++  free(write_buffer);
+   write_buffer = NULL;
+   file_size = 0;
+ }
+@@ -598,6 +618,23 @@ void llvm_gcov_init(fn_ptr wfn, fn_ptr ffn) {
+   if (atexit_ran == 0) {
+     atexit_ran = 1;
+ 
++    /* Beginning of the OE modfication */
++    if (oe_load_module_host_file_system() != OE_OK) {
++      fprintf(stderr, "oe_load_module_host_file_system() failed\n");
++      exit(1);
++    }
++
++    if (mount("/", "/", OE_HOST_FILE_SYSTEM, 0, NULL) != 0) {
++      fprintf(stderr, "[llvm_gcov_init] mount() failed\n");
++      exit(1);
++
++    }
++    // Workaround: Force to install the atexit handler of fdtable
++    //             prior to the llvm handler.
++    FILE *f = fopen("/dev/null", "r");
++    fclose(f);
++    /* End of the OE modification */
++
+     /* Make sure we write out the data and delete the data structures. */
+     atexit(llvm_delete_flush_function_list);
+     atexit(llvm_delete_writeout_function_list);

--- a/3rdparty/libgcov/patches/InstrProfilingUtil.c.patch
+++ b/3rdparty/libgcov/patches/InstrProfilingUtil.c.patch
@@ -1,0 +1,12 @@
+diff --git a/3rdparty/libgcov/compiler-rt/lib/profile/InstrProfilingUtil.c b/3rdparty/libgcov/compiler-rt/lib/profile/InstrProfilingUtil.c
+index 083bf14a3..4b71da592 100644
+--- a/3rdparty/libgcov/compiler-rt/lib/profile/InstrProfilingUtil.c
++++ b/3rdparty/libgcov/compiler-rt/lib/profile/InstrProfilingUtil.c
+@@ -15,6 +15,7 @@
+ #else
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <sys/file.h> // Open Enclave: Include flock().
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <errno.h>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,12 @@ if (CODE_COVERAGE)
       FATAL_ERROR
         "The CODE_COVERAGE option currently is not supported on Windows.")
   endif ()
+  if (USE_DEBUG_MALLOC)
+    message(
+      FATAL_ERROR
+        "The CODE_COVERAGE option currently is not supported when the USE_DEBUG_MALLOC option is ON."
+    )
+  endif ()
   message("-- CODE_COVERAGE set - enable code coverage tests")
 
   if (CMAKE_C_COMPILER_ID MATCHES GNU)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,74 @@ elseif (WITH_EEID AND OE_TRUSTZONE)
   message(FATAL_ERROR "WITH_EEID is not supported on ARM yet.")
 endif ()
 
+# Option to build and expose the libgcov such that enclave applications can use.
+# Note that this option is only effective when CODE_COVERAGE is not set.
+option(BUILD_LIBGCOV "Build the code coverage library" OFF)
+
+option(CODE_COVERAGE "Enable code coverage testing" OFF)
+if (CODE_COVERAGE)
+  if (WIN32)
+    message(
+      FATAL_ERROR
+        "The CODE_COVERAGE option currently is not supported on Windows.")
+  endif ()
+  message("-- CODE_COVERAGE set - enable code coverage tests")
+
+  if (CMAKE_C_COMPILER_ID MATCHES GNU)
+    message(FATAL_ERROR "Code coverage is currently only supported by clang.")
+  else ()
+    if (CMAKE_C_COMPILER_VERSION VERSION_LESS 7 OR CMAKE_C_COMPILER_VERSION
+                                                   VERSION_GREATER 7.99)
+      message(
+        WARNING "Code coverage may not work with clang versions other than 7.")
+    endif ()
+  endif ()
+
+  find_program(LCOV "lcov")
+  if (LCOV)
+    message("-- LCOV is found")
+  else ()
+    message(FATAL_ERROR "LCOV is not found.")
+  endif ()
+
+  add_custom_target(
+    code_coverage
+    COMMAND mkdir -p coverage
+    COMMAND lcov -c -i -d ${CMAKE_BINARY_DIR} --gcov-tool
+            ${OE_SCRIPTSDIR}/code-coverage/llvm-gcov -o coverage/base.info
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+  set(FILTERED_LIST
+      "'${PROJECT_SOURCE_DIR}/tests/*'" "'${PROJECT_SOURCE_DIR}/3rdparty/*'"
+      "'${CMAKE_BINARY_DIR}/tests/*'" "'${CMAKE_BINARY_DIR}/3rdparty/*'")
+
+  add_custom_command(
+    TARGET code_coverage
+    COMMAND
+      lcov -d ${CMAKE_BINARY_DIR} --gcov-tool
+      ${OE_SCRIPTSDIR}/code-coverage/llvm-gcov -c -o cov.info --rc
+      lcov_branch_coverage=1
+    COMMAND lcov -a base.info -a cov.info -o cov_total.info --rc
+            lcov_branch_coverage=1
+    COMMAND lcov --remove cov_total.info ${FILTERED_LIST} -o cov_filtered.info
+            --rc lcov_branch_coverage=1
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coverage)
+
+  add_custom_command(
+    TARGET code_coverage
+    DEPENDS ${CMAKE_BINARY_DIR}/coverage/cov_filtered.info
+    COMMAND
+      ${OE_SCRIPTSDIR}/code-coverage/lcov_cobertura
+      ${CMAKE_BINARY_DIR}/coverage/cov_filtered.info -o
+      ${CMAKE_BINARY_DIR}/coverage/coverage.xml
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+  add_custom_target(
+    code_coverage_clean
+    COMMAND find ${CMAKE_BINARY_DIR} -type f -name '*.gcda' -delete
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+endif ()
+
 find_program(VALGRIND "valgrind")
 if (VALGRIND)
   set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --error-exitcode=1")
@@ -285,7 +353,9 @@ if (NOT COMPILE_SYSTEM_EDL)
     add_subdirectory(tests)
   endif ()
 
-  if (BUILD_ENCLAVES)
+  # Skip samples when enabling the code coverage test.
+  # Otherwise, all the samples need to explicitly link against the libgcov library.
+  if (BUILD_ENCLAVES AND (NOT CODE_COVERAGE))
     add_subdirectory(samples)
   endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,18 +7,10 @@
 # https://rix0r.nl/blog/2015/08/13/cmake-guide/
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
-# Utility to ensure specific submodules are present.
-function (check_submodule_not_empty path)
-  file(GLOB submodule_files "${path}/*")
-  list(LENGTH submodule_files number)
-  if (${number} EQUAL 0)
-    message(
-      FATAL_ERROR
-        "Submodule ${path} is empty. You can initialize the submodule now with \
-         'git submodule update --recursive --init',\
-         or during 'git clone' by passing '--recursive'.")
-  endif ()
-endfunction ()
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Include utilities such as `check_submodule_not_empty`.
+include(utilities)
 
 # Read version from "VERSION" file.
 file(STRINGS "VERSION" OE_VERSION_WITH_V)
@@ -43,8 +35,6 @@ endif ()
 # http://cmake.3232098.n2.nabble.com/Prefer-clang-over-gcc-td7597742.html
 set(CMAKE_C_COMPILER_NAMES clang-7 cc)
 set(CMAKE_CXX_COMPILER_NAMES clang++-7 c++)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Will be overwritten during the cmake initialization.
 set(LVI_MITIGATION

--- a/cmake/enclave_cmake_wrappers.cmake
+++ b/cmake/enclave_cmake_wrappers.cmake
@@ -144,3 +144,14 @@ function (install_enclaves)
     endif ()
   endforeach (target)
 endfunction (install_enclaves)
+
+function (enclave_enable_code_coverage NAME)
+  if (NOT CODE_COVERAGE)
+    return()
+  endif ()
+
+  # Enable code coverage.
+  enclave_compile_options(${NAME} PRIVATE -g -O0 -fprofile-arcs -ftest-coverage)
+  # Link against libgcov.
+  enclave_link_libraries(${NAME} PRIVATE gcov)
+endfunction (enclave_enable_code_coverage)

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -1,0 +1,46 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# Utility to ensure specific submodules are present.
+function (check_submodule_not_empty path)
+  file(GLOB submodule_files "${path}/*")
+  list(LENGTH submodule_files number)
+  if (${number} EQUAL 0)
+    message(
+      FATAL_ERROR
+        "Submodule ${path} is empty. You can initialize the submodule now with \
+         'git submodule update --recursive --init',\
+         or during 'git clone' by passing '--recursive'.")
+  endif ()
+endfunction ()
+
+# Utility to apply patches.
+# Note that each patch should only apply to a single file.
+# The naming rule of the patch should be "file_name.patch".
+function (apply_patches patches_path target_path)
+  file(GLOB PATCHES ${patches_path}/*.patch)
+  if (NOT PATCHES)
+    return()
+  endif ()
+
+  foreach (PATCH ${PATCHES})
+    # Obtain the file name to be patched.
+    get_filename_component(PATCH_NAME ${PATCH} NAME)
+    string(REPLACE ".patch" "" PATCHED_FILE ${PATCH_NAME})
+
+    # Check if the target file is patched already.
+    execute_process(
+      COMMAND git status -s
+      OUTPUT_VARIABLE STATUS
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${target_path})
+    if (STATUS MATCHES ${PATCHED_FILE})
+      message("-- ${PATCHED_FILE} is patched already - skip")
+      continue()
+    endif ()
+
+    # Apply the patch.
+    message("-- Applying the patch ${PATCH_NAME}")
+    execute_process(COMMAND git apply ${PATCH}
+                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  endforeach ()
+endfunction ()

--- a/docs/GettingStartedDocs/Contributors/CodeCoverage.md
+++ b/docs/GettingStartedDocs/Contributors/CodeCoverage.md
@@ -1,0 +1,60 @@
+# Code Coverage in Open Enclave
+
+This document shows how to get the code coverage of OE.
+The code coverage analysis is based on [Gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html), a source-based coverage implementation provided by GNU GCC.
+Currently, both Clang and GCC supports Gcov.
+
+*Note*: The current implementation of OE only supports clang-7.
+
+# Prerequisites
+
+Install the packages that are necessary for the offline analysis.
+
+## Dependent APT packages
+
+`sudo apt install lcov python python-pip llvm-7`
+
+## Dependent PyPI package
+
+`sudo pip install lcov_cobertura`
+
+# CMake Configuration
+
+| Variable                 | Description                                          |
+|--------------------------|------------------------------------------------------|
+| CODE_COVERAGE            | Enable code coverage when setting to *ON*. Default is *OFF*. |
+| BUILD_LIBGCOV            | Build the libgcov only when setting to *ON*. Note that this option is only effective when CODE_COVERAGE is *OFF*. |
+
+# Code Coverage of Core Libraries
+
+To get the code coverage of the OE core libraries given the existing test suite, run the following commands from the build subfolder.
+
+## Configure the build with code coverage enabled.
+
+ `cmake .. -DCODE_COVERAGE=ON`
+
+## Build
+
+`make`
+
+## Run the test suite
+
+`ctest`
+
+## Offline analysis
+
+`make code_coverage`
+
+This command parses the runtime Gcov data of the test run and generates the reports.
+
+The exapmle command line output is as follows.
+```
+Writing data to cov_filtered.info
+Summary coverage rate:
+  lines......: 63.0% (10318 of 16372 lines)
+  functions..: 76.8% (774 of 1008 functions)
+  branches...: 40.3% (4679 of 11603 branches)
+Built target code_coverage
+```
+
+The reports can be found in `build/coverage/coverage.xml` (cobertura) and `build/coverage/cov_filtered.info` (lcov).

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -52,6 +52,8 @@ if (CMAKE_C_COMPILER_ID MATCHES GNU)
   endif ()
 endif ()
 
+enclave_enable_code_coverage(oeenclave)
+
 # Add location of the oeedger8r-generated trusted headers for internal
 # functions implemented via EDL files.
 enclave_include_directories(oeenclave PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/core)

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -293,6 +293,14 @@ endif ()
 
 enclave_compile_options(oecore INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 
+enclave_enable_code_coverage(oecore)
+if (CODE_COVERAGE)
+  # Disable the complier flag to the following sources to
+  # avoid conflicts.
+  set_source_files_properties(once.c sgx/calls.c sgx/init.c
+                              PROPERTIES COMPILE_FLAGS -fno-profile-arcs)
+endif ()
+
 enclave_compile_definitions(
   oecore
   PUBLIC

--- a/enclave/crypto/CMakeLists.txt
+++ b/enclave/crypto/CMakeLists.txt
@@ -20,6 +20,8 @@ add_enclave_library(
 
 maybe_build_using_clangw(oecryptombed)
 
+enclave_enable_code_coverage(oecryptombed)
+
 enclave_link_libraries(oecryptombed PUBLIC mbedcrypto)
 
 set_enclave_property(TARGET oecryptombed PROPERTY ARCHIVE_OUTPUT_DIRECTORY

--- a/host/linux/syscall.c
+++ b/host/linux/syscall.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/epoll.h>
+#include <sys/file.h>
 #include <sys/ioctl.h>
 #include <sys/poll.h>
 #include <sys/signal.h>
@@ -187,6 +188,13 @@ int oe_syscall_close_socket_ocall(oe_host_fd_t fd)
     errno = 0;
 
     return close((int)fd);
+}
+
+int oe_syscall_flock_ocall(oe_host_fd_t fd, int operation)
+{
+    errno = 0;
+
+    return flock((int)fd, operation);
 }
 
 oe_host_fd_t oe_syscall_dup_ocall(oe_host_fd_t oldfd)

--- a/host/windows/syscall.c
+++ b/host/windows/syscall.c
@@ -1426,6 +1426,14 @@ done:
     return ret;
 }
 
+// Unsupported yet.
+int oe_syscall_flock_ocall(oe_host_fd_t fd, int operation)
+{
+    OE_UNUSED(fd);
+    OE_UNUSED(operation);
+    return 0;
+}
+
 static oe_host_fd_t _dup_socket(oe_host_fd_t);
 
 oe_host_fd_t oe_syscall_dup_ocall(oe_host_fd_t fd)

--- a/include/openenclave/edl/fcntl.edl
+++ b/include/openenclave/edl/fcntl.edl
@@ -109,6 +109,11 @@ enclave
             oe_host_fd_t fd)
             propagate_errno;
 
+        int oe_syscall_flock_ocall(
+            oe_host_fd_t fd,
+            int operation)
+            propagate_errno;
+
         oe_host_fd_t oe_syscall_dup_ocall(
             oe_host_fd_t oldfd)
             propagate_errno;

--- a/include/openenclave/internal/syscall/fd.h
+++ b/include/openenclave/internal/syscall/fd.h
@@ -35,6 +35,8 @@ typedef struct _oe_fd_ops
 
     ssize_t (*writev)(oe_fd_t* desc, const struct oe_iovec* iov, int iovcnt);
 
+    int (*flock)(oe_fd_t* desc, int operation);
+
     int (*dup)(oe_fd_t* desc, oe_fd_t** new_fd);
 
     int (*ioctl)(oe_fd_t* desc, unsigned long request, uint64_t arg);

--- a/include/openenclave/internal/syscall/unistd.h
+++ b/include/openenclave/internal/syscall/unistd.h
@@ -80,6 +80,8 @@ unsigned int oe_sleep(unsigned int seconds);
 
 int oe_nanosleep(struct oe_timespec* req, struct oe_timespec* rem);
 
+int oe_flock(int fd, int operation);
+
 int oe_dup(int fd);
 
 int oe_dup2(int fd, int newfd);

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -228,6 +228,7 @@ add_enclave_library(
   ${MUSLSRC}/locale/wcsxfrm.c
   ${MUSLSRC}/linux/mount.c
   ${MUSLSRC}/linux/epoll.c
+  ${MUSLSRC}/linux/flock.c
   ${MUSLSRC}/math/acos.c
   ${MUSLSRC}/math/acosf.c
   ${MUSLSRC}/math/acosh.c

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -865,6 +865,13 @@ if (USE_DEBUG_MALLOC)
   enclave_compile_definitions(oelibc PRIVATE OE_USE_DEBUG_MALLOC)
 endif ()
 
+if (CODE_COVERAGE)
+  # Enable code coverage.
+  enclave_compile_options(oelibc PRIVATE -g -O0 -fprofile-arcs -ftest-coverage)
+  # Link against libgcov.
+  enclave_link_libraries(oelibc PRIVATE gcov)
+endif ()
+
 # This project (and its dependents) require the enclave headers and
 # library, and the musl headers.
 enclave_link_libraries(

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -33,6 +33,7 @@ tests/mbed/tests\..*$
 3rdparty/libcxx/libcxx/.*
 3rdparty/libcxxrt/libcxxrt/.*
 3rdparty/libgcov/compiler-rt/.*
+3rdparty/libgcov/patches/.*
 3rdparty/libunwind/libunwind/.*
 3rdparty/mbedtls/mbedtls/.*
 3rdparty/musl/libc-test/.*

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -32,6 +32,7 @@ tests/mbed/tests\..*$
 3rdparty/dlmalloc/dlmalloc/.*
 3rdparty/libcxx/libcxx/.*
 3rdparty/libcxxrt/libcxxrt/.*
+3rdparty/libgcov/compiler-rt/.*
 3rdparty/libunwind/libunwind/.*
 3rdparty/mbedtls/mbedtls/.*
 3rdparty/musl/libc-test/.*
@@ -48,6 +49,7 @@ docs/*
 
 # Files
 3rdparty/LICENSES
+3rdparty/libgcov/compiler-rt
 3rdparty/libunwind/setcontext\.S
 3rdparty/mbedtls/config\.h
 3rdparty/musl/COPYRIGHT

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -81,6 +81,7 @@ debugger/pythonExtension/readelf\.py
 host/linux/pe\.h
 include/openenclave/internal/queue\.h
 samples/file-encryptor/testfile
+scripts/llvm-gcov
 tests/ocall/debugging\.txt
 tests/str/test1\.txt
 tools/oesign/getopt\.h

--- a/scripts/code-coverage/lcov_cobertura
+++ b/scripts/code-coverage/lcov_cobertura
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+python -m "lcov_cobertura" "$@"

--- a/scripts/code-coverage/llvm-gcov
+++ b/scripts/code-coverage/llvm-gcov
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+llvm-cov-7 gcov "$@"

--- a/syscall/CMakeLists.txt
+++ b/syscall/CMakeLists.txt
@@ -65,13 +65,15 @@ add_enclave_library(oesyscall STATIC ${SOURCES})
 
 maybe_build_using_clangw(oesyscall)
 
+enclave_enable_code_coverage(oesyscall)
+
 add_enclave_dependencies(oesyscall syscall_trusted_edl)
 
 enclave_include_directories(
   oesyscall PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
   ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 
-enclave_link_libraries(oesyscall oecore)
+enclave_link_libraries(oesyscall PUBLIC oecore)
 enclave_compile_options(oesyscall PRIVATE -ffunction-sections)
 
 if (COMPILE_SYSTEM_EDL)

--- a/syscall/devices/hostepoll/CMakeLists.txt
+++ b/syscall/devices/hostepoll/CMakeLists.txt
@@ -8,7 +8,9 @@ maybe_build_using_clangw(oehostepoll)
 enclave_include_directories(oehostepoll PRIVATE ${CMAKE_BINARY_DIR}/syscall
                             ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 
-enclave_link_libraries(oehostepoll oesyscall)
+enclave_enable_code_coverage(oehostepoll)
+
+enclave_link_libraries(oehostepoll PRIVATE oesyscall)
 
 install_enclaves(
   TARGETS

--- a/syscall/devices/hostfs/CMakeLists.txt
+++ b/syscall/devices/hostfs/CMakeLists.txt
@@ -8,7 +8,9 @@ maybe_build_using_clangw(oehostfs)
 enclave_include_directories(oehostfs PRIVATE ${CMAKE_BINARY_DIR}/syscall
                             ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 
-enclave_link_libraries(oehostfs oesyscall)
+enclave_enable_code_coverage(oehostfs)
+
+enclave_link_libraries(oehostfs PRIVATE oesyscall)
 
 install_enclaves(
   TARGETS

--- a/syscall/devices/hostfs/hostfs.c
+++ b/syscall/devices/hostfs/hostfs.c
@@ -437,6 +437,22 @@ static oe_fd_t* _hostfs_open(
     }
 }
 
+static int _hostfs_flock(oe_fd_t* desc, int operation)
+{
+    int ret = -1;
+    file_t* file = _cast_file(desc);
+
+    if (!file)
+        OE_RAISE_ERRNO(OE_EINVAL);
+
+    /* Call the host to perform the flock(). */
+    if (oe_syscall_flock_ocall(&ret, file->host_fd, operation) != OE_OK)
+        OE_RAISE_ERRNO(OE_EINVAL);
+
+done:
+    return ret;
+}
+
 static int _hostfs_dup(oe_fd_t* desc, oe_fd_t** new_file_out)
 {
     int ret = -1;
@@ -1246,6 +1262,7 @@ static oe_file_ops_t _file_ops =
     .fd.write = _hostfs_write,
     .fd.readv = _hostfs_readv,
     .fd.writev = _hostfs_writev,
+    .fd.flock = _hostfs_flock,
     .fd.dup = _hostfs_dup,
     .fd.ioctl = _hostfs_ioctl,
     .fd.fcntl = _hostfs_fcntl,

--- a/syscall/devices/hostresolver/CMakeLists.txt
+++ b/syscall/devices/hostresolver/CMakeLists.txt
@@ -8,7 +8,9 @@ maybe_build_using_clangw(oehostresolver)
 enclave_include_directories(oehostresolver PRIVATE ${CMAKE_BINARY_DIR}/syscall
                             ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 
-enclave_link_libraries(oehostresolver oesyscall)
+enclave_enable_code_coverage(oehostresolver)
+
+enclave_link_libraries(oehostresolver PRIVATE oesyscall)
 
 install_enclaves(
   TARGETS

--- a/syscall/devices/hostsock/CMakeLists.txt
+++ b/syscall/devices/hostsock/CMakeLists.txt
@@ -8,7 +8,9 @@ maybe_build_using_clangw(oehostsock)
 enclave_include_directories(oehostsock PRIVATE ${CMAKE_BINARY_DIR}/syscall
                             ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 
-enclave_link_libraries(oehostsock oesyscall)
+enclave_enable_code_coverage(oehostsock)
+
+enclave_link_libraries(oehostsock PRIVATE oesyscall)
 
 install_enclaves(
   TARGETS

--- a/syscall/syscall.c
+++ b/syscall/syscall.c
@@ -182,6 +182,14 @@ static long _syscall(
             ret = oe_dup(fd);
             goto done;
         }
+        case OE_SYS_flock:
+        {
+            int fd = (int)arg1;
+            int operation = (int)arg2;
+
+            ret = oe_flock(fd, operation);
+            goto done;
+        }
 #if defined(OE_SYS_dup2)
         case OE_SYS_dup2:
         {

--- a/syscall/unistd.c
+++ b/syscall/unistd.c
@@ -288,6 +288,20 @@ done:
     return ret;
 }
 
+int oe_flock(int fd, int operation)
+{
+    int ret = -1;
+    oe_fd_t* desc;
+
+    if (!(desc = oe_fdtable_get(fd, OE_FD_TYPE_ANY)))
+        OE_RAISE_ERRNO(oe_errno);
+
+    ret = desc->ops.fd.flock(desc, operation);
+
+done:
+    return ret;
+}
+
 int oe_dup(int oldfd)
 {
     int ret = -1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,7 +79,6 @@ if (UNIX
     endif ()
     add_subdirectory(child_thread)
     add_subdirectory(cppException)
-    add_subdirectory(create-rapid)
     add_subdirectory(crypto_crls_cert_chains)
     add_subdirectory(debug-mode)
     add_subdirectory(ecall)
@@ -114,6 +113,14 @@ if (UNIX
     add_subdirectory(stack_smashing_protector)
     add_subdirectory(stress)
 
+    # The tests in create-rapid fail when enabling code coverage analysis.
+    # The failure happens if the first enclave process terminates, the
+    # host fs that libgcov requires in the subsequent enclave processes
+    # can no longer be used.
+    if (NOT CODE_COVERAGE)
+      add_subdirectory(create-rapid)
+    endif ()
+
     if (WITH_EEID)
       add_subdirectory(eeid_plugin)
     endif ()
@@ -132,8 +139,14 @@ endif ()
 
 if (UNIX)
   if (OE_SGX)
-    add_subdirectory(child_process)
     add_subdirectory(cmake_name_conflict)
+    # The tests in child_process fail when enabling code coverage analysis.
+    # The failure happens if a child process terminates after the parent
+    # process does. At this point, the host fs that libgcov requires can no
+    # longer be used.
+    if (NOT CODE_COVERAGE)
+      add_subdirectory(child_process)
+    endif ()
   endif ()
   add_subdirectory(libc)
 endif ()

--- a/tests/atexit/enc/enc.cpp
+++ b/tests/atexit/enc/enc.cpp
@@ -52,6 +52,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    8,    /* NumHeapPages */
-    8,    /* NumStackPages */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
     1);   /* NumTCS */

--- a/tests/child_process/enc/enc.cpp
+++ b/tests/child_process/enc/enc.cpp
@@ -19,6 +19,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    8,    /* NumHeapPages */
-    8,    /* NumStackPages */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
     1);   /* NumTCS */

--- a/tests/child_thread/enc/enc.cpp
+++ b/tests/child_thread/enc/enc.cpp
@@ -33,6 +33,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    8,    /* NumHeapPages */
-    8,    /* NumStackPages */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
     4);   /* NumTCS */

--- a/tests/crypto/enclave/enc/CMakeLists.txt
+++ b/tests/crypto/enclave/enc/CMakeLists.txt
@@ -38,5 +38,9 @@ add_enclave(
   ${SRCS}
   crypto_t.c)
 
+if (CODE_COVERAGE)
+  enclave_compile_definitions(crypto_enc PRIVATE CODE_COVERAGE)
+endif ()
+
 enclave_include_directories(crypto_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 enclave_link_libraries(crypto_enc oelibc)

--- a/tests/crypto/enclave/enc/enc.c
+++ b/tests/crypto/enclave/enc/enc.c
@@ -188,6 +188,10 @@ void test()
 {
     oe_register_syscall_hook(_syscall_hook);
     TestAll();
+
+#ifdef CODE_COVERAGE // For code coverage tests.
+    oe_register_syscall_hook(NULL);
+#endif
 }
 
 OE_SET_ENCLAVE_SGX(

--- a/tests/libc/CMakeLists.txt
+++ b/tests/libc/CMakeLists.txt
@@ -9,6 +9,11 @@ endif ()
 
 include(./tests.cmake)
 
+# Run the tests separately for the code coverage test.
+if (CODE_COVERAGE)
+  set(OE_SEPARATE_LIBC_TESTS ON)
+endif ()
+
 if (OE_SEPARATE_LIBC_TESTS)
   foreach (test_file ${LIBC_TESTS})
     string(MAKE_C_IDENTIFIER ${test_file} name)

--- a/tests/libc/enc/CMakeLists.txt
+++ b/tests/libc/enc/CMakeLists.txt
@@ -73,6 +73,10 @@ enclave_compile_options(
   -Wno-unused-value
   -Wno-overflow)
 
+if (CODE_COVERAGE)
+  enclave_compile_definitions(libc_enc PRIVATE CODE_COVERAGE)
+endif ()
+
 if (OE_SGX)
   enclave_compile_options(libc_enc PRIVATE -Wno-macro-redefined
                           -Wno-literal-range -Wno-writable-strings)

--- a/tests/libc/enc/enc.c
+++ b/tests/libc/enc/enc.c
@@ -41,8 +41,9 @@ int device_init()
     OE_TEST(oe_load_module_host_socket_interface() == OE_OK);
     // OE_TEST(oe_load_module_host_epoll() == OE_OK);
 
+#ifndef CODE_COVERAGE
     OE_TEST(mount("/", "/", OE_HOST_FILE_SYSTEM, 0, NULL) == 0);
-
+#endif
     return 0;
 }
 

--- a/tests/libcxxrt/CMakeLists.txt
+++ b/tests/libcxxrt/CMakeLists.txt
@@ -47,7 +47,7 @@ foreach (testcase ${alltests})
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       COMMAND
         ${OE_BASH} -c
-        "./host/libcxxrt_host ./enc/libcxxrttest-${name}_enc > ${name}_output.log 2>&1 &&
+        "OE_LOG_LEVEL=NONE ./host/libcxxrt_host ./enc/libcxxrttest-${name}_enc > ${name}_output.log 2>&1 &&
             diff ${name}_output.log ${RESULTDIR}/exp_${name}_output.log")
   endif ()
 endforeach (testcase)

--- a/tests/libunwind/enc/CMakeLists.txt
+++ b/tests/libunwind/enc/CMakeLists.txt
@@ -61,6 +61,9 @@ function (add_libunwind_test_enc NAME TESTFILE)
   endif ()
   enclave_compile_definitions(libunwindtest-${NAME}_enc PRIVATE -DWITH_MAIN
                               -D__TEST__="${TESTFILE}" -DUNW_LOCAL_ONLY=1)
+  if (CODE_COVERAGE)
+    enclave_compile_definitions(libunwindtest-${NAME}_enc PRIVATE CODE_COVERAGE)
+  endif ()
   enclave_link_libraries(libunwindtest-${NAME}_enc libunwindtest-support)
   enclave_link_libraries(libunwindtest-${NAME}_enc
                          -Wl,--undefined=pthread_mutex_lock)

--- a/tests/libunwind/enc/enc.c
+++ b/tests/libunwind/enc/enc.c
@@ -80,6 +80,11 @@ int test(char test_name[201], uint32_t pid)
     strncpy(test_name, __TEST__, STRLEN_MAX);
 
     free(__environ);
+
+#ifdef CODE_COVERAGE
+    // Set __environ to NULL to avoid failing with code coverage test.
+    __environ = NULL;
+#endif
     return rval;
 }
 

--- a/tests/mbed/enc/CMakeLists.txt
+++ b/tests/mbed/enc/CMakeLists.txt
@@ -65,6 +65,9 @@ function (add_mbed_test_enclave NAME)
   enclave_compile_options(mbedtest_suite_${NAME} PRIVATE -Wno-error)
   enclave_compile_definitions(mbedtest_suite_${NAME} PRIVATE
                               -D__TEST__="${NAME}")
+  if (CODE_COVERAGE)
+    enclave_compile_definitions(mbedtest_suite_${NAME} PRIVATE CODE_COVERAGE)
+  endif ()
   enclave_include_directories(
     mbedtest_suite_${NAME}
     PRIVATE
@@ -138,6 +141,9 @@ function (add_mbed_selftest_enclave)
   enclave_compile_options(mbedtest_selftest PRIVATE -Wno-conversion
                           -Wno-pointer-arith)
   enclave_compile_definitions(mbedtest_selftest PRIVATE -D__TEST__="selftest")
+  if (CODE_COVERAGE)
+    enclave_compile_definitions(mbedtest_selftest PRIVATE CODE_COVERAGE)
+  endif ()
   enclave_include_directories(
     mbedtest_selftest
     PRIVATE

--- a/tests/mbed/enc/enc.c
+++ b/tests/mbed/enc/enc.c
@@ -198,6 +198,11 @@ int test(
     strncpy(out_testname, __TEST__, STRLEN);
     out_testname[STRLEN - 1] = '\0';
 
+#ifdef CODE_COVERAGE
+    // Unregister the syscall hook when enabling code coverage testing.
+    oe_register_syscall_hook(NULL);
+#endif
+
     return return_value;
 }
 

--- a/tests/stress/enc/enc.cpp
+++ b/tests/stress/enc/enc.cpp
@@ -16,6 +16,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    8,    /* HeapPageCount */
-    8,    /* StackPageCount */
+    1024, /* HeapPageCount */
+    1024, /* StackPageCount */
     1);   /* TCSCount */

--- a/tests/syscall/CMakeLists.txt
+++ b/tests/syscall/CMakeLists.txt
@@ -2,12 +2,19 @@
 # Licensed under the MIT License.
 
 add_subdirectory(cpio)
-add_subdirectory(dup)
-add_subdirectory(fs)
-add_subdirectory(hostfs)
 add_subdirectory(resolver)
 add_subdirectory(socket)
 add_subdirectory(tool)
+
+# Skip the fs-related tests when doing code coverage analysis,
+# that cause conflicts to the use of host fs between the
+# tests and libgcov.
+if (NOT CODE_COVERAGE)
+  add_subdirectory(dup)
+  add_subdirectory(fs)
+  add_subdirectory(hostfs)
+endif ()
+
 if (UNIX)
   add_subdirectory(datagram)
   add_subdirectory(epoll)


### PR DESCRIPTION
This is the initial PR that supports code coverage testing on OE. The scope of the PR is as follows.
- Support clang-based gcov coverage test
- Support SGX ubuntu build only
- Focus on the non-third-party, enclave libraries

The PR consists of seven parts (in separate commits)
1. Add the libgcov source to the submodule (llvm compiler-rt)
2. Patches to the libgcov
   - Replace the unsupported file system calls (e.g., `mmap`)
   - Invoke hostfs initialization in the gcov initializer
3. Add the support of flock() used by the libgcov
4. Support the CODE_COVERAGE and BUILD_LIBGCOV cmake options
   - Build the oe with -DCODE_COVERAGE=ON to enable code coverage testing
   - After running ctest, use `make code_coverage` to generate the report
   - Update test cases to avoid failures when enabling code coverage tests
   - Build the oe with -DBUILD_LIBGCOV=ON to build and expose the libgcov to sdk users.
5. Add documentation
6. Jenkins integration
7. Ansible update to install dependencies