### PR TITLE
Switchless one tcs test from Intel and accompanying code fix

### DIFF
--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -1003,11 +1003,19 @@ oe_result_t oe_create_enclave(
     /* Invoke enclave initialization. */
     OE_CHECK(_initialize_enclave(enclave));
 
-    /* Apply the list of settings to the enclave */
-    OE_CHECK(_configure_enclave(enclave, settings, setting_count));
-
     /* Setup logging configuration */
     oe_log_enclave_init(enclave);
+
+    /* Apply the list of settings to the enclave.
+     * This may initialize switchless manager too.
+     * Doing this as the last step in enclave initialization ensures
+     * that all the ecalls necessary for enclave initialization have already
+     * been executed. Now all available tcs can be taken up by ecall worker
+     * threads. If we initialize the switchless manager earlier, then any
+     * normal ecalls required for initialization may not complete if all the
+     * tcs are taken up by ecall worker threads.
+     */
+    OE_CHECK(_configure_enclave(enclave, settings, setting_count));
 
     *enclave_out = enclave;
     result = OE_OK;

--- a/host/sgx/switchless.c
+++ b/host/sgx/switchless.c
@@ -208,7 +208,20 @@ oe_result_t oe_start_switchless_manager(
         }
     }
 
+    // Inform the enclave about the switchless manager through an ECALL
+    if (num_host_workers > 0)
+    {
+        OE_CHECK(oe_sgx_init_context_switchless_ecall(
+            enclave,
+            &result_out,
+            manager->host_worker_contexts,
+            manager->num_host_workers));
+        OE_CHECK(result_out);
+    }
+
     // Start the enclave worker threads, and assign each one a private context.
+    // ecall worker threads are initialized after the regular ecall above to
+    // oe_sgx_init_context_switchless_ecall is complete.
     for (size_t i = 0; i < num_enclave_workers; i++)
     {
         OE_TRACE_INFO("Creating switchless enclave worker thread %d\n", (int)i);
@@ -222,21 +235,20 @@ oe_result_t oe_start_switchless_manager(
         {
             OE_RAISE(OE_THREAD_CREATE_ERROR);
         }
+
+        // Wait until the enclave worker thread has started.
+        // If so, spin_count and/or total_spin_count will be non zero.
+        // This ensures that each ecall worker thread has a dedicated tcs.
+        volatile oe_enclave_worker_context_t* ctx =
+            &manager->enclave_worker_contexts[i];
+        while (!ctx->spin_count && !ctx->total_spin_count)
+        {
+            oe_yield_cpu();
+        }
     }
 
     // Each enclave has at most one switchless manager.
     enclave->switchless_manager = manager;
-
-    // Inform the enclave about the switchless manager through an ECALL
-    if (num_host_workers > 0)
-    {
-        OE_CHECK(oe_sgx_init_context_switchless_ecall(
-            enclave,
-            &result_out,
-            manager->host_worker_contexts,
-            manager->num_host_workers));
-        OE_CHECK(result_out);
-    }
 
     result = OE_OK;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ if (OE_SGX)
   add_subdirectory(switchless_threads)
   add_subdirectory(switchless_nestedcalls)
   add_subdirectory(switchless_worksleep)
+  add_subdirectory(switchless_one_tcs)
 endif ()
 
 if (UNIX

--- a/tests/switchless_one_tcs/CMakeLists.txt
+++ b/tests/switchless_one_tcs/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/switchless_one_tcs switchless_one_tcs_host
+                 switchless_one_tcs_enc)

--- a/tests/switchless_one_tcs/enc/CMakeLists.txt
+++ b/tests/switchless_one_tcs/enc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../switchless_one_tcs.edl)
+
+add_custom_command(
+  OUTPUT switchless_one_tcs_t.h switchless_one_tcs_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND edger8r --trusted ${EDL_FILE} --search-path
+          ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(
+  TARGET
+  switchless_one_tcs_enc
+  UUID
+  d497e154-9e8e-4029-a53d-c0a36533fb95
+  SOURCES
+  enc.c
+  ${CMAKE_CURRENT_BINARY_DIR}/switchless_one_tcs_t.c)
+
+enclave_include_directories(switchless_one_tcs_enc PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})
+enclave_link_libraries(switchless_one_tcs_enc oelibc)

--- a/tests/switchless_one_tcs/enc/enc.c
+++ b/tests/switchless_one_tcs/enc/enc.c
@@ -1,0 +1,31 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/corelibc/string.h>
+#include <openenclave/enclave.h>
+#include <openenclave/internal/print.h>
+#include "switchless_one_tcs_t.h"
+
+void enc_empty_regular(void)
+{
+}
+
+void enc_empty_switchless(status_e* status)
+{
+    int num_waiting = 0;
+    volatile status_e* _status = status;
+    *_status = FUNC_WORKING;
+    while (*_status != FUNC_EXIT)
+    {
+        num_waiting++;
+    }
+    oe_host_printf("enc_empty_switchless exit\n");
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,        /* ProductID */
+    1,        /* SecurityVersion */
+    true,     /* AllowDebug */
+    64,       /* HeapPageCount */
+    64,       /* StackPageCount */
+    NUM_TCS); /* TCSCount */

