### PR TITLE
Adopt oeedger8r preprocessor in tests edl to differentiate platforms

### DIFF
--- a/docs/DesignDocs/system_ocall_opt_in.md
+++ b/docs/DesignDocs/system_ocall_opt_in.md
@@ -145,7 +145,7 @@ in one of the following EDL files
 * `edl/utsname.edl`
 * `edl/sgx/cpu.edl`
 * `edl/sgx/debug.edl`
-* `edl/sgx/sgx_attestation.edl`
+* `edl/sgx/attestation.edl`
 * `edl/sgx/switchless.edl`
 * `edl/sgx/thread.edl`
 

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -3,9 +3,6 @@
 
 set(OE_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
 set(EDL_DIR ${CMAKE_SOURCE_DIR}/include/openenclave/edl)
-if (OE_SGX)
-  set(SGX_EDL_DIR ${EDL_DIR}/sgx)
-endif ()
 
 ##==============================================================================
 ##
@@ -41,12 +38,12 @@ endif ()
 ##
 ##==============================================================================
 
-set(SGX_EDL_FILE ${SGX_EDL_DIR}/platform.edl)
+set(SGX_EDL_FILE ${EDL_DIR}/sgx/platform.edl)
 if (OE_SGX AND COMPILE_SYSTEM_EDL)
   add_custom_command(
     OUTPUT platform_t.h platform_t.c platform_args.h
     DEPENDS ${SGX_EDL_FILE} edger8r
-    COMMAND edger8r --search-path ${SGX_EDL_DIR} --trusted ${SGX_EDL_FILE})
+    COMMAND edger8r --search-path ${OE_INCLUDE_DIR} --trusted ${SGX_EDL_FILE})
 
   add_custom_target(platform_trusted_edl DEPENDS platform_t.h platform_t.c
                                                  platform_args.h)
