### PR TITLE
EXPERIMENTAL: Use C++ implementation of oeedger8r

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "3rdparty/snmalloc"]
 	path = 3rdparty/snmalloc/snmalloc
 	url = https://github.com/Microsoft/snmalloc.git
+[submodule "tools/oeedger8r-cpp"]
+	path = tools/oeedger8r-cpp
+	url = https://github.com/openenclave/oeedger8r-cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,19 @@
 # https://rix0r.nl/blog/2015/08/13/cmake-guide/
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
+# Utility to ensure specific submodules are present.
+function (check_submodule_not_empty path)
+  file(GLOB submodule_files "${path}/*")
+  list(LENGTH submodule_files number)
+  if (${number} EQUAL 0)
+    message(
+      FATAL_ERROR
+        "Submodule ${path} is empty. You can initialize the submodule now with \
+         'git submodule update --recursive --init',\
+         or during 'git clone' by passing '--recursive'.")
+  endif ()
+endfunction ()
+
 # Read version from "VERSION" file.
 file(STRINGS "VERSION" OE_VERSION_WITH_V)
 string(REGEX REPLACE "^v" "" OE_VERSION ${OE_VERSION_WITH_V})

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -43,6 +43,7 @@ devex/vsextension/ItemTemplates/.*
 devex/vsextension/ProjectTemplates/.*
 tools/oeedger8r/esy\.lock/.*
 tools/oeedger8r/intel/.*
+tools/oeedger8r-cpp/*
 tests/libcxxrt/results/.*
 tests/print/results/.*
 docs/*

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,18 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-add_subdirectory(oeedger8r)
+if (USE_CPP_EDGER8R)
+  check_submodule_not_empty(oeedger8r-cpp)
+  set(USE_OEEDGER8R_CPP_AS_SUBMODULE on)
+  add_subdirectory(oeedger8r-cpp)
+  add_executable(edger8r ALIAS oeedger8r)
+  install(
+    TARGETS oeedger8r
+    EXPORT openenclave-targets
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+else ()
+  add_subdirectory(oeedger8r)
+endif ()
 
 if (OE_SGX)
   add_subdirectory(oesgx)


### PR DESCRIPTION
Pass USE_CPP_EDGER8R=on to use C++ oeedger8r instead of Ocaml edger8r.

C++ oeedger8r repository: https://github.com/openenclave/oeedger8r-cpp

The Ocaml implementation has the following drawbacks
- Ocaml is not that common a language and has proven to
  have a high barrier for entry to contributing to oeedger8r
- Ocaml compiler/tools are not readily available on Windows
  This has led to
  - Using not actively maintained build on Ocaml on Windows
  - Or using esy which builds Ocaml compiler on each Windows
    machine it is run on, adding upto 30 additional minutes
    to building the OE SDK on Windows

This C++ implementation is
- intended to improve the ease of contribution to the oeedger8r
  by use of a common language that is well supported on all
  platforms
- sticks to C++11 which is well supported
- is based on a Python rewrite of oeedger8r
  https://github.com/openenclave/oeedger8r-python

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>