### PR TITLE
Update design doc to reflect Sig-Arch Decision.

### DIFF
--- a/docs/DesignDocs/system_ocall_opt_in.md
+++ b/docs/DesignDocs/system_ocall_opt_in.md
@@ -23,12 +23,14 @@ Users can import a system OCall the same way any other EDL file would be importe
 if an enclave with EDL file `sample.edl` wants to use the function `oe_log_ocall()` they can do
 one of the following:
 
-*Note: SGX SDK requires the user to link specific libraries in addition to importing the system edl.
-For example, in order to use the switchless calling feature, the user must import sgx_tswitchless.edl,and
-link sgx_tswitchless.a in enclave and sgx_uswitchless.a in the host. In contrasst, OE SDK will only require
-the user to import switchless.edl, and not require the user to link new libraries for system edls.
-However, The current libraries for system elds  will remain. (e.g: liboehostepoll.a,  liboehostresolver.a, liboelibc.a,
-liboesyscall.a). See [Sig-Arch](https://hackmd.io/@aeva/oesdk-sig-arch#23-June-2020)
+*Note: Both SGX SDK for Linux and Intel SGX SDK for Windows require the user to link specific
+libraries in addition to importing the system edl. For example, in order to use the switchless
+calling feature in SGX SDK for Linux, the user must import sgx_tswitchless.edl, and link
+sgx_tswitchless.a in the enclave and sgx_uswitchless.a in the host. In contrasst, OE SDK will
+only require the user to import switchless.edl, and not require the user to link new
+libraries for system edls. However, the current libraries for system EDLs will remain.
+(i.e.: liboehostepoll.a,  liboehostresolver.a, liboelibc.a, liboesyscall.a).
+See [Sig-Arch](https://hackmd.io/@aeva/oesdk-sig-arch#23-June-2020)
 
 
 *Note: These examples assume that `${install_path}/include` is passed to edger8r as an EDL search path*

--- a/docs/DesignDocs/system_ocall_opt_in.md
+++ b/docs/DesignDocs/system_ocall_opt_in.md
@@ -23,6 +23,14 @@ Users can import a system OCall the same way any other EDL file would be importe
 if an enclave with EDL file `sample.edl` wants to use the function `oe_log_ocall()` they can do
 one of the following:
 
+*Note: SGX SDK requires the user to link specific libraries in addition to importing the system edl.
+For example, in order to use the switchless calling feature, the user must import sgx_tswitchless.edl,and
+link sgx_tswitchless.a in enclave and sgx_uswitchless.a in the host. In contrasst, OE SDK will only require
+the user to import switchless.edl, and not require the user to link new libraries for system edls.
+However, The current libraries for system elds  will remain. (e.g: liboehostepoll.a,  liboehostresolver.a, liboelibc.a,
+liboesyscall.a). See [Sig-Arch](https://hackmd.io/@aeva/oesdk-sig-arch#23-June-2020)
+
+
 *Note: These examples assume that `${install_path}/include` is passed to edger8r as an EDL search path*
 
 1. Import just the required OCall


### PR DESCRIPTION
Contrary to SGX SDK, OE SDK will not necessarily refactor code associated with
system edls into separate libraries that the user will have to link.

This means that for features like switchless, the user does not need to link in
additional libraries; only import switchless.edl.

However, there exists many libraries that accompany system edl:
liboehostepoll.a  liboehostresolver.a  liboesyscall.a
liboehostfs.a     liboehostsock.a

These will remain.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>

fixes #3154 