### PR TITLE
Install/Run OE SDK on non FLC machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reports extract the expected MRSIGNER value from the signer's public key PEM certificate.
 - OE SDK can now be built and run in simulation mode on a non SGX x64 Windows machine by passing HAS_QUOTE_PROVIDER=off.
   Previously, the build would work, but running applications would fail due to missing sgx_enclave_common.dll.
+- OE SDK can now be installed from published packages on SGX machines without FLC, and non-SGX machines.
+  Previously, OE SDK could only be installed on SGX1 FLC machines due to a link-time dependency on sgx_dcap_ql which
+  was available only on SGX1 FLC machines.
 
 ### Changed
 - Mark APIs in include/openenclave/attestation/sgx/attester.h and verifier.h as experimental.
@@ -25,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch to oeedger8r written in C++.
 - Fix #3134. oesign tool will now reject .conf files that contain duplicate property definitions.
 - SGX Simulation Mode does not need SGX libraries to be present in the system.
+- oehost library dynamically loads sgx_dcap_ql shared library instead of linking against it. This allows the SDK to
+  be installed on non-FLC and non-SGX machines.
 
 ### Removed
 - Removed oehostapp and the appendent "-rdynamic" compiling option. Please use oehost instead and add the option back manually if necessary.

--- a/cmake/openenclave-config.cmake.in
+++ b/cmake/openenclave-config.cmake.in
@@ -100,7 +100,6 @@ if (OE_SGX)
                               IMPORTED_LOCATION $ENV{WINDIR}/System32
                               IMPORTED_IMPLIB ${SGX_DCAP_QL_LIB})
       endif ()
-      target_link_libraries(openenclave::oehost INTERFACE openenclave::sgx_dcap_ql)
     endif ()
   endif ()
 endif ()

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -483,7 +483,11 @@ if (OE_SGX)
       set_target_properties(sgx_dcap_ql PROPERTIES IMPORTED_LOCATION
                                                    ${LIBSGX_QE})
     endif ()
-    target_link_libraries(oehost PUBLIC $<BUILD_INTERFACE:sgx_dcap_ql>)
+    # In Windows, add sgx_dcap_ql headers to the include path.
+    # In Linux, they are already available in /usr/include.
+    if (WIN32)
+      target_include_directories(oehost PRIVATE ${INCPATHS})
+    endif ()
     # turn on 'OE_LINK_SGX_DCAP_QL' for the preprocessor
     target_compile_definitions(oehost PUBLIC OE_LINK_SGX_DCAP_QL)
   endif ()

