### PR TITLE
Add new documents for host-verify package

### DIFF
--- a/docs/GettingStartedDocs/Linux_using_host_verify.md
+++ b/docs/GettingStartedDocs/Linux_using_host_verify.md
@@ -1,0 +1,41 @@
+# Using the Open Enclave Host-Verify SDK on Linux
+
+This document provides a brief overview of how to start exploring the Open Enclave Host-Verify SDK
+once you have it installed.
+
+**Note**: The SDK currently does not support 32-bit applications.
+
+## Open Enclave Host-Verify SDK Layout
+
+On Linux, by default, the Open Enclave Host-Verify SDK is installed to `/opt/openenclave`.
+
+It contains the following subfolders:
+
+| Path                         | Description                     |
+|------------------------------|---------------------------------|
+| bin                          | Developer tool for verifying attestation evidence or certificates. |
+| include/openenclave          | Open Enclave Host-Verify runtime headers for use in your attestation verifier application. |
+| lib/openenclave/cmake        | Open Enclave Host-Verify SDK CMake Package for integration with your CMake projects. |
+| lib/openenclave/host         | Libraries for linking into the attestation verifier application. |
+| share/openenclave/samples    | Sample code showing how to use the Open Enclave Host-Verify SDK. |
+
+On Linux, the Open Enclave Host-Verify SDK installation also contains the following folder:
+| share/pkgconfig              | Pkg-config files for header and library includes when building Open Enclave Host-Verify apps. |
+
+## Configure environment variables for Open Enclave Host-Verify SDK for Linux
+For ease of development, we recommend adding:
+- Open Enclave SDK `install` folder to `CMAKE_PREFIX_PATH`, for use of the [CMake package](/cmake/sdk_cmake_targets_readme.md).
+- Open Enclave SDK `pkgconfig` folder to `PKG_CONFIG_PATH`, for use of `pkg-config`.
+
+You can do this by sourcing the `openenclaverc` file that is distributed with the SDK:
+
+```bash
+source /opt/openenclave/share/openenclave/openenclaverc
+```
+
+## Samples
+
+One way to determine if your machine is correctly configured to build and run
+Open Enclave apps is to execute the samples. A description of the host-verify sample,
+what it illustrates, and how to build and run it can be found in
+[share/openenclave/samples/host_verify/README.md](/samples/host_verify/README.md).

--- a/docs/GettingStartedDocs/VisualStudioLinux.md
+++ b/docs/GettingStartedDocs/VisualStudioLinux.md
@@ -7,6 +7,8 @@ Studio Code on a development machine running either Windows or Linux, see the
 
 ## Prerequisites
 
