### PR TITLE
Clean up arguments to OE_SET_ENCLAVE_*() macros

### DIFF
--- a/devex/vscode-extension/assets/baseSolutionTemplateFolder/enc/enc.c.in
+++ b/devex/vscode-extension/assets/baseSolutionTemplateFolder/enc/enc.c.in
@@ -54,6 +54,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "[[project-name]]")

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/ecalls.c
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/ecalls.c
@@ -9,12 +9,12 @@
 #define TA_UUID /* $guid1$ */ $guid1struct$
 
 OE_SET_ENCLAVE_OPTEE(
-    TA_UUID,                                  /* UUID */
-    HEAP_SIZE_BYTES,                          /* HEAP_SIZE */
-    STACK_SIZE_BYTES,                         /* STACK_SIZE */
-    TA_FLAG_MULTI_SESSION | TA_FLAG_EXEC_DDR, /* FLAGS */
-    "1.0.0",                                  /* VERSION */
-    "$projectname$ TA");                      /* DESCRIPTION */
+    TA_UUID,               /* UUID */
+    HEAP_SIZE_BYTES,       /* HEAP_SIZE */
+    STACK_SIZE_BYTES,      /* STACK_SIZE */
+    TA_FLAG_MULTI_SESSION, /* FLAGS */
+    "1.0.0",               /* VERSION */
+    "$projectname$ TA");   /* DESCRIPTION */
 
 OE_SET_ENCLAVE_SGX(
     1, /* ProductID */

--- a/devex/vsextension/ProjectTemplates/oeenclave-windows/ecalls.c
+++ b/devex/vsextension/ProjectTemplates/oeenclave-windows/ecalls.c
@@ -9,12 +9,12 @@
 #define TA_UUID /* $guid1$ */ $guid1struct$
 
 OE_SET_ENCLAVE_OPTEE(
-    TA_UUID,                                  /* UUID */
-    HEAP_SIZE_BYTES,                          /* HEAP_SIZE */
-    STACK_SIZE_BYTES,                         /* STACK_SIZE */
-    TA_FLAG_MULTI_SESSION | TA_FLAG_EXEC_DDR, /* FLAGS */
-    "1.0.0",                                  /* VERSION */
-    "$projectname$ TA");                      /* DESCRIPTION */
+    TA_UUID,               /* UUID */
+    HEAP_SIZE_BYTES,       /* HEAP_SIZE */
+    STACK_SIZE_BYTES,      /* STACK_SIZE */
+    TA_FLAG_MULTI_SESSION, /* FLAGS */
+    "1.0.0",               /* VERSION */
+    "$projectname$ TA");   /* DESCRIPTION */
 
 OE_SET_ENCLAVE_SGX(
     1, /* ProductID */

--- a/tests/SampleApp/enc/SampleApp.cpp
+++ b/tests/SampleApp/enc/SampleApp.cpp
@@ -39,7 +39,7 @@ int secure_str_patching(const char* src, char* dst, size_t dst_length)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    256,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    256,  /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/SampleAppCRT/enc/SampleAppCRT.cpp
+++ b/tests/SampleAppCRT/enc/SampleAppCRT.cpp
@@ -100,7 +100,7 @@ int enc_test()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    256,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    256,  /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/VectorException/enc/enc.c
+++ b/tests/VectorException/enc/enc.c
@@ -381,7 +381,7 @@ int enc_test_ocall_in_handler()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/abortStatus/enc/enc.cpp
+++ b/tests/abortStatus/enc/enc.cpp
@@ -56,7 +56,7 @@ int normal_ecall(void)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    256,  /* HeapPageCount */
-    64,   /* StackPageCount */
-    5);   /* TCSCount */
+    true, /* Debug */
+    256,  /* NumHeapPages */
+    64,   /* NumStackPages */
+    5);   /* NumTCS */

