### PR TITLE
Fix regression on tests with LVI mitigation and a bug in the compiler detection

### DIFF
--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -317,7 +317,7 @@ try{
                 "ACC1604 gcc Debug LVI":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
                 "ACC1604 gcc Release LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
                 "ACC1804 clang-7 Debug LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 clang-7 Release LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 clang-7 Release LVI FULL Tests": { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
                 "ACC1804 gcc Debug LVI":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
                 "ACC1804 gcc Release LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
 

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -136,7 +136,7 @@ try{
                 "Win2019 Ubuntu1804 clang-7 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow', 'ON') },
                 "Win2019 Sim Release Cross Compile LVI ":                 { windowsCrossCompile('acc-win2019', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
                 "Win2019 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
-                "Win2019 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow', '0', 'ON') }
+                "Win2019 Release Cross Compile DCAP LVI FULL Tests":      { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow') }
             ]
             parallel testing_stages
         }

--- a/cmake/configure_lvi_mitigation_build.cmake
+++ b/cmake/configure_lvi_mitigation_build.cmake
@@ -13,29 +13,28 @@ macro (detect_compiler BINDIR CC)
   set(COMPILER "${CC}_COMPILER")
 
   # Use the second level of unwrapping on COMPILER to get the compiler name.
-  # If the default compiler is found, return.
-  if (EXISTS "${BINDIR}/${${COMPILER}}")
-    return()
-  endif ()
-
-  if (NOT OE_IN_PACKAGE)
-    # Build OE. Fallback to gcc/g++.
-    set(${COMPILER} ${GCC})
-  else ()
-    # Build enclave applications. Try to search newer versions of clang/clang++.
-    # Be consistent to the logic implemented by samples/config.mk.
-    foreach (VERSION 9 8 7)
-      set(CLANG_VERSION "")
-      if (EXISTS "${BINDIR}/${${COMPILER}}-${VERSION}")
-        set(CLANG_VERSION ${VERSION})
-        break()
-      endif ()
-    endforeach ()
-    # Set the compiler if a version of clang/clang++ is found.
-    if (CLANG_VERSION)
-      set(${COMPILER} ${CLANG}-${CLANG_VERSION})
-    else ()
+  # If the default compiler is not found, use the following logic to detect
+  # the compiler.
+  if (NOT EXISTS "${BINDIR}/${${COMPILER}}")
+    if (NOT OE_IN_PACKAGE)
+      # Build OE. Fallback to gcc/g++.
       set(${COMPILER} ${GCC})
+    else ()
+      # Build enclave applications. Try to search newer versions of clang/clang++.
+      # Be consistent to the logic implemented by samples/config.mk.
+      foreach (VERSION 9 8 7)
+        set(CLANG_VERSION "")
+        if (EXISTS "${BINDIR}/${${COMPILER}}-${VERSION}")
+          set(CLANG_VERSION ${VERSION})
+          break()
+        endif ()
+      endforeach ()
+      # Set the compiler if a version of clang/clang++ is found.
+      if (CLANG_VERSION)
+        set(${COMPILER} ${CLANG}-${CLANG_VERSION})
+      else ()
+        set(${COMPILER} ${GCC})
+      endif ()
     endif ()
   endif ()
 endmacro ()

--- a/tests/snmalloc/enc/CMakeLists.txt
+++ b/tests/snmalloc/enc/CMakeLists.txt
@@ -10,7 +10,7 @@ add_custom_command(
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
     --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_library(snmalloc_test_lib $<TARGET_OBJECTS:oesnmalloc>)
+add_enclave_library(snmalloc_test_lib $<TARGET_OBJECTS:oesnmalloc>)
 
 add_enclave(
   TARGET
@@ -41,9 +41,8 @@ enclave_link_libraries(snmalloc_enc_link_error oelibc)
 
 # Exclude the enclave from build.
 # From: https://stackoverflow.com/questions/30155619/expected-build-failure-tests-in-cmake
-set_target_properties(
-  snmalloc_enc_link_error PROPERTIES EXCLUDE_FROM_ALL TRUE
-                                     EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+set_enclave_properties(snmalloc_enc_link_error PROPERTIES EXCLUDE_FROM_ALL TRUE
+                       EXCLUDE_FROM_DEFAULT_BUILD TRUE)
 
 add_test(
   NAME pluggable_allocators_expected_multiple_definition_error


### PR DESCRIPTION
This PR fixes the test regression with LVI mitigation. The cause is that we didn't correctly exclude the lvi target that causes the link-time errors.

Also, fixing a bug in the compiler detection when enabling LVI mitigation.
The bug causes the build system fallbacks to use the system installed compiler instead of wrappers when `CC` is not specified.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>