### PR TITLE
SGX: Decouple the td structure from fs register on enter and exit

### DIFF
--- a/enclave/core/sgx/asmcommon.inc
+++ b/enclave/core/sgx/asmcommon.inc
@@ -33,11 +33,13 @@
     mov %r15, %rsi
 
     // Zero out GPRs.
+    // Retain r11 since it is used as a reference to the td structure.
+    // The exit and enter routines are responsible for clearing r11
+    // prior to returning.
     xor %rdx, %rdx
     xor %r8,  %r8
     xor %r9,  %r9
     xor %r10, %r10
-    xor %r11, %r11
     xor %r12, %r12
     xor %r13, %r13
     xor %r14, %r14

--- a/enclave/core/sgx/asmdefs.h
+++ b/enclave/core/sgx/asmdefs.h
@@ -15,6 +15,7 @@
 #define PAGE_SIZE 4096
 #define STATIC_STACK_SIZE 8 * 100
 #define OE_WORD_SIZE 8
+#define TD_FROM_TCS (5 * PAGE_SIZE)
 
 #define CODE_ERET 0x200000000
 

--- a/enclave/core/sgx/asmdefs.h
+++ b/enclave/core/sgx/asmdefs.h
@@ -6,6 +6,7 @@
 
 #ifndef __ASSEMBLER__
 #include <openenclave/enclave.h>
+#include <openenclave/internal/sgx/td.h>
 #endif
 
 #define ENCLU_EGETKEY 1
@@ -50,7 +51,7 @@
 void oe_exit_enclave(uint64_t arg1, uint64_t arg2) OE_NO_RETURN;
 
 /* This is the actual implementation of eexit */
-void oe_asm_exit(uint64_t arg1, uint64_t arg2) OE_NO_RETURN;
+void oe_asm_exit(uint64_t arg1, uint64_t arg2, oe_sgx_td_t* td) OE_NO_RETURN;
 #endif
 
 #ifndef __ASSEMBLER__

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -610,6 +610,7 @@ static void _exit_enclave(uint64_t arg1, uint64_t arg2)
 {
     static bool _initialized = false;
     static bool _stitch_ocall_stack = false;
+    oe_sgx_td_t* td = oe_sgx_get_td();
 
     // Since determining whether an enclave supports debugging is a stateless
     // idempotent operation, there is no need to lock. The result is cached
@@ -623,7 +624,6 @@ static void _exit_enclave(uint64_t arg1, uint64_t arg2)
 
     if (_stitch_ocall_stack)
     {
-        oe_sgx_td_t* td = oe_sgx_get_td();
         oe_ecall_context_t* host_ecall_context = td->host_ecall_context;
 
         // Make sure the context is valid.
@@ -639,7 +639,7 @@ static void _exit_enclave(uint64_t arg1, uint64_t arg2)
             host_ecall_context->debug_eexit_rip = frame[1];
         }
     }
