### PR TITLE
Disable the child_process test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,7 +103,10 @@ endif ()
 
 if (UNIX)
   if (OE_SGX)
-    add_subdirectory(child_process)
+    # This test is currently disabled due to differences in SGX DCAP driver
+    # versions. See child_process/README.md for more info.
+    # add_subdirectory(child_process)
+
     add_subdirectory(cmake_name_conflict)
   endif ()
   add_subdirectory(libc)

--- a/tests/child_process/README.md
+++ b/tests/child_process/README.md
@@ -1,3 +1,13 @@
+**Note:** This test is currently disabled. Version 1.33 of the SGX DCAP driver
+introduces support accessing an enclave from a forked child process. This causes
+this test to fail when using that driver. Version 1.22 does not have fork support
+so this test will pass.
+
+Ultimately when older versions of the DCAP driver are deprecated, this test should
+be re-enabled and modified to check that ecalls/terminate SUCCEEDS from a forked
+child.
+
+
 This directory tests that a parent process' enclave cannot be called or destroyed from a child process. It does so by having a host app create an enclave, fork itself and then invoke the following from the child process:
 1. tests/child_process_ecall tries to make an ECall into an enclave from the child process.
 2. tests/child_process_destroy tries to destroy the enclave from the child process. 

--- a/tests/child_process/host/host.cpp
+++ b/tests/child_process/host/host.cpp
@@ -73,7 +73,12 @@ int main(int argc, const char* argv[])
                 process_result = close(fpipe[0]);
                 OE_TEST(result == OE_OK);
                 oe_terminate_enclave(enclave);
-                wait(NULL);
+
+                // Wait for child
+                int child_status = -1;
+                while (wait(&child_status) > 0)
+                    ;
+                OE_TEST(child_status == 0);
             }
             else
             {
@@ -90,11 +95,19 @@ int main(int argc, const char* argv[])
             else if (pid > 0) // parent process
             {
                 uint32_t magic;
+
                 result = get_magic_ecall(enclave, &magic);
                 OE_TEST(result == OE_OK);
                 OE_TEST(magic == 0x1234);
-                oe_terminate_enclave(enclave);
-                wait(NULL);
+                result = oe_terminate_enclave(enclave);
+                OE_TEST(result == OE_OK);
+                enclave = nullptr;
+
+                // Wait for child
+                int child_status = -1;
+                while (wait(&child_status) > 0)
+                    ;
+                OE_TEST(child_status == 0);
             }
             else
             {
@@ -122,7 +135,12 @@ int main(int argc, const char* argv[])
             {
                 fprintf(stdout, "parent pid = %d\n", getpid());
                 oe_terminate_enclave(enclave);
-                wait(NULL);
+
+                // Wait for child
+                int child_status = -1;
+                while (wait(&child_status) > 0)
+                    ;
+                OE_TEST(child_status == 0);
             }
             else
             {


### PR DESCRIPTION
Disable the child_process test. Version 1.33 of the SGX DCAP driver introduces support accessing an enclave from a forked child process. This causes this test to fail when using that driver. Version 1.22 does not have fork support so this test will pass.