### PR TITLE
Install eeid_verifier.h

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -25,9 +25,11 @@ install(
   COMPONENT OEHOSTVERIFY)
 install(FILES openenclave/attestation/attester.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/attestation/)
-install(FILES openenclave/attestation/sgx/eeid_attester.h
-              openenclave/attestation/sgx/eeid_plugin.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/attestation/sgx)
+install(
+  FILES openenclave/attestation/sgx/eeid_attester.h
+        openenclave/attestation/sgx/eeid_plugin.h
+        openenclave/attestation/sgx/eeid_verifier.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/attestation/sgx)
 install(
   FILES openenclave/attestation/verifier.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/attestation/


### PR DESCRIPTION
Forgot to install a header file in #3131. 

In general: should the plugin initializers be called by the infrastructure, when it receives a request to verify evidence from a non-initialized plugin UUID, or will this stay on the client side?

Signed-off-by: Christoph M. Wintersteiger <cwinter@microsoft.com>