### PR TITLE
Reserve the beginning of the thread data on SGX

### DIFF
--- a/enclave/core/sgx/exception.c
+++ b/enclave/core/sgx/exception.c
@@ -248,15 +248,15 @@ void oe_real_exception_dispatcher(oe_context_t* oe_context)
     oe_sgx_td_t* td = oe_sgx_get_td();
 
     // Change the rip of oe_context to the real exception address.
-    oe_context->rip = td->base.exception_address;
+    oe_context->rip = td->exception_address;
 
     // Compose the oe_exception_record_t.
     // N.B. In second pass exception handling, the XSTATE is recovered by SGX
     // hardware correctly on ERESUME, so we don't touch the XSTATE.
     oe_exception_record_t oe_exception_record = {0};
-    oe_exception_record.code = td->base.exception_code;
-    oe_exception_record.flags = td->base.exception_flags;
-    oe_exception_record.address = td->base.exception_address;
+    oe_exception_record.code = td->exception_code;
+    oe_exception_record.flags = td->exception_flags;
+    oe_exception_record.address = td->exception_address;
     oe_exception_record.context = oe_context;
 
     // Refer to oe_enter in host/sgx/enter.c. The contract we defined for EENTER
@@ -335,31 +335,31 @@ void oe_virtual_exception_dispatcher(
     }
 
     // Get the exception address, code, and flags.
-    td->base.exception_address = ssa_gpr->rip;
-    td->base.exception_code = OE_EXCEPTION_UNKNOWN;
+    td->exception_address = ssa_gpr->rip;
+    td->exception_code = OE_EXCEPTION_UNKNOWN;
     for (uint32_t i = 0; i < OE_COUNTOF(g_vector_to_exception_code_mapping);
          i++)
     {
         if (g_vector_to_exception_code_mapping[i].sgx_vector ==
             ssa_gpr->exit_info.as_fields.vector)
         {
-            td->base.exception_code =
+            td->exception_code =
                 g_vector_to_exception_code_mapping[i].exception_code;
             break;
         }
     }
 
-    td->base.exception_flags = 0;
+    td->exception_flags = 0;
     if (ssa_gpr->exit_info.as_fields.exit_type == SGX_EXIT_TYPE_HARDWARE)
     {
-        td->base.exception_flags |= OE_EXCEPTION_FLAGS_HARDWARE;
+        td->exception_flags |= OE_EXCEPTION_FLAGS_HARDWARE;
     }
     else if (ssa_gpr->exit_info.as_fields.exit_type == SGX_EXIT_TYPE_SOFTWARE)
     {
-        td->base.exception_flags |= OE_EXCEPTION_FLAGS_SOFTWARE;
+        td->exception_flags |= OE_EXCEPTION_FLAGS_SOFTWARE;
     }
 
-    if (td->base.exception_code == OE_EXCEPTION_ILLEGAL_INSTRUCTION &&
+    if (td->exception_code == OE_EXCEPTION_ILLEGAL_INSTRUCTION &&
         _emulate_illegal_instruction(ssa_gpr) == 0)
     {
         // Restore the RBP & RSP as required by return from EENTER

--- a/include/openenclave/internal/sgx/td.h
+++ b/include/openenclave/internal/sgx/td.h
@@ -32,36 +32,27 @@ struct _oe_thread_data
     /* Points to start of this structure */
     uint64_t self_addr;
 
-    /* The last stack pointer (set by enclave when making an OCALL) */
-    uint64_t last_sp;
-
+    uint64_t __reserved_0;
     uint64_t __stack_base_addr;
     uint64_t __stack_limit_addr;
     uint64_t __first_ssa_gpr;
+
     /* Here the name and offset of stack_guard complies to the properties of
        stack_guard defined in tcbhead_t(Struct for Thread Control Block). In
        this way we can make use of the compiler's support of stack smashing
        protector.
      */
     uint64_t stack_guard; /* The offset is 0x28 for x64 */
-    uint64_t __reserved_0;
+
+    uint64_t __reserved_1;
     uint64_t __ssa_frame_size;
     uint64_t __last_error;
-
-    /* The threads implementations uses this to put threads on queues */
-    oe_thread_data_t* next;
-
+    uint64_t __reserved_2;
     uint64_t __tls_addr;
     uint64_t __tls_array;
     uint64_t __exception_flag; /* number of exceptions being handled */
     uint64_t __cxx_thread_info[6];
-
-    // The exception code.
-    uint32_t exception_code;
-    // The exception flags.
-    uint32_t exception_flags;
-    // The rip when exception happened.
-    uint64_t exception_address;
+    uint8_t __padding[16];
 };
 
 OE_CHECK_SIZE(sizeof(oe_thread_data_t), 168);
@@ -89,7 +80,7 @@ oe_thread_data_t* oe_get_thread_data(void);
  * Due to the inability to use OE_OFFSETOF on a struct while defining its
  * members, this value is computed and hard-coded.
  */
-#define OE_THREAD_SPECIFIC_DATA_SIZE (3824)
+#define OE_THREAD_SPECIFIC_DATA_SIZE (3792)
 
 typedef struct _callsite Callsite;
 
@@ -133,6 +124,19 @@ typedef struct _td
     /* Host ecall context pointers */
     struct _oe_ecall_context* host_ecall_context;
     struct _oe_ecall_context* host_previous_ecall_context;
+
+    /* The last stack pointer (set by enclave when making an OCALL) */
+    uint64_t last_sp;
+
+    // The exception code.
+    uint32_t exception_code;
+    // The exception flags.
+    uint32_t exception_flags;
+    // The rip when exception happened.
+    uint64_t exception_address;
+
+    /* The threads implementations uses this to put threads on queues */
+    struct _td* next;
 
     /* Reserved for thread specific data. */
     uint8_t thread_specific_data[OE_THREAD_SPECIFIC_DATA_SIZE];

--- a/tests/ecall/ecall.edl
+++ b/tests/ecall/ecall.edl
@@ -15,7 +15,7 @@ enclave {
         uint64_t num_heap_pages;
         uint64_t num_pages;
         void* base;
-        oe_thread_data_t thread_data;
+        oe_sgx_td_t thread_data;
         uint64_t thread_data_addr;
         unsigned int mm;
         unsigned int dd;

--- a/tests/ecall/enc/enc.cpp
+++ b/tests/ecall/enc/enc.cpp
@@ -36,8 +36,8 @@ void enc_test(test_args* args)
     args->magic2 = NEW_MAGIC;
 
     /* Get thread data */
-    const oe_thread_data_t* td;
-    if ((td = oe_get_thread_data()))
+    const oe_sgx_td_t* td;
+    if ((td = oe_sgx_get_td()))
     {
         args->thread_data = *td;
         args->thread_data_addr = reinterpret_cast<uint64_t>(td);


### PR DESCRIPTION
For the SGX runtime, reserve the beginning of the oe_thread_data_t structure in oecore to allow other libc implementations to be built on top of OE. oelibc and oelibcxx use this space, but an application
should be able to replace those implementations if they choose.