### PR TITLE
Use portable subset of ocaml

### DIFF
--- a/tools/oeedger8r/src/Common.ml
+++ b/tools/oeedger8r/src/Common.ml
@@ -41,9 +41,6 @@ let get_parameter_str (p : pdecl) =
 
 (** ----- End code borrowed and tweaked from {!CodeGen.ml} ----- *)
 
-(* Helper to map and filter out None at the same time. *)
-let filter_map f l = List.of_seq (Seq.filter_map f (List.to_seq l))
-
 (* Helper to flatten and map at the same time. *)
 let flatten_map f l = List.flatten (List.map f l)
 

--- a/tools/oeedger8r/src/Common.mli
+++ b/tools/oeedger8r/src/Common.mli
@@ -7,8 +7,6 @@ val get_array_dims : int list -> string
 
 val get_parameter_str : Intel.Ast.pdecl -> string
 
-val filter_map : ('a -> 'b option) -> 'a list -> 'b list
-
 val flatten_map : ('a -> 'b list) -> 'a list -> 'b list
 
 val flatten_map2 : ('a -> 'b -> 'c list) -> 'a list -> 'b list -> 'c list

--- a/tools/oeedger8r/src/Headers.ml
+++ b/tools/oeedger8r/src/Headers.ml
@@ -51,7 +51,7 @@ let get_composite_type =
   let get_struct (s : struct_def) =
     [
       "#ifndef EDGER8R_STRUCT_" ^ String.uppercase_ascii s.sname;
-      "#define EDGER8R_STRUCT_" ^ String.uppercase_ascii s.sname;
+      "#define EDGER8R_STRUCT_" ^ String.uppercase s.sname;
       "typedef struct " ^ s.sname;
       "{";
       String.concat "\n"
@@ -69,8 +69,8 @@ let get_composite_type =
   in
   let get_union (u : union_def) =
     [
-      "#ifndef EDGER8R_UNION_" ^ String.uppercase_ascii u.uname;
-      "#define EDGER8R_UNION_" ^ String.uppercase_ascii u.uname;
+      "#ifndef EDGER8R_UNION_" ^ String.uppercase u.uname;
+      "#define EDGER8R_UNION_" ^ String.uppercase u.uname;
       "typedef union " ^ u.uname;
       "{";
       String.concat "\n"
@@ -86,8 +86,8 @@ let get_composite_type =
   in
   let get_enum (e : enum_def) =
     [
-      "#ifndef EDGER8R_ENUM_" ^ String.uppercase_ascii e.enname;
-      "#define EDGER8R_ENUM_" ^ String.uppercase_ascii e.enname;
+      "#ifndef EDGER8R_ENUM_" ^ String.uppercase e.enname;
+      "#define EDGER8R_ENUM_" ^ String.uppercase e.enname;
       "typedef enum " ^ e.enname;
       "{";
       String.concat ",\n"
@@ -151,7 +151,7 @@ let get_marshal_struct (fd : func_decl) (errno : bool) =
 (* Generate [args.h] which contains [struct]s for ecalls and ocalls *)
 let generate_args (ec : enclave_content) =
   let guard_macro =
-    "EDGER8R_" ^ String.uppercase_ascii ec.enclave_name ^ "_ARGS_H"
+    "EDGER8R_" ^ String.uppercase ec.enclave_name ^ "_ARGS_H"
   in
   let user_includes =
     let includes = ec.include_list in
@@ -181,7 +181,7 @@ let generate_args (ec : enclave_content) =
 (* Includes are emitted in [args.h]. Imported functions have already
    been brought into function lists. *)
 let generate_trusted (ec : enclave_content) =
-  let guard = "EDGER8R_" ^ String.uppercase_ascii ec.file_shortnm ^ "_T_H" in
+  let guard = "EDGER8R_" ^ String.uppercase ec.file_shortnm ^ "_T_H" in
   let tfs = ec.tfunc_decls in
   let ufs = ec.ufunc_decls in
   let trusted_function_ids =
@@ -271,7 +271,7 @@ let generate_trusted (ec : enclave_content) =
   ]
 
 let generate_untrusted (ec : enclave_content) =
-  let guard = "EDGER8R_" ^ String.uppercase_ascii ec.file_shortnm ^ "_U_H" in
+  let guard = "EDGER8R_" ^ String.uppercase ec.file_shortnm ^ "_U_H" in
   let tfs = ec.tfunc_decls in
   let ufs = ec.ufunc_decls in
   let trusted_function_ids =

--- a/tools/oeedger8r/src/Sources.ml
+++ b/tools/oeedger8r/src/Sources.ml
@@ -10,8 +10,11 @@ let get_struct_by_name (cts : composite_type list) (name : string) =
   (* [cts] is a list of all composite types, but we're only
      interested in the structs, so we filter out the rest and unwrap
      them from [composite_type]. *)
-  let structs = filter_map (function StructDef s -> Some s | _ -> None) cts in
-  List.find_opt (fun s -> s.sname = name) structs
+  match
+    List.filter (function StructDef s -> s.sname = name | _ -> false) cts
+  with
+  | StructDef s::tl -> Some s
+  | _ -> None
 
 (** We need to check [Ptr]s for [Foreign] or [Struct] types, then
     check those against the user's [Struct]s, and then check if any


### PR DESCRIPTION
Avoid use of Seq.filter_map, String.uppercase_ascii.
They are available only in recent versions of Ocaml.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>