### PR TITLE
Remove the import of logging from tls_client.edl

### DIFF
--- a/samples/attested_tls/client/tls_client.edl
+++ b/samples/attested_tls/client/tls_client.edl
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 


### PR DESCRIPTION
The PR removes the import of logging.edl in the sample that was missed by #3151.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>