### PR TITLE
Cleanup to conform to OE naming conventions

### DIFF
--- a/common/sgx/collateral.c
+++ b/common/sgx/collateral.c
@@ -22,7 +22,7 @@
 #include "tcbinfo.h"
 
 // Defaults to Intel SGX 1.8 Release Date.
-oe_datetime_t _sgx_minimim_crl_tcb_issue_date = {2017, 3, 17};
+oe_datetime_t __oe_sgx_minimim_crl_tcb_issue_date = {2017, 3, 17};
 
 oe_result_t __oe_sgx_set_minimum_crl_tcb_issue_date(
     uint32_t year,
@@ -36,7 +36,7 @@ oe_result_t __oe_sgx_set_minimum_crl_tcb_issue_date(
     oe_datetime_t tmp = {year, month, day, hours, minutes, seconds};
 
     OE_CHECK(oe_datetime_is_valid(&tmp));
-    _sgx_minimim_crl_tcb_issue_date = tmp;
+    __oe_sgx_minimim_crl_tcb_issue_date = tmp;
 
     result = OE_OK;
 done:
@@ -158,7 +158,7 @@ static oe_result_t _parse_sgx_extensions(
         OE_RAISE(OE_OUT_OF_MEMORY);
 
     // Try parsing the extensions.
-    result = ParseSGXExtensions(
+    result = oe_parse_sgx_extensions(
         leaf_cert, buffer, &buffer_size, parsed_extension_info);
 
     if (result == OE_BUFFER_TOO_SMALL)
@@ -168,7 +168,7 @@ static oe_result_t _parse_sgx_extensions(
         oe_free(buffer);
         buffer = (uint8_t*)oe_malloc(buffer_size);
 
-        result = ParseSGXExtensions(
+        result = oe_parse_sgx_extensions(
             leaf_cert, buffer, &buffer_size, parsed_extension_info);
     }
 
@@ -381,25 +381,26 @@ oe_result_t oe_validate_revocation_list(
         "Failed to get revocation validity datetime info. %s",
         oe_result_str(result));
 
-    if (oe_datetime_compare(&latest_from, &_sgx_minimim_crl_tcb_issue_date) < 0)
+    if (oe_datetime_compare(
+            &latest_from, &__oe_sgx_minimim_crl_tcb_issue_date) < 0)
     {
         oe_datetime_log("Latest issue date : ", &latest_from);
         oe_datetime_log(
             " is earlier than minimum issue date: ",
-            &_sgx_minimim_crl_tcb_issue_date);
+            &__oe_sgx_minimim_crl_tcb_issue_date);
         OE_RAISE_MSG(
             OE_INVALID_REVOCATION_INFO,
             "Revocation validation failed minimum issue date. %s",
             oe_result_str(result));
     }
 
-    if (oe_datetime_compare(&earliest_until, &_sgx_minimim_crl_tcb_issue_date) <
-        0)
+    if (oe_datetime_compare(
+            &earliest_until, &__oe_sgx_minimim_crl_tcb_issue_date) < 0)
     {
         oe_datetime_log("Next update date : ", &earliest_until);
         oe_datetime_log(
             " is earlier than minimum issue date: ",
-            &_sgx_minimim_crl_tcb_issue_date);
+            &__oe_sgx_minimim_crl_tcb_issue_date);
         OE_RAISE_MSG(
             OE_INVALID_REVOCATION_INFO,
             "Revocation validation failed minimum issue date. %s",

--- a/common/sgx/qeidentity.c
+++ b/common/sgx/qeidentity.c
@@ -8,7 +8,7 @@
 #include "../common.h"
 #include "tcbinfo.h"
 
-extern oe_datetime_t _sgx_minimim_crl_tcb_issue_date;
+extern oe_datetime_t __oe_sgx_minimim_crl_tcb_issue_date;
 
 static void dump_info(
     const char* title,
@@ -102,7 +102,7 @@ oe_result_t oe_validate_qe_identity(
     // Check that issue_date and next_update are after the earliest date that
     // the enclave accepts.
     if (oe_datetime_compare(
-            &parsed_info.issue_date, &_sgx_minimim_crl_tcb_issue_date) < 0)
+            &parsed_info.issue_date, &__oe_sgx_minimim_crl_tcb_issue_date) < 0)
         OE_RAISE_MSG(
             OE_INVALID_QE_IDENTITY_INFO,
             "QE identity info issue date does not meet CRL/TCB minimum issue "
@@ -110,7 +110,7 @@ oe_result_t oe_validate_qe_identity(
             NULL);
 
     if (oe_datetime_compare(
-            &parsed_info.next_update, &_sgx_minimim_crl_tcb_issue_date) < 0)
+            &parsed_info.next_update, &__oe_sgx_minimim_crl_tcb_issue_date) < 0)
         OE_RAISE_MSG(
             OE_INVALID_QE_IDENTITY_INFO,
             "QE identity info next update does not meet CRL/TCB minimum issue "

--- a/common/sgx/sgxcertextensions.c
+++ b/common/sgx/sgxcertextensions.c
@@ -403,7 +403,7 @@ done:
     return result;
 }
 
-oe_result_t ParseSGXExtensions(
+oe_result_t oe_parse_sgx_extensions(
     oe_cert_t* cert,
     uint8_t* buffer,
     size_t* buffer_size,

--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -535,7 +535,7 @@ static oe_result_t _get_format_settings(
         if (!report)
             OE_RAISE(OE_OUT_OF_MEMORY);
 
-        OE_CHECK(sgx_create_report(
+        OE_CHECK(oe_sgx_create_report(
             NULL, 0, NULL, 0, (sgx_report_t*)&report->report));
 
         report->version = OE_REPORT_HEADER_VERSION;

--- a/enclave/core/calls.c
+++ b/enclave/core/calls.c
@@ -21,7 +21,7 @@ bool oe_disable_debug_malloc_check;
 **==============================================================================
 */
 
-ecall_table_t _ecall_tables[OE_MAX_ECALL_TABLES];
+ecall_table_t __oe_ecall_tables[OE_MAX_ECALL_TABLES];
 static oe_spinlock_t _ecall_tables_lock = OE_SPINLOCK_INITIALIZER;
 
 oe_result_t oe_register_ecall_function_table(
@@ -35,8 +35,8 @@ oe_result_t oe_register_ecall_function_table(
         OE_RAISE(OE_INVALID_PARAMETER);
 
     oe_spin_lock(&_ecall_tables_lock);
-    _ecall_tables[table_id].ecalls = ecalls;
-    _ecall_tables[table_id].num_ecalls = num_ecalls;
+    __oe_ecall_tables[table_id].ecalls = ecalls;
+    __oe_ecall_tables[table_id].num_ecalls = num_ecalls;
     oe_spin_unlock(&_ecall_tables_lock);
 
     result = OE_OK;

--- a/enclave/core/calls.h
+++ b/enclave/core/calls.h
@@ -18,6 +18,6 @@ typedef struct _ecall_table
     size_t num_ecalls;
 } ecall_table_t;
 
-extern ecall_table_t _ecall_tables[];
+extern ecall_table_t __oe_ecall_tables[];
 
 #endif /* OE_CALLS_H */

--- a/enclave/core/ctype.c
+++ b/enclave/core/ctype.c
@@ -51,7 +51,7 @@ static const unsigned short _ctype_b[384] = {
 
 const unsigned short* __oe_ctype_b_loc = &_ctype_b[128];
 
-const unsigned int _ctype_toupper[384] = {
+static const unsigned int _ctype_toupper[384] = {
     0x00000080, 0x00000081, 0x00000082, 0x00000083, 0x00000084, 0x00000085,
     0x00000086, 0x00000087, 0x00000088, 0x00000089, 0x0000008a, 0x0000008b,
     0x0000008c, 0x0000008d, 0x0000008e, 0x0000008f, 0x00000090, 0x00000091,
@@ -120,7 +120,7 @@ const unsigned int _ctype_toupper[384] = {
 
 const unsigned int* __oe_ctype_toupper_loc = &_ctype_toupper[128];
 
-const unsigned int _ctype_tolower[384] = {
+static const unsigned int _ctype_tolower[384] = {
     0x00000080, 0x00000081, 0x00000082, 0x00000083, 0x00000084, 0x00000085,
     0x00000086, 0x00000087, 0x00000088, 0x00000089, 0x0000008a, 0x0000008b,
     0x0000008c, 0x0000008d, 0x0000008e, 0x0000008f, 0x00000090, 0x00000091,

--- a/enclave/core/hostcalls.c
+++ b/enclave/core/hostcalls.c
@@ -18,9 +18,9 @@
  * Declare the protoype of the following functions to avoid the
  * missing-prototypes warning.
  */
-oe_result_t _oe_log_is_supported_ocall();
-oe_result_t _oe_log_ocall(uint32_t log_level, const char* message);
-oe_result_t _oe_write_ocall(int device, const char* str, size_t maxlen);
+oe_result_t __oe_log_is_supported_ocall();
+oe_result_t __oe_log_ocall(uint32_t log_level, const char* message);
+oe_result_t __oe_write_ocall(int device, const char* str, size_t maxlen);
 
 /**
  * Make the following OCALLs weak to support the system EDL opt-in.
@@ -29,28 +29,28 @@ oe_result_t _oe_write_ocall(int device, const char* str, size_t maxlen);
  * the implementions (which are strong) in the oeedger8r-generated code will be
  * used.
  */
-oe_result_t _oe_log_is_supported_ocall()
+oe_result_t __oe_log_is_supported_ocall()
 {
     return OE_UNSUPPORTED;
 }
-OE_WEAK_ALIAS(_oe_log_is_supported_ocall, oe_log_is_supported_ocall);
+OE_WEAK_ALIAS(__oe_log_is_supported_ocall, oe_log_is_supported_ocall);
 
-oe_result_t _oe_log_ocall(uint32_t log_level, const char* message)
+oe_result_t __oe_log_ocall(uint32_t log_level, const char* message)
 {
     OE_UNUSED(log_level);
     OE_UNUSED(message);
     return OE_UNSUPPORTED;
 }
-OE_WEAK_ALIAS(_oe_log_ocall, oe_log_ocall);
+OE_WEAK_ALIAS(__oe_log_ocall, oe_log_ocall);
 
-oe_result_t _oe_write_ocall(int device, const char* str, size_t maxlen)
+oe_result_t __oe_write_ocall(int device, const char* str, size_t maxlen)
 {
     OE_UNUSED(device);
     OE_UNUSED(str);
     OE_UNUSED(maxlen);
     return OE_UNSUPPORTED;
 }
-OE_WEAK_ALIAS(_oe_write_ocall, oe_write_ocall);
+OE_WEAK_ALIAS(__oe_write_ocall, oe_write_ocall);
 #endif
 
 void* oe_host_malloc(size_t size)

--- a/enclave/core/optee/gp.c
+++ b/enclave/core/optee/gp.c
@@ -195,8 +195,8 @@ static TEE_Result _handle_call_enclave_function(
         if (args.table_id >= OE_MAX_ECALL_TABLES)
             return TEE_ERROR_ITEM_NOT_FOUND;
 
-        ecall_table.ecalls = _ecall_tables[args.table_id].ecalls;
-        ecall_table.num_ecalls = _ecall_tables[args.table_id].num_ecalls;
+        ecall_table.ecalls = __oe_ecall_tables[args.table_id].ecalls;
+        ecall_table.num_ecalls = __oe_ecall_tables[args.table_id].num_ecalls;
 
         if (!ecall_table.ecalls)
             return TEE_ERROR_ITEM_NOT_FOUND;

--- a/enclave/core/optee/tracee.c
+++ b/enclave/core/optee/tracee.c
@@ -5,7 +5,7 @@
 
 #include "../tracee.h"
 
-bool is_enclave_debug_allowed()
+bool oe_is_enclave_debug_allowed()
 {
     // TODO: Eventually, this must be modifiable.
     return true;

--- a/enclave/core/sgx/arena.c
+++ b/enclave/core/sgx/arena.c
@@ -21,7 +21,7 @@ void oe_deallocate_arena(void* buffer);
 
 static oe_shared_memory_arena_t* _get_arena()
 {
-    /* Note: arenas are zero-initialized by td_init() */
+    /* Note: arenas are zero-initialized by oe_td_init() */
     return &oe_sgx_get_td()->arena;
 }
 

--- a/enclave/core/sgx/backtrace.c
+++ b/enclave/core/sgx/backtrace.c
@@ -20,7 +20,7 @@
 #endif
 
 /* Return null if address is outside of the enclave; else return ptr. */
-const void* _check_address(const void* ptr)
+static const void* _check_address(const void* ptr)
 {
     if (!oe_is_within_enclave(ptr, sizeof(uint64_t)))
         return NULL;

--- a/enclave/core/sgx/keys.c
+++ b/enclave/core/sgx/keys.c
@@ -196,7 +196,7 @@ static oe_result_t _get_default_key_request_attributes(
     oe_result_t result;
 
     // Get a local report of current enclave.
-    result = sgx_create_report(NULL, 0, NULL, 0, &sgx_report);
+    result = oe_sgx_create_report(NULL, 0, NULL, 0, &sgx_report);
 
     if (result != OE_OK)
     {

--- a/enclave/core/sgx/report.c
+++ b/enclave/core/sgx/report.c
@@ -22,7 +22,7 @@ OE_STATIC_ASSERT(sizeof(oe_identity_t) == 96);
 
 OE_STATIC_ASSERT(sizeof(oe_report_t) == 144);
 
-oe_result_t sgx_create_report(
+oe_result_t oe_sgx_create_report(
     const void* report_data,
     size_t report_data_size,
     const void* target_info,
@@ -106,7 +106,7 @@ static oe_result_t _get_local_report(
         OE_RAISE_NO_TRACE(OE_BUFFER_TOO_SMALL);
     }
 
-    OE_CHECK(sgx_create_report(
+    OE_CHECK(oe_sgx_create_report(
         report_data,
         report_data_size,
         opt_params,

--- a/enclave/core/sgx/report.h
+++ b/enclave/core/sgx/report.h
@@ -11,7 +11,7 @@
 
 oe_result_t _handle_get_sgx_report(uint64_t arg_in);
 
-oe_result_t sgx_create_report(
+oe_result_t oe_sgx_create_report(
     const void* report_data,
     size_t report_data_size,
     const void* target_info,

--- a/enclave/core/sgx/td.c
+++ b/enclave/core/sgx/td.c
@@ -64,7 +64,7 @@ oe_thread_data_t* oe_get_thread_data()
 /*
 **==============================================================================
 **
-** td_push_callsite()
+** oe_td_push_callsite()
 **
 **     Insert the Callsite structure for the current ECALL at the
 **     front of the oe_sgx_td_t.callsites list.
@@ -72,7 +72,7 @@ oe_thread_data_t* oe_get_thread_data()
 **==============================================================================
 */
 
-void td_push_callsite(oe_sgx_td_t* td, Callsite* callsite)
+void oe_td_push_callsite(oe_sgx_td_t* td, Callsite* callsite)
 {
     callsite->next = td->callsites;
     td->callsites = callsite;
@@ -91,7 +91,7 @@ void td_push_callsite(oe_sgx_td_t* td, Callsite* callsite)
 **     resigter until it is solved on Windows debugger.
 **     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 **
-** td_from_tcs()
+** oe_td_from_tcs()
 **
 **     This function calculates the address of the oe_sgx_td_t (thread data
 *structure)
@@ -127,7 +127,7 @@ void td_push_callsite(oe_sgx_td_t* td, Callsite* callsite)
 **==============================================================================
 */
 
-oe_sgx_td_t* td_from_tcs(void* tcs)
+oe_sgx_td_t* oe_td_from_tcs(void* tcs)
 {
     return (oe_sgx_td_t*)((uint8_t*)tcs + TD_FROM_TCS);
 }
@@ -135,14 +135,14 @@ oe_sgx_td_t* td_from_tcs(void* tcs)
 /*
 **==============================================================================
 **
-** td_to_tcs()
+** oe_td_to_tcs()
 **
 **     Compute a TCS pointer from a oe_sgx_td_t.
 **
 **==============================================================================
 */
 
-void* td_to_tcs(const oe_sgx_td_t* td)
+void* oe_td_to_tcs(const oe_sgx_td_t* td)
 {
     return (uint8_t*)td - TD_FROM_TCS;
 }
@@ -173,7 +173,7 @@ oe_sgx_td_t* oe_sgx_get_td()
 /*
 **==============================================================================
 **
-** td_initialized()
+** oe_td_initialized()
 **
 **     Returns TRUE if this thread data structure (oe_sgx_td_t) is initialized.
 *An
@@ -186,7 +186,7 @@ oe_sgx_td_t* oe_sgx_get_td()
 **==============================================================================
 */
 
-bool td_initialized(oe_sgx_td_t* td)
+bool oe_td_initialized(oe_sgx_td_t* td)
 {
     if (td && td->magic == TD_MAGIC && td->base.self_addr == (uint64_t)td)
         return true;

--- a/enclave/core/sgx/td.h
+++ b/enclave/core/sgx/td.h
@@ -69,13 +69,13 @@ struct _callsite
 **==============================================================================
 */
 
-void td_push_callsite(oe_sgx_td_t* td, Callsite* ec);
+void oe_td_push_callsite(oe_sgx_td_t* td, Callsite* ec);
 
-oe_sgx_td_t* td_from_tcs(void* tcs);
+oe_sgx_td_t* oe_td_from_tcs(void* tcs);
 
-void* td_to_tcs(const oe_sgx_td_t* td);
+void* oe_td_to_tcs(const oe_sgx_td_t* td);
 
-bool td_initialized(oe_sgx_td_t* td);
+bool oe_td_initialized(oe_sgx_td_t* td);
 
 /*
 **==============================================================================
@@ -85,10 +85,10 @@ bool td_initialized(oe_sgx_td_t* td);
 **==============================================================================
 */
 
-void td_pop_callsite(oe_sgx_td_t* td);
+void oe_td_pop_callsite(oe_sgx_td_t* td);
 
-void td_init(oe_sgx_td_t* td);
+void oe_td_init(oe_sgx_td_t* td);
 
-void td_clear(oe_sgx_td_t* td);
+void oe_td_clear(oe_sgx_td_t* td);
 
 #endif /* _TD_H */

--- a/enclave/core/sgx/td_basic.c
+++ b/enclave/core/sgx/td_basic.c
@@ -18,7 +18,7 @@
 /*
 **==============================================================================
 **
-** td_pop_callsite()
+** oe_td_pop_callsite()
 **
 **     Remove the Callsite structure that is at the head of the
 **     oe_sgx_td_t.callsites list.
@@ -26,7 +26,7 @@
 **==============================================================================
 */
 
-void td_pop_callsite(oe_sgx_td_t* td)
+void oe_td_pop_callsite(oe_sgx_td_t* td)
 {
     if (!td->callsites)
         oe_abort();
@@ -35,7 +35,7 @@ void td_pop_callsite(oe_sgx_td_t* td)
     {
         // The outermost ecall is about to return.
         // Clear the thread-local storage.
-        td_clear(td);
+        oe_td_clear(td);
     }
     else
     {
@@ -48,7 +48,7 @@ void td_pop_callsite(oe_sgx_td_t* td)
 /*
 **==============================================================================
 **
-** td_init()
+** oe_td_init()
 **
 **     Initialize the thread data structure (oe_sgx_td_t) if not already
 *initialized.
@@ -81,10 +81,10 @@ void td_pop_callsite(oe_sgx_td_t* td)
 **==============================================================================
 */
 
-void td_init(oe_sgx_td_t* td)
+void oe_td_init(oe_sgx_td_t* td)
 {
     /* If not already initialized */
-    if (!td_initialized(td))
+    if (!oe_td_initialized(td))
     {
         // oe_sgx_td_t.hostsp, oe_sgx_td_t.hostbp, and oe_sgx_td_t.retaddr
         // already set by oe_enter().
@@ -117,15 +117,15 @@ void td_init(oe_sgx_td_t* td)
 /*
 **==============================================================================
 **
-** td_clear()
+** oe_td_clear()
 **
 **     Clear the oe_sgx_td_t. This is called when the ECALL depth falls to zero
-**     in td_pop_callsite().
+**     in oe_td_pop_callsite().
 **
 **==============================================================================
 */
 
-void td_clear(oe_sgx_td_t* td)
+void oe_td_clear(oe_sgx_td_t* td)
 {
     if (td->depth != 1)
         oe_abort();

--- a/enclave/core/sgx/thread.c
+++ b/enclave/core/sgx/thread.c
@@ -22,7 +22,7 @@
 
 static int _thread_wait(oe_sgx_td_t* self)
 {
-    const void* tcs = td_to_tcs((oe_sgx_td_t*)self);
+    const void* tcs = oe_td_to_tcs((oe_sgx_td_t*)self);
 
     if (oe_ocall(OE_OCALL_THREAD_WAIT, (uint64_t)tcs, NULL) != OE_OK)
         return -1;
@@ -32,7 +32,7 @@ static int _thread_wait(oe_sgx_td_t* self)
 
 static int _thread_wake(oe_sgx_td_t* self)
 {
-    const void* tcs = td_to_tcs((oe_sgx_td_t*)self);
+    const void* tcs = oe_td_to_tcs((oe_sgx_td_t*)self);
 
     if (oe_ocall(OE_OCALL_THREAD_WAKE, (uint64_t)tcs, NULL) != OE_OK)
         return -1;
@@ -43,8 +43,8 @@ static int _thread_wake(oe_sgx_td_t* self)
 static int _thread_wake_wait(oe_sgx_td_t* waiter, oe_sgx_td_t* self)
 {
     int ret = -1;
-    uint64_t waiter_tcs = (uint64_t)td_to_tcs((oe_sgx_td_t*)waiter);
-    uint64_t self_tcs = (uint64_t)td_to_tcs((oe_sgx_td_t*)self);
+    uint64_t waiter_tcs = (uint64_t)oe_td_to_tcs((oe_sgx_td_t*)waiter);
+    uint64_t self_tcs = (uint64_t)oe_td_to_tcs((oe_sgx_td_t*)self);
 
     if (oe_sgx_thread_wake_wait_ocall(oe_get_enclave(), waiter_tcs, self_tcs) !=
         OE_OK)

--- a/enclave/core/sgx/threadlocal.c
+++ b/enclave/core/sgx/threadlocal.c
@@ -368,7 +368,7 @@ oe_result_t oe_thread_local_init(oe_sgx_td_t* td)
         // oe_allocator_init to initialize the enclave and here
         // (oe_thread_local_init) is the natural place to call
         // oe_allocator_thread_init to perform thread-specific allocator
-        // initialization. However, currently, td_init and hence
+        // initialization. However, currently, oe_td_init and hence
         // oe_thread_local_init is called *before* _handle_init_enclave is
         // called. This results in incorrect order of the allocator callbacks.
         // Therefore, we call oe_allocator_init here (via oe_once)

--- a/enclave/core/sgx/tracee.c
+++ b/enclave/core/sgx/tracee.c
@@ -11,7 +11,7 @@
 
 // Read an enclave's identity attribute to see to if it was signed as an debug
 // enclave
-bool is_enclave_debug_allowed()
+bool oe_is_enclave_debug_allowed()
 {
     bool ret = false;
     oe_sgx_td_t* td = oe_sgx_get_td();
@@ -25,7 +25,8 @@ bool is_enclave_debug_allowed()
     {
         // get a report on the enclave itself for enclave identity information
         sgx_report_t sgx_report;
-        oe_result_t result = sgx_create_report(NULL, 0, NULL, 0, &sgx_report);
+        oe_result_t result =
+            oe_sgx_create_report(NULL, 0, NULL, 0, &sgx_report);
         if (result != OE_OK)
             goto done;
 

--- a/enclave/core/tracee.c
+++ b/enclave/core/tracee.c
@@ -21,7 +21,7 @@ static oe_log_level_t _active_log_level = OE_LOG_LEVEL_ERROR;
 static char _enclave_filename[OE_MAX_FILENAME_LEN];
 static bool _debug_allowed_enclave = false;
 
-const char* get_filename_from_path(const char* path)
+static const char* _get_filename_from_path(const char* path)
 {
     if (path)
     {
@@ -60,7 +60,7 @@ void oe_log_init_ecall(const char* enclave_path, uint32_t log_level)
 
     _active_log_level = (oe_log_level_t)log_level;
 
-    if ((filename = get_filename_from_path(enclave_path)))
+    if ((filename = _get_filename_from_path(enclave_path)))
     {
         oe_strlcpy(_enclave_filename, filename, sizeof(_enclave_filename));
     }
@@ -69,7 +69,7 @@ void oe_log_init_ecall(const char* enclave_path, uint32_t log_level)
         memset(_enclave_filename, 0, sizeof(_enclave_filename));
     }
 
-    _debug_allowed_enclave = is_enclave_debug_allowed();
+    _debug_allowed_enclave = oe_is_enclave_debug_allowed();
 }
 
 oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...)

--- a/enclave/core/tracee.h
+++ b/enclave/core/tracee.h
@@ -3,4 +3,4 @@
 
 #include <openenclave/corelibc/stdbool.h>
 
-bool is_enclave_debug_allowed();
+bool oe_is_enclave_debug_allowed();

--- a/include/openenclave/internal/sgxcertextensions.h
+++ b/include/openenclave/internal/sgxcertextensions.h
@@ -24,7 +24,7 @@ typedef struct _parsed_extension_info
     bool opt_cached_keys;
 } ParsedExtensionInfo;
 
-oe_result_t ParseSGXExtensions(
+oe_result_t oe_parse_sgx_extensions(
     oe_cert_t* cert,
     uint8_t* buffer,
     size_t* buffer_size,

--- a/tests/tools/oecertdump/host/sgx_quote.cpp
+++ b/tests/tools/oecertdump/host/sgx_quote.cpp
@@ -114,8 +114,8 @@ void parse_certificate_extension(const uint8_t* data, size_t data_len)
     buffer = (uint8_t*)malloc(buffer_size);
     if (buffer == NULL)
         OE_RAISE(OE_OUT_OF_MEMORY);
-    result =
-        ParseSGXExtensions(&leaf_cert, buffer, &buffer_size, &extension_info);
+    result = oe_parse_sgx_extensions(
+        &leaf_cert, buffer, &buffer_size, &extension_info);
 
     if (result == OE_BUFFER_TOO_SMALL)
     {
@@ -123,7 +123,7 @@ void parse_certificate_extension(const uint8_t* data, size_t data_len)
         buffer = (uint8_t*)malloc(buffer_size);
         if (buffer == NULL)
             OE_RAISE(OE_OUT_OF_MEMORY);
-        result = ParseSGXExtensions(
+        result = oe_parse_sgx_extensions(
             &leaf_cert, buffer, &buffer_size, &extension_info);
     }
     printf(


### PR DESCRIPTION
This PR:
- Adds oe prefixes to various symbols that were lacking them.
- Makes certain functions static (file scope).
- Renames a couple of functions from camel notation to snake notation.