--- a/tests/argv/enc/enc.c
+++ b/tests/argv/enc/enc.c
@@ -90,7 +90,7 @@ void test_argv_ecall(void)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/atexit/enc/enc.cpp
+++ b/tests/atexit/enc/enc.cpp
@@ -51,7 +51,7 @@ void atexit_with_ecall_ecall(void)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    8,    /* HeapPageCount */
-    8,    /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    8,    /* NumHeapPages */
+    8,    /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/attestation_cert_apis/enc/enc.cpp
+++ b/tests/attestation_cert_apis/enc/enc.cpp
@@ -307,7 +307,7 @@ oe_result_t get_tls_cert_signed_with_rsa_key(
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    128,  /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    128,  /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/attestation_plugin/enc/enc.c
+++ b/tests/attestation_plugin/enc/enc.c
@@ -197,7 +197,7 @@ void test_sgx()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    128,  /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    128,  /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/backtrace/enc/enc.cpp
+++ b/tests/backtrace/enc/enc.cpp
@@ -164,7 +164,7 @@ extern "C" bool test_unwind(size_t num_syms, const char** syms)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/c99_compliant/enc/enc.c
+++ b/tests/c99_compliant/enc/enc.c
@@ -41,10 +41,10 @@ int enc_c99_compliant()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    256,  /* HeapPageCount */
-    256,  /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    256,  /* NumHeapPages */
+    256,  /* NumStackPages */
+    2);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* b843807a-e05c-423c-bcfb-1062cadb482f */           \
@@ -58,6 +58,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "C99-compliant test")

--- a/tests/child_process/enc/enc.cpp
+++ b/tests/child_process/enc/enc.cpp
@@ -18,7 +18,7 @@ void get_magic_ecall(void* pdata)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    8,    /* HeapPageCount */
-    8,    /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    8,    /* NumHeapPages */
+    8,    /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/child_thread/enc/enc.cpp
+++ b/tests/child_thread/enc/enc.cpp
@@ -32,7 +32,7 @@ int stay_in_ocall_ecall()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    8,    /* HeapPageCount */
-    8,    /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    8,    /* NumHeapPages */
+    8,    /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/cmake_name_conflict/enc/enc.c
+++ b/tests/cmake_name_conflict/enc/enc.c
@@ -15,7 +15,7 @@ void test_name_conflict(void)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/cppException/enc/enc.cpp
+++ b/tests/cppException/enc/enc.cpp
@@ -52,7 +52,7 @@ int test_unhandled_exception(unhandled_exception_func_num func_num)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    64,   /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    64,   /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/create-errors/enc/enc.c
+++ b/tests/create-errors/enc/enc.c
@@ -13,10 +13,10 @@ int test(void)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* 1083bbac-751e-4d26-ada6-c254bbfbe653 */           \
@@ -30,6 +30,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Create Errors test")

--- a/tests/create-rapid/enc/enc.cpp
+++ b/tests/create-rapid/enc/enc.cpp
@@ -12,10 +12,10 @@ int test(int arg)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    8,    /* HeapPageCount */
-    8,    /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    8,    /* NumHeapPages */
+    8,    /* NumStackPages */
+    1);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* 688ab13f-5bc0-40af-8dc6-01d007fd2210 */           \
@@ -29,6 +29,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Create Rapid test")

--- a/tests/crypto/enclave/enc/enc.c
+++ b/tests/crypto/enclave/enc/enc.c
@@ -193,10 +193,10 @@ void test()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* f0be7db0-ce7c-4dc4-b8c8-b161f4216225 */           \
@@ -210,6 +210,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     2 * 1024 * 1024,
     24 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Crypto test")

--- a/tests/crypto_crls_cert_chains/enc/enc.cpp
+++ b/tests/crypto_crls_cert_chains/enc/enc.cpp
@@ -55,7 +55,7 @@ void ecall_test_crls(
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/debug-mode/enc/props-debug.c
+++ b/tests/debug-mode/enc/props-debug.c
@@ -6,7 +6,7 @@
 OE_SET_ENCLAVE_SGX(
     1234, /* ProductID */
     5678, /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    512,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    512,  /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/debug-mode/enc/props.c
+++ b/tests/debug-mode/enc/props.c
@@ -6,7 +6,7 @@
 OE_SET_ENCLAVE_SGX(
     1234,  /* ProductID */
     5678,  /* SecurityVersion */
-    false, /* AllowDebug */
-    1024,  /* HeapPageCount */
-    512,   /* StackPageCount */
-    4);    /* TCSCount */
+    false, /* Debug */
+    1024,  /* NumHeapPages */
+    512,   /* NumStackPages */
+    4);    /* NumTCS */

--- a/tests/debugger/oegdb/enc/enc.c
+++ b/tests/debugger/oegdb/enc/enc.c
@@ -64,7 +64,7 @@ void enc_test_stack_stitching(void)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/ecall/enc/enc.cpp
+++ b/tests/ecall/enc/enc.cpp
@@ -154,7 +154,7 @@ void enc_test(test_args* args)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/ecall_ocall/enc/enc.cpp
+++ b/tests/ecall_ocall/enc/enc.cpp
@@ -148,7 +148,7 @@ void enc_make_ocall(int n)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    256,  /* HeapPageCount */
-    16,   /* StackPageCount */
-    5);   /* TCSCount */
+    true, /* Debug */
+    256,  /* NumHeapPages */
+    16,   /* NumStackPages */
+    5);   /* NumTCS */

