### PR TITLE
Reduce committed SGX enclave size on Windows

### DIFF
--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -805,7 +805,8 @@ oe_result_t oe_sgx_build_enclave(
         image_size, &props, &enclave_end, &enclave_size));
 
     /* Perform the ECREATE operation */
-    OE_CHECK(oe_sgx_create_enclave(context, enclave_size, &enclave_addr));
+    OE_CHECK(oe_sgx_create_enclave(
+        context, enclave_size, enclave_end, &enclave_addr));
 
     /* Save the enclave base address, size, and text address */
     enclave->addr = enclave_addr;

--- a/host/sgx/sgxload.h
+++ b/host/sgx/sgxload.h
@@ -27,6 +27,7 @@ OE_INLINE bool oe_sgx_is_debug_load_context(
 oe_result_t oe_sgx_create_enclave(
     oe_sgx_load_context_t* context,
     size_t enclave_size,
+    size_t enclave_commit_size,
     uint64_t* enclave_addr);
 
 oe_result_t oe_sgx_load_enclave_data(


### PR DESCRIPTION
`oe_sgx_create_enclave()` currently only takes the enclave size as defined by its
ELRANGE, which can be significantly larger than the actual EPC memory that
needs to be committed to load and launch the enclave.

This change updates `oe_sgx_create_enclave()` to take both an initial commit size
in addition to the enclave ELRANGE size, which should expand the range of
enclave sizes that can successfully load on Windows (see previous issues such
as #2394 and #2397).

Signed-off-by: Simon Leet <simon.leet@microsoft.com>