### PR TITLE
Add check for claims == NULL in oe_verify_evidence

### DIFF
--- a/common/attest_plugin.c
+++ b/common/attest_plugin.c
@@ -224,7 +224,7 @@ oe_result_t oe_verify_evidence(
         claims,
         claims_length));
 
-    if (!_check_claims(*claims, *claims_length))
+    if (claims && claims_length && !_check_claims(*claims, *claims_length))
     {
         verifier->free_claims(verifier, *claims, *claims_length);
         *claims = NULL;


### PR DESCRIPTION
I'm not sure whether we should reject `claims == NULL` in `oe_verify_evidence` outright, as it makes it impossible to report the required claims. I added the check just for `_check_claims` but I think it may be better to make that an `OE_INVALID_PARAMETER`. 

Signed-off-by: Christoph M. Wintersteiger <cwinter@microsoft.com>