### PR TITLE
Use MAP_NORESERVE for simulation mode enclave memory allocation to avoid OOM

### DIFF
--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -186,7 +186,7 @@ static void* _allocate_enclave_memory(size_t enclave_size, int fd)
          * the driver will do the alignment. */
         if (fd == -1)
         {
-            mflags |= MAP_ANONYMOUS;
+            mflags |= MAP_ANONYMOUS | MAP_NORESERVE;
             if (oe_safe_mul_u64(mmap_size, 2, &mmap_size) != OE_OK)
             {
                 OE_TRACE_ERROR(


### PR DESCRIPTION
Discussed originally at https://github.com/lsds/sgx-lkl/issues/208#issuecomment-629310025. For reference I copy my observations:

I did some tests on a DC8 with 29G available memory.

`NumHeapPages = 7340032` (28 GiB):
- SGX: runs fine, virtual memory of SGX-LKL is shown as 32.115 GiB.
- Simulation: fails immediately with `mmap failed mmap_size=68719476736 mflags=0x21 [../../host/sgx/sgxload.c:_allocate_enclave_memory:202]`.

`NumHeapPages = 4456448` (17 GiB):
- SGX: runs fine, virtual memory of SGX-LKL is shown as 32.115 GiB.
- Simulation: fails immediately with `mmap failed mmap_size=68719476736 mflags=0x21 [../../host/sgx/sgxload.c:_allocate_enclave_memory:202]`.

`NumHeapPages = 3932160` (15 GiB):
- SGX: runs fine, virtual memory of SGX-LKL is shown as 16.115 GiB.
- Simulation: fails immediately with `mmap failed mmap_size=34359738368 mflags=0x21 [../../host/sgx/sgxload.c:_allocate_enclave_memory:202]`.

`NumHeapPages = 2097152` (8 GiB):
- SGX: runs fine, virtual memory of SGX-LKL is shown as 16.115 GiB.
- Simulation: fails immediately with `mmap failed mmap_size=34359738368 mflags=0x21 [../../host/sgx/sgxload.c:_allocate_enclave_memory:202]`.

`NumHeapPages = 3932160` (7 GiB):
- SGX: runs fine, virtual memory of SGX-LKL is shown as 8.115 GiB.
- Simulation: runs fine, virtual memory of SGX-LKL is shown as 8.115 GiB.

In summary, SGX seems fine and as expected. However, simulation mode seems quite off. Essentially the maximum heap size I can test on DC8 in simulation mode is ~7.8G (leaving 200 MiB for the ELF image etc. to prevent jumping into the next power-of-two bucket).

As @jhand2 suggested, adding `MAP_NORESERVE` solves this.