### PR TITLE
Usability oriented pointer checks.

### DIFF
--- a/include/openenclave/edger8r/enclave.h
+++ b/include/openenclave/edger8r/enclave.h
@@ -20,6 +20,14 @@
 #include <openenclave/bits/defs.h>
 #include <openenclave/bits/result.h>
 #include <openenclave/bits/types.h>
+
+/**
+ * Define OE_BUILD_ENCLAVE to enable enclave specific checks.
+ */
+#ifndef OE_BUILD_ENCLAVE
+#define OE_BUILD_ENCLAVE
+#endif
+
 #include <openenclave/edger8r/common.h>
 
 #include <openenclave/corelibc/errno.h>

--- a/tests/oeedger8r/edl/security.edl
+++ b/tests/oeedger8r/edl/security.edl
@@ -3,12 +3,25 @@
 
 enclave {
 
+   struct SecurityS {
+       [size=4] int* ptr;
+   };
+
    trusted {
       // Get address of trusted location.
       public int* security_get_secret_ptr();
 
       // trusted memory address as ECALL parameter, will not leak secrets.
       public void security_ecall_test1([size = 4,in] int* ptr);
-   };
+
+      // trusted memory address as ECALL parameter via deepcopy, will not leak secrets.
+      public void security_ecall_test2([in] SecurityS* s);
+
+      // trusted memory address as ECALL in/out parameter, will not leak secrets.
+      public void security_ecall_test3([size = 4, in, out] int* ptr);
+
+      // trusted memory address as ECALL in/out parameter via deepcopy, will not leak secrets.
+      public void security_ecall_test4([count=1, in, out] SecurityS* s);
+  };
 
 };

--- a/tests/oeedger8r/enc/testsecurity.cpp
+++ b/tests/oeedger8r/enc/testsecurity.cpp
@@ -20,14 +20,27 @@ int* security_get_secret_ptr()
 // trusted memory address as ECALL parameter, will not leak secrets.
 void security_ecall_test1(int* ptr)
 {
-    // Since host does serialization completely, the contents of ptr
-    // will not match _secret.
-    OE_TEST(*ptr != _secret);
+    OE_UNUSED(ptr);
+    oe_abort();
+}
 
-    // ptr must lie within the enclave.
-    OE_TEST(oe_is_within_enclave(ptr, sizeof(*ptr)));
+// trusted memory address as ECALL parameter, will not leak secrets.
+void security_ecall_test2(SecurityS* s)
+{
+    OE_UNUSED(s);
+    oe_abort();
+}
 
-    printf("_secret = %d, *ptr = %d\n", _secret, ptr);
+// trusted memory address as ECALL parameter, will not leak secrets.
+void security_ecall_test3(int* ptr)
+{
+    OE_UNUSED(ptr);
+    oe_abort();
+}
 
-    printf("_secret not leaked.\n");
+// trusted memory address as ECALL parameter, will not leak secrets.
+void security_ecall_test4(SecurityS* s)
+{
+    OE_UNUSED(s);
+    oe_abort();
 }

--- a/tests/oeedger8r/host/testsecurity.cpp
+++ b/tests/oeedger8r/host/testsecurity.cpp
@@ -16,7 +16,18 @@ void test_security(oe_enclave_t* enclave)
     OE_TEST(location != NULL);
 
     // Pass location back to enclave.
-    OE_TEST(security_ecall_test1(enclave, location) == OE_OK);
+    OE_TEST(security_ecall_test1(enclave, location) == OE_INVALID_PARAMETER);
 
+    // Pass location back to enclave via struct deepcopy.
+    SecurityS s = {location};
+    OE_TEST(security_ecall_test2(enclave, &s) == OE_INVALID_PARAMETER);
+
+    // Pass location back to enclave via in/out parameter.
+    OE_TEST(security_ecall_test3(enclave, location) == OE_INVALID_PARAMETER);
+
+    // Pass location back to enclave via struct deepcopy in/out parameter.
+    OE_TEST(security_ecall_test4(enclave, &s) == OE_INVALID_PARAMETER);
+
+    printf("=== expect four OE_INVALID_PARAMETER errors above ======\n");
     printf("=== test_security passed\n");
 }

--- a/tests/oeedger8r/host/teststring.cpp
+++ b/tests/oeedger8r/host/teststring.cpp
@@ -301,7 +301,7 @@ void test_string_edl_ecalls(oe_enclave_t* enclave)
 #endif
     }
 
-    printf("=== expect four OE_INVALID_PARAMETER errors above ===");
+    printf("=== expect four OE_INVALID_PARAMETER errors above ===\n");
     printf("=== test_string_edl_ecalls passed\n");
 }
 


### PR DESCRIPTION
When an enclave pointer is passed by the host back into the enclave
either as an in or in/out parameter detect it an raise OE_INVALID_PARAMETER.

Note: OE SDK marshalling strategy does not require these pointers to be passed in.
It is not a security issue. The pointers are now being passed in just for doing
these checks.

Note: Similar usability checks for out parameters are not implemented since
that may require changes to oeedger8r.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>