### PR TITLE
Fix multi-page EEID data measurement.

### DIFF
--- a/common/sgx/eeid.c
+++ b/common/sgx/eeid.c
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include <openenclave/bits/attestation.h>
@@ -11,7 +10,6 @@
 #include <openenclave/internal/crypto/sha.h>
 #include <openenclave/internal/eeid.h>
 #include <openenclave/internal/hexdump.h>
-#include <openenclave/internal/malloc.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/safecrt.h>
 #include <openenclave/internal/types.h>
@@ -266,7 +264,7 @@ done:
     return result;
 }
 
-static oe_result_t _add_page(
+static oe_result_t _measure_page(
     oe_sha256_context_t* hctx,
     uint64_t base,
     void* page,
@@ -311,14 +309,14 @@ oe_result_t oe_remeasure_memory_pages(
     // page.
 
     for (size_t i = 0; i < eeid->size_settings.num_heap_pages; i++)
-        OE_CHECK(_add_page(&hctx, base, &blank_pg, &vaddr, false));
+        OE_CHECK(_measure_page(&hctx, base, &blank_pg, &vaddr, false));
 
     for (size_t i = 0; i < eeid->size_settings.num_tcs; i++)
     {
         vaddr += OE_PAGE_SIZE; /* guard page */
 
         for (size_t i = 0; i < eeid->size_settings.num_stack_pages; i++)
-            OE_CHECK(_add_page(&hctx, base, &stack_pg, &vaddr, true));
+            OE_CHECK(_measure_page(&hctx, base, &stack_pg, &vaddr, true));
 
         vaddr += OE_PAGE_SIZE; /* guard page */
 
@@ -346,29 +344,30 @@ oe_result_t oe_remeasure_memory_pages(
         vaddr += OE_PAGE_SIZE;
 
         for (size_t i = 0; i < 2; i++)
-            _add_page(&hctx, base, &blank_pg, &vaddr, true);
+            _measure_page(&hctx, base, &blank_pg, &vaddr, true);
 
         vaddr += OE_PAGE_SIZE; /* guard page */
 
         for (size_t i = 0; i < 2; i++)
-            _add_page(&hctx, base, &blank_pg, &vaddr, true);
+            _measure_page(&hctx, base, &blank_pg, &vaddr, true);
     }
 
     if (with_eeid_pages)
     {
+        char* eeid_bytes = (char*)eeid;
         size_t num_bytes = oe_eeid_byte_size(eeid);
         size_t num_pages =
             num_bytes / OE_PAGE_SIZE + ((num_bytes % OE_PAGE_SIZE) ? 1 : 0);
 
-        oe_page_t* pages = malloc(sizeof(oe_page_t) * num_pages);
-        memset(pages, 0, sizeof(oe_page_t) * num_pages);
-        memcpy(pages->data, eeid, num_bytes);
-
+        oe_page_t page;
         for (size_t i = 0; i < num_pages; i++)
-            OE_CHECK(
-                _add_page(&hctx, base, pages + i * OE_PAGE_SIZE, &vaddr, true));
-
-        free(pages);
+        {
+            memset(page.data, 0, sizeof(oe_page_t));
+            size_t n = (i != num_pages - 1) ? OE_PAGE_SIZE
+                                            : (num_bytes % OE_PAGE_SIZE);
+            memcpy(page.data, eeid_bytes + OE_PAGE_SIZE * i, n);
+            OE_CHECK(_measure_page(&hctx, base, page.data, &vaddr, true));
+        }
     }
 
     oe_sha256_final(&hctx, computed_enclave_hash);

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -685,27 +685,27 @@ static oe_result_t _add_eeid_pages(
 
     if (eeid)
     {
+        char* eeid_bytes = (char*)eeid;
         size_t num_bytes = oe_eeid_byte_size(eeid);
         size_t num_pages =
             num_bytes / OE_PAGE_SIZE + ((num_bytes % OE_PAGE_SIZE) ? 1 : 0);
 
-        oe_page_t* pages =
-            oe_memalign(OE_PAGE_SIZE, sizeof(oe_page_t) * num_pages);
-        memset(pages, 0, sizeof(oe_page_t) * num_pages);
-        memcpy(pages->data, eeid, num_bytes);
-
+        oe_page_t* page = oe_memalign(OE_PAGE_SIZE, sizeof(oe_page_t));
         for (size_t i = 0; i < num_pages; i++)
         {
-            uint64_t addr = enclave_addr + *vaddr;
-            uint64_t src = (uint64_t)(pages + i * OE_PAGE_SIZE);
-            uint64_t flags = SGX_SECINFO_REG | SGX_SECINFO_R | SGX_SECINFO_W;
+            memset(page->data, 0, sizeof(oe_page_t));
+            size_t n = (i != num_pages - 1) ? OE_PAGE_SIZE
+                                            : (num_bytes % OE_PAGE_SIZE);
+            memcpy(page->data, eeid_bytes + OE_PAGE_SIZE * i, n);
 
+            uint64_t addr = enclave_addr + *vaddr;
+            uint64_t src = (uint64_t)(page->data);
+            uint64_t flags = SGX_SECINFO_REG | SGX_SECINFO_R | SGX_SECINFO_W;
             OE_CHECK(oe_sgx_load_enclave_data(
                 context, enclave_addr, addr, src, flags, true));
             *vaddr += OE_PAGE_SIZE;
         }
-
-        oe_memalign_free(pages);
+        oe_memalign_free(page);
     }
 
     result = OE_OK;

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -700,7 +700,7 @@ static oe_result_t _add_eeid_pages(
 
             uint64_t addr = enclave_addr + *vaddr;
             uint64_t src = (uint64_t)(page->data);
-            uint64_t flags = SGX_SECINFO_REG | SGX_SECINFO_R | SGX_SECINFO_W;
+            uint64_t flags = SGX_SECINFO_REG | SGX_SECINFO_R;
             OE_CHECK(oe_sgx_load_enclave_data(
                 context, enclave_addr, addr, src, flags, true));
             *vaddr += OE_PAGE_SIZE;

--- a/tests/eeid_plugin/host/host.c
+++ b/tests/eeid_plugin/host/host.c
@@ -107,7 +107,7 @@ void one_enclave_tests(const char* filename, uint32_t flags)
 
     oe_enclave_setting_t setting;
     setting.setting_type = OE_EXTENDED_ENCLAVE_INITIALIZATION_DATA;
-    make_test_eeid(&setting.u.eeid);
+    make_test_eeid(&setting.u.eeid, 10 * OE_PAGE_SIZE);
 
     oe_enclave_t* enclave = NULL;
     oe_result_t result = oe_create_eeid_plugin_enclave(
@@ -222,12 +222,12 @@ void multiple_enclaves_tests(const char* filename, uint32_t flags)
 
     // Enclave A
     enclave_stuff_t A;
-    OE_TEST(make_test_eeid(&A.eeid) == OE_OK);
+    OE_TEST(make_test_eeid(&A.eeid, 10) == OE_OK);
     start_enclave(filename, flags, &A);
 
     // Enclave B with reversed EEID
     enclave_stuff_t B;
-    OE_TEST(make_test_eeid(&B.eeid) == OE_OK);
+    OE_TEST(make_test_eeid(&B.eeid, 10) == OE_OK);
     for (size_t i = 0; i < B.eeid->data_size; i++)
         B.eeid->data[i] = (uint8_t)(9 - i);
     start_enclave(filename, flags, &B);
@@ -252,7 +252,7 @@ void multiple_enclaves_tests(const char* filename, uint32_t flags)
 
     // Enclave C with same EEID as A
     enclave_stuff_t C;
-    OE_TEST(make_test_eeid(&C.eeid) == OE_OK);
+    OE_TEST(make_test_eeid(&C.eeid, 10) == OE_OK);
     start_enclave(filename, flags, &C);
 
     // Check that the hashes of A and C are indeed the same

--- a/tests/eeid_plugin/test_helpers.c
+++ b/tests/eeid_plugin/test_helpers.c
@@ -14,16 +14,17 @@
 
 #include "test_helpers.h"
 
-oe_result_t make_test_eeid(oe_eeid_t** eeid)
+oe_result_t make_test_eeid(oe_eeid_t** eeid, size_t data_size)
 {
     oe_result_t result = OE_UNEXPECTED;
 
-    OE_CHECK(oe_create_eeid_sgx(10, eeid));
+    OE_CHECK(oe_create_eeid_sgx(data_size, eeid));
     (*eeid)->version = 1;
-    (*eeid)->data_size = 10;
-    for (size_t i = 0; i < (*eeid)->data_size; i++)
-        (*eeid)->data[i] = (uint8_t)i;
-    (*eeid)->size_settings.num_heap_pages = 100;
+    (*eeid)->data_size = data_size;
+    for (size_t i = 0; i < data_size; i++)
+        (*eeid)->data[i] = 'a' + (i % 26);
+    (*eeid)->data[data_size - 1] = 0;
+    (*eeid)->size_settings.num_heap_pages = 100 + (data_size / OE_PAGE_SIZE);
     (*eeid)->size_settings.num_stack_pages = 50;
     (*eeid)->size_settings.num_tcs = 2;
 

--- a/tests/eeid_plugin/test_helpers.h
+++ b/tests/eeid_plugin/test_helpers.h
@@ -7,6 +7,6 @@
 #include <openenclave/bits/eeid.h>
 #include <openenclave/bits/result.h>
 
-oe_result_t make_test_eeid(oe_eeid_t** eeid);
+oe_result_t make_test_eeid(oe_eeid_t** eeid, size_t data_size);
 
 #endif // _OE_EEID_PLUGIN_TEST_HELPERS_S


### PR DESCRIPTION
Large, multi-page EEID data did not get measured correctly. This fixes it and adapts the tests to exercise the fixed behavior. 

Signed-off-by: Christoph M. Wintersteiger <cwinter@microsoft.com>