### PR TITLE
Remove host library oehostapp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Mark APIs in include/openenclave/attestation/sgx/attester.h and verifier.h as experimental.
 
+### Removed
+- Removed oehostapp and the appendent "-rdynamic" compiling option. Please use oehost instead and add the option back manually if necessary.
+
 [0.9.0][v0.9.0_log]
 ------------
 

--- a/cmake/sdk_cmake_targets_readme.md
+++ b/cmake/sdk_cmake_targets_readme.md
@@ -26,7 +26,7 @@ The targets relevant to users of the SDK are:
 - `openenclave::oeenclave`
 - `openenclave::oelibc`
 - `openenclave::oelibcxx`
-- `openenclave::oehostapp`
+- `openenclave::oehost`
 
 The remaining targets in `openenclave-targets.cmake` are automatically included
 when needed by the above.
@@ -157,12 +157,12 @@ the latter sets up a dependency where it only signs if the enclave is rebuilt.
 ### Creating a host
 
 Host targets in CMake should use `add_executable`, link to
-`openenclave::oehostapp`, and include the untrusted EDL code if `oeedger8r` was
+`openenclave::oehost`, and include the untrusted EDL code if `oeedger8r` was
 used. An example is:
 
 ```cmake
 add_executable(example_host host.cpp example_u.c)
-target_link_libraries(example_host openenclave::oehostapp)
+target_link_libraries(example_host openenclave::oehost)
 ```
 
 ### Running the enclave