@@ -57,7 +54,7 @@ elseif (OE_SGX)
   add_custom_command(
     OUTPUT platform_t.h platform_args.h
     DEPENDS ${SGX_EDL_FILE} edger8r
-    COMMAND edger8r --header-only --search-path ${SGX_EDL_DIR} --trusted
+    COMMAND edger8r --header-only --search-path ${OE_INCLUDE_DIR} --trusted
             ${SGX_EDL_FILE})
 
   add_custom_target(platform_trusted_edl DEPENDS platform_t.h platform_args.h)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -3,9 +3,6 @@
 
 set(OE_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
 set(EDL_DIR ${CMAKE_SOURCE_DIR}/include/openenclave/edl)
-if (OE_SGX)
-  set(SGX_EDL_DIR ${EDL_DIR}/sgx)
-endif ()
 
 ##==============================================================================
 ##
@@ -97,12 +94,12 @@ install(DIRECTORY ${OE_EDL_INCLUDE_DIR}
 ##
 ##==============================================================================
 
-set(SGX_EDL_FILE ${SGX_EDL_DIR}/platform.edl)
+set(SGX_EDL_FILE ${EDL_DIR}/sgx/platform.edl)
 if (OE_SGX AND COMPILE_SYSTEM_EDL)
   add_custom_command(
     OUTPUT platform_u.h platform_u.c platform_args.h
     DEPENDS ${SGX_EDL_FILE} edger8r
-    COMMAND edger8r --search-path ${SGX_EDL_DIR} --untrusted ${SGX_EDL_FILE})
+    COMMAND edger8r --search-path ${OE_INCLUDE_DIR} --untrusted ${SGX_EDL_FILE})
 
   add_custom_target(platform_untrusted_edl DEPENDS platform_u.h platform_u.c
                                                    platform_args.h)
@@ -112,7 +109,7 @@ elseif (OE_SGX)
   add_custom_command(
     OUTPUT platform_u.h platform_args.h
     DEPENDS ${SGX_EDL_FILE} edger8r
-    COMMAND edger8r --header-only --search-path ${SGX_EDL_DIR} --untrusted
+    COMMAND edger8r --header-only --search-path ${OE_INCLUDE_DIR} --untrusted
             ${SGX_EDL_FILE})
 
   add_custom_target(platform_untrusted_edl DEPENDS platform_u.h platform_args.h)

--- a/include/openenclave/edl/sgx/attestation.edl
+++ b/include/openenclave/edl/sgx/attestation.edl
@@ -4,7 +4,7 @@
 /*
 **==============================================================================
 **
-** sgx/sgx_attestation.edl:
+** sgx/attestation.edl:
 **
 **     Internal ECALLs/OCALLs to be used by liboehost/liboecore for SGX-specific
 **     attestation.

--- a/include/openenclave/edl/sgx/platform.edl
+++ b/include/openenclave/edl/sgx/platform.edl
@@ -14,9 +14,9 @@
 
 enclave
 {
-    from "sgx_attestation.edl" import *;
-    from "cpu.edl" import *;
-    from "debug.edl" import *;
-    from "thread.edl" import *;
-    from "switchless.edl" import *;
+    from "openenclave/edl/sgx/attestation.edl" import *;
+    from "openenclave/edl/sgx/cpu.edl" import *;
+    from "openenclave/edl/sgx/debug.edl" import *;
+    from "openenclave/edl/sgx/thread.edl" import *;
+    from "openenclave/edl/sgx/switchless.edl" import *;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,10 +24,9 @@ if (LVI_MITIGATION MATCHES ControlFlow AND LVI_MITIGATION_SKIP_TESTS)
   message("LVI_MITIGATION_SKIP_TESTS set - skip all tests with LVI mitigation")
 endif ()
 
+# Define the `OE_SGX` macro used by the oeedger8r on the SGX build.
 if (OE_SGX)
-  set(PLATFORM_EDL_DIR ${PROJECT_SOURCE_DIR}/include/openenclave/edl/sgx)
-elseif (OE_TRUSTZONE)
-  set(PLATFORM_EDL_DIR ${PROJECT_SOURCE_DIR}/include/openenclave/edl/optee)
+  set(DEFINE_OE_SGX "-DOE_SGX")
 endif ()
 
 add_subdirectory(mem)

--- a/tests/SampleApp/SampleApp.edl
+++ b/tests/SampleApp/SampleApp.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int secure_str_patching(

--- a/tests/SampleApp/enc/CMakeLists.txt
+++ b/tests/SampleApp/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/SampleApp/host/CMakeLists.txt
+++ b/tests/SampleApp/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(SampleAppHost SampleAppHost.cpp SampleApp_u.c)
 

--- a/tests/SampleAppCRT/SampleAppCRT.edl
+++ b/tests/SampleAppCRT/SampleAppCRT.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int enc_test ();

--- a/tests/SampleAppCRT/enc/CMakeLists.txt
+++ b/tests/SampleAppCRT/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/SampleAppCRT/host/CMakeLists.txt
+++ b/tests/SampleAppCRT/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(SampleAppCRTHost SampleAppCRTHost.cpp SampleAppCRT_u.c)
 

--- a/tests/VectorException/VectorException.edl
+++ b/tests/VectorException/VectorException.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     include "openenclave/internal/cpuid.h"
 

--- a/tests/VectorException/enc/CMakeLists.txt
+++ b/tests/VectorException/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 # TODO: Does this need CXX?
 add_enclave(

--- a/tests/VectorException/host/CMakeLists.txt
+++ b/tests/VectorException/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(VectorException_host host.c VectorException_u.c)
 

--- a/tests/abortStatus/abortStatus.edl
+++ b/tests/abortStatus/abortStatus.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int regular_abort();

--- a/tests/abortStatus/enc/CMakeLists.txt
+++ b/tests/abortStatus/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/abortStatus/host/CMakeLists.txt
+++ b/tests/abortStatus/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(abortStatus_host host.cpp abortStatus_u.c)
 

--- a/tests/argv/argv.edl
+++ b/tests/argv/argv.edl
@@ -5,7 +5,11 @@ enclave
 {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted
     {

--- a/tests/argv/enc/CMakeLists.txt
+++ b/tests/argv/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/argv/host/CMakeLists.txt
+++ b/tests/argv/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(argv_host host.c argv_u.c)
 

--- a/tests/atexit/atexit.edl
+++ b/tests/atexit/atexit.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void atexit_1_call_ecall(void);

--- a/tests/atexit/enc/CMakeLists.txt
+++ b/tests/atexit/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/atexit/host/CMakeLists.txt
+++ b/tests/atexit/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(atexit_host host.cpp atexit_u.c)
 

--- a/tests/attestation_cert_apis/enc/CMakeLists.txt
+++ b/tests/attestation_cert_apis/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/attestation_cert_apis/host/CMakeLists.txt
+++ b/tests/attestation_cert_apis/host/CMakeLists.txt
@@ -10,7 +10,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(tls_host host.cpp tls_u.c)
 

--- a/tests/attestation_cert_apis/tls.edl
+++ b/tests/attestation_cert_apis/tls.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public oe_result_t get_tls_cert_signed_with_ec_key([out] unsigned char** data, [out] size_t* data_size);

--- a/tests/attestation_plugin/enc/CMakeLists.txt
+++ b/tests/attestation_plugin/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/attestation_plugin/host/CMakeLists.txt
+++ b/tests/attestation_plugin/host/CMakeLists.txt
@@ -10,7 +10,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(plugin_host host.c ../plugin/tests.c plugin_u.c)
 

--- a/tests/attestation_plugin/plugin.edl
+++ b/tests/attestation_plugin/plugin.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/attestation.edl" import *;
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void run_runtime_test();

--- a/tests/backtrace/backtrace.edl
+++ b/tests/backtrace/backtrace.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public bool test(

--- a/tests/backtrace/enc/CMakeLists.txt
+++ b/tests/backtrace/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/backtrace/host/CMakeLists.txt
+++ b/tests/backtrace/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(backtrace_host host.cpp backtrace_u.c)
 

--- a/tests/bigmalloc/bigmalloc.edl
+++ b/tests/bigmalloc/bigmalloc.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public oe_result_t test_malloc();

--- a/tests/bigmalloc/enc/CMakeLists.txt
+++ b/tests/bigmalloc/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Unlike other tests, this test explicitly requires a signed enclave
 # to test if a big enclave can be signed.

--- a/tests/bigmalloc/host/CMakeLists.txt
+++ b/tests/bigmalloc/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(bigmalloc_host host.c bigmalloc_u.c)
 

--- a/tests/c99_compliant/c99_compliant.edl
+++ b/tests/c99_compliant/c99_compliant.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int enc_c99_compliant();

--- a/tests/c99_compliant/enc/CMakeLists.txt
+++ b/tests/c99_compliant/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/c99_compliant/host/CMakeLists.txt
+++ b/tests/c99_compliant/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(c99_compliant_host host.c c99_compliant_u.c)
 

--- a/tests/child_process/child_process.edl
+++ b/tests/child_process/child_process.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void get_magic_ecall([user_check]void *pdata);

--- a/tests/child_process/enc/CMakeLists.txt
+++ b/tests/child_process/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/child_process/host/CMakeLists.txt
+++ b/tests/child_process/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(child_process_host host.cpp child_process_u.c)
 

--- a/tests/child_thread/child_thread.edl
+++ b/tests/child_thread/child_thread.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void get_magic_ecall([user_check]void *pdata);

--- a/tests/child_thread/enc/CMakeLists.txt
+++ b/tests/child_thread/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/child_thread/host/CMakeLists.txt
+++ b/tests/child_thread/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(child_thread_host host.cpp child_thread_u.c)
 

--- a/tests/cmake_name_conflict/enc/CMakeLists.txt
+++ b/tests/cmake_name_conflict/enc/CMakeLists.txt
@@ -5,8 +5,8 @@ add_custom_command(
   DEPENDS edger8r ../name_conflict.edl
   COMMAND
     edger8r --trusted name_conflict.edl --search-path
-    ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/..)
+    ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 add_enclave(
   TARGET

--- a/tests/cmake_name_conflict/host/CMakeLists.txt
+++ b/tests/cmake_name_conflict/host/CMakeLists.txt
@@ -5,8 +5,8 @@ add_custom_command(
   DEPENDS edger8r ../name_conflict.edl
   COMMAND
     edger8r --untrusted name_conflict.edl --search-path
-    ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/..)
+    ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 add_executable(name_conflict_host host.cpp name_conflict_u.c name_conflict_u.h
                                   name_conflict_args.h)

--- a/tests/cmake_name_conflict/name_conflict.edl
+++ b/tests/cmake_name_conflict/name_conflict.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void test_name_conflict();

--- a/tests/cppException/cppException.edl
+++ b/tests/cppException/cppException.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     enum unhandled_exception_func_num {
         EXCEPTION_SPECIFICATION,

--- a/tests/cppException/enc/CMakeLists.txt
+++ b/tests/cppException/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/cppException/host/CMakeLists.txt
+++ b/tests/cppException/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(cppException_host host.cpp cppException_u.c)
 

--- a/tests/create-errors/create_errors.edl
+++ b/tests/create-errors/create_errors.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int test();

--- a/tests/create-errors/enc/CMakeLists.txt
+++ b/tests/create-errors/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/create-errors/host/CMakeLists.txt
+++ b/tests/create-errors/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(create_errors_host host.c create_errors_u.c)
 

--- a/tests/create-rapid/create_rapid.edl
+++ b/tests/create-rapid/create_rapid.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int test(int arg);

--- a/tests/create-rapid/enc/CMakeLists.txt
+++ b/tests/create-rapid/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/create-rapid/host/CMakeLists.txt
+++ b/tests/create-rapid/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(create_rapid_host host.cpp create_rapid_u.c)
 

--- a/tests/crypto/enclave/crypto.edl
+++ b/tests/crypto/enclave/crypto.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void test();

--- a/tests/crypto/enclave/enc/CMakeLists.txt
+++ b/tests/crypto/enclave/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(SRCS
     enc.c

--- a/tests/crypto/enclave/host/CMakeLists.txt
+++ b/tests/crypto/enclave/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(cryptohost host.c crypto_u.c)
 add_dependencies(cryptohost crypto_test_data)

--- a/tests/crypto_crls_cert_chains/common/crypto_crls_cert_chains.edl
+++ b/tests/crypto_crls_cert_chains/common/crypto_crls_cert_chains.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void ecall_test_cert_chain_positive(

--- a/tests/crypto_crls_cert_chains/enc/CMakeLists.txt
+++ b/tests/crypto_crls_cert_chains/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/crypto_crls_cert_chains/host/CMakeLists.txt
+++ b/tests/crypto_crls_cert_chains/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(crypto-extra_host host.cpp crypto_crls_cert_chains_u.c)
 add_dependencies(crypto-extra_host crypto_crls_cert_chains_test_data)

--- a/tests/debug-mode/debug_mode.edl
+++ b/tests/debug-mode/debug_mode.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int test();

--- a/tests/debug-mode/enc/CMakeLists.txt
+++ b/tests/debug-mode/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/debug-mode/host/CMakeLists.txt
+++ b/tests/debug-mode/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(debug_host host.c debug_mode_u.c)
 

--- a/tests/debugger/oegdb/enc/CMakeLists.txt
+++ b/tests/debugger/oegdb/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/debugger/oegdb/host/CMakeLists.txt
+++ b/tests/debugger/oegdb/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(oe_gdb_test_host host.c contract.c oe_gdb_test_u.c)
 

--- a/tests/debugger/oegdb/oe_gdb_test.edl
+++ b/tests/debugger/oegdb/oe_gdb_test.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     enum magic_t {
         MAGIC_VALUE=112233445566

--- a/tests/ecall/ecall.edl
+++ b/tests/ecall/ecall.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     include "openenclave/internal/sgx/td.h"
     

--- a/tests/ecall/enc/CMakeLists.txt
+++ b/tests/ecall/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/ecall/host/CMakeLists.txt
+++ b/tests/ecall/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(ecall_host host.cpp ecall_u.c)
 

--- a/tests/ecall_ocall/ecall_ocall.edl
+++ b/tests/ecall_ocall/ecall_ocall.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public oe_result_t enc_get_init_ocall_result();

--- a/tests/ecall_ocall/enc/CMakeLists.txt
+++ b/tests/ecall_ocall/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/ecall_ocall/host/CMakeLists.txt
+++ b/tests/ecall_ocall/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(ecall_ocall_host host.cpp ecall_ocall_u.c)
 

--- a/tests/echo/echo.edl
+++ b/tests/echo/echo.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int enc_echo(

--- a/tests/echo/enc/CMakeLists.txt
+++ b/tests/echo/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/echo/host/CMakeLists.txt
+++ b/tests/echo/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(echo_host host.c echo_u.c)
 

--- a/tests/eeid_plugin/eeid_plugin.edl
+++ b/tests/eeid_plugin/eeid_plugin.edl
@@ -6,7 +6,11 @@ enclave {
     from "openenclave/edl/attestation.edl" import *;
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void run_tests();

--- a/tests/eeid_plugin/enc/CMakeLists.txt
+++ b/tests/eeid_plugin/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/eeid_plugin/host/CMakeLists.txt
+++ b/tests/eeid_plugin/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(eeid_plugin_host host.c ../test_helpers.c eeid_plugin_u.c)
 

--- a/tests/enclaveparam/enc/CMakeLists.txt
+++ b/tests/enclaveparam/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/enclaveparam/enclaveparam.edl
+++ b/tests/enclaveparam/enclaveparam.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void test_ocall_enclave_param(

--- a/tests/enclaveparam/host/CMakeLists.txt
+++ b/tests/enclaveparam/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(enclaveparam_host host.c enclaveparam_u.c)
 

--- a/tests/file/enc/CMakeLists.txt
+++ b/tests/file/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/file/file.edl
+++ b/tests/file/file.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     include "../types.h"
 

--- a/tests/file/host/CMakeLists.txt
+++ b/tests/file/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(file_host host.cpp file_u.c)
 

--- a/tests/getenclave/enc/CMakeLists.txt
+++ b/tests/getenclave/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/getenclave/getenclave.edl
+++ b/tests/getenclave/getenclave.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public oe_result_t test_get_enclave_ecall(

--- a/tests/getenclave/host/CMakeLists.txt
+++ b/tests/getenclave/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(getenclave_host host.c getenclave_u.c)
 target_include_directories(getenclave_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/hexdump/enc/CMakeLists.txt
+++ b/tests/hexdump/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/hexdump/hexdump.edl
+++ b/tests/hexdump/hexdump.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int test(

--- a/tests/hexdump/host/CMakeLists.txt
+++ b/tests/hexdump/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(hexdump_host host.c hexdump_u.c)
 

--- a/tests/hostcalls/enc/CMakeLists.txt
+++ b/tests/hostcalls/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/hostcalls/host/CMakeLists.txt
+++ b/tests/hostcalls/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(hostcalls_host host.cpp hostcalls_u.c)
 

--- a/tests/hostcalls/hostcalls.edl
+++ b/tests/hostcalls/hostcalls.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/memory.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     enum definitions {
         TEST_HOSTREALLOC_INIT_VALUE = 88

--- a/tests/initializers/enc/CMakeLists.txt
+++ b/tests/initializers/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/initializers/host/CMakeLists.txt
+++ b/tests/initializers/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(initializers_host host.cpp initializers_u.c)
 

--- a/tests/initializers/initializers.edl
+++ b/tests/initializers/initializers.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     struct dummy_struct {
         int32_t a;

--- a/tests/libc/enc/CMakeLists.txt
+++ b/tests/libc/enc/CMakeLists.txt
@@ -24,7 +24,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(test_extras
     ${PROJECT_SOURCE_DIR}/3rdparty/musl/libc-test/src/common/vmfill.c

--- a/tests/libc/host/CMakeLists.txt
+++ b/tests/libc/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(libc_host host.cpp libc_u.c)
 

--- a/tests/libc/libc.edl
+++ b/tests/libc/libc.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/syscall.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int run_all_tests();

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -10,7 +10,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 # helper lib to contain file needed by some tests
 add_enclave_library(libcxxtest-support enc.cpp fuzzing.cpp memory_resource.cpp

--- a/tests/libcxx/host/CMakeLists.txt
+++ b/tests/libcxx/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(libcxx_host host.cpp libcxx_u.c)
 

--- a/tests/libcxx/libcxx.edl
+++ b/tests/libcxx/libcxx.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/time.edl" import oe_syscall_nanosleep_ocall;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     enum string_limit {
         STRLEN = 1024

--- a/tests/libcxxrt/enc/CMakeLists.txt
+++ b/tests/libcxxrt/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 # helper lib to contain file needed by some tests
 add_enclave_library(libcxxrttest-support libcxxrt_t.c)

--- a/tests/libcxxrt/host/CMakeLists.txt
+++ b/tests/libcxxrt/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(libcxxrt_host host.cpp libcxxrt_u.c)
 

--- a/tests/libcxxrt/libcxxrt.edl
+++ b/tests/libcxxrt/libcxxrt.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
    trusted {
        public int test(

--- a/tests/libunwind/enc/CMakeLists.txt
+++ b/tests/libunwind/enc/CMakeLists.txt
@@ -13,7 +13,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(LIBUNWIND_TEST_DIR ${PROJECT_SOURCE_DIR}/3rdparty/libunwind/libunwind/tests)
 

--- a/tests/libunwind/host/CMakeLists.txt
+++ b/tests/libunwind/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(libunwind_host host.cpp libunwind_u.c)
 

--- a/tests/libunwind/libunwind.edl
+++ b/tests/libunwind/libunwind.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     enum string_limit {
         STRLEN_MAX = 200

--- a/tests/mbed/enc/CMakeLists.txt
+++ b/tests/mbed/enc/CMakeLists.txt
@@ -11,7 +11,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 # This function creates an enclave for a specific mbedTLS test.
 function (add_mbed_test_enclave NAME)

--- a/tests/mbed/host/CMakeLists.txt
+++ b/tests/mbed/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(libmbedtest_host host.c ocalls.c mbed_u.c)
 

--- a/tests/mbed/mbed.edl
+++ b/tests/mbed/mbed.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     include "fcntl.h"
     include "sys/types.h"

--- a/tests/memory/enc/CMakeLists.txt
+++ b/tests/memory/enc/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(
   OUTPUT memory_t.h memory_t.c
   DEPENDS ${EDL_FILE} edger8r
   COMMAND edger8r --trusted ${EDL_FILE} --search-path
-          ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR})
+          ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_enclave(
   TARGET

--- a/tests/memory/host/CMakeLists.txt
+++ b/tests/memory/host/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(
   OUTPUT memory_u.h memory_u.c
   DEPENDS ${EDL_FILE} edger8r
   COMMAND edger8r --untrusted ${EDL_FILE} --search-path
-          ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR})
+          ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_executable(memory_host host.cpp memory_u.c)
 

--- a/tests/memory/memory.edl
+++ b/tests/memory/memory.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     struct buffer {
         unsigned char* buf;

--- a/tests/mixed_c_cpp/enc/CMakeLists.txt
+++ b/tests/mixed_c_cpp/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/mixed_c_cpp/host/CMakeLists.txt
+++ b/tests/mixed_c_cpp/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(mixed_c_cpp_host host.cpp mixed_u.c)
 

--- a/tests/mixed_c_cpp/mixed.edl
+++ b/tests/mixed_c_cpp/mixed.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void foo_c(int a);

--- a/tests/ocall-create/enc/CMakeLists.txt
+++ b/tests/ocall-create/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/ocall-create/host/CMakeLists.txt
+++ b/tests/ocall-create/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(ocall_create_host host.c ocall_create_u.c)
 

--- a/tests/ocall-create/ocall_create.edl
+++ b/tests/ocall-create/ocall_create.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int enc_double(int val);

--- a/tests/ocall/enc/CMakeLists.txt
+++ b/tests/ocall/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/ocall/host/CMakeLists.txt
+++ b/tests/ocall/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(ocall_host host.cpp ocall_u.c)
 

--- a/tests/ocall/ocall.edl
+++ b/tests/ocall/ocall.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     enum constants {
         MY_OCALL_SEED = 1000,

--- a/tests/oeedger8r/edl/all.edl
+++ b/tests/oeedger8r/edl/all.edl
@@ -5,7 +5,7 @@ enclave  {
     // Import system edl
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "openenclave/edl/sgx/sgx_attestation.edl" import *;
+    from "openenclave/edl/sgx/attestation.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;
     from "openenclave/edl/sgx/debug.edl" import *;
     from "openenclave/edl/sgx/thread.edl" import *;

--- a/tests/oeedger8r/edl/other.edl
+++ b/tests/oeedger8r/edl/other.edl
@@ -5,7 +5,7 @@ enclave {
   // Import system edl
   from "openenclave/edl/logging.edl" import oe_write_ocall;
   from "openenclave/edl/fcntl.edl" import *;
-  from "openenclave/edl/sgx/sgx_attestation.edl" import *;
+  from "openenclave/edl/sgx/attestation.edl" import *;
   from "openenclave/edl/sgx/cpu.edl" import *;
   from "openenclave/edl/sgx/debug.edl" import *;
   from "openenclave/edl/sgx/thread.edl" import *;

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -20,8 +20,8 @@ add_custom_command(
           ../edl/switchless_test.edl
   COMMAND
     edger8r --experimental --trusted --search-path
-    ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path
+    ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path
     ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
 
 add_custom_command(

--- a/tests/pingpong-shared/enc/CMakeLists.txt
+++ b/tests/pingpong-shared/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/pingpong-shared/host/CMakeLists.txt
+++ b/tests/pingpong-shared/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(pingpong-shared-lib SHARED host.cpp pingpong_u.c)
 

--- a/tests/pingpong-shared/pingpong.edl
+++ b/tests/pingpong-shared/pingpong.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void Ping(

--- a/tests/pingpong/enc/CMakeLists.txt
+++ b/tests/pingpong/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/pingpong/host/CMakeLists.txt
+++ b/tests/pingpong/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(pingpong_host host.cpp pingpong_u.c)
 

--- a/tests/pingpong/pingpong.edl
+++ b/tests/pingpong/pingpong.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void Ping(

--- a/tests/print/enc/CMakeLists.txt
+++ b/tests/print/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/print/host/CMakeLists.txt
+++ b/tests/print/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(print_host host.cpp print_u.c)
 

--- a/tests/print/print.edl
+++ b/tests/print/print.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int enclave_test_print();

--- a/tests/props/enc/CMakeLists.txt
+++ b/tests/props/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/props/host/CMakeLists.txt
+++ b/tests/props/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(props_host host.c props_u.c)
 

--- a/tests/props/props.edl
+++ b/tests/props/props.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int enc_props(

--- a/tests/qeidentity/enc/CMakeLists.txt
+++ b/tests/qeidentity/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/qeidentity/host/CMakeLists.txt
+++ b/tests/qeidentity/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(qeidentity_host host.cpp qeidentifyinfo.cpp tests_u.c)
 

--- a/tests/qeidentity/tests.edl
+++ b/tests/qeidentity/tests.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     include "includes.h"
     trusted {

--- a/tests/report/enc/CMakeLists.txt
+++ b/tests/report/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/report/host/CMakeLists.txt
+++ b/tests/report/host/CMakeLists.txt
@@ -10,7 +10,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(report_host host.cpp tcbinfo.cpp ../common/tests.cpp tests_u.c)
 

--- a/tests/report/tests.edl
+++ b/tests/report/tests.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/attestation.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     include "includes.h"
 

--- a/tests/safecrt/enc/CMakeLists.txt
+++ b/tests/safecrt/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/safecrt/host/CMakeLists.txt
+++ b/tests/safecrt/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(safecrt_host ../common/test.cpp host.cpp safecrt_u.c)
 

--- a/tests/safecrt/safecrt.edl
+++ b/tests/safecrt/safecrt.edl
@@ -4,7 +4,11 @@
 enclave  {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void enc_test_memcpy_s();

--- a/tests/sealKey/enc/CMakeLists.txt
+++ b/tests/sealKey/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/sealKey/host/CMakeLists.txt
+++ b/tests/sealKey/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(sealKey_host host.cpp sealKey_u.c)
 

--- a/tests/sealKey/sealKey.edl
+++ b/tests/sealKey/sealKey.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/keys.edl" import *;
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int test_seal_key (

--- a/tests/sim-mode/enc/CMakeLists.txt
+++ b/tests/sim-mode/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/sim-mode/host/CMakeLists.txt
+++ b/tests/sim-mode/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(sim_host host.c sim_mode_u.c)
 

--- a/tests/sim-mode/sim_mode.edl
+++ b/tests/sim-mode/sim_mode.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int test();

--- a/tests/snmalloc/enc/CMakeLists.txt
+++ b/tests/snmalloc/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave_library(snmalloc_test_lib $<TARGET_OBJECTS:oesnmalloc>)
 

--- a/tests/snmalloc/host/CMakeLists.txt
+++ b/tests/snmalloc/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(snmalloc_host host.c snmalloc_u.c)
 

--- a/tests/snmalloc/snmalloc.edl
+++ b/tests/snmalloc/snmalloc.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
             public void enc_test_snmalloc_basic(void);

--- a/tests/stack_smashing_protector/enc/CMakeLists.txt
+++ b/tests/stack_smashing_protector/enc/CMakeLists.txt
@@ -4,9 +4,8 @@
 add_custom_command(
   OUTPUT ssp_t.h ssp_t.c ssp_args.h
   DEPENDS ../ssp.edl edger8r
-  COMMAND
-    edger8r --trusted ${CMAKE_CURRENT_SOURCE_DIR}/../ssp.edl --search-path
-    ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR})
+  COMMAND edger8r --trusted ${CMAKE_CURRENT_SOURCE_DIR}/../ssp.edl
+          --search-path ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_enclave(TARGET ssp_enc SOURCES enc.cpp ${CMAKE_CURRENT_BINARY_DIR}/ssp_t.c)
 

--- a/tests/stack_smashing_protector/host/CMakeLists.txt
+++ b/tests/stack_smashing_protector/host/CMakeLists.txt
@@ -4,9 +4,8 @@
 add_custom_command(
   OUTPUT ssp_u.h ssp_u.c ssp_args.h
   DEPENDS ../ssp.edl edger8r
-  COMMAND
-    edger8r --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../ssp.edl --search-path
-    ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR})
+  COMMAND edger8r --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../ssp.edl
+          --search-path ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_executable(ssp_host host.cpp ${CMAKE_CURRENT_BINARY_DIR}/ssp_u.c)
 

--- a/tests/stack_smashing_protector/ssp.edl
+++ b/tests/stack_smashing_protector/ssp.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public bool was_destructor_called();

--- a/tests/stdc/enc/CMakeLists.txt
+++ b/tests/stdc/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/stdc/host/CMakeLists.txt
+++ b/tests/stdc/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(stdc_host host.cpp stdc_u.c)
 

--- a/tests/stdc/stdc.edl
+++ b/tests/stdc/stdc.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/time.edl" import oe_syscall_nanosleep_ocall;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     enum string_limit {
         BUFSIZE = 1024

--- a/tests/stdcxx/enc/CMakeLists.txt
+++ b/tests/stdcxx/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/stdcxx/host/CMakeLists.txt
+++ b/tests/stdcxx/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(stdcxx_host host.cpp stdcxx_u.c)
 

--- a/tests/stdcxx/stdcxx.edl
+++ b/tests/stdcxx/stdcxx.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int enc_test(

--- a/tests/stress/enc/CMakeLists.txt
+++ b/tests/stress/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(TARGET stress_enc SOURCES enc.cpp
             ${CMAKE_CURRENT_BINARY_DIR}/stress_t.c)

--- a/tests/stress/host/CMakeLists.txt
+++ b/tests/stress/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(stress_host host.cpp stress_u.c)
 

--- a/tests/stress/stress.edl
+++ b/tests/stress/stress.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void do_ecall(int arg);

--- a/tests/switchless/switchless_test.edl
+++ b/tests/switchless/switchless_test.edl
@@ -4,7 +4,7 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "openenclave/edl/sgx/sgx_attestation.edl" import *;
+    from "openenclave/edl/sgx/attestation.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;
     from "openenclave/edl/sgx/debug.edl" import *;
     from "openenclave/edl/sgx/thread.edl" import *;

--- a/tests/switchless_nestedcalls/switchless_nestedcalls.edl
+++ b/tests/switchless_nestedcalls/switchless_nestedcalls.edl
@@ -3,7 +3,7 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "openenclave/edl/sgx/sgx_attestation.edl" import *;
+    from "openenclave/edl/sgx/attestation.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;
     from "openenclave/edl/sgx/debug.edl" import *;
     from "openenclave/edl/sgx/thread.edl" import *;

--- a/tests/switchless_one_tcs/switchless_one_tcs.edl
+++ b/tests/switchless_one_tcs/switchless_one_tcs.edl
@@ -4,7 +4,7 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "openenclave/edl/sgx/sgx_attestation.edl" import *;
+    from "openenclave/edl/sgx/attestation.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;
     from "openenclave/edl/sgx/debug.edl" import *;
     from "openenclave/edl/sgx/thread.edl" import *;

--- a/tests/switchless_threads/enc/CMakeLists.txt
+++ b/tests/switchless_threads/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/switchless_threads/host/CMakeLists.txt
+++ b/tests/switchless_threads/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(switchless_threads_host host.c switchless_threads_u.c)
 

--- a/tests/switchless_threads/switchless_threads.edl
+++ b/tests/switchless_threads/switchless_threads.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public int enc_echo_single(

--- a/tests/switchless_worksleep/switchless_worksleep.edl
+++ b/tests/switchless_worksleep/switchless_worksleep.edl
@@ -3,7 +3,7 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "openenclave/edl/sgx/sgx_attestation.edl" import *;
+    from "openenclave/edl/sgx/attestation.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;
     from "openenclave/edl/sgx/debug.edl" import *;
     from "openenclave/edl/sgx/thread.edl" import *;

--- a/tests/syscall/datagram/enc/CMakeLists.txt
+++ b/tests/syscall/datagram/enc/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
 
 add_enclave(TARGET datagram_enc SOURCES enc.c
             ${CMAKE_CURRENT_BINARY_DIR}/test_datagram_t.c)

--- a/tests/syscall/datagram/host/CMakeLists.txt
+++ b/tests/syscall/datagram/host/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
 
 add_executable(datagram_host host.c test_datagram_u.c)
 

--- a/tests/syscall/datagram/test_datagram.edl
+++ b/tests/syscall/datagram/test_datagram.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/socket.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void init_ecall();

--- a/tests/syscall/dup/enc/CMakeLists.txt
+++ b/tests/syscall/dup/enc/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
 
 add_enclave(TARGET dup_enc SOURCES enc.c main.c
             ${CMAKE_CURRENT_BINARY_DIR}/test_dup_t.c)

--- a/tests/syscall/dup/host/CMakeLists.txt
+++ b/tests/syscall/dup/host/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
 
 add_executable(dup_host host.c test_dup_u.c)
 

--- a/tests/syscall/dup/test_dup.edl
+++ b/tests/syscall/dup/test_dup.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void test_dup([string, in] const char* tmp_dir);

--- a/tests/syscall/epoll/enc/CMakeLists.txt
+++ b/tests/syscall/epoll/enc/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(
   OUTPUT epoll_t.h epoll_t.c
   DEPENDS ${EDL_FILE} edger8r
   COMMAND edger8r --trusted ${EDL_FILE} --search-path
-          ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR})
+          ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_enclave(TARGET epoll_enc CXX SOURCES enc.cpp
             ${CMAKE_CURRENT_BINARY_DIR}/epoll_t.c)

--- a/tests/syscall/epoll/epoll.edl
+++ b/tests/syscall/epoll/epoll.edl
@@ -6,7 +6,11 @@ enclave {
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/socket.edl" import *;
     from "openenclave/edl/epoll.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void set_up();

--- a/tests/syscall/epoll/host/CMakeLists.txt
+++ b/tests/syscall/epoll/host/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(
   OUTPUT epoll_u.h epoll_u.c
   DEPENDS ${EDL_FILE} edger8r
   COMMAND edger8r --untrusted ${EDL_FILE} --search-path
-          ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR})
+          ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_executable(epoll_host host.cpp epoll_u.c)
 

--- a/tests/syscall/fs/enc/CMakeLists.txt
+++ b/tests/syscall/fs/enc/CMakeLists.txt
@@ -14,8 +14,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${EDL_SEARCH_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${EDL_SEARCH_DIR})
 
 add_enclave(TARGET fs_enc SOURCES enc.cpp ${CMAKE_CURRENT_BINARY_DIR}/fs_t.c)
 

--- a/tests/syscall/fs/host/CMakeLists.txt
+++ b/tests/syscall/fs/host/CMakeLists.txt
@@ -14,7 +14,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(fs_host ${HOSTSRC} fs_u.c)
 

--- a/tests/syscall/fs/linux/fs.edl
+++ b/tests/syscall/fs/linux/fs.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void test_fs(

--- a/tests/syscall/fs/windows/fs.edl
+++ b/tests/syscall/fs/windows/fs.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void test_fs(

--- a/tests/syscall/hostfs/enc/CMakeLists.txt
+++ b/tests/syscall/hostfs/enc/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
 
 add_enclave(TARGET hostfs_enc SOURCES enc.c main.c
             ${CMAKE_CURRENT_BINARY_DIR}/test_hostfs_t.c)

--- a/tests/syscall/hostfs/host/CMakeLists.txt
+++ b/tests/syscall/hostfs/host/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
 
 add_executable(hostfs_host host.c test_hostfs_u.c)
 

--- a/tests/syscall/hostfs/test_hostfs.edl
+++ b/tests/syscall/hostfs/test_hostfs.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void test_hostfs(

--- a/tests/syscall/ids/enc/CMakeLists.txt
+++ b/tests/syscall/ids/enc/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
 
 add_enclave(TARGET ids_enc SOURCES enc.c main.c
             ${CMAKE_CURRENT_BINARY_DIR}/test_ids_t.c)

--- a/tests/syscall/ids/host/CMakeLists.txt
+++ b/tests/syscall/ids/host/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../device/edl)
 
 add_executable(ids_host host.c test_ids_u.c)
 

--- a/tests/syscall/ids/test_ids.edl
+++ b/tests/syscall/ids/test_ids.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/unistd.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void test_ids(

--- a/tests/syscall/poller/enc/CMakeLists.txt
+++ b/tests/syscall/poller/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/syscall/poller/host/CMakeLists.txt
+++ b/tests/syscall/poller/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(poller_host host.cpp ../client.cpp ../server.cpp ../poller.cpp
                            poller_u.c)

--- a/tests/syscall/poller/poller.edl
+++ b/tests/syscall/poller/poller.edl
@@ -7,7 +7,11 @@ enclave {
     from "openenclave/edl/poll.edl" import *;
     from "openenclave/edl/socket.edl" import *;
     from "openenclave/edl/epoll.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
 

--- a/tests/syscall/resolver/enc/CMakeLists.txt
+++ b/tests/syscall/resolver/enc/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 
 add_enclave(TARGET resolver_enc SOURCES enc.c resolver_test_t.c)
 

--- a/tests/syscall/resolver/host/CMakeLists.txt
+++ b/tests/syscall/resolver/host/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 
 add_executable(resolver_host host.c resolver_test_u.c)
 

--- a/tests/syscall/resolver/resolver_test.edl
+++ b/tests/syscall/resolver/resolver_test.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/socket.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted
     {

--- a/tests/syscall/sendmsg/enc/CMakeLists.txt
+++ b/tests/syscall/sendmsg/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 ##==============================================================================
 ##

--- a/tests/syscall/sendmsg/host/CMakeLists.txt
+++ b/tests/syscall/sendmsg/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(sendmsg_host host.c ../client.c ../server.c sendmsg_u.c)
 

--- a/tests/syscall/sendmsg/sendmsg.edl
+++ b/tests/syscall/sendmsg/sendmsg.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/socket.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void run_enclave_server(uint16_t port);

--- a/tests/syscall/socket/enc/CMakeLists.txt
+++ b/tests/syscall/socket/enc/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 
 add_enclave(TARGET socket_enc SOURCES enc.c
             ${CMAKE_CURRENT_BINARY_DIR}/socket_test_t.c)

--- a/tests/syscall/socket/host/CMakeLists.txt
+++ b/tests/syscall/socket/host/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 
 add_executable(socket_host host.c socket_test_u.c)
 

--- a/tests/syscall/socket/socket_test.edl
+++ b/tests/syscall/socket/socket_test.edl
@@ -6,7 +6,11 @@ enclave {
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/utsname.edl" import oe_syscall_uname_ocall;
     from "openenclave/edl/socket.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         /* define ECALLs here. */

--- a/tests/syscall/socketpair/enc/CMakeLists.txt
+++ b/tests/syscall/socketpair/enc/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 
 add_enclave(TARGET socketpair_enc SOURCES enc.c
             ${CMAKE_CURRENT_BINARY_DIR}/socketpair_test_t.c)

--- a/tests/syscall/socketpair/host/CMakeLists.txt
+++ b/tests/syscall/socketpair/host/CMakeLists.txt
@@ -8,8 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR}
-    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 
 add_executable(socketpair_host host.c socketpair_test_u.c)
 

