### PR TITLE
Add check to ensure EEID data is within enclave memory.

### DIFF
--- a/enclave/core/sgx/init.c
+++ b/enclave/core/sgx/init.c
@@ -73,7 +73,8 @@ static oe_result_t _eeid_patch_memory()
 
         uint8_t* heap_end = (uint8_t*)__oe_get_heap_end();
         uint8_t* tcs_end =
-            heap_end + (6 + 2 + eeid->size_settings.num_stack_pages) *
+            heap_end + (OE_SGX_TCS_CONTROL_PAGES + OE_SGX_TCS_GUARD_PAGES +
+                        eeid->size_settings.num_stack_pages) *
                            OE_PAGE_SIZE * eeid->size_settings.num_tcs;
 
         /* EEID must not overlap with tcs/stack/control pages */

--- a/enclave/core/sgx/init.c
+++ b/enclave/core/sgx/init.c
@@ -69,12 +69,14 @@ static oe_result_t _eeid_patch_memory()
         uint8_t* enclave_base = (uint8_t*)__oe_get_enclave_base();
         uint8_t* heap_base = (uint8_t*)__oe_get_heap_base();
         oe_eeid_marker_t* marker = (oe_eeid_marker_t*)heap_base;
-        uint8_t* eeid_ptr = enclave_base + marker->offset;
+        oe_eeid_t* eeid = (oe_eeid_t*)(enclave_base + marker->offset);
 
-        if (!_is_within_eeid_enclave(eeid_ptr))
+        if (!_is_within_eeid_enclave((uint8_t*)eeid) ||
+            !_is_within_eeid_enclave(eeid->data) ||
+            !_is_within_eeid_enclave(eeid->data + eeid->data_size))
             oe_abort();
 
