### PR TITLE
Move EEID attester plugin and install headers

### DIFF
--- a/common/sgx/eeid_verifier.c
+++ b/common/sgx/eeid_verifier.c
@@ -12,6 +12,7 @@
 #include "../../host/memalign.h"
 #endif
 
+#include <openenclave/attestation/sgx/eeid_plugin.h>
 #include <openenclave/attestation/sgx/eeid_verifier.h>
 #include <openenclave/bits/attestation.h>
 #include <openenclave/bits/eeid.h>
@@ -20,7 +21,6 @@
 #include <openenclave/internal/plugin.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/report.h>
-#include <openenclave/internal/sgx/eeid_plugin.h>
 #include <openenclave/internal/sgx/plugin.h>
 #include <openenclave/internal/trace.h>
 

--- a/enclave/sgx/eeid_attester.c
+++ b/enclave/sgx/eeid_attester.c
@@ -9,6 +9,7 @@
 #include <openenclave/enclave.h>
 
 #include <openenclave/attestation/sgx/eeid_attester.h>
+#include <openenclave/attestation/sgx/eeid_plugin.h>
 #include <openenclave/bits/attestation.h>
 #include <openenclave/bits/eeid.h>
 #include <openenclave/bits/sgx/sgxtypes.h>
@@ -18,7 +19,6 @@
 #include <openenclave/internal/plugin.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/report.h>
-#include <openenclave/internal/sgx/eeid_plugin.h>
 #include <openenclave/internal/sgx/plugin.h>
 #include <openenclave/internal/trace.h>
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -25,6 +25,9 @@ install(
   COMPONENT OEHOSTVERIFY)
 install(FILES openenclave/attestation/attester.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/attestation/)
+install(FILES openenclave/attestation/sgx/eeid_attester.h
+              openenclave/attestation/sgx/eeid_plugin.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/attestation/sgx)
 install(
   FILES openenclave/attestation/verifier.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/attestation/

--- a/include/openenclave/attestation/sgx/eeid_plugin.h
+++ b/include/openenclave/attestation/sgx/eeid_plugin.h
@@ -1,13 +1,10 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-// This file provides an implementation of EEID attester and verifier plugins.
+// This file provides the UUID of the EEID attester and verifier plugins.
 
 #ifndef _OE_EEID_UUID_H
 #define _OE_EEID_UUID_H
-
-#include <openenclave/internal/plugin.h>
-#include <openenclave/internal/sgx/plugin.h>
 
 #define OE_FORMAT_UUID_SGX_EEID_ECDSA_P256                                \
     {                                                                     \


### PR DESCRIPTION
For an enclave to get EEID attestation evidence, it explicitly needs to register the EEID attester and it needs to know the EEID plugin UUID. To expose those, I moved the corresponding header files and added them to the installation target. 

I'm not sure this is the intended way for enclaves to use an attestation plugin. I think we definitely need the plugin UUID in a public header, but should the other headers remain private/internal and the plugin infrastructure would automatically register the plugin corresponding to the UUID?