--- a/tests/syscall/socketpair/socketpair_test.edl
+++ b/tests/syscall/socketpair/socketpair_test.edl
@@ -7,7 +7,11 @@ enclave {
     from "openenclave/edl/time.edl" import oe_syscall_nanosleep_ocall;
     from "openenclave/edl/utsname.edl" import oe_syscall_uname_ocall;
     from "openenclave/edl/socket.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         /* define ECALLs here. */

--- a/tests/thread/enc/CMakeLists.txt
+++ b/tests/thread/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/thread/host/CMakeLists.txt
+++ b/tests/thread/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(thread_host host.cpp rwlocks_test_host.cpp errno_test_host.cpp
                            thread_u.c)

--- a/tests/thread/thread.edl
+++ b/tests/thread/thread.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void cb_test_waiter_thread_impl();

--- a/tests/thread_local/enc/CMakeLists.txt
+++ b/tests/thread_local/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Build enclave without exported thread-locals.
 add_enclave(

--- a/tests/thread_local/host/CMakeLists.txt
+++ b/tests/thread_local/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(thread_local_host host.cpp thread_local_u.c)
 

--- a/tests/thread_local/thread_local.edl
+++ b/tests/thread_local/thread_local.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/time.edl" import oe_syscall_nanosleep_ocall;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         // Prepare enclave for testing.

--- a/tests/thread_local_no_tdata/enc/CMakeLists.txt
+++ b/tests/thread_local_no_tdata/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Build enclave that has no tdata
 add_enclave(

--- a/tests/thread_local_no_tdata/host/CMakeLists.txt
+++ b/tests/thread_local_no_tdata/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(no_tdata_host host.cpp no_tdata_u.c)
 

--- a/tests/thread_local_no_tdata/no_tdata.edl
+++ b/tests/thread_local_no_tdata/no_tdata.edl
@@ -3,7 +3,11 @@
 
 enclave {
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void enc_set_value(uint64_t value);

--- a/tests/threadcxx/enc/CMakeLists.txt
+++ b/tests/threadcxx/enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/threadcxx/host/CMakeLists.txt
+++ b/tests/threadcxx/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(threadcxx_host host.cpp threadcxx_u.c)
 

--- a/tests/threadcxx/threadcxx.edl
+++ b/tests/threadcxx/threadcxx.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public void enc_test_mutex_cxx();

--- a/tests/tls_e2e/client_enc/CMakeLists.txt
+++ b/tests/tls_e2e/client_enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(
   TARGET

--- a/tests/tls_e2e/host/CMakeLists.txt
+++ b/tests/tls_e2e/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(tls_e2e_host host.cpp tls_e2e_u.c)
 

--- a/tests/tls_e2e/server_enc/CMakeLists.txt
+++ b/tests/tls_e2e/server_enc/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_enclave(TARGET tls_server_enc SOURCES server.cpp ../common/utility.cpp
             ${CMAKE_CURRENT_BINARY_DIR}/tls_e2e_t.c)

--- a/tests/tls_e2e/tls_e2e.edl
+++ b/tests/tls_e2e/tls_e2e.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     struct tls_control_args {
         bool fail_cert_verify_callback;

--- a/tests/tools/oecert/enc/CMakeLists.txt
+++ b/tests/tools/oecert/enc/CMakeLists.txt
@@ -4,9 +4,8 @@
 add_custom_command(
   OUTPUT oecert_t.h oecert_t.c oecert_args.h
   DEPENDS ../oecert.edl edger8r
-  COMMAND
-    edger8r --trusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecert.edl --search-path
-    ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR})
+  COMMAND edger8r --trusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecert.edl
+          --search-path ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_enclave(TARGET oecert_enc SOURCES enc.cpp
             ${CMAKE_CURRENT_BINARY_DIR}/oecert_t.c)

--- a/tests/tools/oecert/host/CMakeLists.txt
+++ b/tests/tools/oecert/host/CMakeLists.txt
@@ -4,9 +4,8 @@
 add_custom_command(
   OUTPUT oecert_u.h oecert_u.c oecert_args.h
   DEPENDS ../oecert.edl edger8r
-  COMMAND
-    edger8r --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecert.edl --search-path
-    ${PROJECT_SOURCE_DIR}/include --search-path ${PLATFORM_EDL_DIR})
+  COMMAND edger8r --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecert.edl
+          --search-path ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_executable(oecert host.cpp ${CMAKE_CURRENT_BINARY_DIR}/oecert_u.c)
 

--- a/tests/tools/oecert/oecert.edl
+++ b/tests/tools/oecert/oecert.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/attestation.edl" import *;
     from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public oe_result_t get_tls_cert_signed_with_key(

--- a/tests/tools/oecertdump/enc/CMakeLists.txt
+++ b/tests/tools/oecertdump/enc/CMakeLists.txt
@@ -4,10 +4,8 @@
 add_custom_command(
   OUTPUT oecertdump_t.h oecertdump_t.c oecertdump_args.h
   DEPENDS ../oecertdump.edl edger8r
-  COMMAND
-    edger8r --trusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecertdump.edl
-    --search-path ${PROJECT_SOURCE_DIR}/include --search-path
-    ${PLATFORM_EDL_DIR})
+  COMMAND edger8r --trusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecertdump.edl
+          --search-path ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_enclave(TARGET oecertdump_enc SOURCES enc.cpp
             ${CMAKE_CURRENT_BINARY_DIR}/oecertdump_t.c)

--- a/tests/tools/oecertdump/host/CMakeLists.txt
+++ b/tests/tools/oecertdump/host/CMakeLists.txt
@@ -6,10 +6,8 @@ find_package(OpenSSL REQUIRED)
 add_custom_command(
   OUTPUT oecertdump_u.h oecertdump_u.c oecertdump_args.h
   DEPENDS ../oecertdump.edl edger8r
-  COMMAND
-    edger8r --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecertdump.edl
-    --search-path ${PROJECT_SOURCE_DIR}/include --search-path
-    ${PLATFORM_EDL_DIR})
+  COMMAND edger8r --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecertdump.edl
+          --search-path ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_executable(oecertdump host.cpp sgx_quote.cpp
                           ${CMAKE_CURRENT_BINARY_DIR}/oecertdump_u.c)

--- a/tests/tools/oecertdump/oecertdump.edl
+++ b/tests/tools/oecertdump/oecertdump.edl
@@ -5,7 +5,11 @@ enclave {
     from "openenclave/edl/attestation.edl" import *;
     from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public oe_result_t get_tls_cert_signed_with_ec_key(

--- a/tests/tools/oesign/test-enclave/enclave/CMakeLists.txt
+++ b/tests/tools/oesign/test-enclave/enclave/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Note that this test uses add_executable rather than add_enclave and its
 # related macro definitions since add_enclave does enclave signing as part of

--- a/tests/tools/oesign/test-enclave/host/CMakeLists.txt
+++ b/tests/tools/oesign/test-enclave/host/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    --search-path ${PLATFORM_EDL_DIR} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(oesign_test_host host.c
                                 ${CMAKE_CURRENT_BINARY_DIR}/oesign_test_u.c)

--- a/tests/tools/oesign/test-enclave/oesign_test.edl
+++ b/tests/tools/oesign/test-enclave/oesign_test.edl
@@ -4,7 +4,11 @@
 enclave {
     from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/fcntl.edl" import *;
-    from "platform.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
 
     trusted {
         public bool is_test_signed();


### PR DESCRIPTION
This PR does the following things.
- Adopt the preprocessor feature of oeedger8r to differentiate the platform (sgx or optee).
- Rename the `sgx_attestation.edl` to `attestation` since there is no longer a limitation that two imported edls cannot have the same same (per #2958).

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>