### PR TITLE
Test tool oecertdump to print every field in report/certificate

### DIFF
--- a/tests/tools/oecertdump/host/host.cpp
+++ b/tests/tools/oecertdump/host/host.cpp
@@ -22,9 +22,15 @@
 
 #ifdef OE_LINK_SGX_DCAP_QL
 
-#define INPUT_PARAM_OPTION_OUT_FILE "--out"
 #define INPUT_PARAM_USAGE "--help"
-#define DEFAULT_OUTPUTFILE "oecertdump_out.log"
+#define INPUT_PARAM_OUT_FILE "--out"
+#define DEFAULT_OUT_FILE "oecertdump_out.log"
+#define INPUT_PARAM_OUT_TYPE "--type"
+#define INPUT_PARAM_OUT_TYPE_REPORT "report"
+#define INPUT_PARAM_OUT_TYPE_EC "ec"
+#define INPUT_PARAM_OUT_TYPE_RSA "rsa"
+#define DEFAULT_OUT_TYPE INPUT_PARAM_OUT_TYPE_REPORT
+#define INPUT_PARAM_VERBOSE "--verbose"
 
 // Structure to store input parameters
 //
@@ -32,11 +38,13 @@ typedef struct _input_params
 {
     const char* enclave_filename;
     const char* out_filename;
+    const char* out_type;
+    bool verbose;
 } input_params_t;
 
 static input_params_t _params;
 
-FILE* log_file = NULL;
+FILE* log_file = nullptr;
 
 // This is the identity validation callback. A TLS connecting party (client or
 // server) can verify the passed in "identity" information to decide whether to
@@ -81,50 +89,62 @@ done:
 void output_certificate(const uint8_t* data, size_t data_len)
 {
 #if defined(__linux__)
-    if (log_file)
+    printf("\n");
+    X509* x509;
+    BIO* input = BIO_new_mem_buf(data, (int)data_len);
+    x509 = d2i_X509_bio(input, nullptr);
+    if (x509)
     {
-        fprintf(log_file, "\n");
-        X509* x509;
-        BIO* input = BIO_new_mem_buf(data, (int)data_len);
-        x509 = d2i_X509_bio(input, NULL);
-        if (x509)
-        {
-            X509_print_ex_fp(
-                log_file, x509, XN_FLAG_COMPAT, XN_FLAG_SEP_CPLUS_SPC);
-        }
-        BIO_free_all(input);
-        fprintf(log_file, "\n");
+        X509_print_ex_fp(stdout, x509, XN_FLAG_COMPAT, XN_FLAG_SEP_CPLUS_SPC);
     }
+    BIO_free_all(input);
+    printf("\n");
 #endif
     OE_UNUSED(data);
     OE_UNUSED(data_len);
 }
 
-void validate_certificate(uint8_t* cert, size_t cert_size)
+oe_result_t validate_certificate(uint8_t* certificate, size_t certificate_size)
 {
     oe_result_t result;
 
     result = oe_verify_attestation_certificate(
-        cert, cert_size, enclave_identity_verifier, NULL);
+        certificate, certificate_size, enclave_identity_verifier, nullptr);
 
     log("Certificate verification result: %s\n", oe_result_str(result));
+
+    return result;
 }
 
