### PR TITLE
add oe stress test of ecall and ocall

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ if (UNIX
     add_subdirectory(thread_local_no_tdata)
     add_subdirectory(VectorException)
     add_subdirectory(stack_smashing_protector)
+	add_subdirectory(stress)
 
     if (WITH_EEID)
       add_subdirectory(eeid_plugin)

--- a/tests/stress/CMakeLists.txt
+++ b/tests/stress/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/stress stress_host stress_enc)

--- a/tests/stress/enc/CMakeLists.txt
+++ b/tests/stress/enc/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../stress.edl)
+
+add_custom_command(
+  OUTPUT stress_t.h stress_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND edger8r --trusted ${EDL_FILE} --search-path
+          ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(TARGET stress_enc SOURCES enc.cpp
+            ${CMAKE_CURRENT_BINARY_DIR}/stress_t.c)
+
+enclave_include_directories(stress_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+enclave_link_libraries(stress_enc oelibc)

--- a/tests/stress/enc/enc.cpp
+++ b/tests/stress/enc/enc.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/print.h>
+#include "stress_t.h"
+
+void do_ecall(int arg)
+{
+    oe_host_printf("Do ecall time: %d\n", arg);
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* AllowDebug */
+    8,    /* HeapPageCount */
+    8,    /* StackPageCount */
+    1);   /* TCSCount */

--- a/tests/stress/host/CMakeLists.txt
+++ b/tests/stress/host/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../stress.edl)
+
+add_custom_command(
+  OUTPUT stress_u.h stress_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND edger8r --untrusted ${EDL_FILE} --search-path
+          ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(stress_host host.cpp stress_u.c)
+
+target_include_directories(stress_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(stress_host oehost)

--- a/tests/stress/host/host.cpp
+++ b/tests/stress/host/host.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/calls.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/print.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include "stress_u.h"
+
+void do_ecall_in_enclave(
+    const char* path,
+    uint32_t flags,
+    int ecall_count,
+    int is_diff_enc)
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    result = oe_create_stress_enclave(
+        path, OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);
+
+    if (result != OE_OK)
+        oe_put_err("oe_create_stress_enclave(): result=%u", result);
+
+    if (is_diff_enc != 0)
+        printf("Do ecall in enclave: %d\n", is_diff_enc);
+    for (int i = 0; i < ecall_count; i++)
+    {
+        if ((result = do_ecall(enclave, i)) != OE_OK)
+        {
+            oe_terminate_enclave(enclave);
+            oe_put_err("test(): result=%u", result);
+        }
+    }
+
+    result = oe_terminate_enclave(enclave);
+    if (result != OE_OK)
+        oe_put_err("oe_terminate_enclave(): result=%u", result);
+}
+
+void do_ecall_by_count_in_same_env(
+    const char* path,
+    uint32_t flags,
+    int ecall_count,
+    int is_diff_enc)
+{
+    do_ecall_in_enclave(path, flags, ecall_count, is_diff_enc);
+}
+
+void do_ecall_by_count_in_diff_env_sequential(
+    const char* path,
+    uint32_t flags,
+    int ecall_count,
+    int enclave_count)
+{
+    for (int i = 1; i < enclave_count + 1; i++)
+        do_ecall_in_enclave(path, flags, ecall_count, i);
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE\n", argv[0]);
+        exit(1);
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    // load enclave stress test:
+    // realized in create-rapid
+
+    // do ecall stress test:
+    int ecall_count;
+    int enclave_count;
+    int is_diff_enc;
+
+    // 1. do ecall by count in same enclave
+    // 1 enclave, 100000 ecalls
+    ecall_count = 100000;
+    is_diff_enc = 0;
+    do_ecall_by_count_in_same_env(argv[1], flags, ecall_count, is_diff_enc);
+
+    // 2. do ecall by count in diff enclaves sequentially
+    // 100 enclaves, 10000 ecalls for each enclave, sequential
+    ecall_count = 10000;
+    enclave_count = 100;
+    do_ecall_by_count_in_diff_env_sequential(
+        argv[1], flags, ecall_count, enclave_count);
+
+    // to add more do ecall stress tests:
+    // 3. do ecall by count in diff enclaves parallelly
+    // 4. do ecall by count with multi-threads
+    // 5. do ecall by timeout(hour, min, sec)
+
+    // to add: do ocall stress tests, same as above
+
+    // to add: more stress tests
+}

--- a/tests/stress/stress.edl
+++ b/tests/stress/stress.edl
@@ -1,0 +1,8 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+        public void do_ecall(int arg);
+	};
+};


### PR DESCRIPTION
Add OE sdk stress test to enhance the test capability of OE unit test. Stress test focues on testing the stability of OE and if there are some crashes during great quantity and long time operations.
At first, add following 2 test cases for a trial:
1. do ecall by count in same enclave
2. do ecall by count in diff enclaves sequentially

I run in OE and the test time is OK for unit test:
1. 1 enclave, 100000 ecalls
2. 100 enclaves, 10000 ecalls for each enclave, sequential
    Start 1: tests/stress
1/1 Test #1: tests/stress .....................   Passed   26.66 sec

Next step is to add:
3. do ecall by count in diff enclaves parallelly
4. do ecall by count with multi-threads
5. do ecall by timeout(hour, min, sec)
6. do ocall stress tests
7. other stress tests like thread related APIs