### PR TITLE
Clean up oesign python test scripts

### DIFF
--- a/tests/tools/oesign/sign-and-verify.py
+++ b/tests/tools/oesign/sign-and-verify.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 def call_subprocess(cmd, success_message):
-    retval = subprocess.call(cmd, shell=True)
+    retval = subprocess.call(cmd)
     if retval != 0:
         print("FAIL: (error:{}) {}".format(retval, cmd))
         sys.exit(retval)
@@ -17,36 +17,39 @@ def call_subprocess(cmd, success_message):
 if __name__ == "__main__":
 
     arg_parser = argparse.ArgumentParser(description="Invokes the oesign sign command and attempts to load the signed enclave")
-    arg_parser.add_argument('--oesign-path', default=None, type=str, help="Path to the oesign tool")
-    arg_parser.add_argument('--oesign-args', default=None, type=str, help="Additional arguments to be passed to oesign")
-    arg_parser.add_argument('--enclave-path', default=None, type=str, help="Path to the enclave binary to be signed")
-    arg_parser.add_argument('--host-path', default=None, type=str, help="Path to the enclave host app used to launch the enclave")
+    arg_parser.add_argument('--oesign-path', default=None, type=str, required=True, help="Path to the oesign tool")
+    arg_parser.add_argument('--oesign-args', default=None, type=str, required=True, help="Additional arguments to be passed to oesign")
+    arg_parser.add_argument('--enclave-path', default=None, type=str, required=True, help="Path to the enclave binary to be signed")
+    arg_parser.add_argument('--host-path', default=None, type=str, required=True, help="Path to the enclave host app used to launch the enclave")
     arg_parser.add_argument('--digest-args', default=None, type=str, help="Optional. If provided, sign-and-verify.py will call the oesign digest command with the provided arguments before all other operations.")
     arg_parser.add_argument('--pkeyutl-args', default=None, type=str, help="Optional. If provided, sign-and-verify.py will call openssl pkeyutl after digest creation and before oesign. This should specify the input digest, output signature file name and key to use to sign a digest.")
 
     args = arg_parser.parse_args()
     print("Arguments parsed: {}".format(args))
 
-    if not args.enclave_path or \
-       not args.host_path or \
-       not args.oesign_args or \
-       not args.oesign_path:
-
-        arg_parser.print_help()
-        sys.exit(1)
+    # Note that the arguments that take multiple values use a string format `[a,b,...]` that are parsed out
+    # into lists separately with strip and split operations. While argparse supports taking variable nargs, it doesn't like
+    # taking argument values that look like argument names (begin with '-' or '--') which is what we pass into this function.
+    # This script expects the argument list strings in brackets to avoid this interaction with argparse, and extends the
+    # basic argument list with the parsed list of arguments. While it's preferable to use the * operator for the list
+    # concatenation, it's only available on Python 3.6+ and that's not a currently stated OE SDK requirement on Ubuntu.
 
     if args.digest_args:
-        digest_cmd = "{} digest --enclave {} {}".format(args.oesign_path, args.enclave_path, args.digest_args)
+        digest_cmd = [args.oesign_path, "digest", "--enclave-image", args.enclave_path]
+        digest_cmd.extend(args.digest_args.strip('[]').split(','))
+        print("digest_cmd = {}".format(digest_cmd))
         call_subprocess(digest_cmd, "Digest succeeded")
 
     if args.pkeyutl_args:
-        sign_digest_cmd = "openssl pkeyutl -sign -pkeyopt digest:sha256 {}".format(args.pkeyutl_args)
+        sign_digest_cmd = ["openssl", "pkeyutl", "-sign", "-pkeyopt", "digest:sha256"]
+        sign_digest_cmd.extend(args.pkeyutl_args.strip('[]').split(','))
         call_subprocess(sign_digest_cmd, "Signing of digest succeeded")
 
-    sign_cmd = "{} sign --enclave {} {}".format(args.oesign_path, args.enclave_path, args.oesign_args)
+    sign_cmd = [args.oesign_path, "sign", "--enclave-image", args.enclave_path]
+    sign_cmd.extend(args.oesign_args.strip('[]').split(','))
     call_subprocess(sign_cmd, "Sign succeeded")
 