--- a/tests/echo/enc/enc.c
+++ b/tests/echo/enc/enc.c
@@ -64,7 +64,7 @@ int enc_echo(char* in, char out[100])
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/enclaveparam/enc/enc.c
+++ b/tests/enclaveparam/enc/enc.c
@@ -33,7 +33,7 @@ void test_ocall_enclave_param(char* func)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    64,   /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    64,   /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/exclude_system_edl/enc/enc.c
+++ b/tests/exclude_system_edl/enc/enc.c
@@ -19,10 +19,10 @@ void enc_nanosleep()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    1);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* b07e2f2c-b911-48d3-8c4f-a29831d604d2 */           \
@@ -36,6 +36,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Exclude System EDL test")

--- a/tests/file/enc/enc.cpp
+++ b/tests/file/enc/enc.cpp
@@ -45,7 +45,7 @@ done:
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    256,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    256,  /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/getenclave/enc/enc.c
+++ b/tests/getenclave/enc/enc.c
@@ -35,7 +35,7 @@ __attribute__((constructor)) void global_constructor()
 OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    64,   /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    64,   /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/hexdump/enc/enc.c
+++ b/tests/hexdump/enc/enc.c
@@ -26,10 +26,10 @@ int test(
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* 126830b9-eb9f-412a-89a7-bcc8a517c12e */           \
@@ -43,6 +43,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Hexdump test")

--- a/tests/hostcalls/enc/enc.cpp
+++ b/tests/hostcalls/enc/enc.cpp
@@ -74,10 +74,10 @@ void test_host_free(void_ptr in_ptr)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    128,  /* StackPageCount */
-    16);  /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    128,  /* NumStackPages */
+    16);  /* NumTCS */
 
 #define TA_UUID                                            \
     { /* 60814a64-61e9-4fd9-9159-e158d73f6a2e */           \
@@ -91,6 +91,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Host Calls test")

--- a/tests/initializers/enc/enc.c
+++ b/tests/initializers/enc/enc.c
@@ -86,10 +86,10 @@ void set_globals(
 OE_SET_ENCLAVE_SGX(
     1234, /* ProductID */
     5678, /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    64,   /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    64,   /* NumStackPages */
+    4);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* 62f73b00-bdfe-4763-a06a-dc561a3a34d8 */           \
@@ -103,6 +103,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Initializers test")

--- a/tests/libc/enc/enc.c
+++ b/tests/libc/enc/enc.c
@@ -166,10 +166,10 @@ int run_all_tests()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    512,  /* HeapPageCount */
-    256,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    512,  /* NumHeapPages */
+    256,  /* NumStackPages */
+    4);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* d7fe296a-24e9-46d1-aa78-9c7395082a41 */           \
@@ -183,6 +183,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "libc test")

--- a/tests/libcxx/enc/enc.cpp
+++ b/tests/libcxx/enc/enc.cpp
@@ -281,11 +281,11 @@ int enc_test(char test_name[STRLEN])
 OE_SET_ENCLAVE_SGX(
     1,                   /* ProductID */
     1,                   /* SecurityVersion */
-    true,                /* AllowDebug */
+    true,                /* Debug */
 #ifdef FULL_LIBCXX_TESTS /* Full tests require large heap memory. */
-    12288,               /* HeapPageCount */
+    12288,               /* NumHeapPages */
 #else
-    512, /* HeapPageCount */
+    512, /* NumHeapPages */
 #endif
-    512, /* StackPageCount */
-    8);  /* TCSCount */
+    512, /* NumStackPages */
+    8);  /* NumTCS */

