### PR TITLE
Fix the bug of using weak_alias between static and public functions on windows

### DIFF
--- a/host/sgx/switchless.c
+++ b/host/sgx/switchless.c
@@ -24,6 +24,20 @@
  */
 #define OE_ENCLAVE_WORKER_SPIN_COUNT_THRESHOLD (4096U)
 
+/**
+ * Declare the protoype of the following functions to avoid missing-prototypes
+ * warning.
+ */
+OE_UNUSED_FUNC oe_result_t _oe_sgx_init_context_switchless_ecall(
+    oe_enclave_t* enclave,
+    oe_result_t* _retval,
+    oe_host_worker_context_t* host_worker_contexts,
+    uint64_t num_host_workers);
+
+OE_UNUSED_FUNC oe_result_t _oe_sgx_switchless_enclave_worker_thread_ecall(
+    oe_enclave_t* enclave,
+    oe_enclave_worker_context_t* context);
+
 /*
 ** The thread function that handles switchless ocalls
 **
@@ -443,7 +457,7 @@ oe_result_t oe_switchless_call_enclave_function(
 /*
  * Stubs for switchless.edl ecalls if they are not included in EDL
  */
-OE_UNUSED_FUNC static oe_result_t _oe_sgx_init_context_switchless_ecall(
+OE_UNUSED_FUNC oe_result_t _oe_sgx_init_context_switchless_ecall(
     oe_enclave_t* enclave,
     oe_result_t* _retval,
     oe_host_worker_context_t* host_worker_contexts,
@@ -456,8 +470,7 @@ OE_UNUSED_FUNC static oe_result_t _oe_sgx_init_context_switchless_ecall(
     return OE_UNSUPPORTED;
 }
 
-OE_UNUSED_FUNC static oe_result_t
-_oe_sgx_switchless_enclave_worker_thread_ecall(
+OE_UNUSED_FUNC oe_result_t _oe_sgx_switchless_enclave_worker_thread_ecall(
     oe_enclave_t* enclave,
     oe_enclave_worker_context_t* context)
 {


### PR DESCRIPTION
On windows, the two functions being weak_aliased (i.e., using `/alternatename`) need to have the same visibility (i.e., both are static or public). However, we currently apply the weak_alias between a static function and a public function. This causes a link-time error when the public function is not defined.

To clarify, see the following examples:
```
// foo_internal.c
static _foo () {...}
OE_WEAK(_foo, foo);
```
```
// foo.c
foo() {...}
```
---> Work fine. The `foo` defined in foo.c will be used.

However, if only `foo_internal.c` is used, there will be a link-time error as the `_foo` can not be used as a public function.


Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>