### PR TITLE
Add uniqueness check for oesign .conf values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   application EDL. See [system EDL opt-in document]
   (docs/DesignDocs/system_ocall_opt_in.md#how-to-port-your-application) for more information.
 - Switch to oeedger8r written in C++.
+- Fix #3134. oesign tool will now reject .conf files that contain duplicate property definitions.
 
 ### Removed
 - Removed oehostapp and the appendent "-rdynamic" compiling option. Please use oehost instead and add the option back manually if necessary.

--- a/tests/tools/oesign/test-digest/CMakeLists.txt
+++ b/tests/tools/oesign/test-digest/CMakeLists.txt
@@ -9,12 +9,37 @@ add_custom_command(
   COMMAND cmake -E copy ${CMAKE_CURRENT_SOURCE_DIR}/../sign-and-verify.py
           ${CMAKE_CURRENT_BINARY_DIR})
 
+add_custom_command(
+  OUTPUT oesign_test_enc.baseline.digest.sig
+  DEPENDS oesign_test_enc oesign_test_configs oesign_test_keys
+  COMMAND
+    oesign digest -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/valid.conf -d oesign_test_enc.baseline.digest
+  COMMAND
+    openssl pkeyutl -sign -pkeyopt digest:sha256 -in
+    oesign_test_enc.baseline.digest -inkey
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem -keyform PEM -out
+    oesign_test_enc.baseline.digest.sig)
+
+add_custom_command(
+  OUTPUT oesign_test_alt_enc.baseline.digest.sig
+  DEPENDS oesign_test_alt_enc
+  COMMAND oesign digest -e $<TARGET_FILE:oesign_test_alt_enc> -d
+          oesign_test_alt_enc.baseline.digest
+  COMMAND
+    openssl pkeyutl -sign -pkeyopt digest:sha256 -in
+    oesign_test_alt_enc.baseline.digest -inkey
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem -keyform PEM -out
+    oesign_test_alt_enc.baseline.digest.sig)
+
 add_custom_target(
   oesign_digest_test_dependencies ALL
   DEPENDS oesign
           oesign_test_host
           oesign_test_enc
+          oesign_test_enc.baseline.digest.sig
           oesign_test_alt_enc
+          oesign_test_alt_enc.baseline.digest.sig
           oesign_test_keys
           oesign_test_configs
           sign-and-verify.py)
@@ -111,7 +136,8 @@ add_test(
   NAME tests/oesign-digest-sign-missing-enclave-arg
   COMMAND
     oesign sign -c ${OESIGN_TEST_INPUTS_DIR}/valid.conf -x
-    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d oesign_test_enc.digest.sig)
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d
+    oesign_test_enc.baseline.digest.sig)
 
 set_tests_properties(
   tests/oesign-digest-sign-missing-enclave-arg
@@ -120,8 +146,9 @@ set_tests_properties(
 # Test sign command for digest options missing --x509 (-x) argument
 add_test(
   NAME tests/oesign-digest-sign-missing-x509-arg
-  COMMAND oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
-          ${OESIGN_TEST_INPUTS_DIR}/valid.conf -d oesign_test_enc.digest.sig)
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/valid.conf -d oesign_test_enc.baseline.digest.sig)
 
 set_tests_properties(
   tests/oesign-digest-sign-missing-x509-arg
@@ -147,8 +174,9 @@ add_test(
   COMMAND
     oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
     ${OESIGN_TEST_INPUTS_DIR}/valid.conf -x
-    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d oesign_test_enc.digest.sig
-    -k ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d
+    oesign_test_enc.baseline.digest.sig -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
 
 set_tests_properties(
   tests/oesign-digest-sign-conflicting-key-file-arg
@@ -161,7 +189,8 @@ add_test(
   COMMAND
     oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
     ${OESIGN_TEST_INPUTS_DIR}/valid.conf -x
-    ${OESIGN_TEST_INPUTS_DIR}/sign_key_2.cert.pem -d oesign_test_enc.digest.sig)
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key_2.cert.pem -d
+    oesign_test_enc.baseline.digest.sig)
 
 set(OESIGN_DIGEST_SIGN_MISMATCHED_X509_REGEX
     "ERROR: Digest signature cannot be validated against the specified enclave configuration using the provided certificate"
@@ -178,12 +207,14 @@ set_tests_properties(
              ${OESIGN_DIGEST_SIGN_MISMATCHED_X509_REGEX})
 
 # Test sign command for digest options with mismatched Debug config
+# Also validates that the config Debug value overwrites the build time one
 add_test(
   NAME tests/oesign-digest-sign-new-debug-config
   COMMAND
-    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    oesign sign -e $<TARGET_FILE:oesign_test_alt_enc> -c
     ${OESIGN_TEST_INPUTS_DIR}/non_debug.conf -x
-    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d oesign_test_enc.digest.sig)
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d
+    oesign_test_alt_enc.baseline.digest.sig)
 
 set_tests_properties(
   tests/oesign-digest-sign-new-debug-config
@@ -193,12 +224,14 @@ set_tests_properties(
 )
 
 # Test sign command for digest options with mismatched NumHeapPages config
+# Also validates that the config NumHeapPages value overwrites the build time one
 add_test(
   NAME tests/oesign-digest-sign-new-num-heap-pages
   COMMAND
-    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    oesign sign -e $<TARGET_FILE:oesign_test_alt_enc> -c
     ${OESIGN_TEST_INPUTS_DIR}/more_num_heap_pages.conf -x
-    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d oesign_test_enc.digest.sig)
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d
+    oesign_test_alt_enc.baseline.digest.sig)
 
 set_tests_properties(
   tests/oesign-digest-sign-new-num-heap-pages
@@ -208,12 +241,14 @@ set_tests_properties(
 )
 
 # Test sign command for digest options with mismatched NumStackPages config
+# Also validates that the config NumStackPages value overwrites the build time one
 add_test(
   NAME tests/oesign-digest-sign-new-num-stack-pages
   COMMAND
-    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    oesign sign -e $<TARGET_FILE:oesign_test_alt_enc> -c
     ${OESIGN_TEST_INPUTS_DIR}/more_num_stack_pages.conf -x
-    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d oesign_test_enc.digest.sig)
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d
+    oesign_test_alt_enc.baseline.digest.sig)
 
 set_tests_properties(
   tests/oesign-digest-sign-new-num-stack-pages
@@ -223,12 +258,14 @@ set_tests_properties(
 )
 
 # Test sign command for digest options with mismatched NumTCS config
+# Also validates that the config NumTCS value overwrites the build time one
 add_test(
   NAME tests/oesign-digest-sign-new-num-tcs
   COMMAND
-    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    oesign sign -e $<TARGET_FILE:oesign_test_alt_enc> -c
     ${OESIGN_TEST_INPUTS_DIR}/more_num_tcs.conf -x
-    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d oesign_test_enc.digest.sig)
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d
+    oesign_test_alt_enc.baseline.digest.sig)
 
 set_tests_properties(
   tests/oesign-digest-sign-new-num-tcs
@@ -238,12 +275,14 @@ set_tests_properties(
 )
 
 # Test sign command for digest options with mismatched ProductID config
+# Also validates that the config ProductID value overwrites the build time one
 add_test(
   NAME tests/oesign-digest-sign-new-product-id
   COMMAND
-    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    oesign sign -e $<TARGET_FILE:oesign_test_alt_enc> -c
     ${OESIGN_TEST_INPUTS_DIR}/new_product_id.conf -x
-    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d oesign_test_enc.digest.sig)
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d
+    oesign_test_alt_enc.baseline.digest.sig)
 
 set_tests_properties(
   tests/oesign-digest-sign-new-product-id
@@ -253,12 +292,14 @@ set_tests_properties(
 )
 
 # Test sign command for digest options with mismatched SecurityVersion config
+# Also validates that the config SecurityVersion value overwrites the build time one
 add_test(
   NAME tests/oesign-digest-sign-new-security-version
   COMMAND
-    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    oesign sign -e $<TARGET_FILE:oesign_test_alt_enc> -c
     ${OESIGN_TEST_INPUTS_DIR}/new_security_version.conf -x
-    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d oesign_test_enc.digest.sig)
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d
+    oesign_test_alt_enc.baseline.digest.sig)
 
 set_tests_properties(
   tests/oesign-digest-sign-new-security-version
@@ -273,7 +314,8 @@ add_test(
   COMMAND
     oesign sign -e $<TARGET_FILE:oesign_test_alt_enc> -c
     ${OESIGN_TEST_INPUTS_DIR}/valid.conf -x
-    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d oesign_test_enc.digest.sig)
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.cert.pem -d
+    oesign_test_enc.baseline.digest.sig)
 
 set_tests_properties(
   tests/oesign-digest-sign-alt-enclave

--- a/tests/tools/oesign/test-inputs/CMakeLists.txt
+++ b/tests/tools/oesign/test-inputs/CMakeLists.txt
@@ -1,12 +1,20 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-# Generate test variations from a standard baseline configuration
-# TODO: Any test configurations that consist of more than just manipulations
+# Copy hand authored test configurations to output
+#
+# Any test configurations that consist of more than just manipulations
 # of the standard configuration values (e.g. syntax error tests) should be
 # added to the test-inputs source folder and copied to the binary output
 # folder on build.
+add_custom_command(
+  OUTPUT duplicate_debug.conf duplicate_num_heap_pages.conf
+         duplicate_num_stack_pages.conf duplicate_num_tcs.conf
+         duplicate_product_id.conf duplicate_security_version.conf
+  COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}
+          ${CMAKE_CURRENT_BINARY_DIR})
 
+# Generate test variations from a standard baseline configuration
 add_custom_command(
   OUTPUT valid.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
@@ -63,7 +71,13 @@ add_custom_command(
 
 add_custom_target(
   oesign_test_configs ALL
-  DEPENDS empty.conf
+  DEPENDS duplicate_debug.conf
+          duplicate_num_heap_pages.conf
+          duplicate_num_stack_pages.conf
+          duplicate_num_tcs.conf
+          duplicate_product_id.conf
+          duplicate_security_version.conf
+          empty.conf
           more_num_heap_pages.conf
           more_num_stack_pages.conf
           more_num_tcs.conf

--- a/tests/tools/oesign/test-inputs/duplicate_debug.conf
+++ b/tests/tools/oesign/test-inputs/duplicate_debug.conf
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+Debug=1
+# Duplicate Debug entry
+Debug=1
+NumHeapPages=1024
+NumStackPages=1024
+NumTCS=1
+ProductID=1
+SecurityVersion=1

--- a/tests/tools/oesign/test-inputs/duplicate_num_heap_pages.conf
+++ b/tests/tools/oesign/test-inputs/duplicate_num_heap_pages.conf
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+Debug=1
+NumHeapPages=1024
+# Duplicate NumHeapPages entry
+NumHeapPages=1024
+NumStackPages=1024
+NumTCS=1
+ProductID=1
+SecurityVersion=1

--- a/tests/tools/oesign/test-inputs/duplicate_num_stack_pages.conf
+++ b/tests/tools/oesign/test-inputs/duplicate_num_stack_pages.conf
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+Debug=1
+NumHeapPages=1024
+NumStackPages=1024
+# Duplicate NumStackPages entry
+NumStackPages=1024
+NumTCS=1
+ProductID=1
+SecurityVersion=1

--- a/tests/tools/oesign/test-inputs/duplicate_num_tcs.conf
+++ b/tests/tools/oesign/test-inputs/duplicate_num_tcs.conf
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+Debug=1
+NumHeapPages=1024
+NumStackPages=1024
+NumTCS=1
+# Duplicate NumTCS entry
+NumTCS=1
+ProductID=1
+SecurityVersion=1

--- a/tests/tools/oesign/test-inputs/duplicate_product_id.conf
+++ b/tests/tools/oesign/test-inputs/duplicate_product_id.conf
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+Debug=1
+NumHeapPages=1024
+NumStackPages=1024
+NumTCS=1
+ProductID=1
+# Duplicate ProductID entry
+ProductID=1
+SecurityVersion=1

--- a/tests/tools/oesign/test-inputs/duplicate_security_version.conf
+++ b/tests/tools/oesign/test-inputs/duplicate_security_version.conf
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+Debug=1
+NumHeapPages=1024
+NumStackPages=1024
+NumTCS=1
+ProductID=1
+SecurityVersion=1
+# Duplicate SecurityVersion entry
+SecurityVersion=1

--- a/tests/tools/oesign/test-sign/CMakeLists.txt
+++ b/tests/tools/oesign/test-sign/CMakeLists.txt
@@ -67,6 +67,79 @@ set_tests_properties(
   PROPERTIES PASS_REGULAR_EXPRESSION
              "ERROR: Failed to load file: does_not_exist.pem")
 
+# Test invalid .conf with duplicate Debug property
+add_test(
+  NAME tests/oesign-sign-duplicate-debug-config
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/duplicate_debug.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-duplicate-debug-config
+  PROPERTIES PASS_REGULAR_EXPRESSION "Duplicate 'Debug' value provided")
+
+# Test invalid .conf with duplicate NumHeapPages property
+add_test(
+  NAME tests/oesign-sign-duplicate-num-heap-pages-config
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/duplicate_num_heap_pages.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-duplicate-num-heap-pages-config
+  PROPERTIES PASS_REGULAR_EXPRESSION "Duplicate 'NumHeapPages' value provided")
+
+# Test invalid .conf with duplicate NumStackPages property
+add_test(
+  NAME tests/oesign-sign-duplicate-num-stack-pages-config
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/duplicate_num_stack_pages.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-duplicate-num-stack-pages-config
+  PROPERTIES PASS_REGULAR_EXPRESSION "Duplicate 'NumStackPages' value provided")
+
+# Test invalid .conf with duplicate NumTCS property
+add_test(
+  NAME tests/oesign-sign-duplicate-num-tcs-config
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/duplicate_num_tcs.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-duplicate-num-tcs-config
+  PROPERTIES PASS_REGULAR_EXPRESSION "Duplicate 'NumTCS' value provided")
+
+# Test invalid .conf with duplicate ProductID property
+add_test(
+  NAME tests/oesign-sign-duplicate-product-id-config
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/duplicate_product_id.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-duplicate-product-id-config
+  PROPERTIES PASS_REGULAR_EXPRESSION "Duplicate 'ProductID' value provided")
+
+# Test invalid .conf with duplicate SecurityVersion property
+add_test(
+  NAME tests/oesign-sign-duplicate-security-version-config
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/duplicate_security_version.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-duplicate-security-version-config
+  PROPERTIES PASS_REGULAR_EXPRESSION
+             "Duplicate 'SecurityVersion' value provided")
+
 # Test signing key with invalid exponent for SGX signing
 add_test(
   NAME tests/oesign-sign-invalid-key-exp


### PR DESCRIPTION
- Enforce during oesign parsing of .conf files that each attribute may only be specified once.
- Fix oesign to allow overwriting the `debug` attribute at sign time.
- Add tests for duplicate attribute checks in .conf files.
- Add tests for overwriting SGX enclave properties defined at build time.

Fixes #3134

Signed-off-by: Simon Leet <simon.leet@microsoft.com>