### PR TITLE
[CI/CD] Use consistent shared gallery img definition names

### DIFF
--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -203,8 +203,8 @@ def buildWindowsManagedImage(String os_series, String img_name_suffix, String la
 parallel "Build Ubuntu 16.04"              : { buildLinuxManagedImage("ubuntu", "16.04") },
          "Build Ubuntu 18.04"              : { buildLinuxManagedImage("ubuntu", "18.04") },
          "Build RHEL 8"                    : { buildLinuxManagedImage("rhel", "8") },
-         "Build Windows 2016 SGX1"         : { buildWindowsManagedImage("win2016", "ws2016-SGX-gen2", "SGX1") },
-         "Build Windows 2016 SGX1FLC DCAP" : { buildWindowsManagedImage("win2016", "ws2016-SGX-DCAP-gen2", "SGX1FLC") },
-         "Build Windows 2016 nonSGX"       : { buildWindowsManagedImage("win2016", "ws2016-nonSGX-gen2", "SGX1FLC-NoDriver") },
+         "Build Windows 2016 SGX1"         : { buildWindowsManagedImage("win2016", "ws2016-SGX", "SGX1") },
+         "Build Windows 2016 SGX1FLC DCAP" : { buildWindowsManagedImage("win2016", "ws2016-SGX-DCAP", "SGX1FLC") },
+         "Build Windows 2016 nonSGX"       : { buildWindowsManagedImage("win2016", "ws2016-nonSGX", "SGX1FLC-NoDriver") },
          "Build Windows 2019 SGX1"         : { buildWindowsManagedImage("win2019", "ws2019-SGX", "SGX1-NoDriver") },
          "Build Windows 2019 SGX1FLC DCAP" : { buildWindowsManagedImage("win2019", "ws2019-SGX-DCAP", "SGX1FLC-NoDriver") }


### PR DESCRIPTION
This is an effort to make the shared gallery images definition
names consistent. The PR https://github.com/openenclave/openenclave/pull/3013 switched
the Win 2016 to gen2, since the original gallery definitions
were set to VM generation V1.

However, since the original gallery definitions are not used
anymore, they were recreated to allow publishing VM gen2
images.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>