### PR TITLE
Use the assembly versions of memcpy/memset/memmove on sgx build

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -75,6 +75,9 @@ if (OE_SGX)
   list(
     APPEND
     PLATFORM_SRC
+    ${MUSL_SRC_DIR}/string/x86_64/memcpy.s
+    ${MUSL_SRC_DIR}/string/x86_64/memmove.s
+    ${MUSL_SRC_DIR}/string/x86_64/memset.s
     ../../common/sgx/endorsements.c
     ../../common/sgx/rand.S
     sgx/arena.c
@@ -112,10 +115,27 @@ if (OE_SGX)
   set_source_files_properties(sgx/td_basic.c PROPERTIES COMPILE_FLAGS
                                                         -fno-stack-protector)
 
+  # To avoid the `unused-command-line-argument` warning, which we treat as an
+  # error, we explicitly turn off the warning when compiling these assembly
+  # files.
+  list(
+    APPEND
+    W_NO_UNUSED_COMMAND_LINE_ARGUMENT
+    ${MUSL_SRC_DIR}/string/x86_64/memcpy.s
+    ${MUSL_SRC_DIR}/string/x86_64/memmove.s
+    ${MUSL_SRC_DIR}/string/x86_64/memset.s)
+
+  set_property(
+    SOURCE ${W_NO_UNUSED_COMMAND_LINE_ARGUMENT}
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS "-Wno-error=unused-command-line-argument")
 elseif (OE_TRUSTZONE)
   list(
     APPEND
     PLATFORM_SRC
+    ${MUSL_SRC_DIR}/string/memcpy.c
+    ${MUSL_SRC_DIR}/string/memmove.c
+    ${MUSL_SRC_DIR}/string/memset.c
     optee/backtrace.c
     optee/bounds.c
     optee/calls.c
@@ -133,6 +153,12 @@ elseif (OE_TRUSTZONE)
     optee/stubs.c
     optee/thread.c
     optee/tracee.c)
+
+  list(APPEND NEEDS_STDC_NAMES ${MUSL_SRC_DIR}/string/memmove.c
+       ${MUSL_SRC_DIR}/string/memset.c ${MUSL_SRC_DIR}/string/memcpy.c)
+
+  list(APPEND W_NO_CONVERSION ${MUSL_SRC_DIR}/string/memmove.c
+       ${MUSL_SRC_DIR}/string/memset.c)
 endif ()
 
 if (OE_TRUSTZONE OR (OE_SGX AND (UNIX OR USE_CLANGW)))
@@ -152,9 +178,6 @@ add_enclave_library(
   ../../common/argv.c
   ${MUSL_SRC_DIR}/prng/rand.c
   ${MUSL_SRC_DIR}/string/memcmp.c
-  ${MUSL_SRC_DIR}/string/memcpy.c
-  ${MUSL_SRC_DIR}/string/memmove.c
-  ${MUSL_SRC_DIR}/string/memset.c
   __stack_chk_fail.c
   assert.c
   atexit.c
@@ -187,24 +210,13 @@ add_enclave_library(
 # Additionally, suppress type conversion warnings introduced by 3rdparty code
 set(CORELIBC_INCLUDES ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 
-list(
-  APPEND
-  NEEDS_STDC_NAMES
-  ${MUSL_SRC_DIR}/prng/rand.c
-  ${MUSL_SRC_DIR}/string/memmove.c
-  ${MUSL_SRC_DIR}/string/memset.c
-  ${MUSL_SRC_DIR}/string/memcmp.c
-  ${MUSL_SRC_DIR}/string/memcpy.c
-  debugmalloc.c
-  strtok_r.c)
+list(APPEND NEEDS_STDC_NAMES ${MUSL_SRC_DIR}/prng/rand.c
+     ${MUSL_SRC_DIR}/string/memcmp.c debugmalloc.c strtok_r.c)
 
-list(APPEND W_NO_CONVERSION ${MUSL_SRC_DIR}/prng/rand.c
-     ${MUSL_SRC_DIR}/string/memmove.c ${MUSL_SRC_DIR}/string/memset.c)
+list(APPEND W_NO_CONVERSION ${MUSL_SRC_DIR}/prng/rand.c)
 
-set_property(
-  SOURCE ${W_NO_CONVERSION}
-  APPEND_STRING
-  PROPERTY COMPILE_FLAGS " -Wno-conversion")
+set_property(SOURCE ${W_NO_CONVERSION} APPEND_STRING PROPERTY COMPILE_FLAGS
+                                                              "-Wno-conversion")
 
 set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND_STRING
              PROPERTY COMPILE_FLAGS " -I${CORELIBC_INCLUDES}")

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -21,7 +21,10 @@ if (OE_SGX)
     ${MUSLSRC}/math/x86_64/sqrtl.s
     ${MUSLSRC}/math/x86_64/sqrtf.s
     ${MUSLSRC}/setjmp/x86_64/longjmp.s
-    ${MUSLSRC}/setjmp/x86_64/setjmp.s)
+    ${MUSLSRC}/setjmp/x86_64/setjmp.s
+    ${MUSLSRC}/string/x86_64/memcpy.s
+    ${MUSLSRC}/string/x86_64/memmove.s
+    ${MUSLSRC}/string/x86_64/memset.s)
 elseif (OE_TRUSTZONE)
   add_enclave_library(
     oelibasm
@@ -49,8 +52,14 @@ set(PLATFORM_SRC "")
 if (OE_SGX)
   list(APPEND PLATFORM_SRC sgx/arc4random.c)
 else ()
-  list(APPEND PLATFORM_SRC ${MUSLSRC}/math/exp2l.c optee/abort.c
-       optee/arc4random.c optee/trace.c)
+  list(APPEND PLATFORM_SRC
+    ${MUSLSRC}/math/exp2l.c
+    ${MUSLSRC}/string/memcpy.c
+    ${MUSLSRC}/string/memmove.c
+    ${MUSLSRC}/string/memset.c
+    optee/abort.c
+    optee/arc4random.c
+    optee/trace.c)
 endif ()
 
 add_enclave_library(
@@ -677,12 +686,9 @@ add_enclave_library(
   ${MUSLSRC}/string/memccpy.c
   ${MUSLSRC}/string/memchr.c
   ${MUSLSRC}/string/memcmp.c
-  ${MUSLSRC}/string/memcpy.c
   ${MUSLSRC}/string/memmem.c
-  ${MUSLSRC}/string/memmove.c
   ${MUSLSRC}/string/mempcpy.c
   ${MUSLSRC}/string/memrchr.c
-  ${MUSLSRC}/string/memset.c
   ${MUSLSRC}/string/rindex.c
   ${MUSLSRC}/string/stpcpy.c
   ${MUSLSRC}/string/stpncpy.c


### PR DESCRIPTION
We originally use the platform-independent versions of memcpy/memset/memmove from MUSL (see [here](https://github.com/openenclave/openenclave/tree/master/3rdparty/musl/musl/src/string) for the files). For better performance, this PR switches the SGX build to use the assembly versions of them (under x86_64 folder). This also aligns with MUSL when it's built on x86_64 platform. Note that  the optee build will still use the platform-independent versions.

Some number for the reference:

Running an ecall that does memcpy on two 64000-byte buffers.
Using the platform-independent version of `memcpy` (w/ -O3): 37596.45 cycle
Using the assembly version of `memcpy`: 25541.41 cycle

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>