### PR TITLE
Update ansible script to use Azrure dcap client version 1.5 for RHEL.

### DIFF
--- a/scripts/ansible/roles/linux/az-dcap-client/vars/redhat/main.yml
+++ b/scripts/ansible/roles/linux/az-dcap-client/vars/redhat/main.yml
@@ -8,7 +8,7 @@ yum_packages:
   - "pkg-config"
 
 git_repo_url: "https://github.com/Microsoft/Azure-DCAP-Client.git"
-git_repo_branch: "1.4.0"
+git_repo_branch: "1.5"
 git_local_dir: "/tmp/Azure-DCAP-Client"
 
 validation_distribution_files:


### PR DESCRIPTION
Update ansible script to use Azrure dcap client version 1.5 for RHEL, since the latest version 1.5 is released:

- Added caching of all collateral
- Added ability to enable debug logging independently of logging callback

Signed-off-by: Alvin Chen <alvin@chen.asia>