-    launch_cmd = "{} {}.signed".format(args.host_path, args.enclave_path)
+    launch_cmd = [args.host_path, "{}.signed".format(args.enclave_path)]
     call_subprocess(launch_cmd, "Launch of signed enclave succeeded")
 
     sys.exit(0)

--- a/tests/tools/oesign/test-digest/CMakeLists.txt
+++ b/tests/tools/oesign/test-digest/CMakeLists.txt
@@ -21,14 +21,13 @@ add_custom_target(
 
 # Test digest sign commands with valid short form of arguments succeed
 set(OESIGN_PKEYUTL_ARGS
-    "-in oesign_test_enc.digest -inkey ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem -keyform PEM -out oesign_test_enc.digest.sig"
+    "[-in,oesign_test_enc.digest,-inkey,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem,-keyform,PEM,-out,oesign_test_enc.digest.sig]"
 )
-
 set(OESIGN_SIGN_VALID_SHORT_ARGS
-    "-c ${OESIGN_TEST_INPUTS_DIR}/valid.conf -d oesign_test_enc.digest.sig -x ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem"
+    "[-c,${OESIGN_TEST_INPUTS_DIR}/valid.conf,-d,oesign_test_enc.digest.sig,-x,${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem]"
 )
 set(OESIGN_DIGEST_VALID_SHORT_ARGS
-    "-c ${OESIGN_TEST_INPUTS_DIR}/valid.conf -d oesign_test_enc.digest")
+    "[-c,${OESIGN_TEST_INPUTS_DIR}/valid.conf,-d,oesign_test_enc.digest]")
 
 add_test(
   NAME tests/oesign-digest-valid-short-args
@@ -45,10 +44,10 @@ set_tests_properties(
 
 # Test digest sign commands with valid long form of arguments succeed
 set(OESIGN_SIGN_VALID_LONG_ARGS
-    "--config-file ${OESIGN_TEST_INPUTS_DIR}/valid.conf --digest-signature oesign_test_enc.digest.sig --x509 ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem"
+    "[--config-file,${OESIGN_TEST_INPUTS_DIR}/valid.conf,--digest-signature,oesign_test_enc.digest.sig,--x509,${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem]"
 )
 set(OESIGN_DIGEST_VALID_LONG_ARGS
-    "--config-file ${OESIGN_TEST_INPUTS_DIR}/valid.conf --digest-file oesign_test_enc.digest"
+    "[--config-file,${OESIGN_TEST_INPUTS_DIR}/valid.conf,--digest-file,oesign_test_enc.digest]"
 )
 
 add_test(
@@ -66,14 +65,13 @@ set_tests_properties(
 
 # Test digest sign commands without --config-file (-c) argument on preconfigured enclave succeeds
 set(OESIGN_PKEYUTL_DEV_CONFIG_ARGS
-    "-in oesign_test_alt_enc.digest -inkey ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem -keyform PEM -out oesign_test_alt_enc.digest.sig"
+    "[-in,oesign_test_alt_enc.digest,-inkey,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem,-keyform,PEM,-out,oesign_test_alt_enc.digest.sig]"
 )
-
 set(OESIGN_SIGN_VALID_DEV_CONFIG_ARGS
-    "--digest-signature oesign_test_alt_enc.digest.sig --x509 ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem"
+    "[--digest-signature,oesign_test_alt_enc.digest.sig,--x509,${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem]"
 )
 set(OESIGN_DIGEST_VALID_DEV_CONFIG_ARGS
-    "--digest-file oesign_test_alt_enc.digest")
+    "[--digest-file,oesign_test_alt_enc.digest]")
 
 add_test(
   NAME tests/oesign-digest-valid-dev-config-args

--- a/tests/tools/oesign/test-engine/CMakeLists.txt
+++ b/tests/tools/oesign/test-engine/CMakeLists.txt
@@ -25,7 +25,7 @@ add_custom_target(
 
 # Test oesign succeeds with valid short form of engine signing parameters
 set(OESIGN_ENGINE_VALID_SHORT_ARGS
-    "-c ${OESIGN_TEST_INPUTS_DIR}/valid.conf -n oesign-test-engine -p $<TARGET_FILE:oesign_test_engine> -i ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem"
+    "[-c,${OESIGN_TEST_INPUTS_DIR}/valid.conf,-n,oesign-test-engine,-p,$<TARGET_FILE:oesign_test_engine>,-i,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem]"
 )
 
 add_test(
@@ -41,7 +41,7 @@ set_tests_properties(
 
 # Test oesign succeeds with valid long form of engine signing parameters
 set(OESIGN_ENGINE_VALID_LONG_ARGS
-    "--config-file ${OESIGN_TEST_INPUTS_DIR}/valid.conf --engine oesign-test-engine --load-path $<TARGET_FILE:oesign_test_engine> --key-id ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem"
+    "[--config-file,${OESIGN_TEST_INPUTS_DIR}/valid.conf,--engine,oesign-test-engine,--load-path,$<TARGET_FILE:oesign_test_engine>,--key-id,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem]"
 )
 
 add_test(

--- a/tests/tools/oesign/test-inputs/make-oesign-config.py
+++ b/tests/tools/oesign/test-inputs/make-oesign-config.py
@@ -8,7 +8,7 @@ import argparse
 if __name__ == "__main__":
 
     arg_parser = argparse.ArgumentParser(description="Generates oesign config file variations from a basic valid template")
-    arg_parser.add_argument('--config_file', default=None, type=str, help="Full path to output the generated oesign config file to.")
+    arg_parser.add_argument('--config_file', default=None, type=str, required=True, help="Full path to output the generated oesign config file to.")
     arg_parser.add_argument('--debug', default="1", type=str, help="Value for the Debug property. Defaults to 1 (true).")
     arg_parser.add_argument('--num_heap_pages', default="1024", type=str, help="Value for the NumHeapPages property. Defaults to 1024.")
     arg_parser.add_argument('--num_stack_pages', default="1024", type=str, help="Value for the NumStackPages property. Defaults to 1024.")
@@ -17,11 +17,6 @@ if __name__ == "__main__":
     arg_parser.add_argument('--security_version', default="1", type=str, help="Value for the SecurityVersion property. Defaults to 1.")
 
     args = arg_parser.parse_args()
-
-    if not args.config_file:
-        arg_parser.print_help()
-        sys.exit(1)
-
     print("Generating {} ...".format(args.config_file))
     print("Configuration used: {}".format(args))
 

--- a/tests/tools/oesign/test-sign/CMakeLists.txt
+++ b/tests/tools/oesign/test-sign/CMakeLists.txt
@@ -16,7 +16,7 @@ add_custom_target(
 
 # Test oesign succeeds with valid short form of engine signing parameters
 set(OESIGN_SIGN_VALID_SHORT_ARGS
-    "-c ${OESIGN_TEST_INPUTS_DIR}/valid.conf -k ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem"
+    "[-c,${OESIGN_TEST_INPUTS_DIR}/valid.conf,-k,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem]"
 )
 
 add_test(
@@ -32,7 +32,7 @@ set_tests_properties(
 
 # Test oesign succeeds with valid long form of engine signing parameters
 set(OESIGN_SIGN_VALID_LONG_ARGS
-    "--config-file ${OESIGN_TEST_INPUTS_DIR}/valid.conf --key-file ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem"
+    "[--config-file,${OESIGN_TEST_INPUTS_DIR}/valid.conf,--key-file,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem]"
 )
 
 add_test(


### PR DESCRIPTION
- Per comments in PR #3128, update sign-and-verify.py to pass a list
  of arguments into `subprocess.call()` instead of a formatted string
  and remove the use of the `shell=True` option.
  - Update the callers of sign-and-verify.py to pass in argument lists.
- Mark appropriate arguments in sign-and-verify.py and
  make-oesign-config.py as `required=True` instead of manually checking
  for missing arguments and failing the scripts.

Signed-off-by: Simon Leet <simon.leet@microsoft.com>