### PR TITLE
Install Windows Ocaml binaries

### DIFF
--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -12,6 +12,8 @@ Param(
     # We skip the hash check for the vs_buildtools.exe file because it is regularly updated without a change to the URL, unfortunately.
     [string]$VSBuildToolsURL = 'https://aka.ms/vs/15/release/vs_buildtools.exe',
     [string]$VSBuildToolsHash = '',
+    [string]$OCamlURL = 'https://www.ocamlpro.com/pub/ocpwin/ocpwin-builds/ocpwin64/20160113/ocpwin64-20160113-4.02.1+ocp1-mingw64.zip',
+    [string]$OCamlHash = '369F900F7CDA543ABF674520ED6004CC75008E10BEED0D34845E8A42866D0F3A',
     [string]$NodeURL = 'https://nodejs.org/dist/v10.16.3/node-v10.16.3-x64.msi',
     [string]$NodeHash = 'F68B75EEA46232ADB8FD38126C977DC244166D29E7C6CD2DF930B460C38590A9',
     [string]$Clang7URL = 'http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe',
@@ -61,6 +63,11 @@ $PACKAGES = @{
         "url" = $VSBuildToolsURL
         "hash" = $VSBuildToolsHash
         "local_file" = Join-Path $PACKAGES_DIRECTORY "vs_buildtools.exe"
+    }
+    "ocaml" = @{
+        "url" = $OCamlURL
+        "hash" = $OCamlHash
+        "local_file" = Join-Path $PACKAGES_DIRECTORY "ocpwin64.zip"
     }
     "node" = @{
         "url" = $NodeURL
@@ -451,6 +458,19 @@ function Install-VisualStudio {
                                    "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\BuildTools\Common7\Tools")
 }
 
+function Install-OCaml {
+    $installDir = Join-Path $env:ProgramFiles "OCaml"
+    $tmpDir = Join-Path $PACKAGES_DIRECTORY "ocpwin64"
+    if(Test-Path -Path $tmpDir) {
+        Remove-Item -Recurse -Force -Path $tmpDir
+    }
+    Install-ZipTool -ZipPath $PACKAGES["ocaml"]["local_file"] `
+                    -InstallDirectory $tmpDir `
+                    -EnvironmentPath @("$installDir\bin")
+    New-Directory -Path $installDir -RemoveExisting
+    Move-Item -Path "$tmpDir\*\*" -Destination $installDir
+}
+
 function Install-Node {
     $installDir = Join-Path $env:ProgramFiles "nodejs"
     Install-Tool -InstallerPath $PACKAGES["node"]["local_file"] `
@@ -700,6 +720,7 @@ try {
     Start-LocalPackagesDownload
 
     Install-7Zip
+    Install-OCaml
     Install-Nuget
     Install-Python3
     Install-VisualStudio


### PR DESCRIPTION
This PR mitigates some of the pain points with current Windows Contributor experience:

- Each machine requires anywhere from 30-40mins to build the ocaml compiler
- Each repo requires admin prompt to build.

Based on experiments, ocpwin requires 4-5 mins to download on an end-user machine, whereas it requires around 45 secs to download on an ACC VM.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>