### PR TITLE
direct [in] pointer as ECALL parameter, will not leak data from enclave

### DIFF
--- a/tests/oeedger8r/edl/security.edl
+++ b/tests/oeedger8r/edl/security.edl
@@ -9,6 +9,9 @@ enclave {
 
       // trusted memory address as ECALL parameter, will not leak secrets.
       public void security_ecall_test1([size = 4,in] int* ptr);
+
+      // direct [in] pointer as ECALL parameter, will not leak data from enclave
+      public int security_ecall_test2([size = 16, in] int* ptr);
    };
 
 };

--- a/tests/oeedger8r/enc/testsecurity.cpp
+++ b/tests/oeedger8r/enc/testsecurity.cpp
@@ -31,3 +31,17 @@ void security_ecall_test1(int* ptr)
 
     printf("_secret not leaked.\n");
 }
+
+// direct [in] pointer as ECALL parameter, will not leak data from enclave
+int security_ecall_test2(int* ptr)
+{
+    // ptr must lie within the enclave.
+    OE_TEST(oe_is_within_enclave(ptr, 4 * sizeof(*ptr)));
+
+    if ((512 != *(ptr)) || (1024 != *(ptr + 1)) || (768 != *(ptr + 2)) ||
+        (2048 != *(ptr + 3)))
+        return -1;
+
+    *(ptr) = *(ptr + 1) = *(ptr + 2) = *(ptr + 3) = 0;
+    return 0;
+}

--- a/tests/oeedger8r/host/testsecurity.cpp
+++ b/tests/oeedger8r/host/testsecurity.cpp
@@ -18,5 +18,14 @@ void test_security(oe_enclave_t* enclave)
     // Pass location back to enclave.
     OE_TEST(security_ecall_test1(enclave, location) == OE_OK);
 
+    int indata[4] = {512, 1024, 768, 2048};
+    int ret_value;
+    OE_TEST(security_ecall_test2(enclave, &ret_value, indata) == OE_OK);
+    OE_TEST(ret_value == 0);
+    OE_TEST(indata[0] == 512);
+    OE_TEST(indata[1] == 1024);
+    OE_TEST(indata[2] == 768);
+    OE_TEST(indata[3] == 2048);
+
     printf("=== test_security passed\n");
 }


### PR DESCRIPTION
Signed-off-by: yan xue <yan.xue@intel.com>