--- a/tests/switchless_one_tcs/host/CMakeLists.txt
+++ b/tests/switchless_one_tcs/host/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../switchless_one_tcs.edl)
+
+add_custom_command(
+  OUTPUT switchless_one_tcs_u.h switchless_one_tcs_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND edger8r --untrusted ${EDL_FILE} --search-path
+          ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(switchless_one_tcs_host host.c switchless_one_tcs_u.c)
+
+target_include_directories(switchless_one_tcs_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(switchless_one_tcs_host oehostapp)

--- a/tests/switchless_one_tcs/host/CMakeLists.txt
+++ b/tests/switchless_one_tcs/host/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(switchless_one_tcs_host host.c switchless_one_tcs_u.c)
 
 target_include_directories(switchless_one_tcs_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(switchless_one_tcs_host oehostapp)
+target_link_libraries(switchless_one_tcs_host oehost)

--- a/tests/switchless_one_tcs/host/host.c
+++ b/tests/switchless_one_tcs/host/host.c
@@ -1,0 +1,95 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <inttypes.h>
+#include <limits.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/atomic.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "../../../host/hostthread.h"
+#include "../../../host/strings.h"
+#include "switchless_one_tcs_u.h"
+
+#if defined(__linux__)
+#include <unistd.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#endif
+
+static status_e switchless_func_status = FUNC_NOT_START;
+void* thread_func(void* arg)
+{
+    oe_enclave_t* enclave = (oe_enclave_t*)arg;
+    oe_result_t ret = enc_empty_switchless(enclave, &switchless_func_status);
+    OE_TEST(ret == OE_OK);
+    return NULL;
+}
+
+int main(int argc, const char* argv[])
+{
+    oe_enclave_t* enclave = NULL;
+    oe_result_t result;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE\n", argv[0]);
+        exit(1);
+    }
+
+    printf("OneTCSTest::test\n");
+    printf("Create enclave with Switchless Calls and one TCS only.\n");
+    printf("Call empty switchless ecall, it is expected to pass...\n");
+    printf("Call empty ecall, it is expected to fail since TCS is occupied by "
+           "trusted worker thread...\n");
+
+    const uint32_t flags = oe_get_create_flags();
+
+    oe_enclave_setting_context_switchless_t switchless_setting = {1, 1};
+    oe_enclave_setting_t settings[] = {
+        {.setting_type = OE_ENCLAVE_SETTING_CONTEXT_SWITCHLESS,
+         .u.context_switchless_setting = &switchless_setting}};
+
+    if ((result = oe_create_switchless_one_tcs_enclave(
+             argv[1],
+             OE_ENCLAVE_TYPE_SGX,
+             flags,
+             settings,
+             OE_COUNTOF(settings),
+             &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    oe_thread_t tid;
+    int ret = 0;
+    if ((ret = oe_thread_create(&tid, thread_func, enclave)))
+    {
+        oe_put_err("thread_create(host): ret=%u", ret);
+    }
+
+    volatile status_e* p_switchless_func_status = &switchless_func_status;
+    while (*p_switchless_func_status != FUNC_WORKING)
+    {
+#if defined(__linux__)
+        usleep(100);
+#elif defined(_WIN32)
+        Sleep(0);
+#endif
+    }
+
+    OE_TEST(enc_empty_regular(enclave) == OE_OUT_OF_THREADS);
+
+    // let enclave function to exit
+    *p_switchless_func_status = FUNC_EXIT;
+
+    oe_thread_join(tid);
+
+    OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+
+    printf("=== passed all tests (switchless_one_tcs)\n");
+
+    return 0;
+}

--- a/tests/switchless_one_tcs/switchless_one_tcs.edl
+++ b/tests/switchless_one_tcs/switchless_one_tcs.edl
@@ -1,0 +1,20 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    enum num_tcs_t {
+        NUM_TCS = 1
+    };
+
+    enum status_e {
+        FUNC_NOT_START,
+        FUNC_WORKING,
+        FUNC_EXIT
+    };
+
+    trusted {
+        public void enc_empty_regular (void);
+        public void enc_empty_switchless(
+            [user_check] status_e *status ) transition_using_threads;
+    };
+};


### PR DESCRIPTION
Allow all the regular ecalls to first finish during enclave
initialization. Then launch ecall worker threads and wait
for the threads to enter the enclave and thus acquire a
dedicated tcs.

This allows creating enclaves where all ecalls after initialization
are switchless.

Intel test from #2887 