### PR TITLE
Support sgx/attestation.edl opt-out

### DIFF
--- a/enclave/core/sgx/report.c
+++ b/enclave/core/sgx/report.c
@@ -16,6 +16,81 @@
 #include <openenclave/internal/utils.h>
 #include "platform_t.h"
 
+#if !defined(OE_USE_BUILTIN_EDL)
+/**
+ * Declare the prototypes of the following functions to avoid the
+ * missing-prototypes warning.
+ */
+oe_result_t _oe_get_qetarget_info_ocall(
+    oe_result_t* _retval,
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    sgx_target_info_t* target_info);
+
+oe_result_t _oe_get_quote_ocall(
+    oe_result_t* _retval,
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    const sgx_report_t* sgx_report,
+    void* quote,
+    size_t quote_size,
+    size_t* quote_size_out);
+
+/**
+ * Make the following OCALLs weak to support the system EDL opt-in.
+ * When the user does not opt into (import) the EDL, the linker will pick
+ * the following default implementations. If the user opts into the EDL,
+ * the implementations (which are strong) in the oeedger8r-generated code will
+ * be used.
+ */
+oe_result_t _oe_get_qetarget_info_ocall(
+    oe_result_t* _retval,
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    sgx_target_info_t* target_info)
+{
+    OE_UNUSED(format_id);
+    OE_UNUSED(opt_params);
+    OE_UNUSED(opt_params_size);
+    OE_UNUSED(target_info);
+
+    if (_retval)
+        *_retval = OE_UNSUPPORTED;
+
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_get_qetarget_info_ocall, oe_get_qetarget_info_ocall);
+
+oe_result_t _oe_get_quote_ocall(
+    oe_result_t* _retval,
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    const sgx_report_t* sgx_report,
+    void* quote,
+    size_t quote_size,
+    size_t* quote_size_out)
+{
+    OE_UNUSED(format_id);
+    OE_UNUSED(opt_params);
+    OE_UNUSED(opt_params_size);
+    OE_UNUSED(sgx_report);
+    OE_UNUSED(quote);
+    OE_UNUSED(quote_size);
+    OE_UNUSED(quote_size_out);
+
+    if (_retval)
+        *_retval = OE_UNSUPPORTED;
+
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_get_quote_ocall, oe_get_quote_ocall);
+
+#endif
+
 OE_STATIC_ASSERT(OE_REPORT_DATA_SIZE == sizeof(sgx_report_data_t));
 
 OE_STATIC_ASSERT(sizeof(oe_identity_t) == 96);
