### PR TITLE
Prevent conflicts on the host from the same EDL file being imported

### DIFF
--- a/include/openenclave/edger8r/host.h
+++ b/include/openenclave/edger8r/host.h
@@ -106,6 +106,26 @@ OE_INLINE size_t oe_wcslen(const wchar_t* s)
     return wcslen(s);
 }
 
+#if __GNUC__
+#define EDGER8R_WEAK_ALIAS(OLD, NEW) \
+    extern __typeof(OLD) NEW __attribute__((__weak__, alias(#OLD)))
+#elif _MSC_VER
+#define EDGER8R_WEAK_ALIAS(OLD, NEW) \
+    __pragma(comment(linker, "/alternatename:" #NEW "=" #OLD))
+#else
+#error OE_WEAK_ALIAS not implemented
+#endif
+
+// Statically defined functions which are aliased should be marked as unused
+// to prevent compiler warnings in GCC and Clang
+#if __GNUC__
+#define EDGER8R_UNUSED __attribute__((unused))
+#elif _MSC_VER
+#define EDGER8R_UNUSED
+#else
+#error EDGER8R_UNUSED not implemented
+#endif
+
 OE_EXTERNC_END
 
 #endif // _OE_EDGER8R_HOST_H

--- a/tests/oeedger8r/edl/all.edl
+++ b/tests/oeedger8r/edl/all.edl
@@ -11,6 +11,7 @@ enclave  {
     from "errno.edl"    import *;
     from "foreign.edl"  import *;
     from "pointer.edl"  import *;
+    from "shared.edl" import *;
     from "string.edl"   import *;
     from "struct.edl"   import *;
     from "switchless.edl" import *;

--- a/tests/oeedger8r/edl/other.edl
+++ b/tests/oeedger8r/edl/other.edl
@@ -6,6 +6,8 @@ enclave {
   // shares the same host. This tests the ability of a single host to
   // include multiple enclave headers (and so host multiple enclaves).
 
+  from "shared.edl" import *;
+
   struct MyOther {
     int x;
   };

--- a/tests/oeedger8r/edl/shared.edl
+++ b/tests/oeedger8r/edl/shared.edl
@@ -1,0 +1,8 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+        public void ecall_shared_func();
+    };
+};

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -51,6 +51,7 @@ add_enclave(
   testenum.cpp
   testerrno.cpp
   testforeign.cpp
+  testshared.cpp
   testpointer.cpp
   teststring.cpp
   teststruct.cpp
@@ -82,7 +83,7 @@ add_custom_command(
   OUTPUT other_t.h other_t.c
   DEPENDS ${EDL_FILE} edger8r
   COMMAND edger8r --trusted ${EDL_FILE} --search-path
-          ${CMAKE_CURRENT_SOURCE_DIR})
+          ${CMAKE_CURRENT_SOURCE_DIR}/../edl)
 
 add_enclave(
   TARGET

--- a/tests/oeedger8r/enc/testother.cpp
+++ b/tests/oeedger8r/enc/testother.cpp
@@ -12,6 +12,12 @@ MyOther ecall_other(MyOther o)
     return MyOther{o.x + 1};
 }
 
+void ecall_shared_func()
+{
+    // do nothing
+    return;
+}
+
 void test_other_edl_ocalls()
 {
     MyOther ret;

--- a/tests/oeedger8r/enc/testshared.cpp
+++ b/tests/oeedger8r/enc/testshared.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "all_t.h"
+
+void ecall_shared_func()
+{
+    // do nothing
+    return;
+}

--- a/tests/oeedger8r/host/testother.cpp
+++ b/tests/oeedger8r/host/testother.cpp
@@ -17,4 +17,7 @@ void test_other_edl_ecalls(oe_enclave_t* enclave)
     MyOther ret;
     OE_TEST(ecall_other(enclave, &ret, MyOther{1}) == OE_OK);
     OE_TEST(ret.x == 2);
+
+    OE_TEST(ecall_other(enclave, &ret, MyOther{1}) == OE_OK);
+    OE_TEST(ecall_shared_func(enclave) == OE_OK);
 }

--- a/tools/oeedger8r/src/Headers.ml
+++ b/tools/oeedger8r/src/Headers.ml
@@ -141,10 +141,13 @@ let get_marshal_struct (fd : func_decl) (errno : bool) =
     |> List.flatten
   in
   [
+    "#ifndef EDGER8R_STRUCT_" ^ String.uppercase_ascii struct_name;
+    "#define EDGER8R_STRUCT_" ^ String.uppercase_ascii struct_name;
     "typedef struct _" ^ struct_name;
     "{";
     "    " ^ String.concat "\n    " members;
     "} " ^ struct_name ^ ";";
+    "#endif";
     "";
   ]
 


### PR DESCRIPTION
OE supports the EDL stubs for two different enclaves being linked into the same host binary. To prevent collisions, mark all host functions as weak symbols. Additionally, add include guards around generated argument structs.