### PR TITLE
Support debug.edl opt-in/out

### DIFF
--- a/tests/backtrace/backtrace.edl
+++ b/tests/backtrace/backtrace.edl
@@ -5,7 +5,10 @@ enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall;
     from "openenclave/edl/fcntl.edl" import *;
 #ifdef OE_SGX
-    from "openenclave/edl/sgx/platform.edl" import *;
+    from "openenclave/edl/sgx/attestation.edl" import *;
+    from "openenclave/edl/sgx/cpu.edl" import *;
+    from "openenclave/edl/sgx/thread.edl" import *;
+    from "openenclave/edl/sgx/debug.edl" import *;
 #else
     from "openenclave/edl/optee/platform.edl" import *;
 #endif


### PR DESCRIPTION
This PR allows user to opt-out `debug.edl`, which was a hard requirement (part of #2818). If user does not import the debug.edl but invokes the `backtrace()`, he should be able to see the following log (if the logging feature is enabled)
```
backtrace_enc:In-enclave backtrace is not supported. To enable, please add 

from "openenclave/edl/sgx/debug.edl" import *;

in the edl file.
```

Note that the goal of this PR is having the implementation ready (only modify the edl in the backtrace test). Will wait for getting the consensus (per #3201) before generalizing the changes to both tests and samples.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>