--- a/tests/libcxxrt/enc/enc.cpp
+++ b/tests/libcxxrt/enc/enc.cpp
@@ -69,7 +69,7 @@ extern "C" int test(char** name)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/libunwind/enc/enc.c
+++ b/tests/libunwind/enc/enc.c
@@ -86,7 +86,7 @@ int test(char test_name[201], uint32_t pid)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/mbed/enc/enc.c
+++ b/tests/mbed/enc/enc.c
@@ -224,7 +224,7 @@ void oe_handle_verify_report(uint64_t arg_in, uint64_t* arg_out)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    512,  /* HeapPageCount */
-    512,  /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    512,  /* NumHeapPages */
+    512,  /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/memory/enc/enc.c
+++ b/tests/memory/enc/enc.c
@@ -5,14 +5,14 @@
 #include <openenclave/enclave.h>
 
 OE_SET_ENCLAVE_SGX(
-    1234,                /* ProductID */
-    5678,                /* SecurityVersion */
-    true,                /* AllowDebug */
-#ifdef NO_PAGING_SUPPORT /* Set smaller heap for systems without paging \
-                            support. */
-    2560,                /* HeapPageCount */
+    1234, /* ProductID */
+    5678, /* SecurityVersion */
+    true, /* Debug */
+#ifdef NO_PAGING_SUPPORT
+    /* Set smaller heap for systems without paging support. */
+    2560, /* NumHeapPages */
 #else
-    131072, /* HeapPageCount */
+    131072, /* NumHeapPages */
 #endif
-    32, /* StackPageCount */
-    4); /* TCSCount */
+    32, /* NumStackPages */
+    4); /* NumTCS */

--- a/tests/mixed_c_cpp/enc/enc.cpp
+++ b/tests/mixed_c_cpp/enc/enc.cpp
@@ -13,10 +13,10 @@ void foo_cpp(int a)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    256,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    256,  /* NumStackPages */
+    4);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* 952c55c8-59f3-47a0-814c-ae3276a9808f */           \
@@ -30,6 +30,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Mixed C/C++ test")

--- a/tests/ocall-create/enc/enc.c
+++ b/tests/ocall-create/enc/enc.c
@@ -87,7 +87,7 @@ int enc_test_ocall_enclave(const char* path, uint32_t flags)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    256,  /* HeapPageCount */
-    128,  /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    256,  /* NumHeapPages */
+    128,  /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/ocall/enc/enc.cpp
+++ b/tests/ocall/enc/enc.cpp
@@ -99,7 +99,7 @@ void enc_test_reentrancy()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    128,  /* StackPageCount */
-    16);  /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    128,  /* NumStackPages */
+    16);  /* NumTCS */

--- a/tests/oeedger8r/enc/testother.cpp
+++ b/tests/oeedger8r/enc/testother.cpp
@@ -22,7 +22,7 @@ void test_other_edl_ocalls()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    256,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    256,  /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/oeedger8r/enc/teststruct.cpp
+++ b/tests/oeedger8r/enc/teststruct.cpp
@@ -386,7 +386,7 @@ MyStruct1 ecall_struct1(
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    256,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    256,  /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/pingpong-shared/enc/enc.cpp
+++ b/tests/pingpong-shared/enc/enc.cpp
@@ -12,10 +12,10 @@ void Ping(const char* in, char* out, int out_length)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    256,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    256,  /* NumStackPages */
+    4);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* e229cc0f-3199-4ad3-91a7-47906fcbcc59 */           \
@@ -29,6 +29,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Ping-Pong Shared test")

--- a/tests/pingpong/enc/enc.cpp
+++ b/tests/pingpong/enc/enc.cpp
@@ -12,10 +12,10 @@ void Ping(const char* in, char* out, int out_length)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    256,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    256,  /* NumStackPages */
+    4);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* 0a6cbbd3-160a-4c86-9d9d-c9cf1956be16 */           \
@@ -29,6 +29,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Ping-Pong test")

