### PR TITLE
add 2 more oesign cases on config check:debug_out_of_range and lowercase_debug_property

### DIFF
--- a/tests/tools/oesign/test-inputs/CMakeLists.txt
+++ b/tests/tools/oesign/test-inputs/CMakeLists.txt
@@ -8,9 +8,13 @@
 # added to the test-inputs source folder and copied to the binary output
 # folder on build.
 add_custom_command(
-  OUTPUT duplicate_debug.conf duplicate_num_heap_pages.conf
-         duplicate_num_stack_pages.conf duplicate_num_tcs.conf
-         duplicate_product_id.conf duplicate_security_version.conf
+  OUTPUT duplicate_debug.conf
+         duplicate_num_heap_pages.conf
+         duplicate_num_stack_pages.conf
+         duplicate_num_tcs.conf
+         duplicate_product_id.conf
+         duplicate_security_version.conf
+         lowercase_debug_property.conf
   COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}
           ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -33,6 +37,12 @@ add_custom_command(
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
   COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file non_debug.conf --debug 0)
+
+add_custom_command(
+  OUTPUT debug_out_of_range.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+          --config_file debug_out_of_range.conf --debug 333)
 
 add_custom_command(
   OUTPUT more_num_heap_pages.conf
@@ -77,6 +87,8 @@ add_custom_target(
           duplicate_num_tcs.conf
           duplicate_product_id.conf
           duplicate_security_version.conf
+          lowercase_debug_property.conf
+          debug_out_of_range.conf
           empty.conf
           more_num_heap_pages.conf
           more_num_stack_pages.conf

--- a/tests/tools/oesign/test-inputs/lowercase_debug_property.conf
+++ b/tests/tools/oesign/test-inputs/lowercase_debug_property.conf
@@ -1,0 +1,12 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# Enclave settings:
+# invalid syntax - "debug"
+
+debug=1      #should be Debug=1
+NumHeapPages=1024
+NumStackPages=1024
+NumTCS=1
+ProductID=1
+SecurityVersion=1

--- a/tests/tools/oesign/test-sign/CMakeLists.txt
+++ b/tests/tools/oesign/test-sign/CMakeLists.txt
@@ -180,3 +180,26 @@ set_tests_properties(
   PROPERTIES
     PASS_REGULAR_EXPRESSION
     "ERROR: Invalid enclave property value: header.size_settings.num_tcs")
+
+# Test invalid config file with invalid debug value specified
+add_test(
+  NAME tests/oesign-sign-debug-out-of-range
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/debug_out_of_range.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-debug-out-of-range
+  PROPERTIES PASS_REGULAR_EXPRESSION "'Debug' value must be 0 or 1")
+
+# Test invalid config file with invalid syntax "Debug" --> "debug"
+add_test(
+  NAME tests/oesign-sign-lowercase-debug-property
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/lowercase_debug_property.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(tests/oesign-sign-lowercase-debug-property
+                     PROPERTIES PASS_REGULAR_EXPRESSION "unknown setting")


### PR DESCRIPTION
Signed-off-by: Xiangping Ji <xiangping.ji@intel.com>
another 3 negative test on config file check:
1. invalid debug value in config file
2. 2 syntax check: duplicated fields and invalid field "Debug" as "debug"