### PR TITLE
[SGX-LKL only] Add X flag to memory pages to successfully verify SGX-LKL attestation evidence.

### DIFF
--- a/common/sgx/eeid.c
+++ b/common/sgx/eeid.c
@@ -280,7 +280,7 @@ static oe_result_t _add_page(
         base,
         base + *vaddr,
         (uint64_t)page,
-        SGX_SECINFO_REG | SGX_SECINFO_R | SGX_SECINFO_W,
+        SGX_SECINFO_REG | SGX_SECINFO_R | SGX_SECINFO_W | SGX_SECINFO_X,
         t));
     *vaddr += OE_PAGE_SIZE;
     result = OE_OK;

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -702,7 +702,8 @@ static oe_result_t _add_eeid_pages(
         {
             uint64_t addr = enclave_addr + *vaddr;
             uint64_t src = (uint64_t)(pages + i * OE_PAGE_SIZE);
-            uint64_t flags = SGX_SECINFO_REG | SGX_SECINFO_R | SGX_SECINFO_W;
+            uint64_t flags =
+                SGX_SECINFO_REG | SGX_SECINFO_R | SGX_SECINFO_W | SGX_SECINFO_X;
 
             OE_CHECK(oe_sgx_load_enclave_data(
                 context, enclave_addr, addr, src, flags, true));


### PR DESCRIPTION
Just adds the X flag in two more places. 

Signed-off-by: Christoph M. Wintersteiger <cwinter@microsoft.com>