--- a/tests/print/enc/enc.cpp
+++ b/tests/print/enc/enc.cpp
@@ -56,7 +56,7 @@ int enclave_test_print()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/props/enc/props.c
+++ b/tests/props/enc/props.c
@@ -6,7 +6,7 @@
 OE_SET_ENCLAVE_SGX(
     1234, /* ProductID */
     5678, /* SecurityVersion */
-    true, /* AllowDebug */
-    512,  /* HeapPageCount */
-    512,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    512,  /* NumHeapPages */
+    512,  /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/qeidentity/enc/enc.cpp
+++ b/tests/qeidentity/enc/enc.cpp
@@ -34,7 +34,7 @@ oe_result_t test_verify_qe_identity_info(
 OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/report/enc/enc.cpp
+++ b/tests/report/enc/enc.cpp
@@ -145,7 +145,7 @@ void enclave_test_get_signer_id_from_public_key()
 OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/safecrt/enc/enc.cpp
+++ b/tests/safecrt/enc/enc.cpp
@@ -35,10 +35,10 @@ void enc_test_memset_s()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */
 
 #define TA_UUID                                            \
     { /* 91dc6667-7a33-4bbc-ab3e-ab4fca5215b7 */           \
@@ -52,6 +52,6 @@ OE_SET_ENCLAVE_OPTEE(
     TA_UUID,
     1 * 1024 * 1024,
     12 * 1024,
-    TA_FLAG_EXEC_DDR,
+    0,
     "1.0.0",
     "Safe CRT test")

--- a/tests/sealKey/enc/enc.cpp
+++ b/tests/sealKey/enc/enc.cpp
@@ -631,7 +631,7 @@ int enc_get_public_key(
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    256,  /* HeapPageCount */
-    64,   /* StackPageCount */
-    5);   /* TCSCount */
+    true, /* Debug */
+    256,  /* NumHeapPages */
+    64,   /* NumStackPages */
+    5);   /* NumTCS */

--- a/tests/sim-mode/enc/props.c
+++ b/tests/sim-mode/enc/props.c
@@ -6,7 +6,7 @@
 OE_SET_ENCLAVE_SGX(
     1234,  /* ProductID */
     5678,  /* SecurityVersion */
-    false, /* AllowDebug */
-    1024,  /* HeapPageCount */
-    512,   /* StackPageCount */
-    4);    /* TCSCount */
+    false, /* Debug */
+    1024,  /* NumHeapPages */
+    512,   /* NumStackPages */
+    4);    /* NumTCS */

--- a/tests/stack_smashing_protector/enc/enc.cpp
+++ b/tests/stack_smashing_protector/enc/enc.cpp
@@ -83,7 +83,7 @@ void* ssp_test()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    128,  /* StackPageCount */
-    16);  /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    128,  /* NumStackPages */
+    16);  /* NumTCS */

--- a/tests/stdc/enc/enc.cpp
+++ b/tests/stdc/enc/enc.cpp
@@ -283,7 +283,7 @@ int test(char buf1[BUFSIZE], char buf2[BUFSIZE])
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/stdcxx/enc/enc.cpp
+++ b/tests/stdcxx/enc/enc.cpp
@@ -240,7 +240,7 @@ __attribute__((destructor)) void destructor(void)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    512,  /* HeapPageCount */
-    512,  /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    512,  /* NumHeapPages */
+    512,  /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/stdcxx/enc/global_init_exception.cpp
+++ b/tests/stdcxx/enc/global_init_exception.cpp
@@ -29,7 +29,7 @@ int enc_test(bool*, bool*, size_t*)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/switchless/enc/enc.c
+++ b/tests/switchless/enc/enc.c
@@ -108,7 +108,7 @@ int enc_echo_regular(
 OE_SET_ENCLAVE_SGX(
     1,        /* ProductID */
     1,        /* SecurityVersion */
-    true,     /* AllowDebug */
-    64,       /* HeapPageCount */
-    64,       /* StackPageCount */
-    NUM_TCS); /* TCSCount */
+    true,     /* Debug */
+    64,       /* NumHeapPages */
+    64,       /* NumStackPages */
+    NUM_TCS); /* NumTCS */