+To install the Open Enclave Host-Verify SDK instead, see [installation instructions for Ubuntu 16.04](https://github.com/microsoft/openenclave/blob/master/docs/GettingStartedDocs/install_host_verify_Ubuntu_16.04.md) or [installation instructions for Ubuntu 18.04](https://github.com/microsoft/openenclave/blob/master/docs/GettingStartedDocs/install_host_verify_Ubuntu_18.04.md).
+
 To develop Linux applications using a Windows development machine, you will need the following:
 
 - [Visual Studio](https://visualstudio.microsoft.com/downloads/) 2019
@@ -28,7 +30,9 @@ any of the following:
 - a [Linux VM running on the Windows development machine](HyperVLinuxVMSetup.md)
 
 Ideally, the machine should be SGX capable (see [instructions for determining the SGX support level](https://github.com/microsoft/openenclave/blob/master/docs/GettingStartedDocs/SGXSupportLevel.md) if needed),
-but a non-SGX machine can still be used in simulation mode.
+but a non-SGX machine can still be used:
+ - in simulation mode, or
+ - if you would like to install the Open Enclave Host-Verify SDK and build evidence verification applications without enclaves.
 
 On the Linux build machine, or after opening an ssh session into the VM:
 

--- a/docs/GettingStartedDocs/VisualStudioWindows.md
+++ b/docs/GettingStartedDocs/VisualStudioWindows.md
@@ -10,6 +10,7 @@ Studio Code, see the
 You will need the following:
 
 - A development machine with support for SGX1 or SGX1 with Flexible Launch Control (FLC) (see [instructions for determining the SGX support level](https://github.com/microsoft/openenclave/blob/master/docs/GettingStartedDocs/SGXSupportLevel.md) if needed).
+  - If you would like to install the Open Enclave Host-Verify SDK and build evidence verification applications without enclaves, then this is not necessary. For more information about the Open Enclave Host-Verify SDK, see the [installation instructions](https://github.com/microsoft/openenclave/blob/master/docs/GettingStartedDocs/install_host_verify_Windows.md).
 - Visual Studio 2019, v16.5 or later
   (Community edition, or any other edition) with the "Desktop development
   with C++" workload

--- a/docs/GettingStartedDocs/Windows_using_host_verify.md
+++ b/docs/GettingStartedDocs/Windows_using_host_verify.md
@@ -1,0 +1,38 @@
+# Using the Open Enclave Host-Verify SDK on Windows
+
+This document provides a brief overview of how to start exploring the Open Enclave Host-Verify SDK
+once you have it installed.
+
+**Note**: The SDK currently does not support 32-bit applications.
+
+## Open Enclave Host-Verify SDK Layout
+
+On Windows, if you installed the SDK using the NuGet package, it is by default installed to `%userprofile%\.nuget\packages`.
+If you built the SDK from source and installed it, the SDK is installed to the location specified by `CMAKE_INSTALL_PREFIX` as described [here](Contributors/WindowsInstallInfo.md#basic-install-on-windows)
+
+It contains the following subfolders:
+
+| Path                         | Description                     |
+|------------------------------|---------------------------------|
+| bin                          | Developer tool for verifying attestation evidence or certificates. |
+| include/openenclave          | Open Enclave Host-Verify runtime headers for use in your attestation verifier application. |
+| lib/openenclave/cmake        | Open Enclave Host-Verify SDK CMake Package for integration with your CMake projects. |
+| lib/openenclave/host         | Libraries for linking into the attestation verifier application. |
+| share/openenclave/samples    | Sample code showing how to use the Open Enclave Host-Verify SDK. |
+
+## Configure environment variables for Open Enclave Host-Verify SDK for Windows
+
+- Set `CMAKE_PREFIX_PATH` to the point to the cmake directory of the Open Enclave Host-Verify SDK installation
+
+As an example, if you installed the SDK to C:\openenclave, then you would set `CMAKE_PREFIX_PATH` as shown below.
+
+```cmd
+set CMAKE_PREFIX_PATH=C:\openenclave\lib\openenclave\cmake
+```
+
+## Samples
+
+One way to determine if your machine is correctly configured to build and run
+Open Enclave apps is to execute the samples. A description of the host-verify sample,
+what it illustrates, and how to build and run it can be found in
+[share/openenclave/samples/host_verify/README.md](/samples/host_verify/README.md).

--- a/docs/GettingStartedDocs/install_host_verify_Ubuntu_16.04.md
+++ b/docs/GettingStartedDocs/install_host_verify_Ubuntu_16.04.md
@@ -1,0 +1,39 @@
+# Install the Open Enclave Host-Verify SDK (Ubuntu 16.04)
+
+## Platform requirements
+
+- Ubuntu 16.04-LTS 64-bit.
+    - Instructions are also available for [Ubuntu 18.04-LTS 64-bit](/docs/GettingStartedDocs/install_host_verify-Ubuntu_18.04.md).
+
+### 1. Configure the Intel and Microsoft APT Repositories
+```bash
+echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu xenial main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+
+echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-xenial-7.list
+wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+
+echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/16.04/prod xenial main" | sudo tee /etc/apt/sources.list.d/msprod.list
+wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+```
+
+### 2. Install the Intel and Open Enclave Host-Verify packages and dependencies
+```bash
+sudo apt update
+sudo apt -y install clang-7 libssl-dev gdb libprotobuf9v5 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave-hostverify
+```
+
+> This step also installs the [az-dcap-client](https://github.com/microsoft/azure-dcap-client)
+> package which is necessary for performing remote attestation in Azure. A general
+> implementation for using Intel DCAP outside the Azure environment is coming soon.
+
+If you wish to use the Ninja build system rather than make, also install
+```bash
+sudo apt -y install ninja-build
+```
+
+If you wish to make use of the Open Enclave Host-Verify CMake package, please install CMake and [follow the instructions here](/cmake/sdk_cmake_targets_readme.md).
+
+### 3. Verify the Open Enclave Host-Verify SDK install
+
+See [Using the Open Enclave Host-Verify SDK](Linux_using_host_verify.md) for verifying and using the installed SDK.

--- a/docs/GettingStartedDocs/install_host_verify_Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_host_verify_Ubuntu_18.04.md
@@ -1,0 +1,39 @@
+# Install the Open Enclave Host-Verify SDK (Ubuntu 18.04)
+
+## Platform requirements
+
+- Ubuntu 18.04-LTS 64-bit.
+    - Instructions are also available for [Ubuntu 16.04-LTS 64-bit](/docs/GettingStartedDocs/install_host_verify-Ubuntu_16.04.md).
+
+### 1. Configure the Intel and Microsoft APT Repositories
+```bash
+echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+
+echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
+wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+
+echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
+wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+```
+
+### 2. Install the Intel and Open Enclave Host-Verify packages and dependencies
+```bash
+sudo apt update
+sudo apt -y install clang-7 libssl-dev gdb libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave-hostverify
+```
+
+> This step also installs the [az-dcap-client](https://github.com/microsoft/azure-dcap-client)
+> package which is necessary for performing remote attestation in Azure. A general
+> implementation for using Intel DCAP outside the Azure environment is coming soon.
+
+If you wish to use the Ninja build system rather than make, also install
+```bash
+sudo apt -y install ninja-build
+```
+
+If you wish to make use of the Open Enclave Host-Verify CMake package, please install CMake and [follow the instructions here](/cmake/sdk_cmake_targets_readme.md).
+
+### 3. Verify the Open Enclave Host-Verify SDK install
+
+See [Using the Open Enclave Host-Verify SDK](Linux_using_host_verify.md) for verifying and using the installed SDK.

--- a/docs/GettingStartedDocs/install_host_verify_Windows.md
+++ b/docs/GettingStartedDocs/install_host_verify_Windows.md
@@ -1,0 +1,96 @@
+# Install the Open Enclave Host-Verify SDK NuGet Package
+
+## Platform requirements
+
+- Windows 10, Server 2016 or Server 2019
+
+## Software Prerequisites
+
+### Microsoft Visual Studio Build Tools 2019
+
+Install [Visual Studio Build Tools 2019](https://aka.ms/vs/16/release/vs_buildtools.exe). Choose the "C++ build tools" workload. Visual Studio Build Tools 2019 has support for CMake Version 3.15 (CMake ver 3.12 or above is required for building Open Enclave Host-Verify SDK). For more information about CMake support, look [here](https://blogs.msdn.microsoft.com/vcblog/2016/10/05/cmake-support-in-visual-studio/).
+
+### Git for Windows 64-bit
+
+Download [Git for Windows 64-bit](https://git-scm.com/download/win).
+
+Install Git and add Git Bash to the PATH environment variable.
+Typically, Git Bash is located in `C:\Program Files\Git\bin`.
+Currently the Open Enclave Host-Verify SDK build system uses bash scripts to configure
+and build Linux-based 3rd-party libraries.
+
+Open a command prompt and ensure that Git Bash is added to PATH.
+
+```cmd
+C:\>where bash
+C:\Program Files\Git\bin\bash.exe
+```
+
+Tools available in the Git bash environment are also used for test and sample
+builds. For example, OpenSSL is used to generate test certificates, so it is
+also useful to have the `Git\mingw64\bin` folder added to PATH. This can be checked
+from the command prompt as well:
+
+```cmd
+C:\>where openssl
+C:\Program Files\Git\mingw64\bin\openssl.exe
+```
+
+### Clang
+
+Download [Clang/LLVM for Windows 64-bit](http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe).
+Install Clang 7.0.1 and add the LLVM folder (typically C:\Program Files\LLVM\bin)
+to PATH. Open Enclave Host-Verify SDK uses clang to build the enclave binaries.
+
+Open up a command prompt and ensure that clang is added to PATH.
+
+```cmd
+C:\> where clang
+C:\Program Files\LLVM\bin\clang.exe
+C:\> where llvm-ar
+C:\Program Files\LLVM\bin\llvm-ar.exe
+C:\> where ld.lld
+C:\Program Files\LLVM\bin\ld.lld.exe
+```
+
+## Download and install the Azure DCAP NuGet Package
+
+Download the required Azure DCAP NuGet Package from [here](https://github.com/microsoft/Azure-DCAP-Client/releases/latest) and place it in a directory of your choice. Use the command below to install the NuGet package with the [NuGet Command-Line Interface (CLI) tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe). In this example, we are placing the NuGet Package in `C:\azure_dcap_nuget` and installing it to `C:\azure_dcap`.
+
+```cmd
+ nuget.exe install Microsoft.Azure.DCAP -Source C:\azure_dcap_nuget -OutputDirectory C:\azure_dcap -ExcludeVersion
+```
+
+Once installed, Azure DCAP binary is located in `C:\azure_dcap\Microsoft.Azure.DCAP\build\native`.
+Azure DCAP binary is needed to provide Azure DCAP verification service. Add the folder to PATH and open a command prompt and ensure that it's added to PATH.
+
+```cmd
+c:\>where dcap_quoteprov.dll
+c:\azure_dcap\Microsoft.Azure.DCAP\build\native\dcap_quoteprov.dll
+```
+
+## Download and install the Open Enclave Host-Verify SDK NuGet Package
+
+Download the required Windows NuGet Package from [here](https://github.com/openenclave/openenclave/releases) and place them in a directory of your choice. Enter the directory where you place the NuGet CLI tool, and use the command below to install the NuGet package. In this example, we are placing the NuGet Package in `C:\openenclave_nuget` and installing it to `C:\oe`.
+
+```cmd
+ nuget.exe install open-enclave.OEHOSTVERIFY -Source C:\openenclave_nuget -OutputDirectory C:\oe -ExcludeVersion
+```
+
+Note: If it is an RC package, append `-pre` to the command above.
+
+After the installation, the Open Enclave Host-Verify SDK will be placed in the path `C:\oe\open-enclave.OEHOSTVERIFY\openenclave`.
+Use the following command to copy the SDK to `C:\openenclave`.
+
+```cmd
+xcopy /E  C:\oe\open-enclave.OEHOSTVERIFY\openenclave C:\openenclave\
+```
+
+Alternatively, we can use NuGet Package Manager to install Open Enclave Host-Verify SDK. Click [here](https://docs.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio) for more information on installing and using a NuGet package in Visual Studio.
+
+The rest of the documentation assumes `C:\openenclave` as the default installation path of the SDK.
+
+
+## Verify the Open Enclave Host-Verify SDK installation
+
+See [Using the Open Enclave Host-Verify SDK](Windows_using_host_verify.md) for verifying and using the installed SDK.

--- a/samples/host_verify/README.md
+++ b/samples/host_verify/README.md
@@ -15,7 +15,9 @@ The sample does remote host-side enclave attestation by taking either of the two
 - An SGX report
 - An SGX certificate
 
-A user can generate a report or certificate with `oecert`. See [here](https://github.com/openenclave/openenclave/blob/master/tests/tools/oecert/README.md) for more details.
+The sample also accepts an endorsement file as input. See the end of the file for usage.
+
+A user can generate a report, an endorsement file or a certificate with `oecert`. See [here](https://github.com/openenclave/openenclave/blob/master/tests/tools/oecert/README.md) for more details.
 
 In the main function, if it sees the attribute `-r`, then it will continue to read the next argument to get the report and call `verify_report()` to verify the report.
 Likewise, if it sees the attribute `-c`, then it will continue to read the next argument to get the certificate and call `verify_cert()` to verify the certificate.
@@ -64,7 +66,7 @@ When you see the following message displayed on the screen, it means you have su
 
 ```bash
 Usage:
-  ./host_verify -r <report_file>
+  ./host_verify -r <report_file> [-e <endorsement_file>]
   ./host_verify -c <certificate_file>
 Verify the integrity of enclave remote report or attestation certificate.
 WARNING: host_verify does not have a stable CLI interface. Use with caution.


### PR DESCRIPTION
Add 5 new documents for host-verify package based on existing `install_oe_sdk*.md` and `*using_oe_sdk.md` files. Many thanks to Yen for drafting them!

Fix #2513.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>