### PR TITLE
Security test - Pass enclave ptr back in to enclave

### DIFF
--- a/tests/oeedger8r/edl/all.edl
+++ b/tests/oeedger8r/edl/all.edl
@@ -20,6 +20,7 @@ enclave  {
     from "errno.edl"    import *;
     from "foreign.edl"  import *;
     from "pointer.edl"  import *;
+    from "security.edl" import *;
     from "string.edl"   import *;
     from "struct.edl"   import *;
     from "switchless_test.edl" import *;

--- a/tests/oeedger8r/edl/security.edl
+++ b/tests/oeedger8r/edl/security.edl
@@ -1,0 +1,14 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+
+   trusted {
+      // Get address of trusted location.
+      public int* security_get_secret_ptr();
+
+      // trusted memory address as ECALL parameter, will not leak secrets.
+      public void security_ecall_test1([size = 4,in] int* ptr);
+   };
+
+};

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -14,6 +14,7 @@ add_custom_command(
           ../edl/foreign.edl
           ../edl/other.edl
           ../edl/pointer.edl
+          ../edl/security.edl
           ../edl/string.edl
           ../edl/struct.edl
           ../edl/switchless_test.edl
@@ -53,6 +54,7 @@ add_enclave(
   testerrno.cpp
   testforeign.cpp
   testpointer.cpp
+  testsecurity.cpp
   teststring.cpp
   teststruct.cpp
   testswitchless.cpp)

--- a/tests/oeedger8r/enc/testsecurity.cpp
+++ b/tests/oeedger8r/enc/testsecurity.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "../edltestutils.h"
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <string.h>
+#include "all_t.h"
+
+static int _secret = 11223344;
+
+// Get address of trusted location.
+int* security_get_secret_ptr()
+{
+    return &_secret;
+}
+
+// trusted memory address as ECALL parameter, will not leak secrets.
+void security_ecall_test1(int* ptr)
+{
+    // Since host does serialization completely, the contents of ptr
+    // will not match _secret.
+    OE_TEST(*ptr != _secret);
+
+    // ptr must lie within the enclave.
+    OE_TEST(oe_is_within_enclave(ptr, sizeof(*ptr)));
+
+    printf("_secret = %d, *ptr = %d\n", _secret, ptr);
+
+    printf("_secret not leaked.\n");
+}

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -13,6 +13,7 @@ add_custom_command(
           ../edl/errno.edl
           ../edl/foreign.edl
           ../edl/pointer.edl
+          ../edl/security.edl
           ../edl/string.edl
           ../edl/struct.edl
           ../edl/switchless_test.edl
@@ -52,6 +53,7 @@ add_executable(
   testerrno.cpp
   testforeign.cpp
   testpointer.cpp
+  testsecurity.cpp
   teststring.cpp
   teststruct.cpp
   testswitchless.cpp)

--- a/tests/oeedger8r/host/main.cpp
+++ b/tests/oeedger8r/host/main.cpp
@@ -25,6 +25,7 @@ void test_enum_edl_ecalls(oe_enclave_t* enclave);
 void test_foreign_edl_ecalls(oe_enclave_t* enclave);
 void test_other_edl_ecalls(oe_enclave_t* enclave);
 void test_deepcopy_edl_ecalls(oe_enclave_t* enclave);
+void test_security(oe_enclave_t* enclave);
 
 int main(int argc, const char* argv[])
 {
@@ -109,6 +110,12 @@ int main(int argc, const char* argv[])
     test_deepcopy_edl_ecalls(enclave);
 
     OE_TEST(test_switchless_edl_ocalls(enclave) == OE_OK);
+
+    if (flags & OE_ENCLAVE_FLAG_SIMULATE)
+        printf("Skipping security test in Simulation Mode.\n");
+    else
+        test_security(enclave);
+
 #ifdef FALSE
 // See above
 done:

--- a/tests/oeedger8r/host/testsecurity.cpp
+++ b/tests/oeedger8r/host/testsecurity.cpp
@@ -1,0 +1,22 @@
+
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "../edltestutils.h"
+
+#include <openenclave/host.h>
+#include <openenclave/internal/tests.h>
+#include "all_u.h"
+
+void test_security(oe_enclave_t* enclave)
+{
+    // Get secret memory location from enclave.
+    int* location = NULL;
+    OE_TEST(security_get_secret_ptr(enclave, &location) == OE_OK);
+    OE_TEST(location != NULL);
+
+    // Pass location back to enclave.
+    OE_TEST(security_ecall_test1(enclave, location) == OE_OK);
+
+    printf("=== test_security passed\n");
+}


### PR DESCRIPTION
OE SDK marshalling strategy is different from Intel SGX SDK.
The host is expected to searialize all inputs before sending it
over to the enclave. This is so that the generated code works
without modification on OP-TEE where the enclave cannot access
host memory.

In Intel SDK:
   int* ptr = security_get_secret_ptr(enclave);
   security_ecall_test1(ptr); <-- will return SGX_INVALID_PARAMETER

In OE SDK,
   int* ptr = security_get_secret_ptr(enclave);
   security_ecall_test1(ptr); <-- host marshalls ptr and will obtain
                                  junk value which is sent to the enclave

all the marshalling is expected to be done by the host. Host will
read ptr which will be protected by SGX hardware.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>