--- a/tests/switchless_nestedcalls/enc/enc.c
+++ b/tests/switchless_nestedcalls/enc/enc.c
@@ -19,7 +19,7 @@ void enc_ecall2_switchless(void)
 OE_SET_ENCLAVE_SGX(
     1,        /* ProductID */
     1,        /* SecurityVersion */
-    true,     /* AllowDebug */
-    64,       /* HeapPageCount */
-    64,       /* StackPageCount */
-    NUM_TCS); /* TCSCount */
+    true,     /* Debug */
+    64,       /* NumHeapPages */
+    64,       /* NumStackPages */
+    NUM_TCS); /* NumTCS */

--- a/tests/switchless_threads/enc/enc.c
+++ b/tests/switchless_threads/enc/enc.c
@@ -69,7 +69,7 @@ int enc_echo_multiple(char* in, char out[STRING_LEN], int repeats)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    128,  /* StackPageCount */
-    8);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    128,  /* NumStackPages */
+    8);   /* NumTCS */

--- a/tests/switchless_worksleep/enc/enc.cpp
+++ b/tests/switchless_worksleep/enc/enc.cpp
@@ -19,7 +19,7 @@ void enc_ecall2_switchless(void)
 OE_SET_ENCLAVE_SGX(
     1,        /* ProductID */
     1,        /* SecurityVersion */
-    true,     /* AllowDebug */
-    64,       /* HeapPageCount */
-    64,       /* StackPageCount */
-    NUM_TCS); /* TCSCount */
+    true,     /* Debug */
+    64,       /* NumHeapPages */
+    64,       /* NumStackPages */
+    NUM_TCS); /* NumTCS */

--- a/tests/syscall/datagram/enc/enc.c
+++ b/tests/syscall/datagram/enc/enc.c
@@ -100,7 +100,7 @@ void run_client_ecall(void)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/syscall/dup/enc/enc.c
+++ b/tests/syscall/dup/enc/enc.c
@@ -99,7 +99,7 @@ void test_dup(const char* tmp_dir)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/syscall/epoll/enc/enc.cpp
+++ b/tests/syscall/epoll/enc/enc.cpp
@@ -147,7 +147,7 @@ extern "C" void test_close_without_delete()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    256,  /* StackPageCount */
-    9);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    256,  /* NumStackPages */
+    9);   /* NumTCS */

--- a/tests/syscall/fs/enc/enc.cpp
+++ b/tests/syscall/fs/enc/enc.cpp
@@ -879,7 +879,7 @@ void test_fs_linux(const char* src_dir, const char* tmp_dir)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/syscall/hostfs/enc/enc.c
+++ b/tests/syscall/hostfs/enc/enc.c
@@ -54,7 +54,7 @@ void test_hostfs(const char* tmp_dir)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/syscall/ids/enc/enc.c
+++ b/tests/syscall/ids/enc/enc.c
@@ -43,7 +43,7 @@ void test_ids(
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/syscall/poller/enc/enc.cpp
+++ b/tests/syscall/poller/enc/enc.cpp
@@ -327,7 +327,7 @@ extern "C" void test_fd_set(void)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    256,  /* StackPageCount */
-    9);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    256,  /* NumStackPages */
+    9);   /* NumTCS */

--- a/tests/syscall/resolver/enc/enc.c
+++ b/tests/syscall/resolver/enc/enc.c
@@ -197,7 +197,7 @@ int ecall_getaddrinfo(struct oe_addrinfo** res)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    256,  /* HeapPageCount */
-    256,  /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    256,  /* NumHeapPages */
+    256,  /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/syscall/sendmsg/enc/enc.c
+++ b/tests/syscall/sendmsg/enc/enc.c
@@ -34,7 +34,7 @@ void run_enclave_client(uint16_t port)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    1024, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/syscall/socket/enc/enc.c
+++ b/tests/syscall/socket/enc/enc.c
@@ -222,7 +222,7 @@ int ecall_run_server()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    256,  /* HeapPageCount */
-    256,  /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    256,  /* NumHeapPages */
+    256,  /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/syscall/socketpair/enc/enc.c
+++ b/tests/syscall/socketpair/enc/enc.c
@@ -144,7 +144,7 @@ int run_enclave_server()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    256,  /* HeapPageCount */
-    256,  /* StackPageCount */
-    4);   /* TCSCount */
+    true, /* Debug */
+    256,  /* NumHeapPages */
+    256,  /* NumStackPages */
+    4);   /* NumTCS */

