### PR TITLE
Opt-out logging.edl by default

### DIFF
--- a/docs/DesignDocs/system_ocall_opt_in.md
+++ b/docs/DesignDocs/system_ocall_opt_in.md
@@ -150,11 +150,6 @@ To build the SDK in the way it will be built for v0.10, you can pass
 
 ### Currently required EDL by all applications
 
-**logging.edl**
-
-Logging can not currently be disabled so all enclaves will need the logging
-calls.
-
 **sgx/platform.edl**
 
 There are currently 4 features which use OCalls on SGX which cannot be

--- a/enclave/core/hostcalls.c
+++ b/enclave/core/hostcalls.c
@@ -18,8 +18,8 @@
  * Declare the protoype of the following functions to avoid the
  * missing-prototypes warning.
  */
+oe_result_t _oe_log_is_supported_ocall();
 oe_result_t _oe_log_ocall(uint32_t log_level, const char* message);
-
 oe_result_t _oe_write_ocall(int device, const char* str, size_t maxlen);
 
 /**
@@ -29,6 +29,12 @@ oe_result_t _oe_write_ocall(int device, const char* str, size_t maxlen);
  * the implementions (which are strong) in the oeedger8r-generated code will be
  * used.
  */
+oe_result_t _oe_log_is_supported_ocall()
+{
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_log_is_supported_ocall, oe_log_is_supported_ocall);
+
 oe_result_t _oe_log_ocall(uint32_t log_level, const char* message)
 {
     OE_UNUSED(log_level);

--- a/enclave/core/hostcalls.c
+++ b/enclave/core/hostcalls.c
@@ -13,6 +13,40 @@
 
 #include "core_t.h"
 
+#if !defined(OE_USE_BUILTIN_EDL)
+/**
+ * Declare the protoype of the following functions to avoid the
+ * missing-prototypes warning.
+ */
+oe_result_t _oe_log_ocall(uint32_t log_level, const char* message);
+
+oe_result_t _oe_write_ocall(int device, const char* str, size_t maxlen);
+
+/**
+ * Make the following OCALLs weak to support the system EDL opt-in.
+ * When the user does not opt in (import) the EDL, the linker will picked
+ * the following default implementations. If the user opts in the EDL,
+ * the implementions (which are strong) in the oeedger8r-generated code will be
+ * used.
+ */
+oe_result_t _oe_log_ocall(uint32_t log_level, const char* message)
+{
+    OE_UNUSED(log_level);
+    OE_UNUSED(message);
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_log_ocall, oe_log_ocall);
+
+oe_result_t _oe_write_ocall(int device, const char* str, size_t maxlen)
+{
+    OE_UNUSED(device);
+    OE_UNUSED(str);
+    OE_UNUSED(maxlen);
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_write_ocall, oe_write_ocall);
+#endif
+
 void* oe_host_malloc(size_t size)
 {
     uint64_t arg_in = size;

--- a/enclave/core/tracee.c
+++ b/enclave/core/tracee.c
@@ -53,6 +53,11 @@ void oe_log_init_ecall(const char* enclave_path, uint32_t log_level)
 {
     const char* filename;
 
+    // Returning OE_UNSUPPORTED means that the logging.edl is not properly
+    // imported. Do not perform the initialization in this case.
+    if (oe_log_is_supported_ocall() == OE_UNSUPPORTED)
+        return;
+
     _active_log_level = (oe_log_level_t)log_level;
 
     if ((filename = get_filename_from_path(enclave_path)))

--- a/host/ocalls.c
+++ b/host/ocalls.c
@@ -27,6 +27,11 @@ void HandleFree(uint64_t arg)
     free((void*)arg);
 }
 
+/* A dummy ocall used to check if the logging.edl is imported. */
+void oe_log_is_supported_ocall()
+{
+}
+
 void oe_log_ocall(uint32_t log_level, const char* message)
 {
     oe_log_message(true, (oe_log_level_t)log_level, message);

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -1008,7 +1008,13 @@ oe_result_t oe_create_enclave(
     OE_CHECK(_initialize_enclave(enclave));
 
     /* Setup logging configuration */
-    oe_log_enclave_init(enclave);
+    if (oe_log_enclave_init(enclave) == OE_UNSUPPORTED)
+    {
+        oe_log(
+            OE_LOG_LEVEL_WARNING,
+            "The in-enclave logging is not supported. To enable, please import "
+            "the logging.edl.\n");
+    }
 
     /* Apply the list of settings to the enclave.
      * This may initialize switchless manager too.

--- a/host/traceh_enclave.c
+++ b/host/traceh_enclave.c
@@ -18,6 +18,38 @@
 
 #include "core_u.h"
 
+#if !defined(OE_USE_BUILTIN_EDL)
+/**
+ * Declare the protoype of the following functions to avoid the
+ * missing-prototypes warning.
+ */
+oe_result_t _oe_log_init_ecall(
+    oe_enclave_t* enclave,
+    const char* enclave_path,
+    uint32_t log_level);
+
+/**
+ * Make the following ECALL weak to support the system EDL opt-in.
+ * When the user does not opt in (import) the EDL, the linker will picked
+ * the following default implementation. If the user opts in the EDL,
+ * the implementions (which also weak) in the oeedger8r-generated code will be
+ * used. This behavior is guaranteed by the linker; i.e., the linker will pick
+ * the symbols defined in the object before those in the library.
+ */
+oe_result_t _oe_log_init_ecall(
+    oe_enclave_t* enclave,
+    const char* enclave_path,
+    uint32_t log_level)
+{
+    OE_UNUSED(enclave);
+    OE_UNUSED(enclave_path);
+    OE_UNUSED(log_level);
+    return OE_UNSUPPORTED;
+}
+
+OE_WEAK_ALIAS(_oe_log_init_ecall, oe_log_init_ecall);
+#endif
+
 /*
  * This file is separated from traceh.c since the host verification library
  * should not depend on ECALLS.

--- a/include/openenclave/edl/logging.edl
+++ b/include/openenclave/edl/logging.edl
@@ -24,6 +24,8 @@ enclave
 
     untrusted
     {
+        void oe_log_is_supported_ocall();
+
         void oe_log_ocall(
             uint32_t log_level,
             [in, string] const char* message);

--- a/samples/attested_tls/server/tls_server.edl
+++ b/samples/attested_tls/server/tls_server.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/samples/data-sealing/datasealing.edl
+++ b/samples/data-sealing/datasealing.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/samples/file-encryptor/fileencryptor.edl
+++ b/samples/file-encryptor/fileencryptor.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/samples/helloworld/helloworld.edl
+++ b/samples/helloworld/helloworld.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/samples/local_attestation/localattestation.edl
+++ b/samples/local_attestation/localattestation.edl
@@ -3,7 +3,6 @@
 
 enclave {
     from "openenclave/edl/attestation.edl" import *;
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/samples/remote_attestation/remoteattestation.edl
+++ b/samples/remote_attestation/remoteattestation.edl
@@ -3,7 +3,6 @@
 
 enclave {
     from "openenclave/edl/attestation.edl" import *;
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/samples/switchless/switchless_sample.edl
+++ b/samples/switchless/switchless_sample.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/SampleApp/SampleApp.edl
+++ b/tests/SampleApp/SampleApp.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/SampleAppCRT/SampleAppCRT.edl
+++ b/tests/SampleAppCRT/SampleAppCRT.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/VectorException/VectorException.edl
+++ b/tests/VectorException/VectorException.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/abortStatus/abortStatus.edl
+++ b/tests/abortStatus/abortStatus.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/argv/argv.edl
+++ b/tests/argv/argv.edl
@@ -3,7 +3,7 @@
 
 enclave
 {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/atexit/atexit.edl
+++ b/tests/atexit/atexit.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/attestation_plugin/plugin.edl
+++ b/tests/attestation_plugin/plugin.edl
@@ -3,7 +3,7 @@
 
 enclave {
     from "openenclave/edl/attestation.edl" import *;
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/backtrace/backtrace.edl
+++ b/tests/backtrace/backtrace.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/bigmalloc/bigmalloc.edl
+++ b/tests/bigmalloc/bigmalloc.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/c99_compliant/c99_compliant.edl
+++ b/tests/c99_compliant/c99_compliant.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/child_process/child_process.edl
+++ b/tests/child_process/child_process.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/child_thread/child_thread.edl
+++ b/tests/child_thread/child_thread.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/cmake_name_conflict/name_conflict.edl
+++ b/tests/cmake_name_conflict/name_conflict.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/cppException/cppException.edl
+++ b/tests/cppException/cppException.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/create-errors/create_errors.edl
+++ b/tests/create-errors/create_errors.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/create-rapid/create_rapid.edl
+++ b/tests/create-rapid/create_rapid.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/crypto/enclave/crypto.edl
+++ b/tests/crypto/enclave/crypto.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/crypto_crls_cert_chains/common/crypto_crls_cert_chains.edl
+++ b/tests/crypto_crls_cert_chains/common/crypto_crls_cert_chains.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/debug-mode/debug_mode.edl
+++ b/tests/debug-mode/debug_mode.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/debugger/oegdb/oe_gdb_test.edl
+++ b/tests/debugger/oegdb/oe_gdb_test.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/ecall/ecall.edl
+++ b/tests/ecall/ecall.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/ecall_ocall/ecall_ocall.edl
+++ b/tests/ecall_ocall/ecall_ocall.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/echo/echo.edl
+++ b/tests/echo/echo.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/eeid_plugin/eeid_plugin.edl
+++ b/tests/eeid_plugin/eeid_plugin.edl
@@ -4,7 +4,7 @@
 enclave {
 
     from "openenclave/edl/attestation.edl" import *;
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/enclaveparam/enclaveparam.edl
+++ b/tests/enclaveparam/enclaveparam.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/file/file.edl
+++ b/tests/file/file.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/getenclave/getenclave.edl
+++ b/tests/getenclave/getenclave.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/hexdump/hexdump.edl
+++ b/tests/hexdump/hexdump.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/hostcalls/hostcalls.edl
+++ b/tests/hostcalls/hostcalls.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "openenclave/edl/memory.edl" import *;
     from "platform.edl" import *;

--- a/tests/initializers/initializers.edl
+++ b/tests/initializers/initializers.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/libc/libc.edl
+++ b/tests/libc/libc.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/libcxx/libcxx.edl
+++ b/tests/libcxx/libcxx.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/libcxxrt/libcxxrt.edl
+++ b/tests/libcxxrt/libcxxrt.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/libunwind/libunwind.edl
+++ b/tests/libunwind/libunwind.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/mbed/mbed.edl
+++ b/tests/mbed/mbed.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/memory/memory.edl
+++ b/tests/memory/memory.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/mixed_c_cpp/mixed.edl
+++ b/tests/mixed_c_cpp/mixed.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 
@@ -14,5 +13,3 @@ enclave {
     untrusted {       
     };
 };
-
-

--- a/tests/ocall-create/ocall_create.edl
+++ b/tests/ocall-create/ocall_create.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/ocall/ocall.edl
+++ b/tests/ocall/ocall.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/oeedger8r/edl/all.edl
+++ b/tests/oeedger8r/edl/all.edl
@@ -3,7 +3,7 @@
 
 enclave  {
     // Import system edl
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "openenclave/edl/sgx/sgx_attestation.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;

--- a/tests/oeedger8r/edl/other.edl
+++ b/tests/oeedger8r/edl/other.edl
@@ -3,7 +3,7 @@
 
 enclave {
   // Import system edl
-  from "openenclave/edl/logging.edl" import *;
+  from "openenclave/edl/logging.edl" import oe_write_ocall;
   from "openenclave/edl/syscall.edl" import *;
   from "openenclave/edl/sgx/sgx_attestation.edl" import *;
   from "openenclave/edl/sgx/cpu.edl" import *;

--- a/tests/pingpong-shared/pingpong.edl
+++ b/tests/pingpong-shared/pingpong.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/pingpong/pingpong.edl
+++ b/tests/pingpong/pingpong.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/print/print.edl
+++ b/tests/print/print.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/props/props.edl
+++ b/tests/props/props.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/report/tests.edl
+++ b/tests/report/tests.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "openenclave/edl/attestation.edl" import *;
     from "platform.edl" import *;

--- a/tests/safecrt/safecrt.edl
+++ b/tests/safecrt/safecrt.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave  {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/sealKey/sealKey.edl
+++ b/tests/sealKey/sealKey.edl
@@ -3,7 +3,7 @@
 
 enclave {
     from "openenclave/edl/keys.edl" import *;
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/sim-mode/sim_mode.edl
+++ b/tests/sim-mode/sim_mode.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/snmalloc/snmalloc.edl
+++ b/tests/snmalloc/snmalloc.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/stack_smashing_protector/ssp.edl
+++ b/tests/stack_smashing_protector/ssp.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/stdc/stdc.edl
+++ b/tests/stdc/stdc.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/stdcxx/stdcxx.edl
+++ b/tests/stdcxx/stdcxx.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/stress/stress.edl
+++ b/tests/stress/stress.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/switchless/switchless_test.edl
+++ b/tests/switchless/switchless_test.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "openenclave/edl/sgx/sgx_attestation.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;

--- a/tests/switchless_nestedcalls/switchless_nestedcalls.edl
+++ b/tests/switchless_nestedcalls/switchless_nestedcalls.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "openenclave/edl/sgx/sgx_attestation.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;

--- a/tests/switchless_one_tcs/switchless_one_tcs.edl
+++ b/tests/switchless_one_tcs/switchless_one_tcs.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "openenclave/edl/sgx/sgx_attestation.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;

--- a/tests/switchless_threads/switchless_threads.edl
+++ b/tests/switchless_threads/switchless_threads.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/switchless_worksleep/switchless_worksleep.edl
+++ b/tests/switchless_worksleep/switchless_worksleep.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "openenclave/edl/sgx/sgx_attestation.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;

--- a/tests/syscall/datagram/test_datagram.edl
+++ b/tests/syscall/datagram/test_datagram.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/dup/test_dup.edl
+++ b/tests/syscall/dup/test_dup.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/epoll/epoll.edl
+++ b/tests/syscall/epoll/epoll.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/fs/linux/fs.edl
+++ b/tests/syscall/fs/linux/fs.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/fs/windows/fs.edl
+++ b/tests/syscall/fs/windows/fs.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/hostfs/test_hostfs.edl
+++ b/tests/syscall/hostfs/test_hostfs.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/ids/test_ids.edl
+++ b/tests/syscall/ids/test_ids.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/poller/poller.edl
+++ b/tests/syscall/poller/poller.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/resolver/resolver_test.edl
+++ b/tests/syscall/resolver/resolver_test.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/sendmsg/sendmsg.edl
+++ b/tests/syscall/sendmsg/sendmsg.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/socket/socket_test.edl
+++ b/tests/syscall/socket/socket_test.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/syscall/socketpair/socketpair_test.edl
+++ b/tests/syscall/socketpair/socketpair_test.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/thread/thread.edl
+++ b/tests/thread/thread.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/thread_local/thread_local.edl
+++ b/tests/thread_local/thread_local.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/thread_local_no_tdata/no_tdata.edl
+++ b/tests/thread_local_no_tdata/no_tdata.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/tests/threadcxx/threadcxx.edl
+++ b/tests/threadcxx/threadcxx.edl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 


### PR DESCRIPTION
This PR solves part of #2818; i.e., removing the limitation that the `logging.edl` cannot be excluded.
The PR consists of four parts:
1. Add the default implementations of ecalls/ocalls (defined by `logging.edl`), and make these implementations weak. As a result, when the user does not opt in the edl, these implementations will be used. If the user opts in the edl, the implementations in the oeedger8r-generated source will be used instead.
2. Update the edls under `tests`; removing the import of  `logging.edl` if not necessary.
    Note that most of the test cases still need the `oe_write_ocall` in the edl, which is used by `oe_host_printf` or `OE_TEST`

3. Update the edls in the samples. Samples don't import logging.edl by default.

4. Update the docuementation.