### PR TITLE
Remove outdated oe_enclave_t comment

### DIFF
--- a/host/sgx/enclave.h
+++ b/host/sgx/enclave.h
@@ -87,8 +87,8 @@ typedef struct _thread_binding
 oe_thread_binding_t* oe_get_thread_binding(void);
 
 /**
- *  This structure must be kept in sync with the defines in
- *  debugger/pythonExtension/gdb_sgx_plugin.py.
+ * Host-side representation of properties associated with each
+ * enclave instance.
  */
 typedef struct _oe_enclave
 {


### PR DESCRIPTION
Per changes in PR #2020, gdb_sgx_plugin.py depends on the debugrt
`oe_debug_enclave_t` struct and not the `oe_enclave_t` struct, so updating
the comments for the latter to reflect this decoupling.

Signed-off-by: Simon Leet <simon.leet@microsoft.com>