### PR TITLE
add oe stress test of ecall ocall

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,14 @@ else ()
   message("ENABLE_FULL_LIBCXX_TESTS not set - building some libcxx tests")
 endif ()
 
+option(ENABLE_FULL_STRESS_TESTS
+       "Build all stress tests and include in test list" OFF)
+if (ENABLE_FULL_STRESS_TESTS)
+  message("ENABLE_FULL_STRESS_TESTS set - building all stress tests")
+else ()
+  message("ENABLE_FULL_STRESS_TESTS not set - building some stress tests")
+endif ()
+
 option(LVI_MITIGATION_SKIP_TESTS "Skip all tests with LVI mitigation" OFF)
 if (LVI_MITIGATION MATCHES ControlFlow AND LVI_MITIGATION_SKIP_TESTS)
   message("LVI_MITIGATION_SKIP_TESTS set - skip all tests with LVI mitigation")
@@ -98,6 +106,7 @@ if (UNIX
     add_subdirectory(thread_local_no_tdata)
     add_subdirectory(VectorException)
     add_subdirectory(stack_smashing_protector)
+    add_subdirectory(stress)
 
     if (WITH_EEID)
       add_subdirectory(eeid_plugin)

--- a/tests/stress/CMakeLists.txt
+++ b/tests/stress/CMakeLists.txt
@@ -7,8 +7,21 @@ if (BUILD_ENCLAVES)
   add_subdirectory(enc)
 endif ()
 
-add_enclave_test(tests/stress_ecall_1 stress_host stress_enc 0 1 1000000)
+# stress test case definition:
+# add_enclave_test(tests/your_stress_test_name stress_host stress_enc stress_test_type enclave_count operation_count)
+
+# stress_test_type:
+# - ECALL_STRESS_TEST
+# - OCALL_STRESS_TEST
+# - ECALL_OCALL_STRESS_TEST
+set(ECALL_STRESS_TEST 0)
+set(OCALL_STRESS_TEST 1)
+set(ECALL_OCALL_STRESS_TEST 2)
+
+add_enclave_test(tests/stress_ecall_1 stress_host stress_enc ${ECALL_STRESS_TEST} 1 10000)
+add_enclave_test(tests/stress_ecall_2 stress_host stress_enc ${ECALL_STRESS_TEST} 100 100)
 
 if (ENABLE_FULL_STRESS_TESTS)
-  add_enclave_test(tests/stress_ecall_2 stress_host stress_enc 0 100 100000)
+  add_enclave_test(tests/stress_ecall_1 stress_host stress_enc ${ECALL_STRESS_TEST} 1 1000000)
+  add_enclave_test(tests/stress_ecall_2 stress_host stress_enc ${ECALL_STRESS_TEST} 100 10000)
 endif()

--- a/tests/stress/CMakeLists.txt
+++ b/tests/stress/CMakeLists.txt
@@ -19,7 +19,7 @@ set(OCALL_STRESS_TEST 1)
 set(ECALL_OCALL_STRESS_TEST 2)
 
 add_enclave_test(tests/stress_ecall_1 stress_host stress_enc ${ECALL_STRESS_TEST} 1 10000)
-add_enclave_test(tests/stress_ecall_2 stress_host stress_enc ${ECALL_STRESS_TEST} 100 100)
+add_enclave_test(tests/stress_ecall_2 stress_host stress_enc ${ECALL_STRESS_TEST} 10 100)
 
 if (ENABLE_FULL_STRESS_TESTS)
   add_enclave_test(tests/stress_ecall_1 stress_host stress_enc ${ECALL_STRESS_TEST} 1 1000000)

--- a/tests/stress/CMakeLists.txt
+++ b/tests/stress/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/stress_ecall_1 stress_host stress_enc 0 1 1000000)
+
+if (ENABLE_FULL_STRESS_TESTS)
+  add_enclave_test(tests/stress_ecall_2 stress_host stress_enc 0 100 100000)
+endif()

