### PR TITLE
[CI/CD] Enable RHEL 8 attestation

### DIFF
--- a/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/packer-rhel.json
+++ b/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/packer-rhel.json
@@ -54,10 +54,6 @@
         "{{ user `ansible_group` }}"
       ],
       "playbook_file": "{{ user `ansible_dir` }}/{{ user `playbook_file_name` }}",
-      "extra_arguments": [
-        "--extra-vars",
-        "flc_enabled=false"
-      ],
       "ansible_env_vars": [
         "ANSIBLE_ROLES_PATH={{ user `ansible_dir` }}/roles",
         "ANSIBLE_INVENTORY={{ user `ansible_dir` }}/inventory",

--- a/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
@@ -104,36 +104,37 @@ properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
 
 try{
     oe.emailJobStatus('STARTED')
+    def testing_stages = [
+        "Check CI":                                { checkCI() },
+        "Check Developer Experience Ubuntu 16.04": { checkDevFlows('16.04') },
+        "Check Developer Experience Ubuntu 18.04": { checkDevFlows('18.04') },
+        "AArch64 1604 GNU gcc Debug":              { AArch64GNUTest('16.04', 'Debug') },
+        "AArch64 1604 GNU gcc Release":            { AArch64GNUTest('16.04', 'Release') },
+        "AArch64 1804 GNU gcc Debug":              { AArch64GNUTest('18.04', 'Debug') },
+        "AArch64 1804 GNU gcc Release":            { AArch64GNUTest('18.04', 'Release') }
+    ]
     if(FULL_TEST_SUITE == "true") {
-      stage("Full Test Suite") {
-        parallel "Check CI" :                                               { checkCI() },
-                 "Check Developer Experience Ubuntu 16.04" :                { checkDevFlows('16.04') },
-                 "Check Developer Experience Ubuntu 18.04" :                { checkDevFlows('18.04') },
-                 "AArch64 1604 GNU gcc Debug" :                             { AArch64GNUTest('16.04', 'Debug')},
-                 "AArch64 1604 GNU gcc Release" :                           { AArch64GNUTest('16.04', 'Release')},
-                 "AArch64 1804 GNU gcc Debug" :                             { AArch64GNUTest('18.04', 'Debug')},
-                 "AArch64 1804 GNU gcc Release" :                           { AArch64GNUTest('18.04', 'Release')},
-                 "Sim 1804 clang-7 SGX1 Debug" :                            { simulationTest('18.04', 'SGX1', 'Debug')},
-                 "Sim 1804 clang-7 SGX1 Release" :                          { simulationTest('18.04', 'SGX1', 'Release')},
-                 "Sim 1804 clang-7 SGX1-FLC Debug" :                        { simulationTest('18.04', 'SGX1FLC', 'Debug')},
-                 "Sim 1804 clang-7 SGX1-FLC Release" :                      { simulationTest('18.04', 'SGX1FLC', 'Release')}
-      }
+        stage("Full Test Suite") {
+            testing_stages += [
+                "Sim 1804 clang-7 SGX1 Debug":       { simulationTest('18.04', 'SGX1', 'Debug') },
+                "Sim 1804 clang-7 SGX1 Release":     { simulationTest('18.04', 'SGX1', 'Release') },
+                "Sim 1804 clang-7 SGX1-FLC Debug":   { simulationTest('18.04', 'SGX1FLC', 'Debug') },
+                "Sim 1804 clang-7 SGX1-FLC Release": { simulationTest('18.04', 'SGX1FLC', 'Release') }
+            ]
+            parallel testing_stages
+        }
     } else {
-      stage("PR Testing") {
-        parallel "Check CI" :                                               { checkCI() },
-                 "Check Developer Experience Ubuntu 16.04" :                { checkDevFlows('16.04') },
-                 "Check Developer Experience Ubuntu 18.04" :                { checkDevFlows('18.04') },
-                 "AArch64 1604 GNU gcc Debug" :                             { AArch64GNUTest('16.04', 'Debug')},
-                 "AArch64 1604 GNU gcc Release" :                           { AArch64GNUTest('16.04', 'Release')},
-                 "AArch64 1804 GNU gcc Debug" :                             { AArch64GNUTest('18.04', 'Debug')},
-                 "AArch64 1804 GNU gcc Release" :                           { AArch64GNUTest('18.04', 'Release')},
-                 "Sim 1804 clang-7 SGX1 Release" :                          { simulationTest('18.04', 'SGX1', 'Release', 'ON')},
-                 "Sim 1804 clang-7 SGX1-FLC Debug" :                        { simulationTest('18.04', 'SGX1FLC', 'Debug', 'ON')},
-                 "Sim 1804 clang-7 SGX1-FLC Release" :                      { simulationTest('18.04', 'SGX1FLC', 'Release', 'ON')}
-      }
+        stage("PR Testing") {
+            testing_stages += [
+                "Sim 1804 clang-7 SGX1 Release":     { simulationTest('18.04', 'SGX1', 'Release', 'ON') },
+                "Sim 1804 clang-7 SGX1-FLC Debug":   { simulationTest('18.04', 'SGX1FLC', 'Debug', 'ON') },
+                "Sim 1804 clang-7 SGX1-FLC Release": { simulationTest('18.04', 'SGX1FLC', 'Release', 'ON') }
+            ]
+            parallel testing_stages
+        }
     }
 } catch(Exception e) {
-    println "Caught global pipeline exception :" + e
+    println "Caught global pipeline exception: " + e
     GLOBAL_ERROR = e
     throw e
 } finally {

--- a/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
@@ -14,29 +14,23 @@ AGENTS_LABELS = [
 ]
 
 
-def simulationTest(String version, String platform_mode, String build_type, String lvi_mitigation = 'None', String lvi_mitigation_skip_tests = 'OFF') {
-    def has_quote_provider = "OFF"
-    if (platform_mode == "SGX1FLC") {
-        has_quote_provider = "ON"
-    }
-    stage("Sim clang-7 Ubuntu${version} ${platform_mode} ${build_type} LVI_MITIGATION=${lvi_mitigation}") {
+def simulationContainerTest(String version, String build_type, List extra_cmake_args = []) {
+    stage("Simulation Ubuntu ${version} clang-7 ${build_type}, extra_cmake_args: ${extra_cmake_args}") {
         node(AGENTS_LABELS["ubuntu-nonsgx"]) {
             timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
+                def task = """
+                           cmake ${WORKSPACE}                                           \
+                               -G Ninja                                                 \
+                               -DCMAKE_BUILD_TYPE=${build_type}                         \
+                               -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
+                               ${extra_cmake_args.join(' ')}                            \
+                               -Wdev
+                           ninja -v
+                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
+                           """
                 withEnv(["OE_SIMULATION=1"]) {
-                    def task = """
-                               cmake ${WORKSPACE}                                            \
-                                    -G Ninja                                                 \
-                                    -DCMAKE_BUILD_TYPE=${build_type}                         \
-                                    -DHAS_QUOTE_PROVIDER=${has_quote_provider}               \
-                                    -DLVI_MITIGATION=${lvi_mitigation}                       \
-                                    -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
-                                    -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} \
-                                    -Wdev
-                               ninja -v
-                               ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
-                               """
                     oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-7", task, "--cap-add=SYS_PTRACE")
                 }
             }
@@ -116,19 +110,19 @@ try{
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
-                "Sim 1804 clang-7 SGX1 Debug":       { simulationTest('18.04', 'SGX1', 'Debug') },
-                "Sim 1804 clang-7 SGX1 Release":     { simulationTest('18.04', 'SGX1', 'Release') },
-                "Sim 1804 clang-7 SGX1-FLC Debug":   { simulationTest('18.04', 'SGX1FLC', 'Debug') },
-                "Sim 1804 clang-7 SGX1-FLC Release": { simulationTest('18.04', 'SGX1FLC', 'Release') }
+                "Sim 1804 clang-7 SGX1 Debug":      { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-7 SGX1 Release":    { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-7 SGX1FLC Debug":   { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-7 SGX1FLC Release": { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) }
             ]
             parallel testing_stages
         }
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "Sim 1804 clang-7 SGX1 Release":     { simulationTest('18.04', 'SGX1', 'Release', 'ON') },
-                "Sim 1804 clang-7 SGX1-FLC Debug":   { simulationTest('18.04', 'SGX1FLC', 'Debug', 'ON') },
-                "Sim 1804 clang-7 SGX1-FLC Release": { simulationTest('18.04', 'SGX1FLC', 'Release', 'ON') }
+                "Sim 1804 clang-7 SGX1 Release":    { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "Sim 1804 clang-7 SGX1FLC Debug":   { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "Sim 1804 clang-7 SGX1FLC Release": { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) }
             ]
             parallel testing_stages
         }

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -237,75 +237,72 @@ properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
 
 try{
     oe.emailJobStatus('STARTED')
+    def testing_stages = [
+        "Host verification 1604 Release":         { ACCHostVerificationTest('16.04', 'Release') },
+        "Host verification 1804 Release":         { ACCHostVerificationTest('18.04', 'Release') },
+        "ACC1804 GNU gcc SGX1FLC":                { ACCGNUTest() },
+        "RHEL-8 simulation clang-8 SGX1 Release": { RHEL8Test('clang', 'Release', ["OE_SIMULATION=1"]) },
+        "RHEL-8 simulation clang-8 SGX1 Debug":   { RHEL8Test('clang', 'Debug',   ["OE_SIMULATION=1"]) },
+        "RHEL-8 simulation gcc-8 Release":        { RHEL8Test('gcc',   'Release', ["OE_SIMULATION=1"]) },
+        "RHEL-8 simulation gcc-8 SGX1 Debug":     { RHEL8Test('gcc',   'Debug',   ["OE_SIMULATION=1"]) },
+        "RHEL-8 ACC clang-8 Release":             { RHEL8Test('clang', 'Release') },
+        "RHEL-8 ACC clang-8 Debug":               { RHEL8Test('clang', 'Debug') },
+        "RHEL-8 ACC gcc-8 Release":               { RHEL8Test('gcc',   'Release') },
+        "RHEL-8 ACC gcc-8 Debug":                 { RHEL8Test('gcc',   'Debug') }
+    ]
     if(FULL_TEST_SUITE == "true") {
-      stage("Full Test Suite") {
-        parallel "Host verification 1604 Debug" :                           { ACCHostVerificationTest('16.04', 'Debug') },
-                 "Host verification 1604 Release" :                         { ACCHostVerificationTest('16.04', 'Release') },
-                 "Host verification 1804 Debug" :                           { ACCHostVerificationTest('18.04', 'Debug') },
-                 "Host verification 1804 Release" :                         { ACCHostVerificationTest('18.04', 'Release') },
-                 "ACC1604 clang-7 Debug" :                                  { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug') },
-                 "ACC1604 clang-7 Release" :                                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release') },
-                 "ACC1604 clang-7 Debug LVI" :                              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug', 'ControlFlow') },
-                 "ACC1604 clang-7 Release LVI" :                            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', 'ControlFlow') },
-                 "ACC1604 gcc Debug" :                                      { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Debug') },
-                 "ACC1604 gcc Release" :                                    { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Release') },
-                 "ACC1604 gcc Debug LVI" :                                  { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Debug', 'ControlFlow') },
-                 "ACC1604 gcc Release LVI" :                                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Release', 'ControlFlow') },
-                 "ACC1604 Container RelWithDebInfo" :                       { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04') },
-                 "ACC1604 Container RelWithDebInfo LVI" :                   { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow') },
-                 "ACC1604 Package RelWithDebInfo" :                         { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04') },
-                 "ACC1604 Package RelWithDebInfo LVI" :                     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow') },
-                 "ACC1804 clang-7 Debug" :                                  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug') },
-                 "ACC1804 clang-7 Release" :                                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release') },
-                 "ACC1804 clang-7 Debug LVI" :                              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug', 'ControlFlow') },
-                 "ACC1804 clang-7 Release LVI" :                            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', 'ControlFlow') },
-                 "ACC1804 gcc Debug" :                                      { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Debug') },
-                 "ACC1804 gcc Release" :                                    { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Release') },
-                 "ACC1804 gcc Debug LVI" :                                  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Debug', 'ControlFlow') },
-                 "ACC1804 gcc Release LVI" :                                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Release', 'ControlFlow') },
-                 "ACC1804 Container RelWithDebInfo" :                       { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04') },
-                 "ACC1804 Container RelWithDebInfo LVI" :                   { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow') },
-                 "ACC1804 Package RelWithDebInfo" :                         { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04') },
-                 "ACC1804 Package RelWithDebInfo LVI" :                     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow') },
-                 "ACC1804 GNU gcc SGX1FLC" :                                { ACCGNUTest() },
-                 "RHEL-8 simulation clang-8 SGX1 Release":                  { RHEL8Test('clang', 'Release', ["OE_SIMULATION=1"]) },
-                 "RHEL-8 simulation clang-8 SGX1 Debug":                    { RHEL8Test('clang', 'Debug',   ["OE_SIMULATION=1"]) },
-                 "RHEL-8 simulation gcc-8 Release":                         { RHEL8Test('gcc',   'Release', ["OE_SIMULATION=1"]) },
-                 "RHEL-8 simulation gcc-8 SGX1 Debug":                      { RHEL8Test('gcc',   'Debug',   ["OE_SIMULATION=1"]) },
-                 "RHEL-8 ACC clang-8 Release" :                             { RHEL8Test('clang', 'Release') },
-                 "RHEL-8 ACC clang-8 Debug" :                               { RHEL8Test('clang', 'Debug') },
-                 "RHEL-8 ACC gcc-8 Release" :                               { RHEL8Test('gcc',   'Release') },
-                 "RHEL-8 ACC gcc-8 Debug" :                                 { RHEL8Test('gcc',   'Debug') }
-      }
+        stage("Full Test Suite") {
+            testing_stages += [
+                "Host verification 1604 Debug":         { ACCHostVerificationTest('16.04', 'Debug') },
+                "Host verification 1804 Debug":         { ACCHostVerificationTest('18.04', 'Debug') },
+                "ACC1604 clang-7 Debug":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug') },
+                "ACC1604 clang-7 Release":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release') },
+                "ACC1604 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug', 'ControlFlow') },
+                "ACC1604 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', 'ControlFlow') },
+                "ACC1604 gcc Debug":                    { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Debug') },
+                "ACC1604 gcc Release":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Release') },
+                "ACC1604 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Debug', 'ControlFlow') },
+                "ACC1604 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Release', 'ControlFlow') },
+                "ACC1604 Container RelWithDebInfo":     { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04') },
+                "ACC1604 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow') },
+                "ACC1604 Package RelWithDebInfo":       { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04') },
+                "ACC1604 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow') },
+                "ACC1804 clang-7 Debug":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug') },
+                "ACC1804 clang-7 Release":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release') },
+                "ACC1804 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug', 'ControlFlow') },
+                "ACC1804 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', 'ControlFlow') },
+                "ACC1804 gcc Debug":                    { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Debug') },
+                "ACC1804 gcc Release":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Release') },
+                "ACC1804 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Debug', 'ControlFlow') },
+                "ACC1804 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Release', 'ControlFlow') },
+                "ACC1804 Container RelWithDebInfo":     { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04') },
+                "ACC1804 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow') },
+                "ACC1804 Package RelWithDebInfo":       { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04') },
+                "ACC1804 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow') }
+            ]
+            parallel testing_stages
+        }
     } else {
         stage("PR Testing") {
-          parallel "Host verification 1604 Release" :                         { ACCHostVerificationTest('16.04', 'Release') },
-                   "Host verification 1804 Release" :                         { ACCHostVerificationTest('18.04', 'Release') },
-                   "ACC1604 clang-7 Debug LVI" :                              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug', 'ControlFlow', 'ON') },
-                   "ACC1604 clang-7 Release LVI" :                            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', 'ControlFlow', 'ON') },
-                   "ACC1604 gcc Debug LVI" :                                  { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Debug', 'ControlFlow', 'ON') },
-                   "ACC1604 gcc Release LVI" :                                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Release', 'ControlFlow', 'ON') },
-                   "ACC1604 Container RelWithDebInfo LVI" :                   { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow', 'ON') },
-                   "ACC1604 Package RelWithDebInfo LVI" :                     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow', 'ON') },
-                   "ACC1804 clang-7 Debug LVI" :                              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug', 'ControlFlow', 'ON') },
-                   "ACC1804 clang-7 Release LVI" :                            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', 'ControlFlow', 'ON') },
-                   "ACC1804 gcc Debug LVI" :                                  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Debug', 'ControlFlow', 'ON') },
-                   "ACC1804 gcc Release LVI" :                                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Release', 'ControlFlow', 'ON') },
-                   "ACC1804 Container RelWithDebInfo LVI" :                   { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow', 'ON') },
-                   "ACC1804 Package RelWithDebInfo LVI" :                     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow', 'ON') },
-                   "ACC1804 GNU gcc SGX1FLC" :                                { ACCGNUTest() },
-                   "RHEL-8 simulation clang-8 SGX1 Release":                  { RHEL8Test('clang', 'Release', ["OE_SIMULATION=1"]) },
-                   "RHEL-8 simulation clang-8 SGX1 Debug":                    { RHEL8Test('clang', 'Debug',   ["OE_SIMULATION=1"]) },
-                   "RHEL-8 simulation gcc-8 Release":                         { RHEL8Test('gcc',   'Release', ["OE_SIMULATION=1"]) },
-                   "RHEL-8 simulation gcc-8 SGX1 Debug":                      { RHEL8Test('gcc',   'Debug',   ["OE_SIMULATION=1"]) },
-                   "RHEL-8 ACC clang-8 Release" :                             { RHEL8Test('clang', 'Release') },
-                   "RHEL-8 ACC clang-8 Debug" :                               { RHEL8Test('clang', 'Debug') },
-                   "RHEL-8 ACC gcc-8 Release" :                               { RHEL8Test('gcc',   'Release') },
-                   "RHEL-8 ACC gcc-8 Debug" :                                 { RHEL8Test('gcc',   'Debug') }
+            testing_stages += [
+                "ACC1604 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug', 'ControlFlow', 'ON') },
+                "ACC1604 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', 'ControlFlow', 'ON') },
+                "ACC1604 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Debug', 'ControlFlow', 'ON') },
+                "ACC1604 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Release', 'ControlFlow', 'ON') },
+                "ACC1604 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow', 'ON') },
+                "ACC1604 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow', 'ON') },
+                "ACC1804 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug', 'ControlFlow', 'ON') },
+                "ACC1804 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', 'ControlFlow', 'ON') },
+                "ACC1804 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Debug', 'ControlFlow', 'ON') },
+                "ACC1804 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Release', 'ControlFlow', 'ON') },
+                "ACC1804 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow', 'ON') },
+                "ACC1804 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow', 'ON') }
+            ]
+            parallel testing_stages
         }
     }
 } catch(Exception e) {
-    println "Caught global pipeline exception :" + e
+    println "Caught global pipeline exception: " + e
     GLOBAL_ERROR = e
     throw e
 } finally {

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -268,13 +268,13 @@ try{
                  "ACC1804 Package RelWithDebInfo" :                         { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04') },
                  "ACC1804 Package RelWithDebInfo LVI" :                     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow') },
                  "ACC1804 GNU gcc SGX1FLC" :                                { ACCGNUTest() },
-                 // "RHEL-8 simulation clang-8 SGX1 Release":             { RHEL8Test('clang', 'Release', ["OE_SIMULATION=1"]) }, // Enable when https://github.com/openenclave/openenclave/issues/2556 is fixed.
+                 "RHEL-8 simulation clang-8 SGX1 Release":                  { RHEL8Test('clang', 'Release', ["OE_SIMULATION=1"]) },
                  "RHEL-8 simulation clang-8 SGX1 Debug":                    { RHEL8Test('clang', 'Debug',   ["OE_SIMULATION=1"]) },
-                 // "RHEL-8 simulation gcc-8 Release":                    { RHEL8Test('gcc',   'Release', ["OE_SIMULATION=1"]) }, // Enable when https://github.com/openenclave/openenclave/issues/2558 is fixed.
+                 "RHEL-8 simulation gcc-8 Release":                         { RHEL8Test('gcc',   'Release', ["OE_SIMULATION=1"]) },
                  "RHEL-8 simulation gcc-8 SGX1 Debug":                      { RHEL8Test('gcc',   'Debug',   ["OE_SIMULATION=1"]) },
-                 // "RHEL-8 ACC clang-8 Release" :                        { RHEL8Test('clang', 'Release') },                      // Enable when https://github.com/openenclave/openenclave/issues/2556 is fixed.
-                 // "RHEL-8 ACC clang-8 Debug" :                          { RHEL8Test('clang', 'Debug') },                        // Enable when https://github.com/openenclave/openenclave/issues/2557 is fixed.
-                 // "RHEL-8 ACC gcc-8 Release" :                          { RHEL8Test('gcc',   'Release') },                      // Enable when https://github.com/openenclave/openenclave/issues/2558 is fixed.
+                 "RHEL-8 ACC clang-8 Release" :                             { RHEL8Test('clang', 'Release') },
+                 "RHEL-8 ACC clang-8 Debug" :                               { RHEL8Test('clang', 'Debug') },
+                 "RHEL-8 ACC gcc-8 Release" :                               { RHEL8Test('gcc',   'Release') },
                  "RHEL-8 ACC gcc-8 Debug" :                                 { RHEL8Test('gcc',   'Debug') }
       }
     } else {
@@ -294,13 +294,13 @@ try{
                    "ACC1804 Container RelWithDebInfo LVI" :                   { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow', 'ON') },
                    "ACC1804 Package RelWithDebInfo LVI" :                     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow', 'ON') },
                    "ACC1804 GNU gcc SGX1FLC" :                                { ACCGNUTest() },
-                   // "RHEL-8 simulation clang-8 SGX1 Release":             { RHEL8Test('clang', 'Release', ["OE_SIMULATION=1"]) }, // Enable when https://github.com/openenclave/openenclave/issues/2556 is fixed.
+                   "RHEL-8 simulation clang-8 SGX1 Release":                  { RHEL8Test('clang', 'Release', ["OE_SIMULATION=1"]) },
                    "RHEL-8 simulation clang-8 SGX1 Debug":                    { RHEL8Test('clang', 'Debug',   ["OE_SIMULATION=1"]) },
-                   // "RHEL-8 simulation gcc-8 Release":                    { RHEL8Test('gcc',   'Release', ["OE_SIMULATION=1"]) }, // Enable when https://github.com/openenclave/openenclave/issues/2558 is fixed.
+                   "RHEL-8 simulation gcc-8 Release":                         { RHEL8Test('gcc',   'Release', ["OE_SIMULATION=1"]) },
                    "RHEL-8 simulation gcc-8 SGX1 Debug":                      { RHEL8Test('gcc',   'Debug',   ["OE_SIMULATION=1"]) },
-                   // "RHEL-8 ACC clang-8 Release" :                        { RHEL8Test('clang', 'Release') },                      // Enable when https://github.com/openenclave/openenclave/issues/2556 is fixed.
-                   // "RHEL-8 ACC clang-8 Debug" :                          { RHEL8Test('clang', 'Debug') },                        // Enable when https://github.com/openenclave/openenclave/issues/2557 is fixed.
-                   // "RHEL-8 ACC gcc-8 Release" :                          { RHEL8Test('gcc',   'Release') },                      // Enable when https://github.com/openenclave/openenclave/issues/2558 is fixed.
+                   "RHEL-8 ACC clang-8 Release" :                             { RHEL8Test('clang', 'Release') },
+                   "RHEL-8 ACC clang-8 Debug" :                               { RHEL8Test('clang', 'Debug') },
+                   "RHEL-8 ACC gcc-8 Release" :                               { RHEL8Test('gcc',   'Release') },
                    "RHEL-8 ACC gcc-8 Debug" :                                 { RHEL8Test('gcc',   'Debug') }
         }
     }

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -18,9 +18,9 @@ AGENTS_LABELS = [
 ]
 
 
-def ACCTest(String label, String compiler, String build_type, String lvi_mitigation = 'None', String lvi_mitigation_skip_tests = 'OFF') {
-    stage("${label} ${compiler} SGX1FLC ${build_type} LVI_MITIGATION=${lvi_mitigation}") {
-        node("${label}") {
+def ACCTest(String label, String compiler, String build_type, List extra_cmake_args = [], List test_env = []) {
+    stage("${label} ${compiler} ${build_type}, extra_cmake_args: ${extra_cmake_args}, test_env: ${test_env}") {
+        node(label) {
             timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
@@ -28,14 +28,15 @@ def ACCTest(String label, String compiler, String build_type, String lvi_mitigat
                            cmake ${WORKSPACE}                                           \
                                -G Ninja                                                 \
                                -DCMAKE_BUILD_TYPE=${build_type}                         \
-                               -DLVI_MITIGATION=${lvi_mitigation}                       \
                                -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
-                               -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} \
+                               ${extra_cmake_args.join(' ')}                            \
                                -Wdev
                            ninja -v
                            ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                            """
-                oe.Run(compiler, task)
+                withEnv(test_env) {
+                    oe.Run(compiler, task)
+                }
             }
         }
     }
@@ -58,8 +59,8 @@ def ACCGNUTest() {
     }
 }
 
-def ACCContainerTest(String label, String version, String lvi_mitigation = 'None', String lvi_mitigation_skip_tests = 'OFF') {
-    stage("${label} Container RelWithDebInfo LVI_MITIGATION=${lvi_mitigation}") {
+def ACCContainerTest(String label, String version, List extra_cmake_args = []) {
+    stage("${label} Container ${version} RelWithDebInfo, extra_cmake_args: ${extra_cmake_args}") {
         node("${label}") {
             timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
@@ -68,9 +69,8 @@ def ACCContainerTest(String label, String version, String lvi_mitigation = 'None
                            cmake ${WORKSPACE}                                           \
                                -G Ninja                                                 \
                                -DCMAKE_BUILD_TYPE=RelWithDebInfo                        \
-                               -DLVI_MITIGATION=${lvi_mitigation}                       \
                                -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
-                               -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} \
+                               ${extra_cmake_args.join(' ')}                            \
                                -Wdev
                            ninja -v
                            ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
@@ -81,8 +81,8 @@ def ACCContainerTest(String label, String version, String lvi_mitigation = 'None
     }
 }
 
-def ACCPackageTest(String label, String version, String lvi_mitigation = 'None', String lvi_mitigation_skip_tests = 'OFF') {
-    stage("${label} Container RelWithDebInfo LVI_MITIGATION=${lvi_mitigation}") {
+def ACCPackageTest(String label, String version, List extra_cmake_args = []) {
+    stage("${label} PackageTest ${version} RelWithDebInfo, extra_cmake_args: ${extra_cmake_args}") {
         node("${label}") {
             timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
@@ -93,9 +93,8 @@ def ACCPackageTest(String label, String version, String lvi_mitigation = 'None',
                              -DCMAKE_BUILD_TYPE=RelWithDebInfo                        \
                              -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'           \
                              -DCPACK_GENERATOR=DEB                                    \
-                             -DLVI_MITIGATION=${lvi_mitigation}                       \
                              -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
-                             -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} \
+                             ${extra_cmake_args.join(' ')}                            \
                              -Wdev
                            ninja -v
                            ninja -v package
@@ -122,112 +121,93 @@ def ACCPackageTest(String label, String version, String lvi_mitigation = 'None',
 }
 
 def ACCHostVerificationTest(String version, String build_type) {
-
-        /* Compile tests in SGX machine.  This will generate the necessary certs for the
-        * host_verify test.
-        */
-        stage("ACC-1804 Generate Quote") {
-            node(AGENTS_LABELS["acc-ubuntu-18.04"]) {
-                timeout(GLOBAL_TIMEOUT_MINUTES) {
-                    cleanWs()
-                    checkout scm
-
-                    println("Generating certificates and reports ...")
-                    def task = """
-                            cmake ${WORKSPACE} -G Ninja -DHAS_QUOTE_PROVIDER=ON -DCMAKE_BUILD_TYPE=${build_type} -Wdev
-                            ninja -v
-                            pushd tests/host_verify/host
-                            openssl ecparam -name prime256v1 -genkey -noout -out keyec.pem
-                            openssl ec -in keyec.pem -pubout -out publicec.pem
-                            openssl genrsa -out keyrsa.pem 2048
-                            openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
-                            ../../tools/oecert/host/oecert ../../tools/oecert/enc/oecert_enc --cert keyec.pem publicec.pem --out sgx_cert_ec.der
-                            ../../tools/oecert/host/oecert ../../tools/oecert/enc/oecert_enc --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der
-                            ../../tools/oecert/host/oecert ../../tools/oecert/enc/oecert_enc --report --out sgx_report.bin
-                            popd
-                            """
-                    oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-7", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx")
-
-                    def ec_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_ec.der'
-                    def rsa_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_rsa.der'
-                    def report_created = fileExists 'build/tests/host_verify/host/sgx_report.bin'
-                    if (ec_cert_created) {
-                        println("EC cert file created successfully!")
-                    } else {
-                        error("Failed to create EC cert file.")
-                    }
-                    if (rsa_cert_created) {
-                        println("RSA cert file created successfully!")
-                    } else {
-                        error("Failed to create RSA cert file.")
-                    }
-                    if (report_created) {
-                        println("SGX report file created successfully!")
-                    } else {
-                        error("Failed to create SGX report file.")
-                    }
-
-                    stash includes: 'build/tests/host_verify/host/*.der,build/tests/host_verify/host/*.bin', name: "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
-                }
-            }
-        }
-
-        /* Compile the tests with HAS_QUOTE_PROVIDER=OFF and unstash the certs over for verification.  */
-        stage("Linux nonSGX Verify Quote") {
-            node(AGENTS_LABELS["ubuntu-nonsgx"]) {
-                timeout(GLOBAL_TIMEOUT_MINUTES) {
-                    cleanWs()
-                    checkout scm
-                    unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
-                    def task = """
-                            cmake ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=OFF -DCMAKE_BUILD_TYPE=${build_type} -Wdev
-                            ninja -v
-                            ctest -R host_verify --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
-                            """
-                    // Note: Include the commands to build and run the quote verification test above
-                    oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-7", task, "--cap-add=SYS_PTRACE")
-                }
-            }
-        }
-
-        /* Windows nonSGX stage. */
-        stage("Windows nonSGX Verify Quote") {
-            node(AGENTS_LABELS["windows-nonsgx"]) {
-                timeout(GLOBAL_TIMEOUT_MINUTES) {
-                    cleanWs()
-                    checkout scm
-                    unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
-                    dir('build') {
-                        bat """
-                            vcvars64.bat x64 && \
-                            cmake.exe ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=OFF -DCMAKE_BUILD_TYPE=${build_type} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
-                            ninja -v && \
-                            ctest.exe -V -C ${build_type} -R host_verify --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
-                            """
-                    }
-                }
-            }
-        }
- }
-
-def RHEL8Test(String compiler, String build_type, List test_env = [], List extra_cmake_args = []) {
-    stage("ACC-RHEL-8 ${compiler} ${build_type}, test_env: ${test_env}") {
-        node(AGENTS_LABELS["acc-rhel-8"]) {
+    /* Compile tests in SGX machine.  This will generate the necessary certs for the
+    * host_verify test.
+    */
+    stage("ACC-1804 Generate Quote") {
+        node(AGENTS_LABELS["acc-ubuntu-18.04"]) {
             timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
+
+                println("Generating certificates and reports ...")
                 def task = """
-                           cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} ${extra_cmake_args.join(' ')} -Wdev
+                           cmake ${WORKSPACE} -G Ninja -DHAS_QUOTE_PROVIDER=ON -DCMAKE_BUILD_TYPE=${build_type} -Wdev
                            ninja -v
-                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
+                           pushd tests/host_verify/host
+                           openssl ecparam -name prime256v1 -genkey -noout -out keyec.pem
+                           openssl ec -in keyec.pem -pubout -out publicec.pem
+                           openssl genrsa -out keyrsa.pem 2048
+                           openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
+                           ../../tools/oecert/host/oecert ../../tools/oecert/enc/oecert_enc --cert keyec.pem publicec.pem --out sgx_cert_ec.der
+                           ../../tools/oecert/host/oecert ../../tools/oecert/enc/oecert_enc --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der
+                           ../../tools/oecert/host/oecert ../../tools/oecert/enc/oecert_enc --report --out sgx_report.bin
+                           popd
                            """
-                withEnv(test_env) {
-                    oe.Run(compiler, task)
+                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-7", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx")
+
+                def ec_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_ec.der'
+                def rsa_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_rsa.der'
+                def report_created = fileExists 'build/tests/host_verify/host/sgx_report.bin'
+                if (ec_cert_created) {
+                    println("EC cert file created successfully!")
+                } else {
+                    error("Failed to create EC cert file.")
+                }
+                if (rsa_cert_created) {
+                    println("RSA cert file created successfully!")
+                } else {
+                    error("Failed to create RSA cert file.")
+                }
+                if (report_created) {
+                    println("SGX report file created successfully!")
+                } else {
+                    error("Failed to create SGX report file.")
+                }
+
+                stash includes: 'build/tests/host_verify/host/*.der,build/tests/host_verify/host/*.bin', name: "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+            }
+        }
+    }
+
+    /* Compile the tests with HAS_QUOTE_PROVIDER=OFF and unstash the certs over for verification.  */
+    stage("Linux nonSGX Verify Quote") {
+        node(AGENTS_LABELS["ubuntu-nonsgx"]) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+                def task = """
+                           cmake ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=OFF -DCMAKE_BUILD_TYPE=${build_type} -Wdev
+                           ninja -v
+                           ctest -R host_verify --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
+                           """
+                // Note: Include the commands to build and run the quote verification test above
+                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-7", task, "--cap-add=SYS_PTRACE")
+            }
+        }
+    }
+
+    /* Windows nonSGX stage. */
+    stage("Windows nonSGX Verify Quote") {
+        node(AGENTS_LABELS["windows-nonsgx"]) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+                dir('build') {
+                    bat """
+                        vcvars64.bat x64 && \
+                        cmake.exe ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=OFF -DCMAKE_BUILD_TYPE=${build_type} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
+                        ninja -v && \
+                        ctest.exe -V -C ${build_type} -R host_verify --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
+                        """
                 }
             }
         }
     }
 }
+
 
 properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
                                       artifactNumToKeepStr: '180',
@@ -241,66 +221,72 @@ try{
         "Host verification 1604 Release":         { ACCHostVerificationTest('16.04', 'Release') },
         "Host verification 1804 Release":         { ACCHostVerificationTest('18.04', 'Release') },
         "ACC1804 GNU gcc SGX1FLC":                { ACCGNUTest() },
-        "RHEL-8 simulation clang-8 SGX1 Release": { RHEL8Test('clang', 'Release', ["OE_SIMULATION=1"], ["-DHAS_QUOTE_PROVIDER=OFF"]) },
-        "RHEL-8 simulation clang-8 SGX1 Debug":   { RHEL8Test('clang', 'Debug',   ["OE_SIMULATION=1"], ["-DHAS_QUOTE_PROVIDER=OFF"]) },
-        "RHEL-8 simulation gcc-8 Release":        { RHEL8Test('gcc',   'Release', ["OE_SIMULATION=1"], ["-DHAS_QUOTE_PROVIDER=OFF"]) },
-        "RHEL-8 simulation gcc-8 SGX1 Debug":     { RHEL8Test('gcc',   'Debug',   ["OE_SIMULATION=1"], ["-DHAS_QUOTE_PROVIDER=OFF"]) },
-        "RHEL-8 ACC clang-8 Release":             { RHEL8Test('clang', 'Release', [],                  ["-DHAS_QUOTE_PROVIDER=OFF"]) },
-        "RHEL-8 ACC clang-8 Debug":               { RHEL8Test('clang', 'Debug'    [],                  ["-DHAS_QUOTE_PROVIDER=OFF"]) },
-        "RHEL-8 ACC gcc-8 Release":               { RHEL8Test('gcc',   'Release'  [],                  ["-DHAS_QUOTE_PROVIDER=OFF"]) },
-        "RHEL-8 ACC gcc-8 Debug":                 { RHEL8Test('gcc',   'Debug',   [],                  ["-DHAS_QUOTE_PROVIDER=ON"]) },
-        "RHEL-8 ACC SGX1FLC clang-8 Release":     { RHEL8Test('clang', 'Release', [],                  ["-DHAS_QUOTE_PROVIDER=ON"]) },
-        "RHEL-8 ACC SGX1FLC clang-8 Debug":       { RHEL8Test('clang', 'Debug',   [],                  ["-DHAS_QUOTE_PROVIDER=ON"]) },
-        "RHEL-8 ACC SGX1FLC gcc-8 Release":       { RHEL8Test('gcc',   'Release', [],                  ["-DHAS_QUOTE_PROVIDER=ON"]) },
-        "RHEL-8 ACC SGX1FLC gcc-8 Debug":         { RHEL8Test('gcc',   'Debug',   [],                  ["-DHAS_QUOTE_PROVIDER=ON"]) }
+        "RHEL-8 clang-8 simulation Release":      { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
+        "RHEL-8 clang-8 simulation Debug":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
+        "RHEL-8 gcc-8 simulation Release":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
+        "RHEL-8 gcc-8 simulation Debug":          { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
+        "RHEL-8 ACC clang-8 SGX1 Release":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF']) },
+        "RHEL-8 ACC clang-8 SGX1 Debug":          { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF']) },
+        "RHEL-8 ACC gcc-8 SGX1 Release":          { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF']) },
+        "RHEL-8 ACC gcc-8 SGX1 Debug":            { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF']) }
     ]
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
                 "Host verification 1604 Debug":         { ACCHostVerificationTest('16.04', 'Debug') },
                 "Host verification 1804 Debug":         { ACCHostVerificationTest('18.04', 'Debug') },
-                "ACC1604 clang-7 Debug":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug') },
-                "ACC1604 clang-7 Release":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release') },
-                "ACC1604 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug', 'ControlFlow') },
-                "ACC1604 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', 'ControlFlow') },
-                "ACC1604 gcc Debug":                    { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Debug') },
-                "ACC1604 gcc Release":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Release') },
-                "ACC1604 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Debug', 'ControlFlow') },
-                "ACC1604 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Release', 'ControlFlow') },
-                "ACC1604 Container RelWithDebInfo":     { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04') },
-                "ACC1604 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow') },
-                "ACC1604 Package RelWithDebInfo":       { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04') },
-                "ACC1604 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow') },
-                "ACC1804 clang-7 Debug":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug') },
-                "ACC1804 clang-7 Release":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release') },
-                "ACC1804 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug', 'ControlFlow') },
-                "ACC1804 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', 'ControlFlow') },
-                "ACC1804 gcc Debug":                    { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Debug') },
-                "ACC1804 gcc Release":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Release') },
-                "ACC1804 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Debug', 'ControlFlow') },
-                "ACC1804 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Release', 'ControlFlow') },
-                "ACC1804 Container RelWithDebInfo":     { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04') },
-                "ACC1804 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow') },
-                "ACC1804 Package RelWithDebInfo":       { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04') },
-                "ACC1804 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow') }
+
+                "ACC1604 Package RelWithDebInfo":       { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1604 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 Package RelWithDebInfo":       { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+
+                "ACC1604 Container RelWithDebInfo":     { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1604 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 Container RelWithDebInfo":     { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+
+                "RHEL-8 ACC clang-8 SGX1FLC Release":   { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=ON']) },
+                "RHEL-8 ACC clang-8 SGX1FLC Debug":     { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON']) },
+                "RHEL-8 ACC gcc-8 SGX1FLC Release":     { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=ON']) },
+                "RHEL-8 ACC gcc-8 SGX1FLC Debug":       { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=ON']) },
+
+                "ACC1604 clang-7 Debug":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1604 clang-7 Release":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1604 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1604 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1604 gcc Debug":                    { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1604 gcc Release":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1604 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1604 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 clang-7 Debug":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 clang-7 Release":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 gcc Debug":                    { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 gcc Release":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) }
             ]
             parallel testing_stages
         }
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "ACC1604 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug', 'ControlFlow', 'ON') },
-                "ACC1604 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', 'ControlFlow', 'ON') },
-                "ACC1604 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Debug', 'ControlFlow', 'ON') },
-                "ACC1604 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc', 'Release', 'ControlFlow', 'ON') },
-                "ACC1604 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow', 'ON') },
-                "ACC1604 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', 'ControlFlow', 'ON') },
-                "ACC1804 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug', 'ControlFlow', 'ON') },
-                "ACC1804 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', 'ControlFlow', 'ON') },
-                "ACC1804 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Debug', 'ControlFlow', 'ON') },
-                "ACC1804 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc', 'Release', 'ControlFlow', 'ON') },
-                "ACC1804 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow', 'ON') },
-                "ACC1804 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', 'ControlFlow', 'ON') }
+                "ACC1604 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 Package RelWithDebInfo LVI":   { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+
+                "ACC1604 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+
+                "ACC1604 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1604 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1604 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1604 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 clang-7 Debug LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 clang-7 Release LVI":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 gcc Debug LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 gcc Release LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) }
             ]
             parallel testing_stages
         }

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -210,14 +210,14 @@ def ACCHostVerificationTest(String version, String build_type) {
         }
  }
 
-def RHEL8Test(String compiler, String build_type, List test_env = []) {
+def RHEL8Test(String compiler, String build_type, List test_env = [], List extra_cmake_args = []) {
     stage("ACC-RHEL-8 ${compiler} ${build_type}, test_env: ${test_env}") {
         node(AGENTS_LABELS["acc-rhel-8"]) {
             timeout(GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 checkout scm
                 def task = """
-                           cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DHAS_QUOTE_PROVIDER=OFF -Wdev
+                           cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} ${extra_cmake_args.join(' ')} -Wdev
                            ninja -v
                            ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                            """
@@ -241,14 +241,18 @@ try{
         "Host verification 1604 Release":         { ACCHostVerificationTest('16.04', 'Release') },
         "Host verification 1804 Release":         { ACCHostVerificationTest('18.04', 'Release') },
         "ACC1804 GNU gcc SGX1FLC":                { ACCGNUTest() },
-        "RHEL-8 simulation clang-8 SGX1 Release": { RHEL8Test('clang', 'Release', ["OE_SIMULATION=1"]) },
-        "RHEL-8 simulation clang-8 SGX1 Debug":   { RHEL8Test('clang', 'Debug',   ["OE_SIMULATION=1"]) },
-        "RHEL-8 simulation gcc-8 Release":        { RHEL8Test('gcc',   'Release', ["OE_SIMULATION=1"]) },
-        "RHEL-8 simulation gcc-8 SGX1 Debug":     { RHEL8Test('gcc',   'Debug',   ["OE_SIMULATION=1"]) },
-        "RHEL-8 ACC clang-8 Release":             { RHEL8Test('clang', 'Release') },
-        "RHEL-8 ACC clang-8 Debug":               { RHEL8Test('clang', 'Debug') },
-        "RHEL-8 ACC gcc-8 Release":               { RHEL8Test('gcc',   'Release') },
-        "RHEL-8 ACC gcc-8 Debug":                 { RHEL8Test('gcc',   'Debug') }
+        "RHEL-8 simulation clang-8 SGX1 Release": { RHEL8Test('clang', 'Release', ["OE_SIMULATION=1"], ["-DHAS_QUOTE_PROVIDER=OFF"]) },
+        "RHEL-8 simulation clang-8 SGX1 Debug":   { RHEL8Test('clang', 'Debug',   ["OE_SIMULATION=1"], ["-DHAS_QUOTE_PROVIDER=OFF"]) },
+        "RHEL-8 simulation gcc-8 Release":        { RHEL8Test('gcc',   'Release', ["OE_SIMULATION=1"], ["-DHAS_QUOTE_PROVIDER=OFF"]) },
+        "RHEL-8 simulation gcc-8 SGX1 Debug":     { RHEL8Test('gcc',   'Debug',   ["OE_SIMULATION=1"], ["-DHAS_QUOTE_PROVIDER=OFF"]) },
+        "RHEL-8 ACC clang-8 Release":             { RHEL8Test('clang', 'Release', [],                  ["-DHAS_QUOTE_PROVIDER=OFF"]) },
+        "RHEL-8 ACC clang-8 Debug":               { RHEL8Test('clang', 'Debug'    [],                  ["-DHAS_QUOTE_PROVIDER=OFF"]) },
+        "RHEL-8 ACC gcc-8 Release":               { RHEL8Test('gcc',   'Release'  [],                  ["-DHAS_QUOTE_PROVIDER=OFF"]) },
+        "RHEL-8 ACC gcc-8 Debug":                 { RHEL8Test('gcc',   'Debug',   [],                  ["-DHAS_QUOTE_PROVIDER=ON"]) },
+        "RHEL-8 ACC SGX1FLC clang-8 Release":     { RHEL8Test('clang', 'Release', [],                  ["-DHAS_QUOTE_PROVIDER=ON"]) },
+        "RHEL-8 ACC SGX1FLC clang-8 Debug":       { RHEL8Test('clang', 'Debug',   [],                  ["-DHAS_QUOTE_PROVIDER=ON"]) },
+        "RHEL-8 ACC SGX1FLC gcc-8 Release":       { RHEL8Test('gcc',   'Release', [],                  ["-DHAS_QUOTE_PROVIDER=ON"]) },
+        "RHEL-8 ACC SGX1FLC gcc-8 Debug":         { RHEL8Test('gcc',   'Debug',   [],                  ["-DHAS_QUOTE_PROVIDER=ON"]) }
     ]
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -83,59 +83,66 @@ properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
 
 try{
     oe.emailJobStatus('STARTED')
+    def testing_stages = [:]
     if(FULL_TEST_SUITE == "true") {
-      stage("Full Test Suite") {
-        parallel "Win2016 Ubuntu1604 clang-7 Debug Linux-Elf-build" :       { windowsLinuxElfBuild('acc-win2016-dcap', '16.04', 'clang-7', 'Debug') },
-                 "Win2016 Ubuntu1604 clang-7 Release Linux-Elf-build" :     { windowsLinuxElfBuild('acc-win2016-dcap', '16.04', 'clang-7', 'Release') },
-                 "Win2016 Ubuntu1604 clang-7 Debug Linux-Elf-build LVI" :   { windowsLinuxElfBuild('acc-win2016-dcap', '16.04', 'clang-7', 'Debug', 'ControlFlow') },
-                 "Win2016 Ubuntu1604 clang-7 Release Linux-Elf-build LVI" : { windowsLinuxElfBuild('acc-win2016-dcap', '16.04', 'clang-7', 'Release', 'ControlFlow') },
-                 "Win2016 Ubuntu1804 clang-7 Debug Linux-Elf-build" :       { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Debug') },
-                 "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build" :     { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Release') },
-                 "Win2016 Ubuntu1804 clang-7 Debug Linux-Elf-build LVI" :   { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Debug', 'ControlFlow') },
-                 "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build LVI" : { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow') },
-                 "Win2016 Ubuntu1804 gcc Debug Linux-Elf-build" :           { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'gcc', 'Debug') },
-                 "Win2016 Ubuntu1804 gcc Debug Linux-Elf-build LVI" :       { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'gcc', 'Debug', 'ControlFlow') },
-                 "Win2016 Sim Debug Cross Compile" :                        { windowsCrossCompile('acc-win2016', 'Debug', 'OFF', 'None', '1') },
-                 "Win2016 Sim Release Cross Compile" :                      { windowsCrossCompile('acc-win2016', 'Release','OFF', 'None', '1') },
-                 "Win2016 Sim Debug Cross Compile LVI " :                   { windowsCrossCompile('acc-win2016', 'Debug', 'OFF', 'ControlFlow', '1') },
-                 "Win2016 Sim Release Cross Compile LVI " :                 { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1') },
-                 "Win2016 Debug Cross Compile with DCAP libs" :             { windowsCrossCompile('acc-win2016', 'Debug', 'ON') },
-                 "Win2016 Release Cross Compile with DCAP libs" :           { windowsCrossCompile('acc-win2016', 'Release', 'ON') },
-                 "Win2016 Debug Cross Compile DCAP LVI" :                   { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow') },
-                 "Win2016 Release Cross Compile DCAP LVI" :                 { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow') },
-                 "Win2019 Ubuntu1604 clang-7 Debug Linux-Elf-build" :       { windowsLinuxElfBuild('acc-win2019-dcap', '16.04', 'clang-7', 'Debug') },
-                 "Win2019 Ubuntu1604 clang-7 Release Linux-Elf-build" :     { windowsLinuxElfBuild('acc-win2019-dcap', '16.04', 'clang-7', 'Release') },
-                 "Win2019 Ubuntu1604 clang-7 Debug Linux-Elf-build LVI" :   { windowsLinuxElfBuild('acc-win2019-dcap', '16.04', 'clang-7', 'Debug', 'ControlFlow') },
-                 "Win2019 Ubuntu1604 clang-7 Release Linux-Elf-build LVI" : { windowsLinuxElfBuild('acc-win2019-dcap', '16.04', 'clang-7', 'Release', 'ControlFlow') },
-                 "Win2019 Ubuntu1804 clang-7 Debug Linux-Elf-build" :       { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Debug') },
-                 "Win2019 Ubuntu1804 clang-7 Release Linux-Elf-build" :     { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Release') },
-                 "Win2019 Ubuntu1804 clang-7 Debug Linux-Elf-build LVI" :   { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Debug', 'ControlFlow') },
-                 "Win2019 Ubuntu1804 clang-7 Release Linux-Elf-build LVI" : { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow') },
-                 "Win2019 Ubuntu1804 gcc Debug Linux-Elf-build" :           { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'gcc', 'Debug') },
-                 "Win2019 Ubuntu1804 gcc Debug Linux-Elf-build LVI" :       { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'gcc', 'Debug', 'ControlFlow') },
-                 "Win2019 Sim Debug Cross Compile" :                        { windowsCrossCompile('acc-win2019', 'Debug', 'OFF', 'None', '1') },
-                 "Win2019 Sim Release Cross Compile" :                      { windowsCrossCompile('acc-win2019', 'Release','OFF', 'None', '1') },
-                 "Win2019 Sim Debug Cross Compile LVI " :                   { windowsCrossCompile('acc-win2019', 'Debug', 'OFF', 'ControlFlow', '1') },
-                 "Win2019 Sim Release Cross Compile LVI " :                 { windowsCrossCompile('acc-win2019', 'Release', 'OFF', 'ControlFlow', '1') },
-                 "Win2019 Debug Cross Compile with DCAP libs" :             { windowsCrossCompile('acc-win2019', 'Debug', 'ON') },
-                 "Win2019 Release Cross Compile with DCAP libs" :           { windowsCrossCompile('acc-win2019', 'Release', 'ON') },
-                 "Win2019 Debug Cross Compile DCAP LVI" :                   { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow') },
-                 "Win2019 Release Cross Compile DCAP LVI" :                 { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow') }
-      }
+        stage("Full Test Suite") {
+            testing_stages += [
+                "Win2016 Ubuntu1604 clang-7 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2016-dcap', '16.04', 'clang-7', 'Debug') },
+                "Win2016 Ubuntu1604 clang-7 Release Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2016-dcap', '16.04', 'clang-7', 'Release') },
+                "Win2016 Ubuntu1604 clang-7 Debug Linux-Elf-build LVI":   { windowsLinuxElfBuild('acc-win2016-dcap', '16.04', 'clang-7', 'Debug', 'ControlFlow') },
+                "Win2016 Ubuntu1604 clang-7 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2016-dcap', '16.04', 'clang-7', 'Release', 'ControlFlow') },
+                "Win2016 Ubuntu1804 clang-7 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Debug') },
+                "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Release') },
+                "Win2016 Ubuntu1804 clang-7 Debug Linux-Elf-build LVI":   { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Debug', 'ControlFlow') },
+                "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow') },
+                "Win2016 Ubuntu1804 gcc Debug Linux-Elf-build":           { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'gcc', 'Debug') },
+                "Win2016 Ubuntu1804 gcc Debug Linux-Elf-build LVI":       { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'gcc', 'Debug', 'ControlFlow') },
+                "Win2016 Sim Debug Cross Compile":                        { windowsCrossCompile('acc-win2016', 'Debug', 'OFF', 'None', '1') },
+                "Win2016 Sim Release Cross Compile":                      { windowsCrossCompile('acc-win2016', 'Release','OFF', 'None', '1') },
+                "Win2016 Sim Debug Cross Compile LVI ":                   { windowsCrossCompile('acc-win2016', 'Debug', 'OFF', 'ControlFlow', '1') },
+                "Win2016 Sim Release Cross Compile LVI ":                 { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1') },
+                "Win2016 Debug Cross Compile with DCAP libs":             { windowsCrossCompile('acc-win2016', 'Debug', 'ON') },
+                "Win2016 Release Cross Compile with DCAP libs":           { windowsCrossCompile('acc-win2016', 'Release', 'ON') },
+                "Win2016 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow') },
+                "Win2016 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow') },
+                "Win2019 Ubuntu1604 clang-7 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2019-dcap', '16.04', 'clang-7', 'Debug') },
+                "Win2019 Ubuntu1604 clang-7 Release Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2019-dcap', '16.04', 'clang-7', 'Release') },
+                "Win2019 Ubuntu1604 clang-7 Debug Linux-Elf-build LVI":   { windowsLinuxElfBuild('acc-win2019-dcap', '16.04', 'clang-7', 'Debug', 'ControlFlow') },
+                "Win2019 Ubuntu1604 clang-7 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2019-dcap', '16.04', 'clang-7', 'Release', 'ControlFlow') },
+                "Win2019 Ubuntu1804 clang-7 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Debug') },
+                "Win2019 Ubuntu1804 clang-7 Release Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Release') },
+                "Win2019 Ubuntu1804 clang-7 Debug Linux-Elf-build LVI":   { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Debug', 'ControlFlow') },
+                "Win2019 Ubuntu1804 clang-7 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow') },
+                "Win2019 Ubuntu1804 gcc Debug Linux-Elf-build":           { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'gcc', 'Debug') },
+                "Win2019 Ubuntu1804 gcc Debug Linux-Elf-build LVI":       { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'gcc', 'Debug', 'ControlFlow') },
+                "Win2019 Sim Debug Cross Compile":                        { windowsCrossCompile('acc-win2019', 'Debug', 'OFF', 'None', '1') },
+                "Win2019 Sim Release Cross Compile":                      { windowsCrossCompile('acc-win2019', 'Release','OFF', 'None', '1') },
+                "Win2019 Sim Debug Cross Compile LVI ":                   { windowsCrossCompile('acc-win2019', 'Debug', 'OFF', 'ControlFlow', '1') },
+                "Win2019 Sim Release Cross Compile LVI ":                 { windowsCrossCompile('acc-win2019', 'Release', 'OFF', 'ControlFlow', '1') },
+                "Win2019 Debug Cross Compile with DCAP libs":             { windowsCrossCompile('acc-win2019', 'Debug', 'ON') },
+                "Win2019 Release Cross Compile with DCAP libs":           { windowsCrossCompile('acc-win2019', 'Release', 'ON') },
+                "Win2019 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow') },
+                "Win2019 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow') }
+            ]
+            parallel testing_stages
+        }
     } else {
-      stage("PR Testing") {
-        parallel "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build LVI" : { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow', 'ON') },
-                 "Win2016 Sim Release Cross Compile LVI " :                 { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
-                 "Win2016 Debug Cross Compile DCAP LVI" :                   { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
-                 "Win2016 Release Cross Compile DCAP LVI" :                 { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow', '0', 'ON') },
-                 "Win2019 Ubuntu1804 clang-7 Release Linux-Elf-build LVI" : { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow', 'ON') },
-                 "Win2019 Sim Release Cross Compile LVI " :                 { windowsCrossCompile('acc-win2019', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
-                 "Win2019 Debug Cross Compile DCAP LVI" :                   { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
-                 "Win2019 Release Cross Compile DCAP LVI" :                 { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow', '0', 'ON') }
-      }
+        stage("PR Testing") {
+            testing_stages += [
+                "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow', 'ON') },
+                "Win2016 Sim Release Cross Compile LVI ":                 { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
+                "Win2016 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
+                "Win2016 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow', '0', 'ON') },
+                "Win2019 Ubuntu1804 clang-7 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow', 'ON') },
+                "Win2019 Sim Release Cross Compile LVI ":                 { windowsCrossCompile('acc-win2019', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
+                "Win2019 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
+                "Win2019 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow', '0', 'ON') }
+            ]
+            parallel testing_stages
+        }
     }
 } catch(Exception e) {
-    println "Caught global pipeline exception :" + e
+    println "Caught global pipeline exception: " + e
     GLOBAL_ERROR = e
     throw e
 } finally {

--- a/scripts/ansible/roles/linux/az-dcap-client/tasks/redhat/stable-install.yml
+++ b/scripts/ansible/roles/linux/az-dcap-client/tasks/redhat/stable-install.yml
@@ -15,26 +15,12 @@
   git:
     repo: "{{ git_repo_url }}"
     dest: "{{ git_local_dir }}"
+    version: "{{ git_repo_branch }}"
     update: yes
     force: yes
 
-- name: Get latest git tag
-  shell: git describe --tags `git rev-list --tags --max-count=1`
-  register: latest_tag
-  args:
-    chdir: "{{ git_local_dir }}"
-
-- name: Checkout to latest git tag
-  git:
-    repo: "{{ git_repo_url }}"
-    dest: "{{ git_local_dir }}"
-    version: "{{ latest_tag.stdout }}"
-    clone: no
-    update: yes
-
 - name: Pull prerequisites and setup Makefile
   shell: ./configure
-  register: latest_tag
   args:
     chdir: "{{ git_local_dir }}/src/Linux"
 
@@ -46,6 +32,13 @@
   make:
     target: install
     chdir: "{{ git_local_dir }}/src/Linux"
+
+- name: Create symlink from /usr/local/lib to /usr/lib64
+  file:
+    src: /usr/local/lib/libdcap_quoteprov.so
+    dest: /usr/lib64/libdcap_quoteprov.so
+    force: yes
+    state: link
 
 - name: Cleanup installation
   file:

--- a/scripts/ansible/roles/linux/az-dcap-client/vars/redhat/main.yml
+++ b/scripts/ansible/roles/linux/az-dcap-client/vars/redhat/main.yml
@@ -8,6 +8,7 @@ yum_packages:
   - "pkg-config"
 
 git_repo_url: "https://github.com/Microsoft/Azure-DCAP-Client.git"
+git_repo_branch: "1.4.0"
 git_local_dir: "/tmp/Azure-DCAP-Client"
 
 validation_distribution_files:

--- a/scripts/ansible/roles/linux/common/tasks/yum-repo.yml
+++ b/scripts/ansible/roles/linux/common/tasks/yum-repo.yml
@@ -1,0 +1,13 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+- name: Add YUM repository
+  yum:
+    name: "{{ yum_repository_rpm_url }}"
+    state: present
+
+- name: Add YUM repository key
+  rpm_key:
+    key: "{{ yum_repository_key_path }}"
+    state: present

--- a/scripts/ansible/roles/linux/intel/tasks/redhat/sgx-driver-requirements.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/redhat/sgx-driver-requirements.yml
@@ -2,10 +2,12 @@
 # Licensed under the MIT License.
 
 ---
-- name: Fail if the FLC flag is set
-  fail:
-    msg: "SGX FLC is not yet supported on Red Hat distributions"
-  when: flc_enabled | bool
+- include_role:
+    name: linux/common
+    tasks_from: yum-repo.yml
+  vars:
+    yum_repository_rpm_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+    yum_repository_key_path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 - name: Install the Intel libsgx package dependencies
   yum:

--- a/scripts/ansible/roles/linux/intel/tasks/redhat/sgx-packages-install.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/redhat/sgx-packages-install.yml
@@ -2,11 +2,6 @@
 # Licensed under the MIT License.
 
 ---
-- name: Fail if the FLC flag is set
-  fail:
-    msg: "SGX FLC is not yet supported on Red Hat distributions"
-  when: flc_enabled | bool
-
 - name: Install the Intel libsgx package dependencies
   yum:
     name: "{{ intel_sgx_package_dependencies }}"
@@ -42,6 +37,12 @@
   yum:
     name: "{{ intel_sgx_packages }}"
     state: latest
+
+- name: Install the Intel DCAP packages
+  yum:
+    name: "{{ intel_dcap_packages }}"
+    state: latest
+  when: flc_enabled|bool
 
 - name: Cleanup installation
   file:

--- a/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
@@ -8,6 +8,8 @@ intel_sgx_packages:
   - "libsgx-enclave-common-devel"
   - "libsgx-ae-pce"
   - "libsgx-ae-qe3"
+  - "libsgx-qe3-logic"
+  - "libsgx-pce-logic"
 
 packages_validation_distribution_files:
   - "/usr/include/sgx_attributes.h"

--- a/scripts/ansible/roles/linux/intel/vars/redhat/ootpa.yml
+++ b/scripts/ansible/roles/linux/intel/vars/redhat/ootpa.yml
@@ -2,11 +2,19 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.8/distro/rhel8.0-server/sgx_linux_x64_driver_2.6.0_51c4821.bin"
-intel_sgx_rpm_repo_tgz_url: "https://download.01.org/intel-sgx/sgx-linux/2.8/distro/rhel8.0-server/sgx_rpm_local_repo.tgz"
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.6/linux/distro/rhel8.0-Server/sgx_linux_x64_driver_1.33.bin"
+intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/rhel8.0-server/sgx_linux_x64_driver_2.6.0_95eaa6f.bin"
+intel_sgx_rpm_repo_tgz_url: "https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/rhel8.0-server/sgx_rpm_local_repo.tgz"
 intel_sgx_package_dependencies:
   - "kernel-devel-uname-r == {{ ansible_kernel }}"
   - "elfutils-libelf-devel"
   - "openssl-devel"
   - "libcurl-devel"
   - "protobuf-devel"
+  - "dkms"
+
+intel_dcap_packages:
+  - "https://download.01.org/intel-sgx/sgx-dcap/1.6/linux/distro/rhel8.0-Server/libsgx-ae-qve-1.6.100.2-1.el8.x86_64.rpm"
+  - "https://download.01.org/intel-sgx/sgx-dcap/1.6/linux/distro/rhel8.0-Server/libsgx-dcap-ql-1.6.100.2-1.el8.x86_64.rpm"
+  - "https://download.01.org/intel-sgx/sgx-dcap/1.6/linux/distro/rhel8.0-Server/libsgx-dcap-ql-devel-1.6.100.2-1.el8.x86_64.rpm"
+  - "https://download.01.org/intel-sgx/sgx-dcap/1.6/linux/distro/rhel8.0-Server/libsgx-urts-2.9.101.2-1.el8.x86_64.rpm"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/bionic.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/bionic.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.4/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.21.bin"
-intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.7/distro/ubuntu18.04-server/sgx_linux_x64_driver_2.6.0_4f5bb63.bin"
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.6/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.33.bin"
+intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu18.04-server/sgx_linux_x64_driver_2.6.0_95eaa6f.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf10"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/xenial.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/xenial.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.4/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.21.bin"
-intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.7/distro/ubuntu16.04-server/sgx_linux_x64_driver_2.6.0_4f5bb63.bin"
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.6/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.33.bin"
+intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu16.04-server/sgx_linux_x64_driver_2.6.0_95eaa6f.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf9v5"

--- a/scripts/ansible/roles/linux/openenclave/tasks/redhat/packages-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/redhat/packages-install.yml
@@ -2,6 +2,13 @@
 # Licensed under the MIT License.
 
 ---
+- include_role:
+    name: linux/common
+    tasks_from: yum-repo.yml
+  vars:
+    yum_repository_rpm_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+    yum_repository_key_path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+
 - name: Install all the Open Enclave prerequisites YUM packages for development
   yum:
     name: "{{ yum_packages }}"


### PR DESCRIPTION
* Bump Intel SGX driver URLs for Ubuntu. This makes sure that we use the same version on both Ubuntu / RHEL in our Jenkins CI/CD machines.
* Enable attestation for RHEL 8:
  * Remove `flc_enabled=false` when building RHEL 8 Azure image.
  * Do no fail if `flc_enabled` is enabled on RHEL 8.
  * Create symlink for `libdcap_quoteprov.so` into `/usr/lib64`.
  * Add Intel SGX DCAP driver setup on RHEL 8.
  * Install Azure-DCAP-Client from stable branches on RHEL 8.
* Re-enable RHEL 8 testing stages. The linked issues are already solved.
* Refactor pipelines:
  * Fix spacing.
  * Remove code duplication for stages used with / without `FULL_TEST_SUITE`.
* Add RHEL 8 testing with HAS_QUOTE_PROVIDER=ON:
  * This is a validation that attestation is working as expected.
* Integrate RHEL8Test function into ACCTest
  * This commit also fixes space formating for ACCHostVerificationTest function.
* Cleanup Agnostic/Linux/Jenkinsfile
  * Rename `simulationTest` to `simulationContainerTest` since it runs testing into a container.
  * Change `simulationContainerTest` to accept `extra_cmake_args` instead of individual parameters for the cmake flags.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>