--- a/devex/vscode-extension/assets/edgeSolutionTemplateFolder/modules/[[project-name]]/host/CMakeLists.txt
+++ b/devex/vscode-extension/assets/edgeSolutionTemplateFolder/modules/[[project-name]]/host/CMakeLists.txt
@@ -35,7 +35,7 @@ target_compile_definitions([[project-name]] PRIVATE USE_EDGE_MODULES)
 
 target_include_directories([[project-name]] PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries([[project-name]] openenclave::oehostapp)
+target_link_libraries([[project-name]] openenclave::oehost)
 
 set(AZUREIOT_LIB_FOLDER "/usr/lib/aarch64-linux-gnu")
 find_library(CURL_LIBRARY curl HINTS ${AZUREIOT_LIB_FOLDER})

--- a/devex/vscode-extension/assets/standaloneSolutionTemplateFolder/host/CMakeLists.txt
+++ b/devex/vscode-extension/assets/standaloneSolutionTemplateFolder/host/CMakeLists.txt
@@ -16,4 +16,4 @@ add_executable([[project-name]]
 
 target_include_directories([[project-name]] PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries([[project-name]] openenclave::oehostapp)
+target_link_libraries([[project-name]] openenclave::oehost)

--- a/docs/GettingStartedDocs/DependencyGraph.svg
+++ b/docs/GettingStartedDocs/DependencyGraph.svg
@@ -301,7 +301,7 @@
 <g id="node23" class="node">
 <title>node18</title>
 <polygon fill="none" stroke="#000000" points="1162.3691,-180 1083.3691,-180 1083.3691,-144 1162.3691,-144 1162.3691,-180"/>
-<text text-anchor="middle" x="1122.8691" y="-158.9" font-family="Times,serif" font-size="12.00" fill="#000000">oehostapp</text>
+<text text-anchor="middle" x="1122.8691" y="-158.9" font-family="Times,serif" font-size="12.00" fill="#000000">oehost</text>
 </g>
 <!-- node18&#45;&gt;node20 -->
 <g id="edge27" class="edge">

--- a/docs/GettingStartedDocs/DependencyGraphLVICFG.svg
+++ b/docs/GettingStartedDocs/DependencyGraphLVICFG.svg
@@ -457,7 +457,7 @@
 <g id="node34" class="node">
 <title>node18</title>
 <polygon fill="none" stroke="#000000" points="2496.3214,-180 2417.3214,-180 2417.3214,-144 2496.3214,-144 2496.3214,-180"/>
-<text text-anchor="middle" x="2456.8214" y="-158.9" font-family="Times,serif" font-size="12.00" fill="#000000">oehostapp</text>
+<text text-anchor="middle" x="2456.8214" y="-158.9" font-family="Times,serif" font-size="12.00" fill="#000000">oehost</text>
 </g>
 <!-- node18&#45;&gt;node20 -->
 <g id="edge42" class="edge">

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -563,15 +563,8 @@ target_compile_definitions(
 set_property(TARGET oehost PROPERTY ARCHIVE_OUTPUT_DIRECTORY
                                     ${OE_LIBDIR}/openenclave/host)
 
-# Convenience library for creating a host-app (that needs the
-# -rdynamic link flag). We do this by default for the oehostverify target too.
-add_library(oehostapp INTERFACE)
-
-target_link_libraries(oehostapp INTERFACE oehost)
-
 if (UNIX)
   target_link_libraries(oehost INTERFACE -Wl,-z,noexecstack)
-  target_link_libraries(oehostapp INTERFACE -rdynamic)
   target_link_libraries(oehostverify INTERFACE -Wl,-z,noexecstack -rdynamic)
 endif ()
 
@@ -580,8 +573,6 @@ install(
   TARGETS oehost
   EXPORT openenclave-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host)
-
-install(TARGETS oehostapp EXPORT openenclave-targets)
 
 install(
   TARGETS oehostverify

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -163,7 +163,7 @@ set(HOSTVERIFY_CLIBS
     "-rdynamic -Wl,-z,noexecstack -L\${libdir}/openenclave/host -loehostverify -ldl -lpthread"
 )
 set(HOST_CLIBS
-    "-rdynamic -Wl,-z,noexecstack -L\${libdir}/openenclave/host -loehost -ldl -lpthread ${SGX_LIBS}"
+    "-Wl,-z,noexecstack -L\${libdir}/openenclave/host -loehost -ldl -lpthread ${SGX_LIBS}"
 )
 
 set(HOSTVERIFY_CXXLIBS "${HOSTVERIFY_CLIBS}")

--- a/samples/attested_tls/client/host/CMakeLists.txt
+++ b/samples/attested_tls/client/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(tls_client_host host.cpp
 target_include_directories(tls_client_host PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                                                    ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(tls_client_host openenclave::oehostapp)
+target_link_libraries(tls_client_host openenclave::oehost)

--- a/samples/attested_tls/non_enc_client/CMakeLists.txt
+++ b/samples/attested_tls/non_enc_client/CMakeLists.txt
@@ -11,6 +11,6 @@ target_include_directories(
   tls_non_enc_client PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                              ${CMAKE_CURRENT_BINARY_DIR} -I/usr/include/openssl)
 
-target_link_libraries(tls_non_enc_client openenclave::oehostapp OpenSSL::SSL)
+target_link_libraries(tls_non_enc_client openenclave::oehost OpenSSL::SSL)
 
 add_dependencies(tls_non_enc_client tls_server)

--- a/samples/attested_tls/server/host/CMakeLists.txt
+++ b/samples/attested_tls/server/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(tls_server_host host.cpp
 target_include_directories(tls_server_host PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                                                    ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(tls_server_host openenclave::oehostapp)
+target_link_libraries(tls_server_host openenclave::oehost)

--- a/samples/data-sealing/host/CMakeLists.txt
+++ b/samples/data-sealing/host/CMakeLists.txt
@@ -20,4 +20,4 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../ # For common/shared.h
           ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(data-sealing_host openenclave::oehostapp)
+target_link_libraries(data-sealing_host openenclave::oehost)

--- a/samples/file-encryptor/host/CMakeLists.txt
+++ b/samples/file-encryptor/host/CMakeLists.txt
@@ -20,4 +20,4 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} # Needed for #include "../shared.h"
           ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(file-encryptor_host openenclave::oehostapp)
+target_link_libraries(file-encryptor_host openenclave::oehost)

--- a/samples/helloworld/host/CMakeLists.txt
+++ b/samples/helloworld/host/CMakeLists.txt
@@ -17,4 +17,4 @@ target_include_directories(
   helloworld_host PRIVATE # Needed for the generated file helloworld_u.h
                           ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(helloworld_host openenclave::oehostapp)
+target_link_libraries(helloworld_host openenclave::oehost)

--- a/samples/local_attestation/host/CMakeLists.txt
+++ b/samples/local_attestation/host/CMakeLists.txt
@@ -20,4 +20,4 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../ # For common/shared.h
           ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(local_attestation_host openenclave::oehostapp)
+target_link_libraries(local_attestation_host openenclave::oehost)

--- a/samples/remote_attestation/host/CMakeLists.txt
+++ b/samples/remote_attestation/host/CMakeLists.txt
@@ -21,4 +21,4 @@ if (WIN32)
   add_dependencies(remote_attestation_host remote_attestation_oedebugrt_target)
 endif ()
 
-target_link_libraries(remote_attestation_host openenclave::oehostapp)
+target_link_libraries(remote_attestation_host openenclave::oehost)

--- a/samples/switchless/host/CMakeLists.txt
+++ b/samples/switchless/host/CMakeLists.txt
@@ -18,4 +18,4 @@ target_include_directories(
   switchless_host PRIVATE # Needed for the generated file switchless_u.h
                           ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(switchless_host openenclave::oehostapp)
+target_link_libraries(switchless_host openenclave::oehost)

--- a/tests/SampleApp/host/CMakeLists.txt
+++ b/tests/SampleApp/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(SampleAppHost SampleAppHost.cpp SampleApp_u.c)
 target_include_directories(SampleAppHost PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                  ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(SampleAppHost oehostapp)
+target_link_libraries(SampleAppHost oehost)

--- a/tests/SampleAppCRT/host/CMakeLists.txt
+++ b/tests/SampleAppCRT/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(SampleAppCRTHost SampleAppCRTHost.cpp SampleAppCRT_u.c)
 target_include_directories(SampleAppCRTHost PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                     ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(SampleAppCRTHost oehostapp)
+target_link_libraries(SampleAppCRTHost oehost)

--- a/tests/VectorException/host/CMakeLists.txt
+++ b/tests/VectorException/host/CMakeLists.txt
@@ -11,7 +11,7 @@ add_custom_command(
 
 add_executable(VectorException_host host.c VectorException_u.c)
 
-target_link_libraries(VectorException_host oehostapp)
+target_link_libraries(VectorException_host oehost)
 
 target_include_directories(VectorException_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/abortStatus/host/CMakeLists.txt
+++ b/tests/abortStatus/host/CMakeLists.txt
@@ -18,4 +18,4 @@ endif ()
 target_include_directories(abortStatus_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                     ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(abortStatus_host oehostapp)
+target_link_libraries(abortStatus_host oehost)

--- a/tests/argv/host/CMakeLists.txt
+++ b/tests/argv/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(argv_host host.c argv_u.c)
 
 target_include_directories(argv_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(argv_host oehostapp)
+target_link_libraries(argv_host oehost)

--- a/tests/atexit/host/CMakeLists.txt
+++ b/tests/atexit/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(atexit_host host.cpp atexit_u.c)
 
 target_include_directories(atexit_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(atexit_host oehostapp)
+target_link_libraries(atexit_host oehost)

--- a/tests/attestation_cert_apis/host/CMakeLists.txt
+++ b/tests/attestation_cert_apis/host/CMakeLists.txt
@@ -14,7 +14,7 @@ add_custom_command(
 add_executable(tls_host host.cpp tls_u.c)
 
 target_include_directories(tls_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(tls_host oehostapp)
+target_link_libraries(tls_host oehost)
 
 # On Windows, explicitly add the nuget dependencies for the DCAP client to the target executable
 if (WIN32)

--- a/tests/attestation_plugin/host/CMakeLists.txt
+++ b/tests/attestation_plugin/host/CMakeLists.txt
@@ -14,7 +14,7 @@ add_custom_command(
 add_executable(plugin_host host.c ../plugin/tests.c plugin_u.c)
 
 target_include_directories(plugin_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(plugin_host oehostapp)
+target_link_libraries(plugin_host oehost)
 
 # On Windows, explicitly add the nuget dependencies for the DCAP client to the target executable
 if (WIN32)

--- a/tests/backtrace/host/CMakeLists.txt
+++ b/tests/backtrace/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(backtrace_host host.cpp backtrace_u.c)
 
 target_include_directories(backtrace_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                   ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(backtrace_host oehostapp)
+target_link_libraries(backtrace_host oehost)

--- a/tests/bigmalloc/host/CMakeLists.txt
+++ b/tests/bigmalloc/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(bigmalloc_host host.c bigmalloc_u.c)
 
 target_include_directories(bigmalloc_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(bigmalloc_host oehostapp)
+target_link_libraries(bigmalloc_host oehost)

--- a/tests/c99_compliant/host/CMakeLists.txt
+++ b/tests/c99_compliant/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(c99_compliant_host host.c c99_compliant_u.c)
 
 target_include_directories(c99_compliant_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(c99_compliant_host oehostapp)
+target_link_libraries(c99_compliant_host oehost)

--- a/tests/child_process/host/CMakeLists.txt
+++ b/tests/child_process/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(child_process_host host.cpp child_process_u.c)
 
 target_include_directories(child_process_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(child_process_host oehostapp)
+target_link_libraries(child_process_host oehost)

--- a/tests/child_thread/host/CMakeLists.txt
+++ b/tests/child_thread/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(child_thread_host host.cpp child_thread_u.c)
 
 target_include_directories(child_thread_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(child_thread_host oehostapp)
+target_link_libraries(child_thread_host oehost)

--- a/tests/cmake_name_conflict/host/CMakeLists.txt
+++ b/tests/cmake_name_conflict/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_executable(name_conflict_host host.cpp name_conflict_u.c name_conflict_u.h
 
 target_include_directories(name_conflict_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(name_conflict_host oehostapp)
+target_link_libraries(name_conflict_host oehost)

--- a/tests/cppException/host/CMakeLists.txt
+++ b/tests/cppException/host/CMakeLists.txt
@@ -15,4 +15,4 @@ target_include_directories(
   cppException_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                             ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(cppException_host oehostapp)
+target_link_libraries(cppException_host oehost)

--- a/tests/create-errors/host/CMakeLists.txt
+++ b/tests/create-errors/host/CMakeLists.txt
@@ -15,4 +15,4 @@ target_include_directories(
   create_errors_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                              ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(create_errors_host oehostapp)
+target_link_libraries(create_errors_host oehost)

--- a/tests/create-rapid/host/CMakeLists.txt
+++ b/tests/create-rapid/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(create_rapid_host host.cpp create_rapid_u.c)
 
 target_include_directories(create_rapid_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(create_rapid_host oehostapp)
+target_link_libraries(create_rapid_host oehost)

--- a/tests/crypto/enclave/host/CMakeLists.txt
+++ b/tests/crypto/enclave/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(cryptohost host.c crypto_u.c)
 add_dependencies(cryptohost crypto_test_data)
 target_include_directories(cryptohost PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(cryptohost oehostapp)
+target_link_libraries(cryptohost oehost)

--- a/tests/crypto_crls_cert_chains/host/CMakeLists.txt
+++ b/tests/crypto_crls_cert_chains/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(crypto-extra_host host.cpp crypto_crls_cert_chains_u.c)
 add_dependencies(crypto-extra_host crypto_crls_cert_chains_test_data)
 target_include_directories(crypto-extra_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(crypto-extra_host oehostapp)
+target_link_libraries(crypto-extra_host oehost)

--- a/tests/debug-mode/host/CMakeLists.txt
+++ b/tests/debug-mode/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(debug_host host.c debug_mode_u.c)
 target_include_directories(debug_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                               ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(debug_host oehostapp)
+target_link_libraries(debug_host oehost)

--- a/tests/debugger/oegdb/host/CMakeLists.txt
+++ b/tests/debugger/oegdb/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(oe_gdb_test_host host.c contract.c oe_gdb_test_u.c)
 
 target_include_directories(oe_gdb_test_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(oe_gdb_test_host oehostapp)
+target_link_libraries(oe_gdb_test_host oehost)

--- a/tests/ecall/host/CMakeLists.txt
+++ b/tests/ecall/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(ecall_host host.cpp ecall_u.c)
 
 target_include_directories(ecall_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(ecall_host oehostapp)
+target_link_libraries(ecall_host oehost)

--- a/tests/ecall_ocall/host/CMakeLists.txt
+++ b/tests/ecall_ocall/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(ecall_ocall_host host.cpp ecall_ocall_u.c)
 
 target_include_directories(ecall_ocall_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(ecall_ocall_host oehostapp)
+target_link_libraries(ecall_ocall_host oehost)

--- a/tests/echo/host/CMakeLists.txt
+++ b/tests/echo/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(echo_host host.c echo_u.c)
 
 target_include_directories(echo_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(echo_host oehostapp)
+target_link_libraries(echo_host oehost)

--- a/tests/enclaveparam/host/CMakeLists.txt
+++ b/tests/enclaveparam/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(enclaveparam_host host.c enclaveparam_u.c)
 target_include_directories(enclaveparam_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(enclaveparam_host oehostapp)
+target_link_libraries(enclaveparam_host oehost)

--- a/tests/exclude_system_edl/host/CMakeLists.txt
+++ b/tests/exclude_system_edl/host/CMakeLists.txt
@@ -28,4 +28,4 @@ add_executable(exclude_system_edl_host host.c exclude_system_edl_u.c)
 
 target_include_directories(exclude_system_edl_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(exclude_system_edl_host oehostapp)
+target_link_libraries(exclude_system_edl_host oehost)

--- a/tests/file/host/CMakeLists.txt
+++ b/tests/file/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(file_host host.cpp file_u.c)
 
 target_include_directories(file_host PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                                              ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(file_host oehostapp)
+target_link_libraries(file_host oehost)

--- a/tests/getenclave/host/CMakeLists.txt
+++ b/tests/getenclave/host/CMakeLists.txt
@@ -11,4 +11,4 @@ add_custom_command(
 
 add_executable(getenclave_host host.c getenclave_u.c)
 target_include_directories(getenclave_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(getenclave_host oehostapp)
+target_link_libraries(getenclave_host oehost)

--- a/tests/hexdump/host/CMakeLists.txt
+++ b/tests/hexdump/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(hexdump_host host.c hexdump_u.c)
 
 target_include_directories(hexdump_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(hexdump_host oehostapp)
+target_link_libraries(hexdump_host oehost)

--- a/tests/hostcalls/host/CMakeLists.txt
+++ b/tests/hostcalls/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(hostcalls_host host.cpp hostcalls_u.c)
 
 target_include_directories(hostcalls_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                   ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(hostcalls_host oehostapp)
+target_link_libraries(hostcalls_host oehost)

--- a/tests/initializers/host/CMakeLists.txt
+++ b/tests/initializers/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(initializers_host host.cpp initializers_u.c)
 
 target_include_directories(initializers_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(initializers_host oehostapp)
+target_link_libraries(initializers_host oehost)

--- a/tests/libc/host/CMakeLists.txt
+++ b/tests/libc/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(libc_host host.cpp libc_u.c)
 target_include_directories(libc_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                              ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(libc_host oehostapp)
+target_link_libraries(libc_host oehost)

--- a/tests/libcxx/host/CMakeLists.txt
+++ b/tests/libcxx/host/CMakeLists.txt
@@ -11,6 +11,6 @@ add_custom_command(
 
 add_executable(libcxx_host host.cpp libcxx_u.c)
 
-target_link_libraries(libcxx_host oehostapp)
+target_link_libraries(libcxx_host oehost)
 
 target_include_directories(libcxx_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/libcxxrt/host/CMakeLists.txt
+++ b/tests/libcxxrt/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(libcxxrt_host host.cpp libcxxrt_u.c)
 target_include_directories(libcxxrt_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                  ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(libcxxrt_host oehostapp)
+target_link_libraries(libcxxrt_host oehost)

--- a/tests/libunwind/host/CMakeLists.txt
+++ b/tests/libunwind/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(libunwind_host host.cpp libunwind_u.c)
 target_include_directories(libunwind_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                   ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(libunwind_host oehostapp)
+target_link_libraries(libunwind_host oehost)

--- a/tests/mbed/host/CMakeLists.txt
+++ b/tests/mbed/host/CMakeLists.txt
@@ -19,4 +19,4 @@ endif ()
 
 target_include_directories(libmbedtest_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                     ..)
-target_link_libraries(libmbedtest_host oehostapp)
+target_link_libraries(libmbedtest_host oehost)

--- a/tests/memory/host/CMakeLists.txt
+++ b/tests/memory/host/CMakeLists.txt
@@ -11,9 +11,9 @@ add_custom_command(
 
 add_executable(memory_host host.cpp memory_u.c)
 
-if(USE_DEBUG_MALLOC)
-    target_compile_definitions(memory_host PRIVATE OE_USE_DEBUG_MALLOC)
-endif()
+if (USE_DEBUG_MALLOC)
+  target_compile_definitions(memory_host PRIVATE OE_USE_DEBUG_MALLOC)
+endif ()
 
 target_include_directories(memory_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(memory_host oehostapp)
+target_link_libraries(memory_host oehost)

--- a/tests/mixed_c_cpp/host/CMakeLists.txt
+++ b/tests/mixed_c_cpp/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(mixed_c_cpp_host host.cpp mixed_u.c)
 
 target_include_directories(mixed_c_cpp_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(mixed_c_cpp_host oehostapp)
+target_link_libraries(mixed_c_cpp_host oehost)

--- a/tests/ocall-create/host/CMakeLists.txt
+++ b/tests/ocall-create/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(ocall_create_host host.c ocall_create_u.c)
 target_include_directories(ocall_create_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(ocall_create_host oehostapp)
+target_link_libraries(ocall_create_host oehost)

--- a/tests/ocall/host/CMakeLists.txt
+++ b/tests/ocall/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(ocall_host host.cpp ocall_u.c)
 
 target_include_directories(ocall_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(ocall_host oehostapp)
+target_link_libraries(ocall_host oehost)

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -82,4 +82,4 @@ if (NOT WIN32)
   target_compile_options(edl_host PUBLIC -fstrict-aliasing
                                          -Werror=strict-aliasing)
 endif ()
-target_link_libraries(edl_host oehostapp)
+target_link_libraries(edl_host oehost)

--- a/tests/pingpong-shared/host/CMakeLists.txt
+++ b/tests/pingpong-shared/host/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(pingpong-shared-lib SHARED host.cpp pingpong_u.c)
 
 target_include_directories(pingpong-shared-lib
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(pingpong-shared-lib oehostapp)
+target_link_libraries(pingpong-shared-lib oehost)
 
 add_executable(pingpong-shared_host main.cpp)
 target_link_libraries(pingpong-shared_host pingpong-shared-lib)

--- a/tests/pingpong/host/CMakeLists.txt
+++ b/tests/pingpong/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(pingpong_host host.cpp pingpong_u.c)
 
 target_include_directories(pingpong_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(pingpong_host oehostapp)
+target_link_libraries(pingpong_host oehost)

--- a/tests/print/host/CMakeLists.txt
+++ b/tests/print/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(print_host host.cpp print_u.c)
 
 target_include_directories(print_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(print_host oehostapp)
+target_link_libraries(print_host oehost)

--- a/tests/props/host/CMakeLists.txt
+++ b/tests/props/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(props_host host.c props_u.c)
 
 target_include_directories(props_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(props_host oehostapp)
+target_link_libraries(props_host oehost)

--- a/tests/qeidentity/host/CMakeLists.txt
+++ b/tests/qeidentity/host/CMakeLists.txt
@@ -26,4 +26,4 @@ add_custom_command(
 target_include_directories(
   qeidentity_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                           ${CMAKE_CURRENT_SOURCE_DIR}/../common)
-target_link_libraries(qeidentity_host oehostapp)
+target_link_libraries(qeidentity_host oehost)

--- a/tests/report/host/CMakeLists.txt
+++ b/tests/report/host/CMakeLists.txt
@@ -28,7 +28,7 @@ add_custom_command(
 target_include_directories(
   report_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                       ${CMAKE_CURRENT_SOURCE_DIR}/../common)
-target_link_libraries(report_host oehostapp)
+target_link_libraries(report_host oehost)
 
 # On Windows, explicitly add the nuget dependencies for the DCAP client to the target executable
 if (WIN32)

--- a/tests/safecrt/host/CMakeLists.txt
+++ b/tests/safecrt/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(safecrt_host ../common/test.cpp host.cpp safecrt_u.c)
 
 target_include_directories(safecrt_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(safecrt_host oehostapp)
+target_link_libraries(safecrt_host oehost)

--- a/tests/sealKey/host/CMakeLists.txt
+++ b/tests/sealKey/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(sealKey_host host.cpp sealKey_u.c)
 
 target_include_directories(sealKey_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                 ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(sealKey_host oehostapp)
+target_link_libraries(sealKey_host oehost)

--- a/tests/sim-mode/host/CMakeLists.txt
+++ b/tests/sim-mode/host/CMakeLists.txt
@@ -1,15 +1,16 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-set (EDL_FILE ../sim_mode.edl)
+set(EDL_FILE ../sim_mode.edl)
 
 add_custom_command(
-    OUTPUT sim_mode_u.h sim_mode_u.c
-    DEPENDS ${EDL_FILE} edger8r
-    COMMAND edger8r --untrusted ${EDL_FILE} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+  OUTPUT sim_mode_u.h sim_mode_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND edger8r --untrusted ${EDL_FILE} --search-path
+          ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(sim_host host.c sim_mode_u.c)
 
 target_include_directories(sim_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(sim_host oehostapp)
+target_link_libraries(sim_host oehost)

--- a/tests/stdc/host/CMakeLists.txt
+++ b/tests/stdc/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(stdc_host host.cpp stdc_u.c)
 target_include_directories(stdc_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                              ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(stdc_host oehostapp)
+target_link_libraries(stdc_host oehost)

--- a/tests/stdcxx/host/CMakeLists.txt
+++ b/tests/stdcxx/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(stdcxx_host host.cpp stdcxx_u.c)
 target_include_directories(stdcxx_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(stdcxx_host oehostapp)
+target_link_libraries(stdcxx_host oehost)

--- a/tests/switchless/host/CMakeLists.txt
+++ b/tests/switchless/host/CMakeLists.txt
@@ -12,4 +12,4 @@ add_custom_command(
 add_executable(switchless_host host.c switchless_u.c)
 
 target_include_directories(switchless_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(switchless_host oehostapp)
+target_link_libraries(switchless_host oehost)

--- a/tests/switchless_nestedcalls/host/CMakeLists.txt
+++ b/tests/switchless_nestedcalls/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(switchless_nestedcalls_host host.c switchless_nestedcalls_u.c)
 
 target_include_directories(switchless_nestedcalls_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(switchless_nestedcalls_host oehostapp)
+target_link_libraries(switchless_nestedcalls_host oehost)

--- a/tests/switchless_threads/host/CMakeLists.txt
+++ b/tests/switchless_threads/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(switchless_threads_host host.c switchless_threads_u.c)
 
 target_include_directories(switchless_threads_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(switchless_threads_host oehostapp)
+target_link_libraries(switchless_threads_host oehost)

--- a/tests/switchless_worksleep/host/CMakeLists.txt
+++ b/tests/switchless_worksleep/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(switchless_worksleep_host host.cpp switchless_worksleep_u.c)
 
 target_include_directories(switchless_worksleep_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(switchless_worksleep_host oehostapp)
+target_link_libraries(switchless_worksleep_host oehost)

--- a/tests/syscall/datagram/host/CMakeLists.txt
+++ b/tests/syscall/datagram/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(datagram_host host.c test_datagram_u.c)
 
 target_include_directories(datagram_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(datagram_host oehostapp)
+target_link_libraries(datagram_host oehost)

--- a/tests/syscall/dup/host/CMakeLists.txt
+++ b/tests/syscall/dup/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(dup_host host.c test_dup_u.c)
 
 target_include_directories(dup_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(dup_host oehostapp)
+target_link_libraries(dup_host oehost)

--- a/tests/syscall/epoll/host/CMakeLists.txt
+++ b/tests/syscall/epoll/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(epoll_host host.cpp epoll_u.c)
 
 target_include_directories(epoll_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(epoll_host oehostapp)
+target_link_libraries(epoll_host oehost)

--- a/tests/syscall/fs/host/CMakeLists.txt
+++ b/tests/syscall/fs/host/CMakeLists.txt
@@ -26,5 +26,5 @@ else ()
   set(OESGXFSHOST "")
 endif ()
 
-target_link_libraries(fs_host ${OESGXFSHOST} oehostapp)
+target_link_libraries(fs_host ${OESGXFSHOST} oehost)
 target_link_libraries(fs_host rmdir)

--- a/tests/syscall/hostfs/host/CMakeLists.txt
+++ b/tests/syscall/hostfs/host/CMakeLists.txt
@@ -14,5 +14,5 @@ add_executable(hostfs_host host.c test_hostfs_u.c)
 
 target_include_directories(hostfs_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(hostfs_host oehostapp)
+target_link_libraries(hostfs_host oehost)
 target_link_libraries(hostfs_host rmdir)

--- a/tests/syscall/ids/host/CMakeLists.txt
+++ b/tests/syscall/ids/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(ids_host host.c test_ids_u.c)
 
 target_include_directories(ids_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(ids_host oehostapp)
+target_link_libraries(ids_host oehost)

--- a/tests/syscall/poller/host/CMakeLists.txt
+++ b/tests/syscall/poller/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(poller_host host.cpp ../client.cpp ../server.cpp ../poller.cpp
 
 target_include_directories(poller_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(poller_host oehostapp)
+target_link_libraries(poller_host oehost)

--- a/tests/syscall/resolver/host/CMakeLists.txt
+++ b/tests/syscall/resolver/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(resolver_host host.c resolver_test_u.c)
 
 target_include_directories(resolver_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(resolver_host oehostapp)
+target_link_libraries(resolver_host oehost)

--- a/tests/syscall/sendmsg/host/CMakeLists.txt
+++ b/tests/syscall/sendmsg/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(sendmsg_host host.c ../client.c ../server.c sendmsg_u.c)
 
 target_include_directories(sendmsg_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(sendmsg_host oehostapp)
+target_link_libraries(sendmsg_host oehost)

--- a/tests/syscall/socket/host/CMakeLists.txt
+++ b/tests/syscall/socket/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_custom_command(
 add_executable(socket_host host.c socket_test_u.c)
 
 target_include_directories(socket_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(socket_host oehostapp)
+target_link_libraries(socket_host oehost)

--- a/tests/syscall/socketpair/host/CMakeLists.txt
+++ b/tests/syscall/socketpair/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_custom_command(
 add_executable(socketpair_host host.c socketpair_test_u.c)
 
 target_include_directories(socketpair_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(socketpair_host oehostapp)
+target_link_libraries(socketpair_host oehost)

--- a/tests/thread/host/CMakeLists.txt
+++ b/tests/thread/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(thread_host host.cpp rwlocks_test_host.cpp errno_test_host.cpp
 
 target_include_directories(thread_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(thread_host oehostapp)
+target_link_libraries(thread_host oehost)

--- a/tests/thread_local/host/CMakeLists.txt
+++ b/tests/thread_local/host/CMakeLists.txt
@@ -15,4 +15,4 @@ target_include_directories(thread_local_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_options(thread_local_host
                        PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-std=c++11>)
-target_link_libraries(thread_local_host oehostapp)
+target_link_libraries(thread_local_host oehost)

--- a/tests/thread_local_no_tdata/host/CMakeLists.txt
+++ b/tests/thread_local_no_tdata/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(no_tdata_host host.cpp no_tdata_u.c)
 target_include_directories(no_tdata_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_options(no_tdata_host
                        PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-std=c++11>)
-target_link_libraries(no_tdata_host oehostapp)
+target_link_libraries(no_tdata_host oehost)

--- a/tests/threadcxx/host/CMakeLists.txt
+++ b/tests/threadcxx/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(threadcxx_host host.cpp threadcxx_u.c)
 
 target_include_directories(threadcxx_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(threadcxx_host oehostapp)
+target_link_libraries(threadcxx_host oehost)

--- a/tests/tls_e2e/host/CMakeLists.txt
+++ b/tests/tls_e2e/host/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(tls_e2e_host host.cpp tls_e2e_u.c)
 target_include_directories(tls_e2e_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                                 ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(tls_e2e_host oehostapp)
+target_link_libraries(tls_e2e_host oehost)

--- a/tests/tools/oesign-engine/test-enclave/host/CMakeLists.txt
+++ b/tests/tools/oesign-engine/test-enclave/host/CMakeLists.txt
@@ -12,4 +12,4 @@ target_include_directories(
   helloworld_host PRIVATE # Needed for the generated file helloworld_u.h
                           ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(helloworld_host oehostapp)
+target_link_libraries(helloworld_host oehost)

--- a/tests/win_paths/host/CMakeLists.txt
+++ b/tests/win_paths/host/CMakeLists.txt
@@ -3,4 +3,4 @@
 
 add_executable(test_win_paths host.cpp)
 
-target_link_libraries(test_win_paths oehostapp)
+target_link_libraries(test_win_paths oehost)


### PR DESCRIPTION
Due to oehostapp's redundancy to oehost, oehostapp is removed.
The appendent compiling option "-rdynamic" is also removed. To provide dynsym of oehost for dynamic loaded libraries, users could add this option back manually.

Signed-off-by: Alvin Chen <alvin@chen.asia>
Fixes #2595 