### PR TITLE
Enable 3 more tests in simulation mode

### DIFF
--- a/syscall/iov.c
+++ b/syscall/iov.c
@@ -56,7 +56,7 @@ int oe_iov_pack(
     for (int i = 0; i < iovcnt; i++)
         data_size += iov[i].iov_len;
 
-    /* Caculate the total size of the resulting buffer. */
+    /* Calculate the total size of the resulting buffer. */
     buf_size = (sizeof(struct oe_iovec) * (size_t)iovcnt) + data_size;
 
     /* Allocate the output buffer. */

--- a/tests/host_verify/CMakeLists.txt
+++ b/tests/host_verify/CMakeLists.txt
@@ -6,4 +6,3 @@ add_test(
   NAME tests/host_verify
   COMMAND $<TARGET_FILE:test_host_verify>
   WORKING_DIRECTORY $<TARGET_FILE_DIR:test_host_verify>)
-set_tests_properties(tests/host_verify PROPERTIES SKIP_RETURN_CODE 2)

--- a/tests/host_verify/host/host.cpp
+++ b/tests/host_verify/host/host.cpp
@@ -36,8 +36,6 @@
 #define REPORT_FILENAME "sgx_report.bin"
 #define REPORT_BAD_FILENAME "sgx_report_bad.bin"
 
-#define SKIP_RETURN_CODE 2
-
 oe_result_t enclave_identity_verifier(oe_identity_t* identity, void* arg)
 {
     OE_UNUSED(arg);
@@ -272,14 +270,6 @@ static int _verify_report(
 
 int main()
 {
-    const uint32_t flags = oe_get_create_flags();
-    if ((flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
-    {
-        printf("=== Skipped unsupported test in simulation mode "
-               "(host_verify)\n");
-        return SKIP_RETURN_CODE;
-    }
-
     //
     // Report only tests
     //

--- a/tests/syscall/fs/CMakeLists.txt
+++ b/tests/syscall/fs/CMakeLists.txt
@@ -10,5 +10,3 @@ endif ()
 set(TMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/tmp")
 
 add_enclave_test(tests/fs fs_host fs_enc "${PROJECT_SOURCE_DIR}" "${TMP_DIR}")
-
-set_enclave_tests_properties(tests/fs PROPERTIES SKIP_RETURN_CODE 2)

--- a/tests/syscall/fs/host/host_linux.c
+++ b/tests/syscall/fs/host/host_linux.c
@@ -9,8 +9,6 @@
 #include <sys/types.h>
 #include "fs_u.h"
 
-#define SKIP_RETURN_CODE 2
-
 int recursive_rmdir(const char* path);
 
 int main(int argc, const char* argv[])
@@ -24,12 +22,6 @@ int main(int argc, const char* argv[])
     {
         fprintf(stderr, "Usage: %s ENCLAVE_PATH SRC_DIR BIN_DIR\n", argv[0]);
         return 1;
-    }
-
-    if ((flags & OE_ENCLAVE_FLAG_SIMULATE))
-    {
-        printf("=== Skipped unsupported test in simulation mode (sealKey)\n");
-        return SKIP_RETURN_CODE;
     }
 
     const char* enclave_path = argv[1];

--- a/tests/syscall/fs/host/host_win32.c
+++ b/tests/syscall/fs/host/host_win32.c
@@ -8,8 +8,6 @@
 #include <openenclave/internal/tests.h>
 #include "fs_u.h"
 
-#define SKIP_RETURN_CODE 2
-
 int recursive_rmdir(wchar_t* path);
 
 int wmain(int argc, wchar_t* argv[])
@@ -23,12 +21,6 @@ int wmain(int argc, wchar_t* argv[])
     {
         fprintf(stderr, "Usage: %ls ENCLAVE_PATH SRC_DIR BIN_DIR\n", argv[0]);
         return 1;
-    }
-
-    if ((flags & OE_ENCLAVE_FLAG_SIMULATE))
-    {
-        printf("=== Skipped unsupported test in simulation mode (sealKey)\n");
-        return SKIP_RETURN_CODE;
     }
 
     /* create_enclave takes an ANSI path instead of a Unicode path, so we have

--- a/tests/tools/oesign-engine/test-enclave/CMakeLists.txt
+++ b/tests/tools/oesign-engine/test-enclave/CMakeLists.txt
@@ -113,5 +113,3 @@ add_test(
 
 add_test(NAME tests/oesign-engine-sign-runnable COMMAND host/helloworld_host
                                                         enclave/enclave.signed)
-set_tests_properties(tests/oesign-engine-sign-runnable
-                     PROPERTIES SKIP_RETURN_CODE 2)

--- a/tests/tools/oesign-engine/test-enclave/host/host.c
+++ b/tests/tools/oesign-engine/test-enclave/host/host.c
@@ -10,8 +10,6 @@
 // sdk tool oeedger8r against the helloworld.edl file.
 #include "helloworld_u.h"
 
-#define SKIP_RETURN_CODE 2
-
 bool check_simulate_opt(int* argc, const char* argv[])
 {
     for (int i = 0; i < *argc; i++)
@@ -45,10 +43,6 @@ int main(int argc, const char* argv[])
     if (check_simulate_opt(&argc, argv))
     {
         flags |= OE_ENCLAVE_FLAG_SIMULATE;
-    }
-    else if (flags & OE_ENCLAVE_FLAG_SIMULATE)
-    {
-        return SKIP_RETURN_CODE;
     }
 
     if (argc != 2)


### PR DESCRIPTION
These tests don't need to be skipped in simulation mode:
- host_verify
- syscall/fs
- oesign-engine-sign-runnable