### PR TITLE
Refactoring code toward self-contained liboecore

### DIFF
--- a/3rdparty/dlmalloc/CMakeLists.txt
+++ b/3rdparty/dlmalloc/CMakeLists.txt
@@ -3,16 +3,18 @@
 
 add_enclave_library(oedlmalloc OBJECT allocator.c)
 
-enclave_link_libraries(oedlmalloc PRIVATE oe_includes oelibc_includes)
+enclave_link_libraries(oedlmalloc PRIVATE oe_includes)
 
 if (OE_TRUSTZONE)
-    enclave_link_libraries(oedlmalloc PUBLIC oelibutee_includes)
-    set(TEE_C_FLAGS ${OE_TZ_TA_C_FLAGS})
-else()
-    set(TEE_C_FLAGS "")
-endif()
+  enclave_link_libraries(oedlmalloc PUBLIC oelibutee_includes)
+  set(TEE_C_FLAGS ${OE_TZ_TA_C_FLAGS})
+else ()
+  set(TEE_C_FLAGS "")
+endif ()
 
-enclave_compile_options(oedlmalloc PRIVATE
+enclave_compile_options(
+  oedlmalloc
+  PRIVATE
   -ftls-model=local-exec
   -nostdinc
   -fPIE
@@ -20,10 +22,17 @@ enclave_compile_options(oedlmalloc PRIVATE
   -fvisibility=hidden
   ${TEE_C_FLAGS})
 
+enclave_include_directories(oedlmalloc PRIVATE
+                            ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
+
+# Allow dlmallc to find required stdc functions from corelibc.
+enclave_compile_definitions(oedlmalloc PRIVATE OE_NEED_STDC_NAMES)
+
 # Specify the warning options as source files properties so that
 # they will appear last in the compiler command line and supercede
 # other warning options.
-set_source_files_properties(allocator.c PROPERTIES
-  COMPILE_FLAGS "-Wno-conversion -Wno-null-pointer-arithmetic")
+set_source_files_properties(
+  allocator.c PROPERTIES COMPILE_FLAGS
+                         "-Wno-conversion -Wno-null-pointer-arithmetic")
 
 maybe_build_using_clangw(oedlmalloc)

--- a/3rdparty/dlmalloc/allocator.c
+++ b/3rdparty/dlmalloc/allocator.c
@@ -9,10 +9,7 @@
 #define LACKS_SYS_TYPES_H
 #define LACKS_TIME_H
 #define MORECORE dlmalloc_sbrk
-#define ABORT oe_abort()
 #define USE_DL_PREFIX
-#define LACKS_STDLIB_H
-#define LACKS_STRING_H
 #define USE_LOCKS 1
 #define fprintf _dlmalloc_stats_fprintf
 #define NO_MALLOC_STATS 1
@@ -20,15 +17,6 @@
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Wparentheses-equality"
 #endif
-
-OE_INLINE
-int sched_yield(void)
-{
-#ifdef __x86__
-    asm volatile("pause");
-#endif
-    return 0;
-}
 
 void* dlmalloc_sbrk(ptrdiff_t increment);
 

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -324,9 +324,8 @@ done:
 **
 **==============================================================================
 */
-static void _handle_exit(oe_code_t code, uint16_t func, uint64_t arg)
-    OE_NO_RETURN;
 
+OE_NO_RETURN
 static void _handle_exit(oe_code_t code, uint16_t func, uint64_t arg)
 {
     oe_exit_enclave(oe_make_call_arg1(code, func, 0, OE_OK), arg);

--- a/include/openenclave/corelibc/errno.h
+++ b/include/openenclave/corelibc/errno.h
@@ -307,6 +307,11 @@ extern int* __oe_errno_location(void);
 
 #define errno oe_errno
 
+OE_INLINE int* __errno_location(void)
+{
+    return __oe_errno_location();
+}
+
 #endif /* defined(OE_NEED_STDC_NAMES) */
 
 OE_EXTERNC_END

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -53,6 +53,13 @@ else ()
        optee/arc4random.c optee/trace.c)
 endif ()
 
+# Exclude the following files that are part of oecore.
+# - prng/rand.c
+# - string/memcmp.c
+# - string/memcpy.c
+# - string/memmove.c
+# - string/memset.c
+
 add_enclave_library(
   oelibc
   STATIC
@@ -513,7 +520,6 @@ add_enclave_library(
   ${MUSLSRC}/prng/lrand48.c
   ${MUSLSRC}/prng/mrand48.c
   ${MUSLSRC}/prng/__rand48_step.c
-  ${MUSLSRC}/prng/rand.c
   ${MUSLSRC}/prng/random.c
   ${MUSLSRC}/prng/rand_r.c
   ${MUSLSRC}/prng/__seed48.c
@@ -675,13 +681,9 @@ add_enclave_library(
   ${MUSLSRC}/string/index.c
   ${MUSLSRC}/string/memccpy.c
   ${MUSLSRC}/string/memchr.c
-  ${MUSLSRC}/string/memcmp.c
-  ${MUSLSRC}/string/memcpy.c
   ${MUSLSRC}/string/memmem.c
-  ${MUSLSRC}/string/memmove.c
   ${MUSLSRC}/string/mempcpy.c
   ${MUSLSRC}/string/memrchr.c
-  ${MUSLSRC}/string/memset.c
   ${MUSLSRC}/string/rindex.c
   ${MUSLSRC}/string/stpcpy.c
   ${MUSLSRC}/string/stpncpy.c


### PR DESCRIPTION
This PR refactors the code related to libcore with the goal of making it self-contained as follows.
- Remove the dependencies on libc from dlmalloc (as part of libcore).
- Remove the files that are part of of libcore from oelibc.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>