### PR TITLE
Use platform's OCaml to build edger8r if available.

### DIFF
--- a/tools/oeedger8r/CMakeLists.txt
+++ b/tools/oeedger8r/CMakeLists.txt
@@ -1,6 +1,76 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
+find_program(OCAMLOPT ocamlopt)
+
+if (OCAMLOPT)
+  set(BINARY ${CMAKE_CURRENT_BINARY_DIR}/oeedger8r${CMAKE_EXECUTABLE_SUFFIX})
+  add_custom_command(
+    OUTPUT ${BINARY}
+    # Copy sources to build folder.
+    COMMAND cmake -E copy ${CMAKE_CURRENT_SOURCE_DIR}/intel/*
+            ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND cmake -E copy ${CMAKE_CURRENT_SOURCE_DIR}/src/*
+            ${CMAKE_CURRENT_BINARY_DIR}
+    # Generate lexer and parser.
+    COMMAND ocamllex Lexer.mll
+    COMMAND ocamlyacc Parser.mly
+    # Generate Intel library.
+    # Use -w -3 to suppress
+    # warning 3: deprecated: String.lowercase
+    COMMAND
+      ocamlopt -c -bin-annot -for-pack Intel -w -3 Ast.ml Util.ml SimpleStack.ml
+      Plugin.ml Preprocessor.ml Parser.mli Parser.ml Lexer.ml CodeGen.ml
+    COMMAND ocamlopt -pack -o Intel.cmx Ast.cmx Util.cmx SimpleStack.cmx
+            Plugin.cmx Preprocessor.cmx Parser.cmx Lexer.cmx CodeGen.cmx
+    # Generate oeedger8r
+    # Additionally suppress
+    # Warning 40: input_files was selected from type Intel.Util.edger8r_params.
+    # It is not visible in the current scope, and will not
+    # be selected if the type becomes unknown.
+    COMMAND
+      ocamlopt -bin-annot str.cmxa unix.cmxa Intel.cmx -w -3-40 Common.mli
+      Common.ml Headers.mli Headers.ml Sources.mli Sources.ml Emitter.ml main.ml
+      -o ${BINARY}
+    DEPENDS src/dune
+            src/Common.mli
+            src/Common.ml
+            src/Headers.mli
+            src/Headers.mli
+            src/Sources.mli
+            src/Sources.mli
+            src/Emitter.ml
+            src/main.ml
+            intel/dune
+            intel/Ast.ml
+            intel/CodeGen.ml
+            intel/Edger8r.ml
+            intel/Lexer.mll
+            intel/Parser.mly
+            intel/Plugin.ml
+            intel/Preprocessor.ml
+            intel/SimpleStack.ml
+            intel/Util.ml
+            CMakeLists.txt)
+
+  # The names here are important because the output file must be named
+  # `oeedger8r`, and our targets must not clash with that.
+  add_executable(edger8r IMPORTED GLOBAL)
+  set_target_properties(edger8r PROPERTIES IMPORTED_LOCATION ${BINARY})
+  add_custom_target(oeedger8r_target DEPENDS ${BINARY})
+  add_dependencies(edger8r oeedger8r_target)
+
+  # Can't use `install(TARGETS)` on an imported executable, because it
+  # causes CMake to crash. Instead, see `openenclave-config.cmake.in`
+  # for the manual "export" of this target.
+  install(
+    PROGRAMS ${BINARY}
+    RENAME oeedger8r${CMAKE_EXECUTABLE_SUFFIX}
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  return()
+endif ()
+
 # NOTE: The custom commands below first copy the input files to the
 # build directory and then invoke the OCaml tools because those tools
 # do not emit to the current working directory, they always emit to


### PR DESCRIPTION
This restores the original way in which oeedger8r was built
on both platforms, if ocaml compiler is already available.
If not, it lets esy build the ocaml compiler and then build
oeedger8r.

Note: ocaml needs to be added back to prereqs on both platforms
to ensure a pain free/fast build of oeedger8r.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>