### PR TITLE
Fix spurious warning about a buffer being to small

### DIFF
--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -103,11 +103,17 @@ oe_result_t oe_sgx_get_supported_attester_format_ids(
         OE_RAISE(OE_INVALID_PARAMETER);
 
     // Case when DCAP is used
-    if (!format_ids || *format_ids_size < sizeof(oe_uuid_t))
+    if (!format_ids && *format_ids_size == 0)
     {
         *format_ids_size = sizeof(oe_uuid_t);
         return OE_BUFFER_TOO_SMALL;
     }
+    else if (!format_ids || *format_ids_size < sizeof(oe_uuid_t))
+    {
+        *format_ids_size = sizeof(oe_uuid_t);
+        OE_RAISE(OE_BUFFER_TOO_SMALL);
+    }
+
     memcpy(format_ids, &_ecdsa_uuid, sizeof(oe_uuid_t));
     *format_ids_size = sizeof(oe_uuid_t);
 

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -106,7 +106,7 @@ oe_result_t oe_sgx_get_supported_attester_format_ids(
     if (!format_ids || *format_ids_size < sizeof(oe_uuid_t))
     {
         *format_ids_size = sizeof(oe_uuid_t);
-        OE_RAISE(OE_BUFFER_TOO_SMALL);
+        return OE_BUFFER_TOO_SMALL;
     }
     memcpy(format_ids, &_ecdsa_uuid, sizeof(oe_uuid_t));
     *format_ids_size = sizeof(oe_uuid_t);


### PR DESCRIPTION
In `oe_sgx_get_supported_attester_format_ids` OE complains that a buffer is too small in trace/debug output, while this is completely expected (the size being 0 is used to indicate that the required buffer size should be computed). This had some of us confused as it starting showing up in unrelated test runs. 