### PR TITLE
Dynamically load sgx_enclave_common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `oe_sgx_get_signer_id_from_public_key()` function which helps a verifier of SGX
   reports extract the expected MRSIGNER value from the signer's public key PEM certificate.
+- OE SDK can now be built and run in simulation mode on a non SGX x64 Windows machine by passing HAS_QUOTE_PROVIDER=off.
+  Previously, the build would work, but running applications would fail due to missing sgx_enclave_common.dll.
 
 ### Changed
 - Mark APIs in include/openenclave/attestation/sgx/attester.h and verifier.h as experimental.
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (docs/DesignDocs/system_ocall_opt_in.md#how-to-port-your-application) for more information.
 - Switch to oeedger8r written in C++.
 - Fix #3134. oesign tool will now reject .conf files that contain duplicate property definitions.
+- SGX Simulation Mode does not need SGX libraries to be present in the system.
 
 ### Removed
 - Removed oehostapp and the appendent "-rdynamic" compiling option. Please use oehost instead and add the option back manually if necessary.

--- a/cmake/openenclave-config.cmake.in
+++ b/cmake/openenclave-config.cmake.in
@@ -81,29 +81,6 @@ if (WIN32)
 endif ()
 
 if (OE_SGX)
-  if (NOT TARGET openenclave::sgx_enclave_common)
-    if (UNIX)
-      find_library(SGX_ENCLAVE_COMMON_LIB NAMES sgx_enclave_common HINTS "/usr")
-    elseif (WIN32)
-      find_library(SGX_ENCLAVE_COMMON_LIB NAMES sgx_enclave_common
-           HINTS ${NUGET_PACKAGE_PATH}/EnclaveCommonAPI/lib/native/x64-Release)
-    endif ()
-    if (NOT SGX_ENCLAVE_COMMON_LIB)
-      message(FATAL_ERROR "-- Looking for sgx_enclave_common library - not found")
-    else ()
-      message(VERBOSE "-- Looking for sgx_enclave_common library - found")
-      add_library(openenclave::sgx_enclave_common SHARED IMPORTED)
-      if (UNIX)
-        set_target_properties(openenclave::sgx_enclave_common PROPERTIES IMPORTED_LOCATION ${SGX_ENCLAVE_COMMON_LIB})
-      elseif (WIN32)
-        set_target_properties(openenclave::sgx_enclave_common PROPERTIES
-                              IMPORTED_LOCATION $ENV{WINDIR}/System32
-                              IMPORTED_IMPLIB ${SGX_ENCLAVE_COMMON_LIB})
-      endif ()
-      target_link_libraries(openenclave::oehost INTERFACE openenclave::sgx_enclave_common)
-    endif ()
-  endif ()
-
   if (NOT TARGET openenclave::sgx_dcap_ql)
     if (UNIX)
       find_library(SGX_DCAP_QL_LIB NAMES sgx_dcap_ql HINTS "/usr")
@@ -128,7 +105,7 @@ if (OE_SGX)
   endif ()
 endif ()
 
-# This target is an OCaml executable, not C++, so we have to manually
+# This target is an external project, so we have to manually
 # "export" it here for users of the package.
 if(NOT TARGET openenclave::oeedger8r)
   add_executable(openenclave::oeedger8r IMPORTED)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -269,6 +269,7 @@ if (OE_SGX)
     sgx/quote.c
     sgx/registers.c
     sgx/report.c
+    sgx/sgx_enclave_common_wrapper.c
     sgx/sgxload.c
     sgx/sgxquote.c
     sgx/sgxsign.c
@@ -449,34 +450,9 @@ endif ()
 target_include_directories(oehost PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 if (OE_SGX)
-  # Always link with the EnclaveCommonAPI
-  if (WIN32)
-    set(LIBPATHS ${NUGET_PACKAGE_PATH}/EnclaveCommonAPI/lib/native/x64-Release)
-    set(INCPATHS "${NUGET_PACKAGE_PATH}/EnclaveCommonAPI/Header Files")
-  endif ()
   if (NOT LIBPATHS)
     set(LIBPATHS "/usr")
   endif ()
-  find_library(
-    LIBSGX_COMMON
-    NAMES sgx_enclave_common
-    HINTS ${LIBPATHS})
-  if (NOT LIBSGX_COMMON)
-    message(
-      FATAL_ERROR "Intel SGX EnclaveCommonAPI library not found, aborting!")
-  endif ()
-  add_library(sgx_enclave_common SHARED IMPORTED)
-  if (WIN32)
-    set_target_properties(
-      sgx_enclave_common
-      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${INCPATHS}"
-                 IMPORTED_LOCATION $ENV{WINDIR}/System32 IMPORTED_IMPLIB
-                                                         ${LIBSGX_COMMON})
-  elseif (UNIX)
-    set_target_properties(sgx_enclave_common PROPERTIES IMPORTED_LOCATION
-                                                        ${LIBSGX_COMMON})
-  endif ()
-  target_link_libraries(oehost PUBLIC $<BUILD_INTERFACE:sgx_enclave_common>)
 
   # Optionally link in DCAP library
   if (HAS_QUOTE_PROVIDER)

--- a/host/sgx/sgx_enclave_common_wrapper.c
+++ b/host/sgx/sgx_enclave_common_wrapper.c
@@ -1,0 +1,207 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "sgx_enclave_common_wrapper.h"
+#include <openenclave/host.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/trace.h>
+#include <stdlib.h>
+#include "../hostthread.h"
+
+/**
+ * Pointers to functions that will be looked up from sgx_enclave_common.so/.dll
+ */
+
+static void* (*_enclave_create)(
+    void* base_address,
+    size_t virtual_size,
+    size_t initial_commit,
+    uint32_t type,
+    const void* info,
+    size_t info_size,
+    uint32_t* enclave_error);
+
+static size_t (*_enclave_load_data)(
+    void* target_address,
+    size_t target_size,
+    const void* source_buffer,
+    uint32_t data_properties,
+    uint32_t* enclave_error);
+
+bool (*_enclave_initialize)(
+    void* base_address,
+    const void* info,
+    size_t info_size,
+    uint32_t* enclave_error);
+
+bool (*_enclave_delete)(void* base_address, uint32_t* enclave_error);
+
+static bool (*_enclave_set_information)(
+    void* base_address,
+    uint32_t info_type,
+    void* input_info,
+    size_t input_info_size,
+    uint32_t* enclave_error);
+
+/****** Dynamic loading of libsgx_enclave_common.so/.dll **************/
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#define LIBRARY_NAME "sgx_enclave_common.dll"
+// Use LOAD_LIBRARY_SEARCH_SYSTEM32 flag since sgx_enclave_common.dll is part of
+// the Intel driver components and should only be loaded from there.
+#define LOAD_SGX_ENCLAVE_COMMON() \
+    (void*)LoadLibraryEx(LIBRARY_NAME, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+
+#define LOOKUP_FUNCTION(fcn) (void*)GetProcAddress((HANDLE)_module, fcn)
+
+#define UNLOAD_SGX_ENCLAVE_COMMON() FreeLibrary((HANDLE)_module)
+
+#else
+
+#include <dlfcn.h>
+
+#define LIBRARY_NAME "libsgx_enclave_common.so"
+
+// Use best practices
+// - RTLD_NOW  Bind all undefined symbols before dlopen returns.
+// - RTLD_GLOBAL Make symbols from this shared library visible to
+//   subsequently loaded libraries.
+#define LOAD_SGX_ENCLAVE_COMMON() dlopen(LIBRARY_NAME, RTLD_NOW | RTLD_GLOBAL)
+
+#define LOOKUP_FUNCTION(fcn) (void*)dlsym(_module, fcn)
+
+#define UNLOAD_SGX_ENCLAVE_COMMON() dlclose(_module)
+
+#endif
+
+static void* _module;
+
+static void _unload_sgx_enclave_common(void)
+{
+    if (_module)
+    {
+        UNLOAD_SGX_ENCLAVE_COMMON();
+        _module = NULL;
+    }
+}
+
+static oe_result_t _lookup_function(const char* name, void** function_ptr)
+{
+    oe_result_t result = OE_FAILURE;
+    *function_ptr = LOOKUP_FUNCTION(name);
+    if (!*function_ptr)
+    {
+        OE_TRACE_ERROR("%s function not found.\n", name);
+        goto done;
+    }
+    result = OE_OK;
+done:
+    return result;
+}
+
+static void _load_sgx_enclave_common_impl(void)
+{
+    oe_result_t result = OE_FAILURE;
+    OE_TRACE_INFO("Loading %s\n", LIBRARY_NAME);
+    _module = LOAD_SGX_ENCLAVE_COMMON();
+
+    if (_module)
+    {
+        OE_CHECK(_lookup_function("enclave_create", (void**)&_enclave_create));
+        OE_CHECK(
+            _lookup_function("enclave_load_data", (void**)&_enclave_load_data));
+        OE_CHECK(_lookup_function(
+            "enclave_initialize", (void**)&_enclave_initialize));
+        OE_CHECK(_lookup_function("enclave_delete", (void**)&_enclave_delete));
+        OE_CHECK(_lookup_function(
+            "enclave_set_information", (void**)&_enclave_set_information));
+
+        atexit(_unload_sgx_enclave_common);
+        result = OE_OK;
+        OE_TRACE_INFO("Loaded %s\n", LIBRARY_NAME);
+    }
+    else
+    {
+        OE_TRACE_ERROR("Failed to load %s\n", LIBRARY_NAME);
+        goto done;
+    }
+
+done:
+    if (result != OE_OK)
+    {
+        // It is a catastrophic error if sgx_enclave_common library cannot be
+        // successfully loaded.
+        OE_TRACE_ERROR("Terminating host application.");
+        abort();
+    }
+}
+
+static bool _load_sgx_enclave_common(void)
+{
+    static oe_once_type _once;
+    oe_once(&_once, _load_sgx_enclave_common_impl);
+    return (_module != NULL);
+}
+
+void* oe_sgx_enclave_create(
+    void* base_address,
+    size_t virtual_size,
+    size_t initial_commit,
+    uint32_t type,
+    const void* info,
+    size_t info_size,
+    uint32_t* enclave_error)
+{
+    _load_sgx_enclave_common();
+    return _enclave_create(
+        base_address,
+        virtual_size,
+        initial_commit,
+        type,
+        info,
+        info_size,
+        enclave_error);
+}
+
+size_t oe_sgx_enclave_load_data(
+    void* target_address,
+    size_t target_size,
+    const void* source_buffer,
+    uint32_t data_properties,
+    uint32_t* enclave_error)
+{
+    return _enclave_load_data(
+        target_address,
+        target_size,
+        source_buffer,
+        data_properties,
+        enclave_error);
+}
+
+bool oe_sgx_enclave_initialize(
+    void* base_address,
+    const void* info,
+    size_t info_size,
+    uint32_t* enclave_error)
+{
+    return _enclave_initialize(base_address, info, info_size, enclave_error);
+}
+
+bool oe_sgx_enclave_delete(void* base_address, uint32_t* enclave_error)
+{
+    return _enclave_delete(base_address, enclave_error);
+}
+
+bool oe_sgx_enclave_set_information(
+    void* base_address,
+    uint32_t info_type,
+    void* input_info,
+    size_t input_info_size,
+    uint32_t* enclave_error)
+{
+    return _enclave_set_information(
+        base_address, info_type, input_info, input_info_size, enclave_error);
+}

--- a/host/sgx/sgx_enclave_common_wrapper.h
+++ b/host/sgx/sgx_enclave_common_wrapper.h
@@ -1,0 +1,68 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+#ifndef _OE_HOST_SGX_ENCLAVE_COMMON_WRAPPER_H
+#define _OE_HOST_SGX_ENCLAVE_COMMON_WRAPPER_H
+
+#include <openenclave/bits/defs.h>
+#include <openenclave/bits/result.h>
+#include <openenclave/bits/types.h>
+
+#ifndef ENCLAVE_TYPE_SGX
+#define ENCLAVE_TYPE_SGX                                                   \
+    0x00000001 /* An enclave for the Intel Software Guard Extensions (SGX) \
+                  architecture version 1. */
+#endif
+#ifndef ENCLAVE_TYPE_SGX2
+#define ENCLAVE_TYPE_SGX2                                                  \
+    0x00000002 /* An enclave for the Intel Software Guard Extensions (SGX) \
+                  architecture version 2. */
+#endif
+#define ENCLAVE_TYPE_SGX1 ENCLAVE_TYPE_SGX
+
+typedef enum
+{
+    ENCLAVE_PAGE_READ =
+        1 << 0, /* Enables read access to the committed region of pages. */
+    ENCLAVE_PAGE_WRITE =
+        1 << 1, /* Enables write access to the committed region of pages. */
+    ENCLAVE_PAGE_EXECUTE =
+        1 << 2, /* Enables execute access to the committed region of pages. */
+    ENCLAVE_PAGE_THREAD_CONTROL =
+        1 << 8, /* The page contains a thread control structure. */
+    ENCLAVE_PAGE_UNVALIDATED =
+        1 << 12, /* The page contents that you supply are excluded from
+                    measurement and content validation. */
+} enclave_page_properties_t;
+
+void* oe_sgx_enclave_create(
+    void* base_address,
+    size_t virtual_size,
+    size_t initial_commit,
+    uint32_t type,
+    const void* info,
+    size_t info_size,
+    uint32_t* enclave_error);
+
+size_t oe_sgx_enclave_load_data(
+    void* target_address,
+    size_t target_size,
+    const void* source_buffer,
+    uint32_t data_properties,
+    uint32_t* enclave_error);
+
+bool oe_sgx_enclave_initialize(
+    void* base_address,
+    const void* info,
+    size_t info_size,
+    uint32_t* enclave_error);
+
+bool oe_sgx_enclave_delete(void* base_address, uint32_t* enclave_error);
+
+bool oe_sgx_enclave_set_information(
+    void* base_address,
+    uint32_t info_type,
+    void* input_info,
+    size_t input_info_size,
+    uint32_t* enclave_error);
+
+#endif //  _OE_HOST_SGX_ENCLAVE_COMMON_WRAPPER_H

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -3,7 +3,7 @@
 
 #include "sgxload.h"
 #if !defined(OEHOSTMR)
-#include <sgx_enclave_common.h>
+#include "sgx_enclave_common_wrapper.h"
 #endif // OEHOSTMR
 #if defined(__linux__)
 #include <sys/mman.h>
@@ -292,7 +292,7 @@ static oe_result_t _sgx_free_enclave_memory(
     if (!is_simulation)
     {
         uint32_t enclave_error = 0;
-        if (!enclave_delete(addr, &enclave_error) || enclave_error != 0)
+        if (!oe_sgx_enclave_delete(addr, &enclave_error) || enclave_error != 0)
         {
             OE_TRACE_ERROR(
                 "enclave_delete failed with enclave_error=%d", enclave_error);
@@ -464,7 +464,7 @@ oe_result_t oe_sgx_create_enclave(
     else
     {
         uint32_t enclave_error;
-        void* base = enclave_create(
+        void* base = oe_sgx_enclave_create(
             NULL, /* Let OS choose the enclave base address */
             secs->size,
             enclave_commit_size,
@@ -691,7 +691,7 @@ oe_result_t oe_sgx_load_enclave_data(
             protect |= ENCLAVE_PAGE_UNVALIDATED;
 
         uint32_t enclave_error;
-        if (enclave_load_data(
+        if (oe_sgx_enclave_load_data(
                 (void*)addr,
                 OE_PAGE_SIZE,
                 (const void*)src,
@@ -742,7 +742,7 @@ oe_result_t oe_sgx_initialize_enclave(
         OE_CHECK(_get_sig_struct(properties, mrenclave, &sigstruct));
 
         uint32_t enclave_error = 0;
-        if (!enclave_initialize(
+        if (!oe_sgx_enclave_initialize(
                 (void*)addr,
                 (const void*)&sigstruct,
                 sizeof(sgx_sigstruct_t),

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -154,9 +154,9 @@ set(HOST_CXXFLAGS_GCC ${HOST_CFLAGS_GCC})
 ##==============================================================================
 
 if (HAS_QUOTE_PROVIDER)
-  set(SGX_LIBS "-lsgx_enclave_common -lsgx_dcap_ql")
+  set(SGX_LIBS "-lsgx_dcap_ql")
 else ()
-  set(SGX_LIBS "-lsgx_enclave_common")
+  set(SGX_LIBS "")
 endif ()
 
 set(HOSTVERIFY_CLIBS


### PR DESCRIPTION
OE SDK can now be built for Simulation Mode on non SGX x64 systems
by passing HAS_QUOTE_PROVIDER=off

Simulation mode does not require SGX libraries to be present in the system.

Note: OE SDK debian packages will still have dependencies on SGX packages. It is safe to install SGX packages on non SGX machines.

Addresses the technical/implementation aspect of the following issues; documentation needs to be updated
- #2717
- #2728
- #1983
- #3127 

I have manually verified that this PR fixes #3127 
On a fresh Ubuntu 18.04 non SGX VM
```bash
sudo apt update
git clone --recursive https://github.com/anakrish/openenclave
cd openenclave
sudo scripts/ansible/install-ansible.sh
sudo ansible-playbook scripts/ansible/oe-vanilla-prelibsgx-setup.yml 
mkdir build
cd build
cmake .. -DHAS_QUOTE_PROVIDER=off
make -j 16
OE_SIMULATION=1 ctest
```

fixes #3217

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>