### PR TITLE
Minimize host-verify package without separating oehost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,20 +351,22 @@ add_subdirectory(host)
 # Tests and samples have been ported to manually include system edl files.
 # They can no longer be used when system EDL is builtin.
 if (NOT COMPILE_SYSTEM_EDL)
-  if (BUILD_TESTS)
+  if (BUILD_TESTS AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
     add_subdirectory(tests)
   endif ()
 
   # Skip samples when enabling the code coverage test.
   # Otherwise, all the samples need to explicitly link against the libgcov library.
-  if (BUILD_ENCLAVES AND (NOT CODE_COVERAGE))
+  if (NOT CODE_COVERAGE)
     add_subdirectory(samples)
   endif ()
 endif ()
 
-add_subdirectory(tools)
+if (NOT COMPONENT MATCHES OEHOSTVERFIY)
+  add_subdirectory(tools)
+endif ()
 
-if (BUILD_ENCLAVES)
+if (BUILD_ENCLAVES AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
   add_subdirectory(enclave)
   add_subdirectory(3rdparty)
   add_subdirectory(libc)
@@ -372,7 +374,7 @@ if (BUILD_ENCLAVES)
   add_subdirectory(syscall)
 endif ()
 
-if (OE_SGX)
+if (OE_SGX AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
   add_subdirectory(debugger)
 endif ()
 

--- a/cmake/openenclave-config.cmake.in
+++ b/cmake/openenclave-config.cmake.in
@@ -13,7 +13,8 @@ set_and_check(OE_BINDIR "@PACKAGE_CMAKE_INSTALL_BINDIR@")
 set_and_check(OE_DATADIR "@PACKAGE_CMAKE_INSTALL_DATADIR@")
 set_and_check(OE_INCLUDEDIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 set(OE_SCRIPTSDIR "@PACKAGE_CMAKE_INSTALL_BINDIR@/scripts")
-set (OE_SGX "@OE_SGX@")
+set(OE_SGX "@OE_SGX@")
+set(COMPONENT "@COMPONENT@")
 
 if (WIN32)
   set(USE_CLANGW ON)
@@ -74,13 +75,13 @@ endif ()
 
 # Include the automatically exported targets.
 include("${CMAKE_CURRENT_LIST_DIR}/openenclave-targets.cmake")
-if (WIN32)
+if (WIN32 AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
   include("${CMAKE_CURRENT_LIST_DIR}/add_dcap_client_target.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/copy_oedebugrt_target.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/maybe_build_using_clangw.cmake")
 endif ()
 
-if (OE_SGX)
+if (OE_SGX AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
   if (NOT TARGET openenclave::sgx_dcap_ql)
     if (UNIX)
       find_library(SGX_DCAP_QL_LIB NAMES sgx_dcap_ql HINTS "/usr")
@@ -104,33 +105,35 @@ if (OE_SGX)
   endif ()
 endif ()
 
-# This target is an external project, so we have to manually
-# "export" it here for users of the package.
-if(NOT TARGET openenclave::oeedger8r)
-  add_executable(openenclave::oeedger8r IMPORTED)
-  set_target_properties(openenclave::oeedger8r PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oeedger8r)
-endif ()
+if(NOT COMPONENT MATCHES OEHOSTVERIFY)
+  # This target is an external project, so we have to manually
+  # "export" it here for users of the package.
+  if(NOT TARGET openenclave::oeedger8r)
+    add_executable(openenclave::oeedger8r IMPORTED)
+    set_target_properties(openenclave::oeedger8r PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oeedger8r)
+  endif ()
 
-# Similarly, this is a shell script.
-if(NOT TARGET openenclave::oegdb)
-  add_executable(openenclave::oegdb IMPORTED)
-  set_target_properties(openenclave::oegdb PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oegdb)
-endif ()
+  # Similarly, this is a shell script.
+  if(NOT TARGET openenclave::oegdb)
+    add_executable(openenclave::oegdb IMPORTED)
+    set_target_properties(openenclave::oegdb PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oegdb)
+  endif ()
 
-# Apply Spectre mitigations if available.
-set(OE_SPECTRE_MITIGATION_FLAGS "@SPECTRE_MITIGATION_FLAGS@")
+  # Apply Spectre mitigations if available.
+  set(OE_SPECTRE_MITIGATION_FLAGS "@SPECTRE_MITIGATION_FLAGS@")
 
-# Check for compiler flags support.
-if (CMAKE_C_COMPILER)
-  include(CheckCCompilerFlag)
-  check_c_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED)
-endif ()
+  # Check for compiler flags support.
+  if (CMAKE_C_COMPILER)
+    include(CheckCCompilerFlag)
+    check_c_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED)
+  endif ()
 
-if (CMAKE_CXX_COMPILER)
-  include(CheckCXXCompilerFlag)
-  check_cxx_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
-endif ()
+  if (CMAKE_CXX_COMPILER)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
+  endif ()
 
-if (OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED OR OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
-  target_compile_options(openenclave::oecore INTERFACE ${OE_SPECTRE_MITIGATION_FLAGS})
+  if (OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED OR OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
+    target_compile_options(openenclave::oecore INTERFACE ${OE_SPECTRE_MITIGATION_FLAGS})
+  endif ()
 endif ()

--- a/cmake/package_settings.cmake
+++ b/cmake/package_settings.cmake
@@ -104,8 +104,7 @@ install(
   FILES
     ${CMAKE_BINARY_DIR}/cmake/openenclave-lvi-mitigation-config.cmake
     ${CMAKE_BINARY_DIR}/cmake/openenclave-lvi-mitigation-config-version.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
-  COMPONENT OEHOSTVERIFY)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake)
 
 if (UNIX)
   # Generate the openenclaverc script.

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -551,7 +551,8 @@ endif ()
 install(
   TARGETS oehost
   EXPORT openenclave-targets
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host)
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host
+          COMPONENT OEHOSTVERIFY)
 
 install(
   TARGETS oehostverify

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -230,7 +230,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oehost-gcc.pc
                ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-gcc.pc @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-gcc.pc
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig")
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+        COMPONENT OEHOSTVERIFY)
 
 ##==============================================================================
 ##
@@ -242,7 +243,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oehost-g++.pc
                ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-g++.pc @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-g++.pc
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig")
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+        COMPONENT OEHOSTVERIFY)
 
 ##==============================================================================
 ##
@@ -344,7 +346,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oehost-clang.pc
                ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang.pc @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang.pc
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig")
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+        COMPONENT OEHOSTVERIFY)
 
 ##==============================================================================
 ##
@@ -357,7 +360,8 @@ configure_file(
   ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang++.pc @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang++.pc
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig")
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+        COMPONENT OEHOSTVERIFY)
 
 ##==============================================================================
 ##

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-if (HAS_QUOTE_PROVIDER)
+if (BUILD_ENCLAVES AND HAS_QUOTE_PROVIDER)
   install(
     DIRECTORY remote_attestation
     DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples
@@ -65,8 +65,10 @@ if (WIN32)
     DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples
     RENAME README.md)
 else ()
-  install(FILES config.mk
-          DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples)
+  install(
+    FILES config.mk
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples
+    COMPONENT OEHOSTVERIFY)
   install(
     FILES README_Linux.md
     DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/samples

--- a/samples/test-samples.cmake
+++ b/samples/test-samples.cmake
@@ -6,7 +6,12 @@
 #
 #     cmake -DHAS_QUOTE_PROVIDER=ON -DSOURCE_DIR=~/openenclave -DBUILD_DIR=~/openenclave/build -DPREFIX_DIR=/opt/openenclave -P ~/openenclave/samples/test-samples.cmake
 
-set(SAMPLES_LIST helloworld file-encryptor switchless host_verify)
+# Set SAMPLES_LIST so that helloworld becomes the first if BUILD_ENCLAVES=ON.
+if (BUILD_ENCLAVES)
+  set(SAMPLES_LIST helloworld file-encryptor switchless host_verify)
+else ()
+  set(SAMPLES_LIST host_verify)
+endif ()
 
 if ($ENV{OE_SIMULATION})
   message(
@@ -21,13 +26,15 @@ else ()
   # This sample can run on SGX, both with and without FLC, meaning
   # they can run even if they weren't built against SGX, because in
   # that cause they directly interface with the AESM service.
-  list(APPEND SAMPLES_LIST data-sealing local_attestation)
+  if (BUILD_ENCLAVES)
+    list(APPEND SAMPLES_LIST data-sealing local_attestation)
 
-  # These tests can only run with SGX-FLC, meaning they were built
-  # against SGX.
-  if (HAS_QUOTE_PROVIDER)
-    list(APPEND SAMPLES_LIST remote_attestation)
-    list(APPEND SAMPLES_LIST attested_tls)
+    # These tests can only run with SGX-FLC, meaning they were built
+    # against SGX.
+    if (HAS_QUOTE_PROVIDER)
+      list(APPEND SAMPLES_LIST remote_attestation)
+      list(APPEND SAMPLES_LIST attested_tls)
+    endif ()
   endif ()
 endif ()
 

--- a/tests/tools/oesign/CMakeLists.txt
+++ b/tests/tools/oesign/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # oesign tests need to build a target enclave to sign
-if (BUILD_ENCLAVES)
+if (BUILD_ENCLAVES AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
   add_subdirectory(test-enclave)
   add_subdirectory(test-digest)
   add_subdirectory(test-inputs)

--- a/tools/oesign/CMakeLists.txt
+++ b/tools/oesign/CMakeLists.txt
@@ -22,25 +22,27 @@ if (NOT HAVE_GETOPT_LONG)
   list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/getopt_long.c)
 endif ()
 
-add_executable(oesign ${SOURCES})
+if (NOT COMPONENT MATCHES OEHOSTVERIFY)
+  add_executable(oesign ${SOURCES})
 
-if (NOT HAVE_GETOPT_LONG)
-  target_include_directories(oesign PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-endif ()
+  if (NOT HAVE_GETOPT_LONG)
+    target_include_directories(oesign PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  endif ()
 
-# Link oesign against liboehostmr, which has no dependency on
-# lib_sgx_enclave_common and libsgx_dcap_ql.
-target_link_libraries(oesign oehostmr)
+  # Link oesign against liboehostmr, which has no dependency on
+  # lib_sgx_enclave_common and libsgx_dcap_ql.
+  target_link_libraries(oesign oehostmr)
 
-# assemble into proper collector dir
-set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
+  # assemble into proper collector dir
+  set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
-# install rule
-install(
-  TARGETS oesign
-  EXPORT openenclave-targets
-  DESTINATION ${CMAKE_INSTALL_BINDIR})
+  # install rule
+  install(
+    TARGETS oesign
+    EXPORT openenclave-targets
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-if (WITH_EEID)
-  target_compile_definitions(oesign PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+  if (WITH_EEID)
+    target_compile_definitions(oesign PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+  endif ()
 endif ()


### PR DESCRIPTION
This is a workaround based on pull request #3123 and issues #3160 and #3181 so that we do not have to revise any logic or testing flow for now.

This change makes it possible to use `cpack` to create a usable `open-enclave-hostverify` package with only necessary header files and targets, including `openenclave::oehost` ~~and `openenclave::oesign`~~ which ~~are~~ is unable to separate; that is, we can build the `host-verify` sample without any modification of files installed from `open-enclave-hostverify`.

This pull request fixes #2263 partially, since it still includes targets `openenclave::oehost` ~~and `openenclave::oesign`~~.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>