### PR TITLE
Re-enable DEBUG_MALLOC in debug builds. Fix detected memory leaks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,14 +208,10 @@ option(
 
 # TODO: See #756: Fix this because it is incompatible with
 # multi-configuration generators
-if (uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" AND NOT WIN32)
-  # In non-win32 debug build, debug_malloc is on by default
+if (uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+  # In debug builds, debug_malloc is on by default
   option(USE_DEBUG_MALLOC
          "Build oeenclave with memory leak detection capability." ON)
-else ()
-  # In win32 or non-debug builds, debug_malloc is off by default
-  option(USE_DEBUG_MALLOC
-         "Build oeenclave with memory leak detection capability." OFF)
 endif ()
 
 option(ADD_WINDOWS_ENCLAVE_TESTS "Build Windows enclave tests" OFF)

--- a/enclave/core/debugmalloc.c
+++ b/enclave/core/debugmalloc.c
@@ -351,7 +351,7 @@ void* oe_debug_calloc(size_t nmemb, size_t size)
 
     const size_t total_size = nmemb * size;
 
-    if (!(ptr = oe_allocator_malloc(total_size)))
+    if (!(ptr = oe_debug_malloc(total_size)))
         return NULL;
 
     oe_memset_s(ptr, total_size, 0, total_size);

--- a/enclave/core/malloc.c
+++ b/enclave/core/malloc.c
@@ -10,6 +10,28 @@
 #include <openenclave/internal/safecrt.h>
 #include <openenclave/internal/utils.h>
 
+#ifdef OE_USE_DEBUG_MALLOC
+
+#include "debugmalloc.h"
+
+#define MALLOC oe_debug_malloc
+#define FREE oe_debug_free
+#define CALLOC oe_debug_calloc
+#define REALLOC oe_debug_realloc
+#define POSIX_MEMALIGN oe_debug_posix_memalign
+#define MALLOC_USABLE_SIZE oe_debug_malloc_usable_size
+
+#else
+
+#define MALLOC oe_allocator_malloc
+#define FREE oe_allocator_free
+#define CALLOC oe_allocator_calloc
+#define REALLOC oe_allocator_realloc
+#define POSIX_MEMALIGN oe_allocator_posix_memalign
+#define MALLOC_USABLE_SIZE oe_allocator_malloc_usable_size
+
+#endif
+
 static oe_allocation_failure_callback_t _failure_callback;
 
 void oe_set_allocation_failure_callback(
@@ -20,7 +42,7 @@ void oe_set_allocation_failure_callback(
 
 void* oe_malloc(size_t size)
 {
-    void* p = oe_allocator_malloc(size);
+    void* p = MALLOC(size);
 
     if (!p && size)
     {
@@ -33,12 +55,12 @@ void* oe_malloc(size_t size)
 
 void oe_free(void* ptr)
 {
-    oe_allocator_free(ptr);
+    FREE(ptr);
 }
 
 void* oe_calloc(size_t nmemb, size_t size)
 {
-    void* p = oe_allocator_calloc(nmemb, size);
+    void* p = CALLOC(nmemb, size);
 
     if (!p && nmemb && size)
     {
@@ -51,7 +73,7 @@ void* oe_calloc(size_t nmemb, size_t size)
 
 void* oe_realloc(void* ptr, size_t size)
 {
-    void* p = oe_allocator_realloc(ptr, size);
+    void* p = REALLOC(ptr, size);
 
     if (!p && size)
     {
@@ -77,7 +99,7 @@ void* oe_memalign(size_t alignment, size_t size)
 
 int oe_posix_memalign(void** memptr, size_t alignment, size_t size)
 {
-    int rc = oe_allocator_posix_memalign(memptr, alignment, size);
+    int rc = POSIX_MEMALIGN(memptr, alignment, size);
 
     if (rc != 0 && size)
     {
@@ -90,5 +112,5 @@ int oe_posix_memalign(void** memptr, size_t alignment, size_t size)
 
 size_t oe_malloc_usable_size(void* ptr)
 {
-    return oe_allocator_malloc_usable_size(ptr);
+    return MALLOC_USABLE_SIZE(ptr);
 }

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -3,6 +3,8 @@
 
 #include "../calls.h"
 #include <openenclave/advanced/allocator.h>
+#include <openenclave/attestation/attester.h>
+#include <openenclave/attestation/verifier.h>
 #include <openenclave/bits/sgx/sgxtypes.h>
 #include <openenclave/corelibc/stdlib.h>
 #include <openenclave/corelibc/string.h>
@@ -422,6 +424,12 @@ static void _handle_ecall(
 
             /* Call all finalization functions */
             oe_call_fini_functions();
+
+            /* Cleanup attesters */
+            oe_attester_shutdown();
+
+            /* Cleanup verifiers */
+            oe_verifier_shutdown();
 
 #if defined(OE_USE_DEBUG_MALLOC)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,10 @@ if (OE_SGX)
   else ()
     message("The C++ compiler cannot compile snmalloc. Skipping snmalloc test.")
   endif ()
+
+  if (USE_DEBUG_MALLOC)
+    add_subdirectory(debug_malloc)
+  endif ()
 endif ()
 
 if (UNIX

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -347,6 +347,7 @@ void register_verifier()
 
     OE_TEST_CODE(oe_verifier_initialize(), OE_OK);
     OE_TEST_CODE(oe_verifier_get_formats(&formats, &formats_length), OE_OK);
+    free(formats);
 }
 
 void unregister_verifier()

--- a/tests/debug_malloc/CMakeLists.txt
+++ b/tests/debug_malloc/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/debug_malloc debug_malloc_host debug_malloc_enc)

--- a/tests/debug_malloc/debug_malloc.edl
+++ b/tests/debug_malloc/debug_malloc.edl
@@ -1,0 +1,19 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public void enc_allocate_memory();
+
+        public void enc_cleanup_memory();
+    };
+
+};

--- a/tests/debug_malloc/enc/CMakeLists.txt
+++ b/tests/debug_malloc/enc/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../debug_malloc.edl)
+
+add_custom_command(
+  OUTPUT debug_malloc_t.h debug_malloc_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(
+  TARGET
+  debug_malloc_enc
+  UUID
+  29070d0f-11e3-4612-aef7-7456924eb7ac
+  SOURCES
+  enc.c
+  ${CMAKE_CURRENT_BINARY_DIR}/debug_malloc_t.c)
+
+enclave_include_directories(debug_malloc_enc PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})
+enclave_link_libraries(debug_malloc_enc oelibc)

--- a/tests/debug_malloc/enc/enc.c
+++ b/tests/debug_malloc/enc/enc.c
@@ -1,0 +1,31 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/corelibc/string.h>
+#include <openenclave/enclave.h>
+#include <openenclave/internal/print.h>
+#include <stdlib.h>
+#include "debug_malloc_t.h"
+
+void* ptr;
+
+void enc_allocate_memory()
+{
+    // Allocate memory, but do not free it.
+    // This will be tracked as a leak by debug_malloc and enclave termination
+    // will fail with OE_MEMORY_LEAK, if it is not freed.
+    ptr = malloc(1024);
+}
+
+void enc_cleanup_memory()
+{
+    free(ptr);
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    64,   /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/debug_malloc/host/CMakeLists.txt
+++ b/tests/debug_malloc/host/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../debug_malloc.edl)
+
+add_custom_command(
+  OUTPUT debug_malloc_u.h debug_malloc_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(debug_malloc_host host.c debug_malloc_u.c)
+
+target_include_directories(debug_malloc_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(debug_malloc_host oehost)

--- a/tests/debug_malloc/host/host.c
+++ b/tests/debug_malloc/host/host.c
@@ -1,0 +1,53 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <limits.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "debug_malloc_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    {
+        // Create enclave, allocate memory, but do not free it.
+        if ((result = oe_create_debug_malloc_enclave(
+                 argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) !=
+            OE_OK)
+            oe_put_err("oe_create_enclave(): result=%u", result);
+
+        OE_TEST(enc_allocate_memory(enclave) == OE_OK);
+
+        // Unfreed memory will be reported as a leak.
+        OE_TEST(oe_terminate_enclave(enclave) == OE_MEMORY_LEAK);
+    }
+    {
+        // Create enclave, allocate memory, and free it.
+        if ((result = oe_create_debug_malloc_enclave(
+                 argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) !=
+            OE_OK)
+            oe_put_err("oe_create_enclave(): result=%u", result);
+
+        OE_TEST(enc_allocate_memory(enclave) == OE_OK);
+        OE_TEST(enc_cleanup_memory(enclave) == OE_OK);
+
+        // No leaks will be reported.
+        OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+    }
+    printf("=== passed all tests (debug_malloc)\n");
+
+    return 0;
+}


### PR DESCRIPTION
DEBUG_MALLOC now works with pluggable allocators.
Lock down with test.

Invoke oe_attester_shutdown to clean up attesters that
were being reported as leaks during enclave termination.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>