### PR TITLE
Add retry logic during dependencies installation

### DIFF
--- a/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
+++ b/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
@@ -6,14 +6,23 @@
   apt:
     name: apt-transport-https
     state: latest
+  retries: 10
+  register: add_transport
+  until: add_transport is success
 
 - name: Add APT repository key
   apt_key:
     url: "{{ apt_key_url }}"
     state: present
+  retries: 10
+  register: add_key
+  until: add_key is success
 
 - name: Add APT repository
   apt_repository:
     repo: "{{ apt_repository }}"
     state: present
     update_cache: yes
+  retries: 10
+  register: add_repo
+  until: add_repo is success

--- a/scripts/ansible/roles/linux/intel/tasks/redhat/sgx-packages-install.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/redhat/sgx-packages-install.yml
@@ -6,6 +6,9 @@
   yum:
     name: "{{ intel_sgx_package_dependencies }}"
     state: latest
+  retries: 10
+  register: install_sgx_dependencies
+  until: install_sgx_dependencies is success
 
 - name: Create Intel SGX directory
   file:
@@ -17,7 +20,7 @@
     url: "{{ intel_sgx_rpm_repo_tgz_url }}"
     dest: "/tmp/sgx_rpm_local_repo.tgz"
     timeout: 120
-  retries: 3
+  retries: 5
 
 - name: Unarchive Intel SGX local rpm repo tgz
   unarchive:
@@ -37,12 +40,18 @@
   yum:
     name: "{{ intel_sgx_packages }}"
     state: latest
+  retries: 10
+  register: install_sgx
+  until: install_sgx is success
 
 - name: Install the Intel DCAP packages
   yum:
     name: "{{ intel_dcap_packages }}"
     state: latest
   when: flc_enabled|bool
+  retries: 10
+  register: install_dcap
+  until: install_dcap is success
 
 - name: Cleanup installation
   file:

--- a/scripts/ansible/roles/linux/openenclave/tasks/redhat/packages-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/redhat/packages-install.yml
@@ -13,6 +13,9 @@
   yum:
     name: "{{ yum_packages }}"
     state: latest
+  retries: 10
+  register: install
+  until: install is success
 
 - name: Download ShellCheck tar.xz archive
   get_url:

--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
@@ -22,3 +22,6 @@
     state: latest
     update_cache: yes
     install_recommends: no
+  retries: 10
+  register: install
+  until: install is success


### PR DESCRIPTION
Issue #3101

Automated builds were failing, among other reasons, due to dependencies installation. Based on investigations failures were not linked to one problem, which include, but are not limited to issues connecting to the repositories, or package installation lock issues.

Adding retry logic might not be the most elegant solution, but it should help mitigate false negative builds.

Signed-off-by: Rob Sanchez <rosan@microsoft.com>