### PR TITLE
Tweak oeedger8r tests

### DIFF
--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -41,21 +41,19 @@ add_enclave(
   e71cbbea-a638-4653-b46e-2e58a2ca3408
   CXX
   SOURCES
-  all_t.c
+  all_t.h
+  all_t_wrapper.cpp
   bar_t.h
   bar.cpp
   config.cpp
   foo.cpp
   testaliasing.cpp
   testarray.cpp
-  testbasic.cpp
   testdeepcopy.cpp
   testenum.cpp
-  testerrno.cpp
   testforeign.cpp
   testpointer.cpp
   testsecurity.cpp
-  teststring.cpp
   teststruct.cpp
   testswitchless.cpp)
 
@@ -64,9 +62,10 @@ add_enclave(
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU
     OR CMAKE_CXX_COMPILER_ID MATCHES Clang
     OR USE_CLANGW)
-  set_source_files_properties(all_t.c PROPERTIES COMPILE_FLAGS
-                                                 "-Wno-conversion")
-  set_source_files_properties(testpointer.cpp teststring.cpp
+  set_source_files_properties(
+    all_t_wrapper.cpp PROPERTIES COMPILE_FLAGS
+                                 "-Wno-conversion -Wno-sign-compare")
+  set_source_files_properties(testpointer.cpp
                               PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 endif ()
 

--- a/tests/oeedger8r/enc/all_t_wrapper.cpp
+++ b/tests/oeedger8r/enc/all_t_wrapper.cpp
@@ -1,0 +1,7 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "all_t.c"
+#include "testbasic.cpp"
+#include "testerrno.cpp"
+#include "teststring.cpp"

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -41,28 +41,27 @@ add_custom_target(edl_host_gen DEPENDS all_u.h all_u.c all_args.h bar_u.h
 
 add_executable(
   edl_host
-  all_u.c
+  all_u.h
+  all_u_wrapper.cpp
   bar_u.h
   main.cpp
   bar.cpp
   foo.cpp
   testarray.cpp
-  testbasic.cpp
   testdeepcopy.cpp
   testenum.cpp
-  testerrno.cpp
   testforeign.cpp
   testpointer.cpp
   testsecurity.cpp
-  teststring.cpp
   teststruct.cpp
   testswitchless.cpp)
 
 # The tests intentionally use floats etc in size context.
 # Disable warnings.
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  set_source_files_properties(all_u.c PROPERTIES COMPILE_FLAGS
-                                                 "-Wno-conversion")
+  set_source_files_properties(
+    all_u_wrapper.cpp PROPERTIES COMPILE_FLAGS
+                                 "-Wno-conversion -Wno-sign-compare")
   set_source_files_properties(testpointer.cpp teststring.cpp
                               PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 endif ()

--- a/tests/oeedger8r/host/all_u_wrapper.cpp
+++ b/tests/oeedger8r/host/all_u_wrapper.cpp
@@ -1,0 +1,7 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "all_u.c"
+#include "testbasic.cpp"
+#include "testerrno.cpp"
+#include "teststring.cpp"

--- a/tests/oeedger8r/host/teststring.cpp
+++ b/tests/oeedger8r/host/teststring.cpp
@@ -357,6 +357,7 @@ void ocall_string_fun5(char* s)
 
 void ocall_string_fun6(const char* s)
 {
+    OE_UNUSED(s);
     ocall_string_fun6_args_t args;
     // constness is discarded when marshaling.
     check_type<char*>(args.s);
@@ -468,6 +469,7 @@ void ocall_wstring_fun5(wchar_t* s)
 
 void ocall_wstring_fun6(const wchar_t* s)
 {
+    OE_UNUSED(s);
     ocall_wstring_fun6_args_t args;
     // constness is discarded when marshaling.
     check_type<wchar_t*>(args.s);


### PR DESCRIPTION
oeedger8r will emit marshalling struct/enums etc only in the relevant cpp
files. Tests that make compile time assertions on the marshalling structs
need the struct definition. Such tests are grouped into _wrapper files that
include the corresponding all_u.c/all_t.c files.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>