-        oe_eeid = (oe_eeid_t*)eeid_ptr;
+        oe_eeid = eeid;
 
         // Wipe the marker page
         memset(heap_base, 0, OE_PAGE_SIZE);

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -325,7 +325,7 @@ static oe_result_t _calculate_enclave_size(
     {
 #ifdef OE_WITH_EXPERIMENTAL_EEID
         if (is_eeid_base_image(props))
-            *enclave_size = EEID_ELRANGE;
+            *enclave_size = OE_EEID_SGX_ELRANGE;
         else
 #endif
             /* Calculate the total size of the enclave */

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -325,7 +325,7 @@ static oe_result_t _calculate_enclave_size(
     {
 #ifdef OE_WITH_EXPERIMENTAL_EEID
         if (is_eeid_base_image(props))
-            *enclave_size = EEID_SECS_SIZE;
+            *enclave_size = EEID_ELRANGE;
         else
 #endif
             /* Calculate the total size of the enclave */

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -325,12 +325,7 @@ static oe_result_t _calculate_enclave_size(
     {
 #ifdef OE_WITH_EXPERIMENTAL_EEID
         if (is_eeid_base_image(props))
-        {
-            /* This is the maximum size SGX allows. When signing base images we
-             * don't know the size that the final image will have, so we chose
-             * the maximum here. */
-            *enclave_size = 68719476736;
-        }
+            *enclave_size = EEID_SECS_SIZE;
         else
 #endif
             /* Calculate the total size of the enclave */

--- a/include/openenclave/bits/sgx/sgxproperties.h
+++ b/include/openenclave/bits/sgx/sgxproperties.h
@@ -28,6 +28,13 @@ typedef struct _oe_sgx_enclave_image_info_t
 /* Max number of threads in an enclave supported */
 #define OE_SGX_MAX_TCS 32
 
+#ifdef OE_WITH_EXPERIMENTAL_EEID
+/* This is the maximum size SGX (currently) allows. When signing EEID base
+ * images we don't know the size that the final image will have, so chose
+ * this maximum. */
+#define EEID_SECS_SIZE 68719476736
+#endif
+
 // oe_sgx_enclave_properties_t SGX enclave properties derived type
 #define OE_SGX_FLAGS_DEBUG 0x0000000000000002ULL
 #define OE_SGX_FLAGS_MODE64BIT 0x0000000000000004ULL

--- a/include/openenclave/bits/sgx/sgxproperties.h
+++ b/include/openenclave/bits/sgx/sgxproperties.h
@@ -28,13 +28,6 @@ typedef struct _oe_sgx_enclave_image_info_t
 /* Max number of threads in an enclave supported */
 #define OE_SGX_MAX_TCS 32
 
-#ifdef OE_WITH_EXPERIMENTAL_EEID
-/* This is the maximum size SGX (currently) allows (64GB). When signing EEID
- * base images we don't know the size that the final image will have, so we
- * chose this maximum. */
-#define EEID_SECS_SIZE 0x1000000000
-#endif
-
 // oe_sgx_enclave_properties_t SGX enclave properties derived type
 #define OE_SGX_FLAGS_DEBUG 0x0000000000000002ULL
 #define OE_SGX_FLAGS_MODE64BIT 0x0000000000000004ULL

--- a/include/openenclave/bits/sgx/sgxproperties.h
+++ b/include/openenclave/bits/sgx/sgxproperties.h
@@ -29,10 +29,10 @@ typedef struct _oe_sgx_enclave_image_info_t
 #define OE_SGX_MAX_TCS 32
 
 #ifdef OE_WITH_EXPERIMENTAL_EEID
-/* This is the maximum size SGX (currently) allows. When signing EEID base
- * images we don't know the size that the final image will have, so chose
- * this maximum. */
-#define EEID_SECS_SIZE 68719476736
+/* This is the maximum size SGX (currently) allows (64GB). When signing EEID
+ * base images we don't know the size that the final image will have, so we
+ * chose this maximum. */
+#define EEID_SECS_SIZE 0x1000000000
 #endif
 
 // oe_sgx_enclave_properties_t SGX enclave properties derived type

--- a/include/openenclave/internal/eeid.h
+++ b/include/openenclave/internal/eeid.h
@@ -15,6 +15,12 @@
 
 #include <openenclave/bits/eeid.h>
 
+#ifdef OE_WITH_EXPERIMENTAL_EEID
+/* When signing EEID base images we don't know the size that the final image
+ * will have, so we chose a reasonably large size here (64GB). */
+#define EEID_ELRANGE 0x1000000000
+#endif
+
 /** This is the public key corresponding to the private key OE_DEBUG_SIGN_KEY in
  * signkey.c/.h. */
 static const uint8_t OE_DEBUG_PUBLIC_KEY[] = {

--- a/include/openenclave/internal/eeid.h
+++ b/include/openenclave/internal/eeid.h
@@ -15,11 +15,12 @@
 
 #include <openenclave/bits/eeid.h>
 
-#ifdef OE_WITH_EXPERIMENTAL_EEID
 /* When signing EEID base images we don't know the size that the final image
  * will have, so we chose a reasonably large size here (64GB). */
 #define EEID_ELRANGE 0x1000000000
-#endif
+
+#define OE_SGX_TCS_CONTROL_PAGES 6
+#define OE_SGX_TCS_GUARD_PAGES 2
 
 /** This is the public key corresponding to the private key OE_DEBUG_SIGN_KEY in
  * signkey.c/.h. */

--- a/include/openenclave/internal/eeid.h
+++ b/include/openenclave/internal/eeid.h
@@ -17,7 +17,7 @@
 
 /* When signing EEID base images we don't know the size that the final image
  * will have, so we chose a reasonably large size here (64GB). */
-#define EEID_ELRANGE 0x1000000000
+#define OE_EEID_SGX_ELRANGE 0x1000000000
 
 #define OE_SGX_TCS_CONTROL_PAGES 6
 #define OE_SGX_TCS_GUARD_PAGES 2


### PR DESCRIPTION
This adds a check to ensure the EEID marker offset is in fact within the enclave boundaries. 

The host is in control of the offset value on the marker page. So, in theory, they could make this point into host memory, so that the host has control over the EEID content during attestation, which the hardware would not catch.

Thanks to @bodzhang for reporting this issue and suggesting a fix.

Signed-off-by: Christoph M. Wintersteiger <cwinter@microsoft.com>