--- a/tests/thread/enc/enc.cpp
+++ b/tests/thread/enc/enc.cpp
@@ -292,7 +292,7 @@ size_t enc_tcs_used_thread_count()
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    16,   /* StackPageCount */
-    16);  /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    16,   /* NumStackPages */
+    16);  /* NumTCS */

--- a/tests/thread/host/host.cpp
+++ b/tests/thread/host/host.cpp
@@ -249,7 +249,7 @@ void* tcs_thread(oe_enclave_t* enclave, size_t expected_out_of_threads)
 void test_tcs_exhaustion(oe_enclave_t* enclave)
 {
     std::vector<std::thread> threads;
-    // Set the test_tcs_count to a value greater than the enclave TCSCount
+    // Set the test_tcs_count to a value greater than the enclave NumTCS
     const size_t test_tcs_req_count = enclave->num_bindings * 2;
     const size_t expected_out_of_threads = enclave->num_bindings;
     printf(

--- a/tests/thread_local/enc/enc.cpp
+++ b/tests/thread_local/enc/enc.cpp
@@ -178,7 +178,7 @@ void enclave_thread(int thread_num, int iters, int step)
 OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
-    true, /* AllowDebug */
-    64,   /* HeapPageCount */
-    16,   /* StackPageCount */
-    16);  /* TCSCount */
+    true, /* Debug */
+    64,   /* NumHeapPages */
+    16,   /* NumStackPages */
+    16);  /* NumTCS */

--- a/tests/thread_local_no_tdata/enc/enc.cpp
+++ b/tests/thread_local_no_tdata/enc/enc.cpp
@@ -38,7 +38,7 @@ uint64_t enc_get_value()
 OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
-    true, /* AllowDebug */
-    64,   /* HeapPageCount */
-    16,   /* StackPageCount */
-    16);  /* TCSCount */
+    true, /* Debug */
+    64,   /* NumHeapPages */
+    16,   /* NumStackPages */
+    16);  /* NumTCS */

--- a/tests/threadcxx/enc/enc.cpp
+++ b/tests/threadcxx/enc/enc.cpp
@@ -297,7 +297,7 @@ void enc_lock_and_unlock_mutexes_cxx(const char* mutexes)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    16,   /* StackPageCount */
-    16);  /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    16,   /* NumStackPages */
+    16);  /* NumTCS */

--- a/tests/tls_e2e/client_enc/client.cpp
+++ b/tests/tls_e2e/client_enc/client.cpp
@@ -396,7 +396,7 @@ int setup_tls_server(struct tls_control_args* config, char* server_port)
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    128,  /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    128,  /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/tls_e2e/server_enc/server.cpp
+++ b/tests/tls_e2e/server_enc/server.cpp
@@ -437,7 +437,7 @@ done:
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    128,  /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    128,  /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/tools/oecert/enc/enc.cpp
+++ b/tests/tools/oecert/enc/enc.cpp
@@ -115,7 +115,7 @@ done:
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    128,  /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    128,  /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/tools/oecertdump/enc/enc.cpp
+++ b/tests/tools/oecertdump/enc/enc.cpp
@@ -304,7 +304,7 @@ oe_result_t get_tls_cert_signed_with_rsa_key(
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    128,  /* StackPageCount */
-    1);   /* TCSCount */
+    true, /* Debug */
+    128,  /* NumHeapPages */
+    128,  /* NumStackPages */
+    1);   /* NumTCS */


### PR DESCRIPTION
This PR has code changes corresponding to doc changes/comments in PR #3026.
There are two changes in this PR, to code that uses these macros:

1. for OP-TEE, TA_FLAG_EXEC_DDR is deprecated and has a value of 0 so can be omitted
2. for SGX, the names of the values should match the names supported in the .conf file
   (the names in the comments would be more consistent with the API
   guidelines, but they can only be changed to the better names if the
   names in the .conf were changed)

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>