@@ -127,14 +202,21 @@ static oe_result_t _get_sgx_target_info(
     size_t opt_params_size,
     sgx_target_info_t* target_info)
 {
+    oe_result_t result = OE_UNEXPECTED;
     uint32_t retval;
 
-    if (oe_get_qetarget_info_ocall(
-            &retval, format_id, opt_params, opt_params_size, target_info) !=
-        OE_OK)
-        return OE_FAILURE;
+    OE_CHECK(oe_get_qetarget_info_ocall(
+        &retval, format_id, opt_params, opt_params_size, target_info));
+    result = (oe_result_t)retval;
 
-    return (oe_result_t)retval;
+done:
+    if (result == OE_UNSUPPORTED)
+        OE_TRACE_WARNING(
+            "SGX remote attestation is not enabled. To "
+            "enable, please add\n\n"
+            "from \"openenclave/edl/sgx/attestation.edl\" import *;\n\n"
+            "in the edl file.\n");
+    return result;
 }
 
 static oe_result_t _get_quote(
@@ -166,7 +248,12 @@ static oe_result_t _get_quote(
     result = (oe_result_t)retval;
 
 done:
-
+    if (result == OE_UNSUPPORTED)
+        OE_TRACE_WARNING(
+            "SGX remote attestation is not enabled. To "
+            "enable, please add\n\n"
+            "from \"openenclave/edl/sgx/attestation.edl\" import *;\n\n"
+            "in the edl file.\n");
     return result;
 }
 

--- a/enclave/sgx/collateralinfo.c
+++ b/enclave/sgx/collateralinfo.c
@@ -12,6 +12,103 @@
 #include "../common/sgx/collateral.h"
 #include "platform_t.h"
 
+#if !defined(OE_USE_BUILTIN_EDL)
+/**
+ * Declare the prototype of the following function to avoid the
+ * missing-prototypes warning.
+ */
+oe_result_t _oe_get_quote_verification_collateral_ocall(
+    oe_result_t* _retval,
+    uint8_t fmspc[6],
+    void* tcb_info,
+    size_t tcb_info_size,
+    size_t* tcb_info_size_out,
+    void* tcb_info_issuer_chain,
+    size_t tcb_info_issuer_chain_size,
+    size_t* tcb_info_issuer_chain_size_out,
+    void* pck_crl,
+    size_t pck_crl_size,
+    size_t* pck_crl_size_out,
+    void* root_ca_crl,
+    size_t root_ca_crl_size,
+    size_t* root_ca_crl_size_out,
+    void* pck_crl_issuer_chain,
+    size_t pck_crl_issuer_chain_size,
+    size_t* pck_crl_issuer_chain_size_out,
+    void* qe_identity,
+    size_t qe_identity_size,
+    size_t* qe_identity_size_out,
+    void* qe_identity_issuer_chain,
+    size_t qe_identity_issuer_chain_size,
+    size_t* qe_identity_issuer_chain_size_out);
+
+/**
+ * Make the following OCALL weak to support the system EDL opt-in.
+ * When the user does not opt into (import) the EDL, the linker will pick
+ * the following default implementation. If the user opts into the EDL,
+ * the implementation (which is strong) in the oeedger8r-generated code will be
+ * used.
+ */
+oe_result_t _oe_get_quote_verification_collateral_ocall(
+    oe_result_t* _retval,
+    uint8_t fmspc[6],
+    void* tcb_info,
+    size_t tcb_info_size,
+    size_t* tcb_info_size_out,
+    void* tcb_info_issuer_chain,
+    size_t tcb_info_issuer_chain_size,
+    size_t* tcb_info_issuer_chain_size_out,
+    void* pck_crl,
+    size_t pck_crl_size,
+    size_t* pck_crl_size_out,
+    void* root_ca_crl,
+    size_t root_ca_crl_size,
+    size_t* root_ca_crl_size_out,
+    void* pck_crl_issuer_chain,
+    size_t pck_crl_issuer_chain_size,
+    size_t* pck_crl_issuer_chain_size_out,
+    void* qe_identity,
+    size_t qe_identity_size,
+    size_t* qe_identity_size_out,
+    void* qe_identity_issuer_chain,
+    size_t qe_identity_issuer_chain_size,
+    size_t* qe_identity_issuer_chain_size_out)
+{
+    OE_UNUSED(fmspc);
+    OE_UNUSED(tcb_info);
+    OE_UNUSED(tcb_info_size);
+    OE_UNUSED(tcb_info_size_out);
+    OE_UNUSED(tcb_info_issuer_chain_size_out);
+    OE_UNUSED(tcb_info_issuer_chain);
+    OE_UNUSED(tcb_info_issuer_chain_size);
+    OE_UNUSED(tcb_info_issuer_chain_size_out);
+    OE_UNUSED(pck_crl);
+    OE_UNUSED(pck_crl_size);
+    OE_UNUSED(pck_crl_size_out);
+    OE_UNUSED(root_ca_crl);
+    OE_UNUSED(root_ca_crl_size);
+    OE_UNUSED(root_ca_crl_size_out);
+    OE_UNUSED(pck_crl_issuer_chain);
+    OE_UNUSED(pck_crl_issuer_chain_size);
+    OE_UNUSED(pck_crl_issuer_chain_size_out);
+    OE_UNUSED(qe_identity);
+    OE_UNUSED(qe_identity_size);
+    OE_UNUSED(qe_identity_size_out);
+    OE_UNUSED(qe_identity_issuer_chain);
+    OE_UNUSED(qe_identity_issuer_chain_size);
+    OE_UNUSED(qe_identity_issuer_chain_size_out);
+
+    if (_retval)
+        *_retval = OE_UNSUPPORTED;
+
+    return OE_OK;
+}
+OE_WEAK_ALIAS(
+    _oe_get_quote_verification_collateral_ocall,
+    oe_get_quote_verification_collateral_ocall);
+
+#endif
+
 /**
  * Update these default size values as needed.
  * These represent the default buffer sizes that can store their
@@ -91,33 +188,30 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
     {
         memcpy(&out, &in, sizeof(out));
 
-        if (oe_get_quote_verification_collateral_ocall(
-                &retval,
-                out.fmspc,
-                out.tcb_info,
-                out.tcb_info_size,
-                &out.tcb_info_size,
-                out.tcb_info_issuer_chain,
-                out.tcb_info_issuer_chain_size,
-                &out.tcb_info_issuer_chain_size,
-                out.pck_crl,
-                out.pck_crl_size,
-                &out.pck_crl_size,
-                out.root_ca_crl,
-                out.root_ca_crl_size,
-                &out.root_ca_crl_size,
-                out.pck_crl_issuer_chain,
-                out.pck_crl_issuer_chain_size,
-                &out.pck_crl_issuer_chain_size,
-                out.qe_identity,
-                out.qe_identity_size,
-                &out.qe_identity_size,
-                out.qe_identity_issuer_chain,
-                out.qe_identity_issuer_chain_size,
-                &out.qe_identity_issuer_chain_size) != OE_OK)
-        {
-            OE_RAISE(OE_FAILURE);
-        }
+        OE_CHECK(oe_get_quote_verification_collateral_ocall(
+            &retval,
+            out.fmspc,
+            out.tcb_info,
+            out.tcb_info_size,
+            &out.tcb_info_size,
+            out.tcb_info_issuer_chain,
+            out.tcb_info_issuer_chain_size,
+            &out.tcb_info_issuer_chain_size,
+            out.pck_crl,
+            out.pck_crl_size,
+            &out.pck_crl_size,
+            out.root_ca_crl,
+            out.root_ca_crl_size,
+            &out.root_ca_crl_size,
+            out.pck_crl_issuer_chain,
+            out.pck_crl_issuer_chain_size,
+            &out.pck_crl_issuer_chain_size,
+            out.qe_identity,
+            out.qe_identity_size,
+            &out.qe_identity_size,
+            out.qe_identity_issuer_chain,
+            out.qe_identity_issuer_chain_size,
+            &out.qe_identity_issuer_chain_size));
 
         if (retval != (oe_result_t)OE_BUFFER_TOO_SMALL)
             break;
@@ -217,6 +311,11 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
     result = OE_OK;
 
 done:
+    if (result == OE_UNSUPPORTED)
+        OE_TRACE_WARNING(
+            "SGX remote attestation is not enabled. To enable, please add\n\n"
+            "from \"openenclave/edl/sgx/attestation.edl\" import *;\n\n"
+            "in the edl file.\n");
 
     /* Free buffers. */
     if (result != OE_OK)

--- a/tests/report/tests.edl
+++ b/tests/report/tests.edl
@@ -6,7 +6,9 @@ enclave {
     from "openenclave/edl/fcntl.edl" import *;
     from "openenclave/edl/attestation.edl" import *;
 #ifdef OE_SGX
-    from "openenclave/edl/sgx/platform.edl" import *;
+    from "openenclave/edl/sgx/attestation.edl" import *;
+    from "openenclave/edl/sgx/cpu.edl" import *;
+    from "openenclave/edl/sgx/thread.edl" import *;
 #else
     from "openenclave/edl/optee/platform.edl" import *;
 #endif


### PR DESCRIPTION
This PR allows `sgx/attestation.edl` to be opt-out, which was a hard requirement (part of #2818).  This edl file includes two ecalls and four ocalls. When a user invokes those calls without importing the edls, he should be the corresponding log message (when the logging feature is enabled).

For example, the message of `oe_verify_local_report_ecall` is as follows
```
oe_verify_local_report_ecall is not supported. To enable, please add 

from "openenclave/edl/sgx/attestation.edl" import oe_verify_local_report_ecall;

in the edl file.
```

Given the `oe_get_report_v2_ecall` ecall and all the four ocalls are currently required by the attestation, the message for each of calls is the same as follows.
```
sgx remote attestation is not fully supported. To enable, please add 

from "openenclave/edl/sgx/attestation.edl" import *;

in the edl file.
```

Note that the goal of this PR is having the implementation ready (only modifies the edl in the report test). Will wait for getting the consensus (per #3201) before generalizing the changes to both tests and samples.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>