### PR TITLE
Fix #2978, reinstall attestation plugin headers.

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -10,6 +10,10 @@ target_include_directories(
             $<BUILD_INTERFACE:${OE_INCDIR}>
             $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>)
 install(
+  DIRECTORY openenclave/attestation
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/
+  COMPONENT OEHOSTVERIFY)
+install(
   DIRECTORY openenclave/bits
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/
   COMPONENT OEHOSTVERIFY)
@@ -21,16 +25,6 @@ install(FILES openenclave/host.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(
   FILES openenclave/host_verify.h
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/
-  COMPONENT OEHOSTVERIFY)
-install(
-  FILES openenclave/attestation/plugin.h
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/
-  COMPONENT OEHOSTVERIFY)
-install(FILES openenclave/attestation/sgx/attester.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
-install(
-  FILES openenclave/attestation/sgx/verifier.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/
   COMPONENT OEHOSTVERIFY)
 install(TARGETS oe_includes EXPORT openenclave-targets)


### PR DESCRIPTION
Fixes #2978, attestation plugin headers are reinstalled here:
include/openenclave/attestation/plugin.h
include/openenclave/attestation/sgx/attester.h
include/openenclave/attestation/sgx/verifier.h

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>