### PR TITLE
Add vectored exception handling in simulation mode on Linux

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -282,10 +282,17 @@ if (OE_SGX)
       PLATFORM_SDK_ONLY_SRC
       sgx/linux/aep.S
       sgx/enter.c
+      sgx/exception_sim.c
       sgx/linux/exception.c
       sgx/linux/sgxioctl.c
       sgx/linux/switchless.c
       sgx/linux/xstate.c)
+
+    # Functions in sgx/exception_sim.c will change the fs register and may trigger
+    # stack check fail, thus it is necessary to turn off stack check.
+    set_source_files_properties(sgx/exception_sim.c
+                                PROPERTIES COMPILE_FLAGS -fno-stack-protector)
+
   else ()
     list(APPEND PLATFORM_HOST_ONLY_SRC sgx/windows/sgxquoteproviderloader.c)
 

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -114,6 +114,9 @@ static oe_result_t _enter_sim(
     td = (oe_sgx_td_t*)(enclave->addr + tcs->gsbase);
     td->simulate = true;
 
+    td->host_fsbase = (uint64_t)oe_get_fs_register_base();
+    td->host_gsbase = (uint64_t)oe_get_gs_register_base();
+
     /* Call into enclave */
     if (arg3)
         *arg3 = 0;

--- a/host/sgx/enter.c
+++ b/host/sgx/enter.c
@@ -254,7 +254,9 @@ void oe_enter_sim(
 
         // Define register bindings and initialize the registers.
         // See oe_enter for ENCLU contract.
-        OE_DEFINE_REGISTER(rax, 0 /* CSSA */);
+
+        /* CSSA */
+        OE_DEFINE_REGISTER(rax, ((sgx_tcs_t*)tcs)->cssa);
         OE_DEFINE_REGISTER(rbx, tcs);
         OE_DEFINE_REGISTER(rcx, 0 /* filled in asm snippet */);
         OE_DEFINE_REGISTER(rdx, &ecall_context);

--- a/host/sgx/exception.c
+++ b/host/sgx/exception.c
@@ -58,7 +58,7 @@ uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
         }
         else
         {
-            // Un-handled enclave exception happened.
+            // Unhandled enclave exception happened.
             // We continue the exception handler search as if it were a
             // non-enclave exception.
             return OE_EXCEPTION_CONTINUE_SEARCH;

--- a/host/sgx/exception.h
+++ b/host/sgx/exception.h
@@ -6,6 +6,9 @@
 
 #include <openenclave/bits/types.h>
 #include <openenclave/internal/calls.h>
+#if defined(__linux__)
+#include <ucontext.h>
+#endif
 
 typedef struct _host_exception_context
 {
@@ -19,5 +22,13 @@ void oe_initialize_host_exception(void);
 
 /* Platform neutral exception handler */
 uint64_t oe_host_handle_exception(oe_host_exception_context_t* context);
+
+#if defined(__linux__)
+/* Check if the current enclave is in simulation mode. */
+bool is_simulation(void);
+
+/* Exception handler in simulation mode on Linux. */
+uint64_t oe_host_handle_exception_sim(ucontext_t* context, int sig_num);
+#endif
 
 #endif // _OE_HOST_EXCEPTION_H

--- a/host/sgx/exception_sim.c
+++ b/host/sgx/exception_sim.c
@@ -1,0 +1,220 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/registers.h>
+#include <openenclave/internal/sgx/td.h>
+#include <signal.h>
+#include <ucontext.h>
+#include "enclave.h"
+#include "exception.h"
+
+bool is_simulation(void)
+{
+    // In simulation mode the fs still points to td.
+    oe_sgx_td_t* td = (oe_sgx_td_t*)oe_get_fs_register_base();
+    return (
+        td && td->magic == TD_MAGIC && td->base.self_addr == (uint64_t)td &&
+        td->simulate);
+}
+
+static void _oe_aex_sim(sgx_tcs_t* tcs)
+{
+    // Update cssa as AEX does in real mode.
+    tcs->cssa++;
+
+    // Change the FS/GS segment registers to host side.
+    oe_sgx_td_t* td =
+        (oe_sgx_td_t*)((unsigned char*)tcs + OE_TD_FROM_TCS_BYTE_OFFSET);
+    oe_set_fs_register_base((const void*)(td->host_fsbase));
+    oe_set_gs_register_base((const void*)(td->host_gsbase));
+}
+
+static void _oe_eresume_sim(sgx_tcs_t* tcs)
+{
+    // Update cssa as ERESUME does in real mode.
+    tcs->cssa--;
+
+    // Change the FS/GS segment registers to enclave side.
+    oe_enclave_t* enclave = oe_query_enclave_instance((void*)tcs);
+    uint64_t enclave_start = enclave->addr;
+    uint64_t enclave_fsbase = enclave_start + tcs->fsbase;
+    uint64_t enclave_gsbase = enclave_start + tcs->gsbase;
+    oe_set_fs_register_base((const void*)enclave_fsbase);
+    oe_set_gs_register_base((const void*)enclave_gsbase);
+}
+
+static sgx_ssa_gpr_t* _get_ssa_gpr(sgx_tcs_t* tcs)
+{
+    uint32_t cssa = tcs->cssa;
+    oe_sgx_td_t* td =
+        (oe_sgx_td_t*)((unsigned char*)tcs + OE_TD_FROM_TCS_BYTE_OFFSET);
+    uint64_t ssa_frame_size = td->base.__ssa_frame_size;
+    if (ssa_frame_size == 0)
+    {
+        ssa_frame_size = OE_DEFAULT_SSA_FRAME_SIZE;
+    }
+
+    unsigned char* ssa_base_address =
+        (unsigned char*)tcs + OE_SSA_FROM_TCS_BYTE_OFFSET;
+
+    // cssa always points to the unfilled ssa.
+    return (
+        sgx_ssa_gpr_t*)(ssa_base_address + cssa * ssa_frame_size * OE_PAGE_SIZE - OE_SGX_GPR_BYTE_SIZE);
+}
+
+static void _update_ssa_from_context(ucontext_t* context, sgx_tcs_t* tcs)
+{
+    sgx_ssa_gpr_t* ssa_gpr = _get_ssa_gpr(tcs);
+
+    // Update gpr.
+    ssa_gpr->rax = (uint64_t)(context->uc_mcontext.gregs[REG_RAX]);
+    ssa_gpr->rbx = (uint64_t)(context->uc_mcontext.gregs[REG_RBX]);
+    ssa_gpr->rcx = (uint64_t)(context->uc_mcontext.gregs[REG_RCX]);
+    ssa_gpr->rdx = (uint64_t)(context->uc_mcontext.gregs[REG_RDX]);
+    ssa_gpr->rsp = (uint64_t)(context->uc_mcontext.gregs[REG_RSP]);
+    ssa_gpr->rbp = (uint64_t)(context->uc_mcontext.gregs[REG_RBP]);
+    ssa_gpr->rsi = (uint64_t)(context->uc_mcontext.gregs[REG_RSI]);
+    ssa_gpr->rdi = (uint64_t)(context->uc_mcontext.gregs[REG_RDI]);
+    ssa_gpr->r8 = (uint64_t)(context->uc_mcontext.gregs[REG_R8]);
+    ssa_gpr->r9 = (uint64_t)(context->uc_mcontext.gregs[REG_R9]);
+    ssa_gpr->r10 = (uint64_t)(context->uc_mcontext.gregs[REG_R10]);
+    ssa_gpr->r11 = (uint64_t)(context->uc_mcontext.gregs[REG_R11]);
+    ssa_gpr->r12 = (uint64_t)(context->uc_mcontext.gregs[REG_R12]);
+    ssa_gpr->r13 = (uint64_t)(context->uc_mcontext.gregs[REG_R13]);
+    ssa_gpr->r14 = (uint64_t)(context->uc_mcontext.gregs[REG_R14]);
+    ssa_gpr->r15 = (uint64_t)(context->uc_mcontext.gregs[REG_R15]);
+    ssa_gpr->rip = (uint64_t)(context->uc_mcontext.gregs[REG_RIP]);
+    ssa_gpr->rflags = (uint64_t)(context->uc_mcontext.gregs[REG_EFL]);
+
+    // This flag is checked by virtual dispacher.
+    ssa_gpr->exit_info.as_fields.valid = true;
+}
+
+static void _update_sgx_vector(int sig_num, sgx_tcs_t* tcs)
+{
+    // Hardcode here must match g_vector_to_exception_code_mapping[] in
+    // enclave/core/sgx/exception.c
+    uint32_t sgx_vector = OE_EXCEPTION_UNKNOWN;
+    switch (sig_num)
+    {
+        case SIGFPE: // OE_EXCEPTION_DIVIDE_BY_ZERO
+            sgx_vector = 0;
+            break;
+        case SIGTRAP: // OE_EXCEPTION_BREAKPOIN
+            sgx_vector = 3;
+            break;
+        case SIGILL: // OE_EXCEPTION_ILLEGAL_INSTRUCTION
+            sgx_vector = 6;
+            break;
+        case SIGSEGV: // OE_EXCEPTION_ACCESS_VIOLATION
+            sgx_vector = 13;
+            break;
+        case SIGBUS: // OE_EXCEPTION_MISALIGNMENT
+            sgx_vector = 17;
+            break;
+    }
+
+    sgx_ssa_gpr_t* ssa_gpr = _get_ssa_gpr(tcs);
+    // Check struct sgx_exit_info for the detail that lhs is 8 bits only.
+    ssa_gpr->exit_info.as_fields.vector = (uint8_t)sgx_vector;
+}
+
+static void _update_context_from_ssa(ucontext_t* context, sgx_tcs_t* tcs)
+{
+    sgx_ssa_gpr_t* ssa_gpr = _get_ssa_gpr(tcs);
+
+    context->uc_mcontext.gregs[REG_RAX] = (greg_t)ssa_gpr->rax;
+    context->uc_mcontext.gregs[REG_RBX] = (greg_t)ssa_gpr->rbx;
+    context->uc_mcontext.gregs[REG_RCX] = (greg_t)ssa_gpr->rcx;
+    context->uc_mcontext.gregs[REG_RDX] = (greg_t)ssa_gpr->rdx;
+    context->uc_mcontext.gregs[REG_RSP] = (greg_t)ssa_gpr->rsp;
+    context->uc_mcontext.gregs[REG_RBP] = (greg_t)ssa_gpr->rbp;
+    context->uc_mcontext.gregs[REG_RSI] = (greg_t)ssa_gpr->rsi;
+    context->uc_mcontext.gregs[REG_RDI] = (greg_t)ssa_gpr->rdi;
+    context->uc_mcontext.gregs[REG_R8] = (greg_t)ssa_gpr->r8;
+    context->uc_mcontext.gregs[REG_R9] = (greg_t)ssa_gpr->r9;
+    context->uc_mcontext.gregs[REG_R10] = (greg_t)ssa_gpr->r10;
+    context->uc_mcontext.gregs[REG_R11] = (greg_t)ssa_gpr->r11;
+    context->uc_mcontext.gregs[REG_R12] = (greg_t)ssa_gpr->r12;
+    context->uc_mcontext.gregs[REG_R13] = (greg_t)ssa_gpr->r13;
+    context->uc_mcontext.gregs[REG_R14] = (greg_t)ssa_gpr->r14;
+    context->uc_mcontext.gregs[REG_R15] = (greg_t)ssa_gpr->r15;
+    context->uc_mcontext.gregs[REG_RIP] = (greg_t)ssa_gpr->rip;
+    context->uc_mcontext.gregs[REG_EFL] = (greg_t)ssa_gpr->rflags;
+}
+
+uint64_t oe_host_handle_exception_sim(ucontext_t* context, int sig_num)
+{
+    void* enclave_fsbase = oe_get_fs_register_base();
+    oe_sgx_td_t* td = (oe_sgx_td_t*)enclave_fsbase;
+    sgx_tcs_t* tcs =
+        (sgx_tcs_t*)((unsigned char*)td - OE_TD_FROM_TCS_BYTE_OFFSET);
+    uint64_t ret = OE_EXCEPTION_CONTINUE_SEARCH;
+
+    uint64_t enclave_start, enclave_end, rip;
+    oe_enclave_t* enclave = oe_query_enclave_instance((void*)tcs);
+    if (enclave == NULL)
+    {
+        goto done;
+    }
+
+    enclave_start = enclave->addr;
+    enclave_end = enclave->addr + enclave->size;
+    rip = (uint64_t)(context->uc_mcontext.gregs[REG_RIP]);
+    if (rip >= enclave_start && rip < enclave_end)
+    {
+        // Simulate the AEX in SGX hardware mode.
+        // Copy the data of context into ssa manually.
+        _oe_aex_sim(tcs);
+        _update_ssa_from_context(context, tcs);
+        _update_sgx_vector(sig_num, tcs);
+
+        // Check if the enclave exception happens inside the first pass
+        // exception handler.
+        oe_thread_binding_t* thread_data = oe_get_thread_binding();
+        if (thread_data->flags & _OE_THREAD_HANDLING_EXCEPTION)
+        {
+            abort();
+        }
+
+        // Set the flag marks this thread is handling an enclave exception.
+        thread_data->flags |= _OE_THREAD_HANDLING_EXCEPTION;
+
+        // Call into enclave first pass exception handler.
+        uint64_t arg_out = 0;
+        oe_result_t result =
+            oe_ecall(enclave, OE_ECALL_VIRTUAL_EXCEPTION_HANDLER, 0, &arg_out);
+
+        // Some info about the exception are updated in SSA.
+        // Copy the data back to context manually.
+        _update_context_from_ssa(context, tcs);
+
+        // Reset the flag
+        thread_data->flags &= (~_OE_THREAD_HANDLING_EXCEPTION);
+        if (result == OE_OK && arg_out == OE_EXCEPTION_CONTINUE_EXECUTION)
+        {
+            // This exception has been handled by the enclave. Let's resume.
+            ret = OE_EXCEPTION_CONTINUE_EXECUTION;
+        }
+        else
+        {
+            // Unhandled enclave exception happened.
+            // We continue the exception handler search as if it were a
+            // non-enclave exception.
+            ret = OE_EXCEPTION_CONTINUE_SEARCH;
+        }
+
+        // Simulate the ERESUME in SGX hardware mode.
+        _oe_eresume_sim(tcs);
+    }
+    else
+    {
+        // Not an exclave exception.
+        // Continue searching for other handlers.
+        ret = OE_EXCEPTION_CONTINUE_SEARCH;
+    }
+
+done:
+    return ret;
+}

--- a/host/sgx/exception_sim.c
+++ b/host/sgx/exception_sim.c
@@ -28,10 +28,12 @@ static void _oe_aex_sim(sgx_tcs_t* tcs)
         (oe_sgx_td_t*)((unsigned char*)tcs + OE_TD_FROM_TCS_BYTE_OFFSET);
     oe_set_fs_register_base((const void*)(td->host_fsbase));
     oe_set_gs_register_base((const void*)(td->host_gsbase));
+    printf("__LINE__: %d\n",__LINE__);//
 }
 
 static void _oe_eresume_sim(sgx_tcs_t* tcs)
 {
+    printf("__LINE__: %d\n",__LINE__);//
     // Update cssa as ERESUME does in real mode.
     tcs->cssa--;
 
@@ -46,6 +48,7 @@ static void _oe_eresume_sim(sgx_tcs_t* tcs)
 
 static sgx_ssa_gpr_t* _get_ssa_gpr(sgx_tcs_t* tcs)
 {
+    printf("__LINE__: %d\n",__LINE__);//
     uint32_t cssa = tcs->cssa;
     oe_sgx_td_t* td =
         (oe_sgx_td_t*)((unsigned char*)tcs + OE_TD_FROM_TCS_BYTE_OFFSET);
@@ -65,6 +68,7 @@ static sgx_ssa_gpr_t* _get_ssa_gpr(sgx_tcs_t* tcs)
 
 static void _update_ssa_from_context(ucontext_t* context, sgx_tcs_t* tcs)
 {
+    printf("__LINE__: %d\n",__LINE__);//
     sgx_ssa_gpr_t* ssa_gpr = _get_ssa_gpr(tcs);
 
     // Update gpr.
@@ -93,6 +97,7 @@ static void _update_ssa_from_context(ucontext_t* context, sgx_tcs_t* tcs)
 
 static void _update_sgx_vector(int sig_num, sgx_tcs_t* tcs)
 {
+    printf("__LINE__: %d\n",__LINE__);//
     // Hardcode here must match g_vector_to_exception_code_mapping[] in
     // enclave/core/sgx/exception.c
     uint32_t sgx_vector = OE_EXCEPTION_UNKNOWN;
@@ -122,6 +127,7 @@ static void _update_sgx_vector(int sig_num, sgx_tcs_t* tcs)
 
 static void _update_context_from_ssa(ucontext_t* context, sgx_tcs_t* tcs)
 {
+    printf("__LINE__: %d\n",__LINE__);//
     sgx_ssa_gpr_t* ssa_gpr = _get_ssa_gpr(tcs);
 
     context->uc_mcontext.gregs[REG_RAX] = (greg_t)ssa_gpr->rax;

--- a/host/sgx/linux/exception.c
+++ b/host/sgx/linux/exception.c
@@ -38,8 +38,16 @@ static void _host_signal_handler(
     host_context.rbx = (uint64_t)context->uc_mcontext.gregs[REG_RBX];
     host_context.rip = (uint64_t)context->uc_mcontext.gregs[REG_RIP];
 
-    // Call platform neutral handler.
-    uint64_t action = oe_host_handle_exception(&host_context);
+    uint64_t action;
+    if (!is_simulation())
+    {
+        // Call platform neutral handler.
+        action = oe_host_handle_exception(&host_context);
+    }
+    else
+    {
+        action = oe_host_handle_exception_sim(context, sig_num);
+    }
 
     if (action == OE_EXCEPTION_CONTINUE_EXECUTION)
     {

--- a/include/openenclave/internal/sgx/td.h
+++ b/include/openenclave/internal/sgx/td.h
@@ -81,7 +81,7 @@ oe_thread_data_t* oe_get_thread_data(void);
  * Due to the inability to use OE_OFFSETOF on a struct while defining its
  * members, this value is computed and hard-coded.
  */
-#define OE_THREAD_SPECIFIC_DATA_SIZE (3744)
+#define OE_THREAD_SPECIFIC_DATA_SIZE (3728)
 
 typedef struct _callsite Callsite;
 
@@ -162,6 +162,10 @@ typedef struct _td
     /* TLS atexit functions (see enclave/core/sgx/threadlocal.c) */
     oe_tls_atexit_t* tls_atexit_functions;
     uint64_t num_tls_atexit_functions;
+
+    /* FS/GS segment registers of host side */
+    uint64_t host_fsbase;
+    uint64_t host_gsbase;
 
     /* Reserved for thread specific data. */
     uint8_t thread_specific_data[OE_THREAD_SPECIFIC_DATA_SIZE];

--- a/tests/VectorException/host/host.c
+++ b/tests/VectorException/host/host.c
@@ -146,12 +146,14 @@ int main(int argc, const char* argv[])
            "functionalities.\n");
 
     const uint32_t flags = oe_get_create_flags();
+#if defined(_WIN32)
     if ((flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
     {
         printf("=== Skipped unsupported test in simulation mode "
                "(VectorException)\n");
         return SKIP_RETURN_CODE;
     }
+#endif
 
     if ((result = oe_create_VectorException_enclave(
              argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) != OE_OK)
@@ -162,7 +164,13 @@ int main(int argc, const char* argv[])
     OE_TEST(enc_test_cpuid_in_global_constructors(enclave) == OE_OK);
 
     test_vector_exception(enclave);
-    test_sigill_handling(enclave);
+
+    // SGX specific test is not available in simulation.
+    if (!(flags & OE_ENCLAVE_FLAG_SIMULATE))
+    {
+        test_sigill_handling(enclave);
+    }
+
     test_ocall_in_handler(enclave);
 
     oe_terminate_enclave(enclave);


### PR DESCRIPTION
By mock of aex and eresume in SGX mode, vectored exception handling is enabled.
partially fix #2124 since now it is enabled on Linux only.