### PR TITLE
Fix `__oe_get_enclave_size()` to return ELRANGE size

### DIFF
--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -138,7 +138,6 @@ extern bool oe_disable_debug_malloc_check;
 #ifdef OE_WITH_EXPERIMENTAL_EEID
 extern volatile const oe_sgx_enclave_properties_t oe_enclave_properties_sgx;
 extern oe_eeid_t* oe_eeid;
-extern size_t oe_eeid_extended_size;
 
 int _is_eeid_base_image(const volatile oe_sgx_enclave_properties_t* properties)
 {
@@ -147,7 +146,7 @@ int _is_eeid_base_image(const volatile oe_sgx_enclave_properties_t* properties)
            properties->header.size_settings.num_tcs == 1;
 }
 
-static oe_result_t _eeid_patch_memory_sizes()
+static oe_result_t _eeid_patch_memory()
 {
     oe_result_t r = OE_OK;
 
@@ -157,7 +156,6 @@ static oe_result_t _eeid_patch_memory_sizes()
         uint8_t* heap_base = (uint8_t*)__oe_get_heap_base();
         oe_eeid_marker_t* marker = (oe_eeid_marker_t*)heap_base;
         oe_eeid = (oe_eeid_t*)(enclave_base + marker->offset);
-        oe_eeid_extended_size = marker->size;
 
         // Wipe the marker page
         memset(heap_base, 0, OE_PAGE_SIZE);
@@ -196,7 +194,7 @@ static oe_result_t _handle_init_enclave(uint64_t arg_in)
             oe_enclave_t* enclave = (oe_enclave_t*)arg_in;
 
 #ifdef OE_WITH_EXPERIMENTAL_EEID
-            OE_CHECK(_eeid_patch_memory_sizes());
+            OE_CHECK(_eeid_patch_memory());
 #endif
 
 #ifdef OE_USE_BUILTIN_EDL

--- a/enclave/core/sgx/globals.c
+++ b/enclave/core/sgx/globals.c
@@ -130,7 +130,6 @@ static volatile uint64_t _reloc_size;
 
 #ifdef OE_WITH_EXPERIMENTAL_EEID
 oe_eeid_t* oe_eeid = NULL;
-size_t oe_eeid_extended_size = 0;
 #endif
 
 /*
@@ -148,12 +147,7 @@ const void* __oe_get_enclave_base()
 
 size_t __oe_get_enclave_size()
 {
-#ifdef OE_WITH_EXPERIMENTAL_EEID
-    if (oe_eeid)
-        return oe_eeid_extended_size;
-    else
-#endif
-        return oe_enclave_properties_sgx.image_info.enclave_size;
+    return oe_enclave_properties_sgx.image_info.enclave_size;
 }
 
 const void* __oe_get_enclave_elf_header(void)

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -813,7 +813,7 @@ oe_result_t oe_sgx_build_enclave(
     enclave->text = enclave_addr + oeimage.text_rva;
 
     /* Patch image */
-    OE_CHECK(oeimage.patch(&oeimage, enclave_end));
+    OE_CHECK(oeimage.patch(&oeimage, enclave_size));
 
     /* Add image to enclave */
     OE_CHECK(oeimage.add_pages(&oeimage, context, enclave, &vaddr));

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -621,8 +621,11 @@ static oe_result_t _add_eeid_marker_page(
         memset(page, 0, sizeof(oe_page_t));
         oe_eeid_marker_t* marker = (oe_eeid_marker_t*)page;
 
+        /* The offset to the EEID in marker->offset is also the extended
+         * commit size of the base image and dynamically configured data
+         * pages (stacks + heap) excluding the EEID data size.
+         */
         _calculate_enclave_size(image_size, props, &marker->offset, NULL);
-        marker->size = enclave->size;
 
         uint64_t addr = enclave->addr + *vaddr;
         uint64_t src = (uint64_t)page;

--- a/include/openenclave/internal/eeid.h
+++ b/include/openenclave/internal/eeid.h
@@ -75,7 +75,6 @@ oe_result_t oe_deserialize_eeid(
 typedef struct
 {
     uint64_t offset;
-    uint64_t size;
 } oe_eeid_marker_t;
 
 /**

--- a/tests/eeid_plugin/eeid_plugin.edl
+++ b/tests/eeid_plugin/eeid_plugin.edl
@@ -3,6 +3,11 @@
 
 enclave {
 
+    from "openenclave/edl/attestation.edl" import *;
+    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/syscall.edl" import *;
+    from "platform.edl" import *;
+
     trusted {
         public void run_tests();
 

--- a/tests/eeid_plugin/enc/CMakeLists.txt
+++ b/tests/eeid_plugin/enc/CMakeLists.txt
@@ -6,8 +6,9 @@ set(EDL_FILE ../eeid_plugin.edl)
 add_custom_command(
   OUTPUT eeid_plugin_t.h eeid_plugin_t.c
   DEPENDS ${EDL_FILE} edger8r
-  COMMAND edger8r --trusted ${EDL_FILE} --search-path
-          ${CMAKE_CURRENT_SOURCE_DIR})
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/eeid_plugin/host/CMakeLists.txt
+++ b/tests/eeid_plugin/host/CMakeLists.txt
@@ -6,8 +6,9 @@ set(EDL_FILE ../eeid_plugin.edl)
 add_custom_command(
   OUTPUT eeid_plugin_u.h eeid_plugin_u.c
   DEPENDS ${EDL_FILE} edger8r
-  COMMAND edger8r --untrusted ${EDL_FILE} --search-path
-          ${CMAKE_CURRENT_SOURCE_DIR})
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(eeid_plugin_host host.c ../test_helpers.c eeid_plugin_u.c)
 


### PR DESCRIPTION
`__oe_get_enclave_size()` is used in the `oe_is_within_enclave()` and `oe_is_outside_enclave()` checks, but currently only reflects the initially committed enclave pages during enclave creation, not the actual linear address range (ELRANGE) protected by SGX. This can create unexpected failures in SGX1 as a write to a unbacked page in ELRANGE as if it is outside the enclave will fail.

- Update `oe_sgx_build_enclave()` to patch oeimage with `enclave_size` instead of `enclave_end` (size of committed pages only).

- Remove extra EEID logic to provide the incorrect initial committed size as the enclave size. That code path behaves as in the normal case now.

Also updates tests/eeid_plugin to import the required OE system and platform EDLs;
PR #2961 refactored all tests to explicitly import their required EDLs, but did not update the EEID tests because they only build with the WITH_EEID experimental feature flag enabled.

Fixes #3056