-    oe_asm_exit(arg1, arg2);
+    oe_asm_exit(arg1, arg2, td);
 }
 
 /*

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -230,12 +230,7 @@ oe_enter:
 
 .clear_enclave_registers:
 
-    // Clear these so information will not be leaked to host
-    // Retain %r11 which is used to reference the td structure. It will be
-    // cleared immediately before EEXIT.
-    mov %r11, OM_ENC_TD
     oe_cleanup_registers
-    mov OM_ENC_TD, %r11
 
 .restore_host_registers:
 

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -233,7 +233,6 @@ oe_enter:
     // Clear these so information will not be leaked to host
     // Retain %r11 which is used to reference the td structure. It will be
     // cleared immediately before EEXIT.
-    push %r11
     mov %r11, OM_ENC_TD
     oe_cleanup_registers
     mov OM_ENC_TD, %r11

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -39,20 +39,30 @@
 oe_enter:
 .cfi_startproc
 
+.get_td:
+
+    // Get the location of the td_t structure for this thread. This value is
+    // expected to be present in %r11 for the remainder of oe_enter.
+    //
+    // Upon first entry to the enclave, td->base.self in the td_t structure
+    // is not yet initialized. However, the loader in host/sgx/create.c places
+    // the td_t structure as a specific offset from TCS.
+    lea TD_FROM_TCS(%rbx), %r11
+
 .save_host_registers:
     // Backup the current host rbp, rsp, and context to previous.
-    mov %fs:td_host_rbp, %r8
-    mov %r8, %fs:td_host_previous_rbp
-    mov %fs:td_host_rsp, %r8
-    mov %r8, %fs:td_host_previous_rsp
-    mov %fs:td_host_ecall_context, %r8
-    mov %r8, %fs:td_host_previous_ecall_context
+    mov td_host_rbp(%r11), %r8
+    mov %r8, td_host_previous_rbp(%r11)
+    mov td_host_rsp(%r11), %r8
+    mov %r8, td_host_previous_rsp(%r11)
+    mov td_host_ecall_context(%r11), %r8
+    mov %r8, td_host_previous_ecall_context(%r11)
 
     // Save host registers (restored on EEXIT)
-    mov %rcx, %fs:td_host_rcx // host return address here
-    mov %rsp, %fs:td_host_rsp
-    mov %rbp, %fs:td_host_rbp
-    mov %rdx, %fs:td_host_ecall_context
+    mov %rcx, td_host_rcx(%r11) // host return address here
+    mov %rsp, td_host_rsp(%r11)
+    mov %rbp, td_host_rbp(%r11)
+    mov %rdx, td_host_ecall_context(%r11)
 
 .determine_entry_type:
     // Check if this is exception dispatching request.
@@ -66,7 +76,7 @@ oe_enter:
 
     // Check whether this is a clean entry or a nested entry
     // clean-entry-check.
-    mov %fs:td_depth, %r8
+    mov td_depth(%r11), %r8
     cmp $0, %r8
     je .clean_entry
     jmp .nested_entry
@@ -103,7 +113,7 @@ oe_enter:
     lfence
 
     // Restore stack pointer and enclave registers:
-    mov %fs:td_last_sp, %rsp
+    mov td_last_sp(%r11), %rsp
 
     // align the stack
     and $-16, %rsp
@@ -142,8 +152,8 @@ oe_enter:
     popfq
 
     // Get the host stack pointer.
-    mov %fs:td_host_rsp, %r8
-    mov %fs:td_host_rbp, %r9
+    mov td_host_rsp(%r11), %r8
+    mov td_host_rbp(%r11), %r9
 
     // Construct the frame and align the stack.
     pushq $0
@@ -160,20 +170,24 @@ oe_enter:
 #define OM_HOST_RBP                 (-2*8)(%rbp)
 #define OM_HOST_OUTPUT_ARG1         (-3*8)(%rbp)
 #define OM_HOST_OUTPUT_ARG2         (-4*8)(%rbp)
-#define OM_HOST_RETURN_ADDR         (-5*8)(%rbp)
+#define OM_ENC_TD                   (-5*8)(%rbp)
+#define OM_HOST_RETURN_ADDR         (-6*8)(%rbp)
 
     // Allocate stack.
     sub $OM_STACK_LENGTH, %rsp
 
     // Save the host stack pointers to enclave stack.
-    mov %fs:td_host_rsp, %r8
-    mov %fs:td_host_rbp, %r9
+    mov td_host_rsp(%r11), %r8
+    mov td_host_rbp(%r11), %r9
     mov %r8, OM_HOST_RSP
     mov %r9, OM_HOST_RBP
 
     // Save the host return address to enclave stack.
-    mov %fs:td_host_rcx, %r8
+    mov td_host_rcx(%r11), %r8
     mov %r8, OM_HOST_RETURN_ADDR
+
+    // Save reference to the td structure to enclave stack.
+    mov %r11, OM_ENC_TD
 
     // Call __oe_handle_main(ARG1=RDI, ARG2=RSI, CSSA=RDX, TCS=RCX, OUTPUTARG1=R8, OUTPUTARG2=R9)
     mov %rax, %rdx
@@ -186,11 +200,14 @@ oe_enter:
     mov OM_HOST_OUTPUT_ARG1, %rdi
     mov OM_HOST_OUTPUT_ARG2, %rsi
 
+    // Restore td pointer
+    mov OM_ENC_TD, %r11
+
 .determine_exit_type:
 
     // Check the depth of the ECALL stack (zero for clean exit)
     // exit-type-check.
-    mov %fs:td_depth, %r8
+    mov td_depth(%r11), %r8
     cmp $0, %r8
     je .clean_exit
 
@@ -199,7 +216,7 @@ oe_enter:
     // exit-type-check.
     lfence
 
-    mov %rsp, %fs:td_last_sp
+    mov %rsp, td_last_sp(%r11)
 
     jmp .clear_enclave_registers
 
@@ -209,12 +226,17 @@ oe_enter:
     lfence
 
     // Clear the oe_sgx_td_t.last_sp field (force oe_enter to calculate stack pointer)
-    movq $0, %fs:td_last_sp
+    movq $0, td_last_sp(%r11)
 
 .clear_enclave_registers:
 
     // Clear these so information will not be leaked to host
+    // Retain %r11 which is used to reference the td structure. It will be
+    // cleared immediately before EEXIT.
+    push %r11
+    mov %r11, OM_ENC_TD
     oe_cleanup_registers
+    mov OM_ENC_TD, %r11
 
 .restore_host_registers:
 
@@ -227,7 +249,7 @@ oe_enter:
 
     // Check oe_sgx_td_t.simulate flag
     // simulation-flag-check.
-    mov %fs:td_simulate, %rax
+    mov td_simulate(%r11), %rax
     cmp $0, %rax
     jz .execute_eexit_instruction
 
@@ -235,6 +257,9 @@ oe_enter:
     // Stop speculative execution at fallthrough of conditional
     // simulate-flag-check.
     lfence
+
+    // Clear %r11 which was being used to maintain td pointer
+    xor %r11, %r11
 
     // Jump to return address:
     mov $1, %rax
@@ -245,6 +270,9 @@ oe_enter:
     // Stop speculative execution at target of conditional jump
     // simulate-flag-check.
     lfence
+
+    // Clear %r11 which was being used to maintain td pointer
+    xor %r11, %r11
 
     // EEXIT(RAX=EEXIT, RBX=RETADDR, RCX=AEP, RDI=ARG1, RSI=ARG2)
     //mov %rcx, %rbx

--- a/enclave/core/sgx/exit.S
+++ b/enclave/core/sgx/exit.S
@@ -60,7 +60,7 @@ oe_asm_exit:
 
     // Check the depth of the ECALL stack (zero for clean exit)
     // exit-type-check.
-    mov td_depth(%r9), %r8
+    mov td_depth(%r11), %r8
     cmp $0, %r8
     je .clean_exit
 
@@ -69,7 +69,7 @@ oe_asm_exit:
     // exit-type-check.
     lfence 
 
-    mov %rsp, td_last_sp(%r9)
+    mov %rsp, td_last_sp(%r11)
 
     jmp .clear_enclave_registers
 
@@ -79,28 +79,23 @@ oe_asm_exit:
     lfence
 
     // Clear the oe_sgx_td_t.last_sp field (force oe_enter to calculate stack pointer)
-    movq $0, td_last_sp(%r9)
+    movq $0, td_last_sp(%r11)
 
 .clear_enclave_registers:
 
-    // Clear registers so information will not be leaked to host
-    // Retain %r9 which is used to reference the td structure. It will be
-    // cleared immediately before EEXIT.
-    push %r9
     oe_cleanup_registers
-    pop %r9
 
 .restore_host_registers:
 
-    mov td_host_rcx(%r9), %rcx
-    mov td_host_rsp(%r9), %rsp
-    mov td_host_rbp(%r9), %rbp
+    mov td_host_rcx(%r11), %rcx
+    mov td_host_rsp(%r11), %rsp
+    mov td_host_rbp(%r11), %rbp
 
 .execute_eexit:
 
     // Check oe_sgx_td_t.simulate flag
     // simulate-flag-check.
-    mov td_simulate(%r9), %rax
+    mov td_simulate(%r11), %rax
     cmp $0, %rax
     jz .execute_eexit_instruction
 
@@ -109,8 +104,8 @@ oe_asm_exit:
     // simulate-flag-check.
     lfence
 
-    // Clear %r9 which was being used to maintain td pointer
-    xor %r9, %r9
+    // Clear %r11 which was being used to maintain td pointer
+    xor %r11, %r11
 
     // Jump to return address:
     mov $1, %rax
@@ -123,7 +118,7 @@ oe_asm_exit:
     lfence
 
     // Clear %r9 which was being used to maintain td pointer
-    xor %r9, %r9
+    xor %r11, %r11
     
     // EEXIT(RAX=EEXIT, RBX=RETADDR, RCX=AEP, RDI=ARG1, RSI=ARG2)
     mov %rcx, %rbx

--- a/enclave/core/sgx/exit.S
+++ b/enclave/core/sgx/exit.S
@@ -6,11 +6,12 @@
 
 //==============================================================================
 //
-// void oe_asm_exit(uint64_t arg1, uint64_t arg2)
+// void oe_asm_exit(uint64_t arg1, uint64_t arg2, oe_sgx_td_t* td)
 //
 // Registers:
 //     RDI - arg1
 //     RSI - arg2
+//     RDX - td
 //
 // Purpose:
 //     Restores user registers and executes the EEXIT instruction to leave the
@@ -51,11 +52,15 @@
 oe_asm_exit:
 .cfi_startproc
 
+.get_td:
+
+    mov %rdx, %r11
+
 .determine_exit_type:
 
     // Check the depth of the ECALL stack (zero for clean exit)
     // exit-type-check.
-    mov %fs:td_depth, %r8
+    mov td_depth(%r9), %r8
     cmp $0, %r8
     je .clean_exit
 
@@ -64,7 +69,7 @@ oe_asm_exit:
     // exit-type-check.
     lfence 
 
-    mov %rsp, %fs:td_last_sp
+    mov %rsp, td_last_sp(%r9)
 
     jmp .clear_enclave_registers
 
@@ -74,24 +79,28 @@ oe_asm_exit:
     lfence
 
     // Clear the oe_sgx_td_t.last_sp field (force oe_enter to calculate stack pointer)
-    movq $0, %fs:td_last_sp
+    movq $0, td_last_sp(%r9)
 
 .clear_enclave_registers:
 
-    // Clear these so information will not be leaked to host
+    // Clear registers so information will not be leaked to host
+    // Retain %r9 which is used to reference the td structure. It will be
+    // cleared immediately before EEXIT.
+    push %r9
     oe_cleanup_registers
+    pop %r9
 
 .restore_host_registers:
 
-    mov %fs:td_host_rcx, %rcx
-    mov %fs:td_host_rsp, %rsp
-    mov %fs:td_host_rbp, %rbp
+    mov td_host_rcx(%r9), %rcx
+    mov td_host_rsp(%r9), %rsp
+    mov td_host_rbp(%r9), %rbp
 
 .execute_eexit:
 
     // Check oe_sgx_td_t.simulate flag
     // simulate-flag-check.
-    mov %fs:td_simulate, %rax
+    mov td_simulate(%r9), %rax
     cmp $0, %rax
     jz .execute_eexit_instruction
 
@@ -99,6 +108,9 @@ oe_asm_exit:
     // Stop speculative execution at fallthrough of conditional
     // simulate-flag-check.
     lfence
+
+    // Clear %r9 which was being used to maintain td pointer
+    xor %r9, %r9
 
     // Jump to return address:
     mov $1, %rax
@@ -109,6 +121,9 @@ oe_asm_exit:
     // Stop speculative execution at target of conditional jump
     // after simulate-flag-check.
     lfence
+
+    // Clear %r9 which was being used to maintain td pointer
+    xor %r9, %r9
     
     // EEXIT(RAX=EEXIT, RBX=RETADDR, RCX=AEP, RDI=ARG1, RSI=ARG2)
     mov %rcx, %rbx

--- a/enclave/core/sgx/td.c
+++ b/enclave/core/sgx/td.c
@@ -15,8 +15,6 @@
 #include "thread.h"
 #include "threadlocal.h"
 
-#define TD_FROM_TCS (5 * OE_PAGE_SIZE)
-
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_sgx_td_t, magic) == td_magic);
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_sgx_td_t, depth) == td_depth);
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_sgx_td_t, host_rcx) == td_host_rcx);


### PR DESCRIPTION
If the Linux kernel is configured to allow it, an enclave application can change the fs register during execution. Currently if an application does this, it will break assumptions OE makes about where the `oe_sgx_td_t` structure (stores thread specific information) is stored.

Decouple the exit and enter code to be decoupled from the fs register. This allows OE to cleanly change where it stores the td struct for certain applications.

In particular, this is to support a library OS such as SGX-LKL which uses modifies the fs register upon usermode thread context switches.

I know this touches some critical code paths and assembly is error prone so I am not in a rush to merge this, we can take our time discussing/validating.