### PR TITLE
Disable child_process_destroy test.

### DIFF
--- a/tests/child_process/CMakeLists.txt
+++ b/tests/child_process/CMakeLists.txt
@@ -9,7 +9,10 @@ endif ()
 
 add_enclave_test(tests/child_process_ecall child_process_host child_process_enc
                  0)
-add_enclave_test(tests/child_process_destroy child_process_host
-                 child_process_enc 1)
+
+# Disabling until #3099 is addressed.
+#add_enclave_test(tests/child_process_destroy child_process_host
+#                 child_process_enc 1)
+
 add_enclave_test(tests/child_process_create child_process_host
                  child_process_enc 2)


### PR DESCRIPTION
This test fails sporadically in CI.
Issue 3099 captures the investigation.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>