--- a/tests/stress/enc/CMakeLists.txt
+++ b/tests/stress/enc/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../stress.edl)
+
+add_custom_command(
+  OUTPUT stress_t.h stress_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(TARGET stress_enc SOURCES enc.cpp
+            ${CMAKE_CURRENT_BINARY_DIR}/stress_t.c)
+
+enclave_include_directories(stress_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+enclave_link_libraries(stress_enc oelibc)

--- a/tests/stress/enc/enc.cpp
+++ b/tests/stress/enc/enc.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/print.h>
+#include "stress_t.h"
+
+void do_ecall(int arg)
+{
+    oe_host_printf("Do ecall time: %d\n", arg);
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* AllowDebug */
+    8,    /* HeapPageCount */
+    8,    /* StackPageCount */
+    1);   /* TCSCount */

--- a/tests/stress/enc/enc.cpp
+++ b/tests/stress/enc/enc.cpp
@@ -4,11 +4,12 @@
 #include <openenclave/internal/print.h>
 #include "stress_t.h"
 
+static int rcv = 0;
+
 void do_ecall(int arg)
 {
-    // almost do nothing, just assign value
-    int rcv = 0;
-    rcv = arg;
+    // almost do nothing
+    rcv = arg + 1;
 }
 
 OE_SET_ENCLAVE_SGX(

--- a/tests/stress/enc/enc.cpp
+++ b/tests/stress/enc/enc.cpp
@@ -6,7 +6,9 @@
 
 void do_ecall(int arg)
 {
-    oe_host_printf("Do ecall time: %d\n", arg);
+    // almost do nothing, just assign value
+    int rcv = 0;
+    rcv = arg;
 }
 
 OE_SET_ENCLAVE_SGX(

--- a/tests/stress/host/CMakeLists.txt
+++ b/tests/stress/host/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../stress.edl)
+
+add_custom_command(
+  OUTPUT stress_u.h stress_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(stress_host host.cpp stress_u.c)
+
+target_include_directories(stress_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(stress_host oehost)

--- a/tests/stress/host/host.cpp
+++ b/tests/stress/host/host.cpp
@@ -83,15 +83,13 @@ int main(int argc, const char* argv[])
     switch (atoi(argv[2]))
     {
         // TEST_TYPE=0 - do ecall stress test
+        // 1. do ecall by count in same enclave: 1 enclave, 1000000 ecalls
+        // 2. do ecall by count in diff enclaves sequentially: 100 enclaves, 100000 ecalls for each enclave, sequential
         case ECALL_STRESS_TEST:
-            // 1. do ecall by count in same enclave
-            // 1 enclave, 1000000 ecalls
-            do_ecall_by_count_in_same_env(
-                argv[1], flags, atoi(argv[3]), atoi(argv[4]));
-            // 2. do ecall by count in diff enclaves sequentially
-            // 100 enclaves, 100000 ecalls for each enclave, sequential
-            do_ecall_by_count_in_diff_env_sequential(
-                argv[1], flags, atoi(argv[3]), atoi(argv[4]));
+            if (atoi(argv[3]) == 1)
+                do_ecall_by_count_in_same_env(argv[1], flags, atoi(argv[3]), atoi(argv[4]));
+            if (atoi(argv[3]) > 1)
+                do_ecall_by_count_in_diff_env_sequential(argv[1], flags, atoi(argv[3]), atoi(argv[4]));
             // to add more do ecall stress tests:
             // 3. do ecall by count in diff enclaves parallelly
             // 4. do ecall by count with multi-threads

--- a/tests/stress/host/host.cpp
+++ b/tests/stress/host/host.cpp
@@ -29,7 +29,7 @@ void do_ecall_in_enclave(
     if (result != OE_OK)
         oe_put_err("oe_create_stress_enclave(): result=%u", result);
 
-    printf("Do ecall in enclave: %d\n", enclave_count);
+    printf("Start to do ecall in enclave: %d\n", enclave_count);
     for (int i = 0; i < ecall_count; i++)
     {
         if ((result = do_ecall(enclave, i)) != OE_OK)
@@ -38,22 +38,14 @@ void do_ecall_in_enclave(
             oe_put_err("test(): result=%u", result);
         }
     }
+    printf("Finish doing ecall in enclave: %d, total %d ecalls\n", enclave_count, ecall_count);	
 
     result = oe_terminate_enclave(enclave);
     if (result != OE_OK)
         oe_put_err("oe_terminate_enclave(): result=%u", result);
 }
 
-void do_ecall_by_count_in_same_env(
-    const char* path,
-    uint32_t flags,
-    int enclave_count,
-    int ecall_count)
-{
-    do_ecall_in_enclave(path, flags, enclave_count, ecall_count);
-}
-
-void do_ecall_by_count_in_diff_env_sequential(
+void do_ecall_by_count_in_env_sequential(
     const char* path,
     uint32_t flags,
     int enclave_count,
@@ -83,17 +75,13 @@ int main(int argc, const char* argv[])
     switch (atoi(argv[2]))
     {
         // TEST_TYPE=0 - do ecall stress test
-        // 1. do ecall by count in same enclave: 1 enclave, 1000000 ecalls
-        // 2. do ecall by count in diff enclaves sequentially: 100 enclaves, 100000 ecalls for each enclave, sequential
+        // 1. do ecall by count in env sequentially
         case ECALL_STRESS_TEST:
-            if (atoi(argv[3]) == 1)
-                do_ecall_by_count_in_same_env(argv[1], flags, atoi(argv[3]), atoi(argv[4]));
-            if (atoi(argv[3]) > 1)
-                do_ecall_by_count_in_diff_env_sequential(argv[1], flags, atoi(argv[3]), atoi(argv[4]));
+                do_ecall_by_count_in_env_sequential(argv[1], flags, atoi(argv[3]), atoi(argv[4]));
             // to add more do ecall stress tests:
-            // 3. do ecall by count in diff enclaves parallelly
-            // 4. do ecall by count with multi-threads
-            // 5. do ecall by timeout(hour, min, sec)
+            // 2. do ecall by count in env parallelly
+            // 3. do ecall by count with multi-threads
+            // 4. do ecall by timeout(hour, min, sec)
             break;
         // to add: TEST_TYPE=1 - do ocall stress test
         case OCALL_STRESS_TEST:

--- a/tests/stress/host/host.cpp
+++ b/tests/stress/host/host.cpp
@@ -38,7 +38,10 @@ void do_ecall_in_enclave(
             oe_put_err("test(): result=%u", result);
         }
     }
-    printf("Finish doing ecall in enclave: %d, total %d ecalls\n", enclave_count, ecall_count);	
+    printf(
+        "Finish doing ecall in enclave: %d, total %d ecalls\n",
+        enclave_count,
+        ecall_count);
 
     result = oe_terminate_enclave(enclave);
     if (result != OE_OK)
@@ -77,7 +80,8 @@ int main(int argc, const char* argv[])
         // TEST_TYPE=0 - do ecall stress test
         // 1. do ecall by count in env sequentially
         case ECALL_STRESS_TEST:
-                do_ecall_by_count_in_env_sequential(argv[1], flags, atoi(argv[3]), atoi(argv[4]));
+            do_ecall_by_count_in_env_sequential(
+                argv[1], flags, atoi(argv[3]), atoi(argv[4]));
             // to add more do ecall stress tests:
             // 2. do ecall by count in env parallelly
             // 3. do ecall by count with multi-threads

--- a/tests/stress/host/host.cpp
+++ b/tests/stress/host/host.cpp
@@ -9,10 +9,10 @@
 #include <stdio.h>
 #include "stress_u.h"
 
-#define ECALL_STRESS_TEST 		0
-#define OCALL_STRESS_TEST 		1
+#define ECALL_STRESS_TEST 0
+#define OCALL_STRESS_TEST 1
 #define ECALL_OCALL_STRESS_TEST 2
-//to add: more stress test types
+// to add: more stress test types
 
 void do_ecall_in_enclave(
     const char* path,
@@ -67,7 +67,10 @@ int main(int argc, const char* argv[])
 {
     if (argc != 5)
     {
-        fprintf(stderr, "Usage: %s ENCLAVE_PATH TEST_TYPE ENCLAVE_COUNT ECALL_COUNT\n", argv[0]);
+        fprintf(
+            stderr,
+            "Usage: %s ENCLAVE_PATH TEST_TYPE ENCLAVE_COUNT ECALL_COUNT\n",
+            argv[0]);
         exit(1);
     }
 
@@ -83,22 +86,24 @@ int main(int argc, const char* argv[])
         case ECALL_STRESS_TEST:
             // 1. do ecall by count in same enclave
             // 1 enclave, 1000000 ecalls
-            do_ecall_by_count_in_same_env(argv[1], flags, atoi(argv[3]), atoi(argv[4]));  
+            do_ecall_by_count_in_same_env(
+                argv[1], flags, atoi(argv[3]), atoi(argv[4]));
             // 2. do ecall by count in diff enclaves sequentially
             // 100 enclaves, 100000 ecalls for each enclave, sequential
-            do_ecall_by_count_in_diff_env_sequential(argv[1], flags, atoi(argv[3]), atoi(argv[4]));	
-            //to add more do ecall stress tests:
+            do_ecall_by_count_in_diff_env_sequential(
+                argv[1], flags, atoi(argv[3]), atoi(argv[4]));
+            // to add more do ecall stress tests:
             // 3. do ecall by count in diff enclaves parallelly
             // 4. do ecall by count with multi-threads
             // 5. do ecall by timeout(hour, min, sec)
             break;
-        //to add: TEST_TYPE=1 - do ocall stress test
+        // to add: TEST_TYPE=1 - do ocall stress test
         case OCALL_STRESS_TEST:
             break;
-        //to add: TEST_TYPE=2 - do ecall + ocall stress test
+        // to add: TEST_TYPE=2 - do ecall + ocall stress test
         case ECALL_OCALL_STRESS_TEST:
             break;
-        //to add: more stress tests
+        // to add: more stress tests
         default:
             break;
     }

--- a/tests/stress/host/host.cpp
+++ b/tests/stress/host/host.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/calls.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/print.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include "stress_u.h"
+
+#define ECALL_STRESS_TEST 		0
+#define OCALL_STRESS_TEST 		1
+#define ECALL_OCALL_STRESS_TEST 2
+//to add: more stress test types
+
+void do_ecall_in_enclave(
+    const char* path,
+    uint32_t flags,
+    int enclave_count,
+    int ecall_count)
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    result = oe_create_stress_enclave(
+        path, OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);
+
+    if (result != OE_OK)
+        oe_put_err("oe_create_stress_enclave(): result=%u", result);
+
+    printf("Do ecall in enclave: %d\n", enclave_count);
+    for (int i = 0; i < ecall_count; i++)
+    {
+        if ((result = do_ecall(enclave, i)) != OE_OK)
+        {
+            oe_terminate_enclave(enclave);
+            oe_put_err("test(): result=%u", result);
+        }
+    }
+
+    result = oe_terminate_enclave(enclave);
+    if (result != OE_OK)
+        oe_put_err("oe_terminate_enclave(): result=%u", result);
+}
+
+void do_ecall_by_count_in_same_env(
+    const char* path,
+    uint32_t flags,
+    int enclave_count,
+    int ecall_count)
+{
+    do_ecall_in_enclave(path, flags, enclave_count, ecall_count);
+}
+
+void do_ecall_by_count_in_diff_env_sequential(
+    const char* path,
+    uint32_t flags,
+    int enclave_count,
+    int ecall_count)
+{
+    for (int i = 1; i < enclave_count + 1; i++)
+        do_ecall_in_enclave(path, flags, i, ecall_count);
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc != 5)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH TEST_TYPE ENCLAVE_COUNT ECALL_COUNT\n", argv[0]);
+        exit(1);
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    // load enclave stress test:
+    // realized in create-rapid
+
+    // do ecall / ocall / ecall + ocall stress test:
+    switch (atoi(argv[2]))
+    {
+        // TEST_TYPE=0 - do ecall stress test
+        case ECALL_STRESS_TEST:
+            // 1. do ecall by count in same enclave
+            // 1 enclave, 1000000 ecalls
+            do_ecall_by_count_in_same_env(argv[1], flags, atoi(argv[3]), atoi(argv[4]));  
+            // 2. do ecall by count in diff enclaves sequentially
+            // 100 enclaves, 100000 ecalls for each enclave, sequential
+            do_ecall_by_count_in_diff_env_sequential(argv[1], flags, atoi(argv[3]), atoi(argv[4]));	
+            //to add more do ecall stress tests:
+            // 3. do ecall by count in diff enclaves parallelly
+            // 4. do ecall by count with multi-threads
+            // 5. do ecall by timeout(hour, min, sec)
+            break;
+        //to add: TEST_TYPE=1 - do ocall stress test
+        case OCALL_STRESS_TEST:
+            break;
+        //to add: TEST_TYPE=2 - do ecall + ocall stress test
+        case ECALL_OCALL_STRESS_TEST:
+            break;
+        //to add: more stress tests
+        default:
+            break;
+    }
+}

--- a/tests/stress/stress.edl
+++ b/tests/stress/stress.edl
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/syscall.edl" import *;
+    from "platform.edl" import *;
+
+    trusted {
+        public void do_ecall(int arg);
+    };
+};


### PR DESCRIPTION
I create a new branch add_oe_stress_test_of_ecall_ocall which resolve all comments of PR 3085: https://github.com/openenclave/openenclave/pull/3085

Sorry for the inconvenience, I made some unexpected operations of the branch of PR 3085 in my local git, and it is hard to recover... So please help to review this PR 3098, previous PR 3085 is closed by me.