### PR TITLE
Fix memory allocator intialization with EEID

### DIFF
--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -159,6 +159,10 @@ static oe_result_t _eeid_patch_memory()
 
         // Wipe the marker page
         memset(heap_base, 0, OE_PAGE_SIZE);
+
+        // Re-initialize the memory allocator with updated heap size
+        oe_allocator_init(
+            (void*)__oe_get_heap_base(), (void*)__oe_get_heap_end());
     }
 
     return r;


### PR DESCRIPTION
This fixes the memory allocator heap size during enclave initialization. @anakrish: the recent sn/dlmalloc changes had the effect that dlmalloc always failed in EEID enclaves, because it thought there is 0 heap. This would not be necessary if the allocator would be initialized after `_eeid_patch_memory`, but I'm not sure whether that's feasible/desired.

CC @jhand2 

Signed-off-by: Christoph M. Wintersteiger <cwinter@microsoft.com>