-static oe_result_t _gen_cert(oe_enclave_t* enclave)
+oe_result_t generate_certificate(oe_enclave_t* enclave, bool verbose)
 {
     oe_result_t result = OE_FAILURE;
     oe_result_t ecall_result;
-    unsigned char* cert = NULL;
-    size_t cert_size = 0;
+    unsigned char* certificate = nullptr;
+    size_t certificate_size = 0;
+    uint8_t* report = nullptr;
+    size_t report_size = 0;
 
-    log("========== Getting certificates\n");
+    if (strcmp(INPUT_PARAM_OUT_TYPE_EC, _params.out_type) == 0)
+    {
+        result = get_tls_cert_signed_with_ec_key(
+            enclave, &ecall_result, &certificate, &certificate_size);
+    }
+    else if (strcmp(INPUT_PARAM_OUT_TYPE_RSA, _params.out_type) == 0)
+    {
+        result = get_tls_cert_signed_with_rsa_key(
+            enclave, &ecall_result, &certificate, &certificate_size);
+    }
+    else
+    {
+        printf("Invalid out type - %s.\n", _params.out_type);
+        return OE_INVALID_PARAMETER;
+    }
 
-    // EC Key
-    result = get_tls_cert_signed_with_ec_key(
-        enclave, &ecall_result, &cert, &cert_size);
     if ((result != OE_OK) || (ecall_result != OE_OK))
     {
-        log("Failed to create EC certificate. Enclave: %s, Host: %s\n",
+        printf(
+            "Failed to create certificate. Enclave: %s, Host: %s\n",
             oe_result_str(ecall_result),
             oe_result_str(result));
 
@@ -132,46 +152,45 @@ static oe_result_t _gen_cert(oe_enclave_t* enclave)
     }
     else
     {
-        output_certificate(cert, cert_size);
-        validate_certificate(cert, cert_size);
-    }
-    if (cert)
-    {
-        free(cert);
-        cert = NULL;
-    }
-    cert_size = 0;
+        result = validate_certificate(certificate, certificate_size);
 
-    // RSA Key
-    result = get_tls_cert_signed_with_rsa_key(
-        enclave, &ecall_result, &cert, &cert_size);
-    if ((result != OE_OK) || (ecall_result != OE_OK))
-    {
-        log("Failed to create RSA certificate. Enclave: %s, Host: %s\n",
-            oe_result_str(ecall_result),
-            oe_result_str(result));
+        if (verbose)
+        {
+            output_certificate(certificate, certificate_size);
 
-        goto exit;
-    }
-    else
-    {
-        output_certificate(cert, cert_size);
-        validate_certificate(cert, cert_size);
+            if (get_sgx_report_from_certificate(
+                    certificate, certificate_size, &report, &report_size) ==
+                OE_OK)
+            {
+                output_sgx_report(report, report_size);
+            }
+        }
     }
 
 exit:
-    // deallcate resources
-    if (cert)
-        free(cert);
+    if (certificate)
+        free(certificate);
+    if (report)
+        free(report);
 
     return result;
 }
 
 static void _display_help(const char* cmd)
 {
-    printf("Usage: %s ENCLAVE_PATH Options\n", cmd);
-    printf("\tOptions:\n");
-    printf("\t%s : output filename.\n", INPUT_PARAM_OPTION_OUT_FILE);
+    printf("Usage: %s ENCLAVE_PATH [Options]\n\n", cmd);
+    printf("Options:\n");
+    printf(
+        " %s <output-type>: %s (default), %s, or %s\n",
+        INPUT_PARAM_OUT_TYPE,
+        INPUT_PARAM_OUT_TYPE_REPORT,
+        INPUT_PARAM_OUT_TYPE_EC,
+        INPUT_PARAM_OUT_TYPE_RSA);
+    printf(
+        " %s <output-filename>: %s (default).\n",
+        INPUT_PARAM_OUT_FILE,
+        DEFAULT_OUT_FILE);
+    printf(" %s\n", INPUT_PARAM_VERBOSE);
 }
 
 static int _parse_args(int argc, const char* argv[])
@@ -188,7 +207,9 @@ static int _parse_args(int argc, const char* argv[])
     int i = 1; // current index
     // save
     _params.enclave_filename = argv[i++];
-    _params.out_filename = DEFAULT_OUTPUTFILE;
+    _params.out_filename = DEFAULT_OUT_FILE;
+    _params.out_type = DEFAULT_OUT_TYPE;
+    _params.verbose = false;
 
     // Verify enclave file is valid
     FILE* fp;
@@ -207,7 +228,7 @@ static int _parse_args(int argc, const char* argv[])
 
     while (i < argc)
     {
-        if (strcmp(INPUT_PARAM_OPTION_OUT_FILE, argv[i]) == 0)
+        if (strcmp(DEFAULT_OUT_FILE, argv[i]) == 0)
         {
             if (argc >= i + 1)
             {
@@ -217,11 +238,31 @@ static int _parse_args(int argc, const char* argv[])
             else
             {
                 printf(
-                    "%s has invalid number of parameters.\n",
-                    INPUT_PARAM_OPTION_OUT_FILE);
+                    "%s has invalid number of parameters.\n", DEFAULT_OUT_FILE);
                 _display_help(argv[0]);
                 return 1;
             }
+        }
+        else if (strcmp(INPUT_PARAM_OUT_TYPE, argv[i]) == 0)
+        {
+            if (argc >= i + 1)
+            {
+                _params.out_type = argv[i + 1];
+                i += 2;
+            }
+            else
+            {
+                printf(
+                    "%s has invalid number of parameters.\n",
+                    INPUT_PARAM_OUT_TYPE);
+                _display_help(argv[0]);
+                return 1;
+            }
+        }
+        else if (strcmp(INPUT_PARAM_VERBOSE, argv[i]) == 0)
+        {
+            _params.verbose = true;
+            i++;
         }
         else if (strcmp(INPUT_PARAM_USAGE, argv[i]) == 0)
         {
@@ -242,11 +283,14 @@ static oe_result_t _process_params(oe_enclave_t* enclave)
 {
     oe_result_t result = OE_FAILURE;
 
-    result = gen_report(enclave);
-    if (result != OE_OK)
-        return result;
-
-    result = _gen_cert(enclave);
+    if (strcmp(INPUT_PARAM_OUT_TYPE_REPORT, _params.out_type) == 0)
+    {
+        result = generate_sgx_report(enclave, _params.verbose);
+    }
+    else
+    {
+        result = generate_certificate(enclave, _params.verbose);
+    }
 
     return result;
 }
@@ -259,7 +303,7 @@ int main(int argc, const char* argv[])
 
 #ifdef OE_LINK_SGX_DCAP_QL
     oe_result_t result;
-    oe_enclave_t* enclave = NULL;
+    oe_enclave_t* enclave = nullptr;
 
     const uint32_t flags = oe_get_create_flags();
     if ((flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
@@ -276,7 +320,7 @@ int main(int argc, const char* argv[])
              _params.enclave_filename,
              OE_ENCLAVE_TYPE_AUTO,
              OE_ENCLAVE_FLAG_DEBUG,
-             NULL,
+             nullptr,
              0,
              &enclave)) != OE_OK)
     {

--- a/tests/tools/oecertdump/host/sgx_quote.cpp
+++ b/tests/tools/oecertdump/host/sgx_quote.cpp
@@ -71,19 +71,155 @@ void set_log_callback()
     sgx_ql_set_logging_function_t set_log_fcn =
         (sgx_ql_set_logging_function_t)dlsym(
             provider.handle, "sgx_ql_set_logging_function");
-    if (set_log_fcn != NULL)
+    if (set_log_fcn != nullptr)
     {
         set_log_fcn(oecertdump_quote_provider_log);
     }
 #endif
 }
 
-oe_result_t gen_report(oe_enclave_t* enclave)
+OE_INLINE uint16_t read_uint16(const uint8_t* p)
+{
+    return (uint16_t)(p[0] | (p[1] << 8));
+}
+
+OE_INLINE uint32_t read_uint32(const uint8_t* p)
+{
+    return (uint32_t)(p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24));
+}
+
+oe_result_t output_sgx_report(const uint8_t* report, size_t report_size)
+{
+    oe_result_t result = OE_OK;
+    oe_report_header_t* header = (oe_report_header_t*)report;
+    sgx_quote_t* quote = (sgx_quote_t*)header->report;
+    sgx_report_body_t* report_body = (sgx_report_body_t*)&quote->report_body;
+    sgx_quote_auth_data_t* quote_auth_data =
+        (sgx_quote_auth_data_t*)quote->signature;
+    sgx_report_body_t* qe_report_body =
+        (sgx_report_body_t*)&quote_auth_data->qe_report_body;
+    sgx_qe_auth_data_t qe_auth_data = {0};
+    sgx_qe_cert_data_t qe_cert_data = {0};
+
+    uint8_t* p = (uint8_t*)quote_auth_data;
+
+    // Boundary check
+    if (report_size <
+        ((size_t)(p - report) + sizeof(sgx_quote_auth_data_t) + 2))
+    {
+        printf("Invalid report format. report_size=%zu\n", report_size);
+        return OE_REPORT_PARSE_ERROR;
+    }
+
+    p += sizeof(sgx_quote_auth_data_t);
+    qe_auth_data.size = read_uint16(p);
+    p += 2;
+    qe_auth_data.data = (uint8_t*)p;
+
+    // Boundary check
+    if (report_size <
+        ((size_t)(p - report) + qe_auth_data.size + qe_cert_data.size + 6))
+    {
+        printf("Invalid report format. report_size=%zu\n", report_size);
+        return OE_REPORT_PARSE_ERROR;
+    }
+
+    p += qe_auth_data.size;
+    qe_cert_data.type = read_uint16(p);
+    p += 2;
+    qe_cert_data.size = read_uint32(p);
+    p += 4;
+    qe_cert_data.data = (uint8_t*)p;
+
+    printf("\nOE Report:\n");
+    printf("oe_report_header {\n");
+    printf("    version: %d\n", header->version);
+    printf("    report_type: %d\n", header->report_type);
+    printf("    report_size: %zu\n", header->report_size);
+
+    printf("    sgx_quote_t {\n");
+    printf("        version: %d\n", quote->version);
+    printf("        sign_type: %d\n", quote->sign_type);
+    printf("        qe_svn: 0x%x\n", quote->qe_svn);
+    printf("        pce_svn: 0x%x\n", quote->pce_svn);
+    printf("        uuid: ");
+    oe_hex_dump(quote->uuid, OE_COUNTOF(quote->uuid));
+    printf("        user_data (first_32_bytes == qe_id) (hex): ");
+    oe_hex_dump(quote->user_data, OE_COUNTOF(quote->user_data));
+
+    printf("        report_body {\n");
+    printf("            cpusvn (hex): ");
+    oe_hex_dump(report_body->cpusvn, OE_COUNTOF(report_body->cpusvn));
+    printf("            miscselect: 0x%x\n", report_body->miscselect);
+    printf("            attributes (hex): ");
+    oe_hex_dump(&report_body->attributes, sizeof(report_body->attributes));
+    printf("            mrenclave (hex): ");
+    oe_hex_dump(report_body->mrenclave, sizeof(report_body->mrenclave));
+    printf("            mrsigner (hex): ");
+    oe_hex_dump(report_body->mrsigner, sizeof(report_body->mrsigner));
+    printf("            isvprodid: 0x%x\n", report_body->isvprodid);
+    printf("            isvsvn: 0x%x\n", report_body->isvsvn);
+    printf("            report_data (hex): ");
+    oe_hex_dump(&report_body->report_data, sizeof(report_body->report_data));
+    printf("        } report_body\n");
+
+    printf("        signature_len: %d\n", quote->signature_len);
+    printf("        sgx_quote_auth_data_t {\n");
+    printf("            signature (hex): ");
+    oe_hex_dump(
+        &quote_auth_data->signature, sizeof(quote_auth_data->signature));
+    printf("            attestation_key (hex): ");
+    oe_hex_dump(
+        &quote_auth_data->attestation_key,
+        sizeof(quote_auth_data->attestation_key));
+
+    printf("            qe_report_body {\n");
+    printf("                cpusvn (hex): ");
+    oe_hex_dump(qe_report_body->cpusvn, OE_COUNTOF(qe_report_body->cpusvn));
+    printf("                miscselect: 0x%x\n", qe_report_body->miscselect);
+    printf("                attributes (hex): ");
+    oe_hex_dump(
+        &qe_report_body->attributes, sizeof(qe_report_body->attributes));
+    printf("                mrenclave (hex): ");
+    oe_hex_dump(qe_report_body->mrenclave, sizeof(qe_report_body->mrenclave));
+    printf("                mrsigner (hex): ");
+    oe_hex_dump(qe_report_body->mrsigner, sizeof(qe_report_body->mrsigner));
+    printf("                isvprodid: 0x%x\n", qe_report_body->isvprodid);
+    printf("                isvsvn: 0x%x\n", qe_report_body->isvsvn);
+    printf("                report_data (hex): ");
+    oe_hex_dump(
+        &qe_report_body->report_data, sizeof(qe_report_body->report_data));
+    printf("            } qe_report_body\n");
+
+    printf("        qe_report_body_signature: ");
+    oe_hex_dump(
+        &quote_auth_data->qe_report_body_signature,
+        sizeof(quote_auth_data->qe_report_body_signature));
+
+    printf("    qe_auth_data {\n");
+    printf("        size: %d\n", qe_auth_data.size);
+    printf("        data (hex): ");
+    oe_hex_dump(qe_auth_data.data, qe_auth_data.size);
+    printf("    } qe_auth_data\n");
+
+    printf("    qe_cert_data {\n");
+    printf("        type: 0x%x\n", qe_cert_data.type);
+    printf("        size: %d\n", qe_cert_data.size);
+    printf("        qe cert:\n");
+    printf("%s\n", qe_cert_data.data);
+    printf("    } qe_cert_data\n");
+
+    printf("} oe_report_header\n");
+
+    return result;
+}
+
+oe_result_t generate_sgx_report(oe_enclave_t* enclave, bool verbose)
 {
     size_t report_size = OE_MAX_REPORT_SIZE;
-    uint8_t* remote_report = NULL;
-    oe_report_header_t* header = NULL;
-    sgx_quote_t* quote = NULL;
+    uint8_t* remote_report = nullptr;
+    oe_report_header_t* header = nullptr;
+    sgx_quote_t* quote = nullptr;
     uint64_t quote_size = 0;
 
     log("========== Getting report\n");
@@ -91,7 +227,7 @@ oe_result_t gen_report(oe_enclave_t* enclave)
     oe_result_t result = oe_get_report(
         enclave,
         OE_REPORT_FLAGS_REMOTE_ATTESTATION,
-        NULL, // opt_params must be null
+        nullptr, // opt_params must be null
         0,
         (uint8_t**)&remote_report,
         &report_size);
@@ -117,7 +253,7 @@ oe_result_t gen_report(oe_enclave_t* enclave)
 
         // Print endorsements
         {
-            uint8_t* endorsements_data = NULL;
+            uint8_t* endorsements_data = nullptr;
             size_t endorsements_data_size = 0;
 
             result = oe_get_sgx_endorsements(
@@ -153,21 +289,29 @@ oe_result_t gen_report(oe_enclave_t* enclave)
 
             oe_report_t parsed_report;
             result = oe_verify_report(
-                NULL, remote_report, report_size, &parsed_report);
+                nullptr, remote_report, report_size, &parsed_report);
+            if (verbose)
+            {
+                output_sgx_report(remote_report, report_size);
+            }
+            else
+            {
+                // Print basic collaterl info to console
+                printf("QEID: ");
+                oe_hex_dump(quote->user_data, 16);
+                printf("CPU_SVN: ");
+                oe_hex_dump(quote->report_body.cpusvn, SGX_CPUSVN_SIZE);
+                printf("PCE_SVN: %02x\n", quote->pce_svn);
+            }
+
             if (result != OE_OK)
             {
                 log("Failed to verify report. result=%u (%s)\n",
                     result,
                     oe_result_str(result));
 
-                // Print TCB Info to console if verification failed
                 printf(
                     "oe_verify_report failure (%s)\n", oe_result_str(result));
-                printf("QEID: ");
-                oe_hex_dump(quote->user_data, 16);
-                printf("CPU_SVN: ");
-                oe_hex_dump(quote->report_body.cpusvn, SGX_CPUSVN_SIZE);
-                printf("PCE_SVN: %02x\n", quote->pce_svn);
 
                 goto exit;
             }
@@ -185,6 +329,47 @@ oe_result_t gen_report(oe_enclave_t* enclave)
 exit:
     if (remote_report)
         oe_free_report(remote_report);
+
+    return result;
+}
+
+oe_result_t get_sgx_report_from_certificate(
+    const uint8_t* certificate_in_der,
+    size_t certificate_in_der_length,
+    uint8_t** report,
+    size_t* report_size)
+{
+    oe_result_t result = OE_OK;
+    uint8_t* report_buffer = nullptr;
+    size_t report_buffer_size = certificate_in_der_length;
+    oe_cert_t certificate = {0};
+
+    result = oe_cert_read_der(
+        &certificate, certificate_in_der, certificate_in_der_length);
+    if (result != OE_OK)
+        return result;
+
+    report_buffer = (uint8_t*)malloc(report_buffer_size);
+    if (!report_buffer)
+        return OE_OUT_OF_MEMORY;
+
+    // find the extension
+    result = oe_cert_find_extension(
+        &certificate,
+        X509_OID_FOR_QUOTE_STRING,
+        report_buffer,
+        &report_buffer_size);
+
+    if (result == OE_OK)
+    {
+        *report = report_buffer;
+        *report_size = report_buffer_size;
+    }
+    else
+    {
+        if (!report_buffer)
+            free(report_buffer);
+    }
 
     return result;
 }

--- a/tests/tools/oecertdump/host/sgx_quote.h
+++ b/tests/tools/oecertdump/host/sgx_quote.h
@@ -13,6 +13,12 @@ void oecertdump_quote_provider_log(
     const char* message);
 void set_log_callback();
 
-oe_result_t gen_report(oe_enclave_t* enclave);
+oe_result_t generate_sgx_report(oe_enclave_t* enclave, bool verbose);
+oe_result_t output_sgx_report(const uint8_t* report, size_t report_size);
+oe_result_t get_sgx_report_from_certificate(
+    const uint8_t* certificate_in_der,
+    size_t certificate_in_der_length,
+    uint8_t** report,
+    size_t* report_size);
 
 #endif // _SGX_QUOTE


### PR DESCRIPTION
Test tool oecertdump was used to generate and verify report and certificate.

Additional input parameters are added to
1. Print every field in report or certificate
2. Select whether to print report, EC certificate, or RSA certificate

The additional parameters make it possible to reveal current TCB configuration as well as understand the details of a report buffer.

Signed-off-by: Yen Lee <yenlee@microsoft.com>