### PR TITLE
Fix malloc random size fragment test

### DIFF
--- a/tests/memory/enc/fragment.c
+++ b/tests/memory/enc/fragment.c
@@ -80,7 +80,7 @@ static int _malloc_free_random_size(int times, unsigned int seed)
     srand(seed);
     for (i = 0; i < times; i++)
     {
-        size = _randx(_get_heap_size());
+        size = _randx(_get_heap_size() - 23);
         buffer = malloc(size);
         if (NULL == buffer)
         {


### PR DESCRIPTION
#2776 

Seems like this issue got automatically closed when the PR closed, but it was never actually fixed. 

Basically, I think the problem with the test is that when random size memory being malloced is too large (in this case within 23 bytes of _get_heap_size()), dlmalloc will automatically increase the size of the heap. After the heap reaches its maximum size (2097024 bytes), the heap is shrunk back down (3968 bytes), before once again increasing in size if _randx(_get_heap_size()) is too large.

The simple fix is to restrict the max possible size being allocated in the random size fragment test.