### PR TITLE
2 oesign cases: 1. sign w/ empty config 2. sign with config containing neg vals

### DIFF
--- a/tests/tools/oesign-engine/test-enclave/CMakeLists.txt
+++ b/tests/tools/oesign-engine/test-enclave/CMakeLists.txt
@@ -16,6 +16,14 @@ else ()
   set(SIMULATION OFF)
 endif ()
 
+# Generate an empty config file
+add_custom_command(OUTPUT empty.conf
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/oesign-customize-config.py 0)
+
+# Generate a config file with negative value
+add_custom_command(OUTPUT neg.conf
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/oesign-customize-config.py 1)
+
 # Generate key
 add_custom_command(
   OUTPUT private.pem public.pem
@@ -102,6 +110,26 @@ add_test(
     'oesign-test-engine' --engine-load-path
     ${CMAKE_CURRENT_BINARY_DIR}/../test-engine/liboesign-test-engine.so
     --key-id ${CMAKE_CURRENT_BINARY_DIR}/wrongprivate.pem --expect-fail)
+
+add_test(
+  NAME tests/oesign-engine-sign-config-negval
+  COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/oesign-test.py --oesign-binary
+    ${OE_BINDIR}/oesign --enclave-binary $<TARGET_FILE:enclave> --config-file
+    ${CMAKE_CURRENT_SOURCE_DIR}/neg.conf --engine-id
+    'oesign-test-engine' --engine-load-path
+    ${CMAKE_CURRENT_BINARY_DIR}/../test-engine/liboesign-test-engine.so
+    --key-id ${CMAKE_CURRENT_BINARY_DIR}/private.pem --expect-fail)
+
+add_test(
+  NAME tests/oesign-engine-sign-empty-config
+  COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/oesign-test.py --oesign-binary
+    ${OE_BINDIR}/oesign --enclave-binary $<TARGET_FILE:enclave> --config-file
+    ${CMAKE_CURRENT_SOURCE_DIR}/empty.conf --engine-id
+    'oesign-test-engine' --engine-load-path
+    ${CMAKE_CURRENT_BINARY_DIR}/../test-engine/liboesign-test-engine.so
+    --key-id ${CMAKE_CURRENT_BINARY_DIR}/private.pem --expect-fail)
 
 add_test(
   NAME tests/oesign-engine-sign

--- a/tests/tools/oesign-engine/test-enclave/oesign-custmize-config.py
+++ b/tests/tools/oesign-engine/test-enclave/oesign-custmize-config.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# generate user-defined config files for oesign tests.
+# usage: oesign-customize-config.py 0|1
+
+import argparse
+import os
+
+def generate_empty_config():
+    print("Generating empty config")
+    cfgname = "empty.conf"
+    abs_cfg = os.path.join(os.getcwd(),cfgname)
+    print(abs_cfg)
+    fh = open(abs_cfg, 'a+')
+    fh.close()
+
+def generate_neg_config():
+    print("Generating config file w/ negative values")
+    cfgname = "neg.conf"
+    abs_cfg = os.path.join(os.getcwd(),cfgname)
+    print(abs_cfg)
+    fh = open(abs_cfg, 'a+')
+    cfg_seq = [
+        "NumHeapPages=-3    \n",
+        "NumStackPages=1024 \n",
+        "NumTCS=1           \n",
+        "ProductID=1        \n",
+        "SecurityVersion=1  \n"
+    ]
+    fh.writelines(cfg_seq)
+    fh.close()
+
+def print_help_info():
+    print("Input Arguments Invalid!! Expected [0|1]!")
+
+if __name__ == "__main__":
+    print("Generating user-defined config file")
+    cfg_argparser = argparse.ArgumentParser(usage='%(prog)s [0|1]',
+        description='0 for empty config, 1 for neg config')
+
+    cfg_argparser.add_argument("type", type=int,
+        help="0 - empty config, 1 - config containing neg val")
+
+    cmd_args = cfg_argparser.parse_args()
+
+    if cmd_args.type == 0:
+        generate_empty_config()
+    elif cmd_args.type == 1:
+        generate_neg_config()
+    else:
+        print_help_info()


### PR DESCRIPTION
obselete pull request 3020, the same commit of 3020. 