--- a/host/sgx/sgx_enclave_common_wrapper.c
+++ b/host/sgx/sgx_enclave_common_wrapper.c
@@ -69,7 +69,11 @@ static bool (*_enclave_set_information)(
 // - RTLD_NOW  Bind all undefined symbols before dlopen returns.
 // - RTLD_GLOBAL Make symbols from this shared library visible to
 //   subsequently loaded libraries.
+<<<<<<< HEAD
 #define LOAD_SGX_ENCLAVE_COMMON() dlopen(LIBRARY_NAME, RTLD_NOW | RTLD_GLOBAL)
+=======
+#define LOAD_SGX_ENCLAVE_COMMON() dlopen(LIBRARY_NAME, RTLD_NOW | RTLD_LOCAL)
+>>>>>>> Dynamically load sgx_enclave_common
 
 #define LOOKUP_FUNCTION(fcn) (void*)dlsym(_module, fcn)
 

--- a/host/sgx/sgx_enclave_common_wrapper.c
+++ b/host/sgx/sgx_enclave_common_wrapper.c
@@ -69,11 +69,7 @@ static bool (*_enclave_set_information)(
 // - RTLD_NOW  Bind all undefined symbols before dlopen returns.
 // - RTLD_GLOBAL Make symbols from this shared library visible to
 //   subsequently loaded libraries.
-<<<<<<< HEAD
 #define LOAD_SGX_ENCLAVE_COMMON() dlopen(LIBRARY_NAME, RTLD_NOW | RTLD_GLOBAL)
-=======
-#define LOAD_SGX_ENCLAVE_COMMON() dlopen(LIBRARY_NAME, RTLD_NOW | RTLD_LOCAL)
->>>>>>> Dynamically load sgx_enclave_common
 
 #define LOOKUP_FUNCTION(fcn) (void*)dlsym(_module, fcn)
 

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -8,11 +8,122 @@
 #include <openenclave/internal/sgx/plugin.h>
 #include <openenclave/internal/trace.h>
 #include <sgx_dcap_ql_wrapper.h>
+#include <stdlib.h>
 #include <string.h>
+#include "../hostthread.h"
 
 // Check consistency with OE definition.
 OE_STATIC_ASSERT(sizeof(sgx_target_info_t) == 512);
 OE_STATIC_ASSERT(sizeof(sgx_report_t) == 432);
+
+static quote3_error_t (*_sgx_qe_get_target_info)(
+    sgx_target_info_t* p_qe_target_info);
+
+static quote3_error_t (*_sgx_qe_get_quote_size)(uint32_t* p_quote_size);
+
+static quote3_error_t (*_sgx_qe_get_quote)(
+    const sgx_report_t* p_app_report,
+    uint32_t quote_size,
+    uint8_t* p_quote);
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#define LIBRARY_NAME "sgx_dcap_ql.dll"
+// Use LOAD_LIBRARY_SEARCH_SYSTEM32 flag since sgx_enclave_common.dll is part of
+// the Intel driver components and should only be loaded from there.
+#define LOAD_SGX_DCAP_QL() \
+    (void*)LoadLibraryEx(LIBRARY_NAME, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+
+#define LOOKUP_FUNCTION(fcn) (void*)GetProcAddress((HANDLE)_module, fcn)
+
+#define UNLOAD_SGX_DCAP_QL() FreeLibrary((HANDLE)_module)
+
+#else
+
+#include <dlfcn.h>
+
+#define LIBRARY_NAME "libsgx_dcap_ql.so"
+
+// Use best practices
+// - RTLD_NOW  Bind all undefined symbols before dlopen returns.
+// - RTLD_GLOBAL Make symbols from this shared library visible to
+//   subsequently loaded libraries.
+#define LOAD_SGX_DCAP_QL() dlopen(LIBRARY_NAME, RTLD_NOW | RTLD_GLOBAL)
+
+#define LOOKUP_FUNCTION(fcn) (void*)dlsym(_module, fcn)
+
+#define UNLOAD_SGX_DCAP_QL() dlclose(_module)
+
+#endif
+
+static void* _module;
+
+static void _unload_sgx_dcap_ql(void)
+{
+    if (_module)
+    {
+        UNLOAD_SGX_DCAP_QL();
+        _module = NULL;
+    }
+}
+
+static oe_result_t _lookup_function(const char* name, void** function_ptr)
+{
+    oe_result_t result = OE_FAILURE;
+    *function_ptr = LOOKUP_FUNCTION(name);
+    if (!*function_ptr)
+    {
+        OE_TRACE_ERROR("%s function not found.\n", name);
+        goto done;
+    }
+    result = OE_OK;
+done:
+    return result;
+}
+
+static void _load_sgx_dcap_ql_impl(void)
+{
+    oe_result_t result = OE_FAILURE;
+    OE_TRACE_INFO("Loading %s\n", LIBRARY_NAME);
+    _module = LOAD_SGX_DCAP_QL();
+
+    if (_module)
+    {
+        OE_CHECK(_lookup_function(
+            "sgx_qe_get_target_info", (void**)&_sgx_qe_get_target_info));
+        OE_CHECK(_lookup_function(
+            "sgx_qe_get_quote_size", (void**)&_sgx_qe_get_quote_size));
+        OE_CHECK(
+            _lookup_function("sgx_qe_get_quote", (void**)&_sgx_qe_get_quote));
+
+        atexit(_unload_sgx_dcap_ql);
+        result = OE_OK;
+        OE_TRACE_INFO("Loaded %s\n", LIBRARY_NAME);
+    }
+    else
+    {
+        OE_TRACE_ERROR("Failed to load %s\n", LIBRARY_NAME);
+        goto done;
+    }
+
+done:
+    if (result != OE_OK)
+    {
+        // It is a catastrophic error if sgx_dcap_ql library cannot be
+        // successfully loaded.
+        OE_TRACE_ERROR("Terminating host application.");
+        abort();
+    }
+}
+
+static bool _load_sgx_dcap_ql(void)
+{
+    static oe_once_type _once;
+    oe_once(&_once, _load_sgx_dcap_ql_impl);
+    return (_module != NULL);
+}
 
 oe_result_t oe_sgx_qe_get_target_info(
     const oe_uuid_t* format_id,
@@ -26,8 +137,8 @@ oe_result_t oe_sgx_qe_get_target_info(
     OE_UNUSED(format_id);
     OE_UNUSED(opt_params);
     OE_UNUSED(opt_params_size);
-
-    err = sgx_qe_get_target_info((sgx_target_info_t*)target_info);
+    _load_sgx_dcap_ql();
+    err = _sgx_qe_get_target_info((sgx_target_info_t*)target_info);
 
     if (err != SGX_QL_SUCCESS)
         OE_RAISE_MSG(OE_PLATFORM_ERROR, "quote3_error_t=0x%x\n", err);
@@ -50,8 +161,8 @@ oe_result_t oe_sgx_qe_get_quote_size(
     OE_UNUSED(format_id);
     OE_UNUSED(opt_params);
     OE_UNUSED(opt_params_size);
-
-    err = sgx_qe_get_quote_size(local_quote_size);
+    _load_sgx_dcap_ql();
+    err = _sgx_qe_get_quote_size(local_quote_size);
 
     if (err != SGX_QL_SUCCESS)
         OE_RAISE_MSG(OE_PLATFORM_ERROR, "quote3_error_t=0x%x\n", err);
@@ -81,8 +192,9 @@ oe_result_t oe_sgx_qe_get_quote(
         OE_RAISE(OE_INVALID_PARAMETER);
 
     local_quote_size = (uint32_t)quote_size;
+    _load_sgx_dcap_ql();
 
-    err = sgx_qe_get_quote((sgx_report_t*)report, local_quote_size, quote);
+    err = _sgx_qe_get_quote((sgx_report_t*)report, local_quote_size, quote);
     if (err != SGX_QL_SUCCESS)
         OE_RAISE_MSG(OE_PLATFORM_ERROR, "quote3_error_t=0x%x\n", err);
     OE_TRACE_INFO("quote_size=%d", local_quote_size);

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -153,18 +153,11 @@ set(HOST_CXXFLAGS_GCC ${HOST_CFLAGS_GCC})
 ##
 ##==============================================================================
 
-if (HAS_QUOTE_PROVIDER)
-  set(SGX_LIBS "-lsgx_dcap_ql")
-else ()
-  set(SGX_LIBS "")
-endif ()
-
 set(HOSTVERIFY_CLIBS
     "-rdynamic -Wl,-z,noexecstack -L\${libdir}/openenclave/host -loehostverify -ldl -lpthread"
 )
 set(HOST_CLIBS
-    "-Wl,-z,noexecstack -L\${libdir}/openenclave/host -loehost -ldl -lpthread ${SGX_LIBS}"
-)
+    "-Wl,-z,noexecstack -L\${libdir}/openenclave/host -loehost -ldl -lpthread")
 
 set(HOSTVERIFY_CXXLIBS "${HOSTVERIFY_CLIBS}")
 set(HOST_CXXLIBS "${HOST_CLIBS}")


### PR DESCRIPTION
Currently oehost.a links in sgx_dcap_ql shared library. sgx_dcap_ql is available only on FLC machines. Therefore it is not possible to install OE SDK package on non FLC machines and execute  enclaves in hardware mode (if the system supports SGX) or in simulation mode.

This PR removes the link time dependency by dynamically loading sgx_dcap_ql.This allows OE SDK to be installed on non FLC machines and execute enclaves in hardware mode (if machine supports SGX) or in simulation mode.


PR #3155 enabled the ability to build OE SDK from source on non-sgx machines by removing the link-time dependency on sgx_enclave_common.dll. Such a build of the SDK does not support attestation.

This PR enables installing OE SDK from future published packages on non FLC machines and non SGX machines.
Both the PR together address 
#2717
#2728
#1983

The documentation needs to be changed to explain the newly enabled workflow.