### PR TITLE
fix oesign digest usage typo issue. add 3 oesign key test cases

### DIFF
--- a/tests/tools/oesign/test-inputs/CMakeLists.txt
+++ b/tests/tools/oesign/test-inputs/CMakeLists.txt
@@ -109,6 +109,30 @@ add_custom_command(
     "/C=US/ST=Washington/L=Redmond/O=Open Enclave/CN=Self-signed Test Enclave Signer"
 )
 
+# Generate a valid SGX signing key-pair: private and public key
+add_custom_command(
+  OUTPUT sign_key.public.pem
+  DEPENDS sign_key.private.pem
+  COMMAND
+    openssl rsa -in sign_key.private.pem -pubout -out sign_key.public.pem
+)
+
+# Generate SGX signing key: private key and private key w/ wrong end
+add_custom_command(
+  OUTPUT sign_key.end_wrong.pem
+  DEPENDS sign_key.private.pem ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-key.py
+  COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-key.py --input sign_key.private.pem --outfile sign_key.end_wrong.pem
+)
+
+# Generate SGX signing key: private key and private key w/ wrong format
+add_custom_command(
+  OUTPUT sign_key.wrong_format.pem
+  DEPENDS sign_key.private.pem ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-key.py
+  COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-key.py --input sign_key.private.pem --outfile sign_key.wrong_format.pem
+)
+
 # Generate an alternative valid SGX signing key-pair and signing certificate
 add_custom_command(
   OUTPUT sign_key_2.private.pem sign_key_2.cert.pem
@@ -126,4 +150,5 @@ add_custom_command(OUTPUT bad_exp_key.private.pem
 add_custom_target(
   oesign_test_keys ALL
   DEPENDS sign_key.private.pem sign_key.cert.pem sign_key_2.private.pem
-          sign_key_2.cert.pem bad_exp_key.private.pem)
+          sign_key_2.cert.pem bad_exp_key.private.pem sign_key.public.pem
+		  sign_key.wrong_format.pem sign_key.end_wrong.pem)

--- a/tests/tools/oesign/test-inputs/make-oesign-key.py
+++ b/tests/tools/oesign/test-inputs/make-oesign-key.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+import sys
+import argparse
+
+if __name__ == "__main__":
+
+    arg_parser = argparse.ArgumentParser(description="Generates oesign key file for test")
+    arg_parser.add_argument('--input', default=None, type=str, required=True, help="Full path to the input key file(correct private key)")
+    arg_parser.add_argument('--outfile', default=None, type=str, required=True, help="Full path to the output key file(incorrect key)")
+
+    args = arg_parser.parse_args()
+    print("input file: " + args.input)
+    print("out file: " + args.outfile)
+
+    in_file = open(args.input, 'r')
+    out_file = open(args.outfile, 'w+')
+
+    out_file_name = args.outfile
+    s = format(in_file.read())
+
+    if out_file_name.find("wrong_format") >= 0:
+        print("Generate wrong format key")
+        out_file.write(s + "Proc-Type: 4, ENCRYPTED")
+    elif out_file_name.find("end_wrong") >= 0:
+        print("Generate key with wrong end")
+        end_str = "-----END RSA PRIVATE KEY-----"
+        incorrect_end_str = "-----WRONG RSA PRIVATE KEY-----"
+        if s.find(end_str) > 0:
+            s = s.replace(end_str, incorrect_end_str)
+            out_file.write(s)
+        else:
+            print("no end str found in file:" + format(args.input))
+    else:
+        print("please check the out file name")
+    in_file.close()
+    out_file.close()

--- a/tests/tools/oesign/test-sign/CMakeLists.txt
+++ b/tests/tools/oesign/test-sign/CMakeLists.txt
@@ -57,15 +57,42 @@ set_tests_properties(
   PROPERTIES PASS_REGULAR_EXPRESSION
              "ERROR: Failed to load configuration file: does_not_exist.conf")
 
-# Test invalid --key-file (-k) argument
-add_test(NAME tests/oesign-sign-invalid-key-file
+# Test --key-file (-k) actually not exist
+add_test(NAME tests/oesign-sign-not-exist-key-file
          COMMAND oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
                  ${OESIGN_TEST_INPUTS_DIR}/valid.conf -k does_not_exist.pem)
 
 set_tests_properties(
-  tests/oesign-sign-invalid-key-file
+  tests/oesign-sign-not-exist-key-file
   PROPERTIES PASS_REGULAR_EXPRESSION
              "ERROR: Failed to load file: does_not_exist.pem")
+
+# Test --key-file (-k) argument w/ public key file
+add_test(NAME tests/oesign-sign-public-key-file
+         COMMAND oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+				${OESIGN_TEST_INPUTS_DIR}/valid.conf -k ${OESIGN_TEST_INPUTS_DIR}/sign_key.public.pem)
+
+set_tests_properties(
+	tests/oesign-sign-public-key-file
+	PROPERTIES WILL_FAIL TRUE)
+
+# Test --key-file (-k) argument: key file in wrong format
+add_test(NAME tests/oesign-sign-key-file-wrong-format
+         COMMAND oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+                 ${OESIGN_TEST_INPUTS_DIR}/valid.conf -k ${OESIGN_TEST_INPUTS_DIR}/sign_key.wrong_format.pem)
+
+set_tests_properties(
+	tests/oesign-sign-key-file-wrong-format
+	PROPERTIES WILL_FAIL TRUE)
+
+# Test --key-file (-k) argument: key file w/ wrong end
+add_test(NAME tests/oesign-sign-key-file-end-wrong
+         COMMAND oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+                 ${OESIGN_TEST_INPUTS_DIR}/valid.conf -k ${OESIGN_TEST_INPUTS_DIR}/sign_key.end_wrong.pem)
+
+set_tests_properties(
+	tests/oesign-sign-key-file-end-wrong
+	PROPERTIES WILL_FAIL TRUE)
 
 # Test invalid .conf with duplicate Debug property
 add_test(

--- a/tools/oesign/main.c
+++ b/tools/oesign/main.c
@@ -106,7 +106,7 @@ static const char _usage_sign[] =
     "\n";
 
 static const char _usage_digest[] =
-    "Usage: %s -e ENCLAVE_IMAGE [-c CONFIG_FILE] -d DIGEST_FILE\n"
+    "Usage: %s digest -e ENCLAVE_IMAGE [-c CONFIG_FILE] -d DIGEST_FILE\n"
     "\n"
     "Options:\n"
     "  -e, --enclave-image      path of an enclave image file.\n"


### PR DESCRIPTION
Signed-off-by: Xiangping Ji <xiangping.ji@intel.com>

1. fix oesign digest typo in usage
2. rename oesign test case of invalid-key-file test to not-exist-key-file
3. added 3 test cases : 
   3.1 key file end wrong -- PASS
   3.2 sign using public key -- PASS
   3.3 sign using key file format wrong -- FAIL