### PR TITLE
Update the url of Intel SGX DEB key

### DIFF
--- a/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md
@@ -62,7 +62,7 @@ echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu xenial 
 
 Add the key to the list of trusted keys used by the apt to authenticate packages:
 ```bash
-wget -qO - https://download.01.org/intelsgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
 ```
 
 Update the apt


### PR DESCRIPTION
Hi all,

I am trying to set up the development environment for OE SDK. I follow the instruction in the document in https://github.com/openenclave/openenclave/blob/582b4dcbdb49d32b132454c2be0be480bc76c59c/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md

It looks like the URL of Intel SGX DEB key in the document is outdated. I update the URL and it works on my own machine.  