### PR TITLE
Add basic KSS support (ISVFAMILYID and ISVEXTPRODID) to OE SDK #3114

### DIFF
--- a/docs/GettingStartedDocs/buildandsign.md
+++ b/docs/GettingStartedDocs/buildandsign.md
@@ -88,7 +88,7 @@ In addition, the following two properties are defined by the developer and map d
   incremented whenever a security fix is made to the enclave code.
 
 Here is the example from helloworld.conf used in the helloworld sample:
-```
+
 # Enclave settings:
 ProductID=1
 SecurityVersion=1
@@ -97,6 +97,15 @@ NumHeapPages=1024
 NumStackPages=1024
 NumTCS=1
 ```
+Additionally, for platform that supports for Key sharing and separation (KSS),
+the following properties can be used:
+ **IsvFamilyID**: ISV assigned product family identity (ISVFAMILYID)
+ **IsvExtProductID**: ISV assigned extended product identity (ISVEXTPRODID)
+ ```
+ The example from kss_valid.conf
+ IsvFamilyID=47183823-2574-4bfd-b411-99ed177d3e43
+ IsvExtProductID=47183823-2574-4bfd-b411-99ed177d3e43
+ ```
 
 As a convenience, you can also specify the enclave properties in code using the
 `OE_SET_ENCLAVE_SGX` macro.  For example, the equivalent properties could be

--- a/enclave/core/sgx/properties.c
+++ b/enclave/core/sgx/properties.c
@@ -17,13 +17,13 @@ OE_STATIC_ASSERT(
 
 OE_CHECK_SIZE(sizeof(oe_enclave_properties_header_t), 32);
 
-OE_CHECK_SIZE(sizeof(oe_sgx_enclave_config_t), 24);
+OE_CHECK_SIZE(sizeof(oe_sgx_enclave_config_t), 56);
 
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, header), 0);
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, config), 32);
-OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 56);
-OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 104);
-OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 1920);
+OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 88);
+OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 136);
+OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 1952);
 
 //
 // Declare an invalid oeinfo to ensure .oeinfo section exists

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -807,6 +807,11 @@ oe_result_t oe_sgx_build_enclave(
     OE_CHECK(_calculate_enclave_size(
         image_size, &props, &enclave_end, &enclave_size));
 
+    if (props.config.attributes & OE_SGX_FLAGS_KSS)
+    {
+        context->attributes.flags |= OE_SGX_FLAGS_KSS;
+    }
+
     /* Perform the ECREATE operation */
     OE_CHECK(oe_sgx_create_enclave(
         context, enclave_size, enclave_end, &enclave_addr));

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -345,6 +345,8 @@ static oe_result_t _get_sig_struct(
             properties->config.security_version,
             OE_DEBUG_SIGN_KEY,
             OE_DEBUG_SIGN_KEY_SIZE,
+            properties->config.isv_family_id,
+            properties->config.isv_ext_product_id,
             sigstruct));
     }
     else
@@ -445,6 +447,11 @@ oe_result_t oe_sgx_create_enclave(
     /* Create SECS structure */
     if (!(secs = _new_secs((uint64_t)base, enclave_size, context)))
         OE_RAISE(OE_OUT_OF_MEMORY);
+
+    if (context->attributes.flags & OE_SGX_FLAGS_KSS)
+    {
+        secs->flags |= OE_SGX_FLAGS_KSS;
+    }
 
     /* Measure this operation */
     OE_CHECK(oe_sgx_measure_create_enclave(&context->hash_context, secs));

--- a/host/sgx/sgxsign.c
+++ b/host/sgx/sgxsign.c
@@ -654,13 +654,13 @@ static oe_result_t _init_sigstruct(
                 sigstruct->isvfamilyid,
                 sizeof(sigstruct->isvfamilyid),
                 isv_family_id,
-                sizeof(sigstruct->isvfamilyid)));
+                sizeof(*isv_family_id)));
         if (isv_ext_product_id)
             OE_CHECK(oe_memcpy_s(
                 sigstruct->isvextprodid,
                 sizeof(sigstruct->isvextprodid),
                 isv_ext_product_id,
-                sizeof(sigstruct->isvextprodid)));
+                sizeof(*isv_ext_product_id)));
     }
 
     /* sgx_sigstruct_t.isvprodid */

--- a/include/openenclave/bits/sgx/sgxproperties.h
+++ b/include/openenclave/bits/sgx/sgxproperties.h
@@ -31,17 +31,20 @@ typedef struct _oe_sgx_enclave_image_info_t
 // oe_sgx_enclave_properties_t SGX enclave properties derived type
 #define OE_SGX_FLAGS_DEBUG 0x0000000000000002ULL
 #define OE_SGX_FLAGS_MODE64BIT 0x0000000000000004ULL
+#define OE_SGX_FLAGS_KSS 0x0000000000000080ULL
 #define OE_SGX_SIGSTRUCT_SIZE 1808
 
 typedef struct oe_sgx_enclave_config_t
 {
     uint16_t product_id;
     uint16_t security_version;
+    uint8_t isv_family_id[16];
+    uint8_t isv_ext_product_id[16];
 
     /* Padding to make packed and unpacked size the same */
     uint32_t padding;
 
-    /* (OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT) */
+    /* (OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT | OE_SGX_FLAGS_KSS) */
     uint64_t attributes;
 
     /* XSave Feature Request Mask */
@@ -73,6 +76,10 @@ typedef struct _oe_sgx_enclave_properties
 
 #define OE_MAKE_ATTRIBUTES(ALLOW_DEBUG) \
     (OE_SGX_FLAGS_MODE64BIT | (ALLOW_DEBUG ? OE_SGX_FLAGS_DEBUG : 0))
+
+#define OE_MAKE_ATTRIBUTES_EX(ALLOW_KSS, ALLOW_DEBUG)              \
+    (OE_SGX_FLAGS_MODE64BIT | (ALLOW_KSS ? OE_SGX_FLAGS_KSS : 0) | \
+     (ALLOW_DEBUG ? OE_SGX_FLAGS_DEBUG : 0))
 
 // This macro initializes and injects an oe_sgx_enclave_properties_t struct
 // into the .oeinfo section.

--- a/include/openenclave/bits/sgx/sgxtypes.h
+++ b/include/openenclave/bits/sgx/sgxtypes.h
@@ -24,6 +24,7 @@ OE_EXTERNC_BEGIN
 #define SGX_FLAGS_MODE64BIT 0x0000000000000004ULL
 #define SGX_FLAGS_PROVISION_KEY 0x0000000000000010ULL
 #define SGX_FLAGS_EINITTOKEN_KEY 0x0000000000000020ULL
+#define SGX_FLAGS_KSS 0x0000000000000080ULL
 
 /* Legacy XFRM which includes basic feature bits required by SGX i.e. X87
  * (bit 0) and SSE state (bit 1)
@@ -185,7 +186,10 @@ typedef struct _sgx_sigstruct
     uint32_t miscmask;
 
     /* (908) Reserved. Must be 0. */
-    uint8_t reserved2[20];
+    uint8_t reserved2[4];
+
+    /* (912) ISV assigned Product Family Id, must be 0 for SGX1 devices*/
+    uint8_t isvfamilyid[16];
 
     /* (928) Enclave Attributes that must be set */
     sgx_attributes_t attributes;
@@ -197,7 +201,10 @@ typedef struct _sgx_sigstruct
     uint8_t enclavehash[OE_SHA256_SIZE];
 
     /* (992) Must be 0 */
-    uint8_t reserved3[32];
+    uint8_t reserved3[16];
+
+    /* (1008) ISV assigned extended Product ID, must be 0 for SGX1 devices */
+    uint8_t isvextprodid[16];
 
     /* (1024) ISV assigned Product ID */
     uint16_t isvprodid;
@@ -572,7 +579,10 @@ typedef struct _sgx_report_body
     uint32_t miscselect;
 
     /* (20) Reserved */
-    uint8_t reserved1[28];
+    uint8_t reserved1[12];
+
+    /* (32) Enclave extended product ID */
+    uint8_t isvextprodid[16];
 
     /* (48) Enclave attributes */
     sgx_attributes_t attributes;
@@ -596,7 +606,10 @@ typedef struct _sgx_report_body
     uint16_t isvsvn;
 
     /* (260) Reserved */
-    uint8_t reserved4[60];
+    uint8_t reserved4[44];
+
+    /* (304) Enclave family ID */
+    uint8_t isvfamilyid[16];
 
     /* (320) User report data */
     sgx_report_data_t report_data;
@@ -928,7 +941,14 @@ OE_STATIC_ASSERT(sizeof(sgx_quote_signature_t) == 664);
 /* Key policy. */
 #define SGX_KEYPOLICY_MRENCLAVE 0x0001
 #define SGX_KEYPOLICY_MRSIGNER 0x0002
-#define SGX_KEYPOLICY_ALL (SGX_KEYPOLICY_MRENCLAVE | SGX_KEYPOLICY_MRSIGNER)
+#define SGX_KEYPOLICY_NOISVPRODID 0x0004
+#define SGX_KEYPOLICY_CONFIGID 0x0008
+#define SGX_KEYPOLICY_ISVFAMILYID 0x0010
+#define SGX_KEYPOLICY_ISVEXTPRODID 0x0020
+#define SGX_KEYPOLICY_ALL                                 \
+    (SGX_KEYPOLICY_MRENCLAVE | SGX_KEYPOLICY_MRSIGNER |   \
+     SGX_KEYPOLICY_NOISVPRODID | SGX_KEYPOLICY_CONFIGID | \
+     SGX_KEYPOLICY_ISVFAMILYID | SGX_KEYPOLICY_ISVEXTPRODID)
 
 OE_PACK_BEGIN
 typedef struct _sgx_key_request

--- a/include/openenclave/internal/sgx/sgxproperties.h
+++ b/include/openenclave/internal/sgx/sgxproperties.h
@@ -32,7 +32,7 @@ OE_INLINE bool oe_sgx_is_valid_num_tcs(uint64_t x)
 OE_INLINE bool oe_sgx_is_valid_attributes(uint64_t x)
 {
     /* Check for illegal bits */
-    if (x & ~(OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT))
+    if (x & ~(OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT | OE_SGX_FLAGS_KSS))
         return false;
 
     /* Check for missing MODE64BIT */

--- a/include/openenclave/internal/sgxsign.h
+++ b/include/openenclave/internal/sgxsign.h
@@ -25,6 +25,8 @@ OE_EXTERNC_BEGIN
  * @param security_version[in] ISVSVN value for the SGX sigstruct
  * @param pem_data[in] PEM buffer containing the signing key
  * @param pem_size[in] size of the PEM buffer
+ * @param isv_family_id[in] ISVFAMILYID value for the SGX sigstruct
+ * @param isv_ext_product_id[in] ISVEXTPRODID value for the SGX sigstruct
  * @param sigstruct[out] the SGX signature
  *
  * @return OE_OK success
@@ -36,6 +38,8 @@ oe_result_t oe_sgx_sign_enclave(
     uint16_t security_version,
     const uint8_t* pem_data,
     size_t pem_size,
+    const uint8_t* isv_family_id,
+    const uint8_t* isv_ext_product_id,
     sgx_sigstruct_t* sigstruct);
 
 /**
@@ -53,6 +57,8 @@ oe_result_t oe_sgx_sign_enclave(
  * @param engine_id[in] text name of the engine to use
  * @param engine_load_path[in] file path to the openssl engine to use
  * @param key_id[in] integer handle for the key to use
+ * @param isv_family_id[in] ISVFAMILYID value for the SGX sigstruct
+ * @param isv_ext_product_id[in] ISVEXTPRODID value for the SGX sigstruct
  * @param sigstruct[out] the SGX signature
  *
  * @return OE_OK success
@@ -65,6 +71,8 @@ oe_result_t oe_sgx_sign_enclave_from_engine(
     const char* engine_id,
     const char* engine_load_path,
     const char* key_id,
+    const uint8_t* isv_family_id,
+    const uint8_t* isv_ext_product_id,
     sgx_sigstruct_t* sigstruct);
 
 /**

--- a/include/openenclave/internal/str.h
+++ b/include/openenclave/internal/str.h
@@ -13,10 +13,6 @@
 #include <string.h>
 #include "mem.h"
 
-#ifndef _WIN32
-#define _strdup strdup
-#endif
-
 #define STR_NPOS ((size_t)-1)
 
 #define STR_NULL_INIT \
@@ -426,71 +422,6 @@ MEM_INLINE int str_split(str_t* str, const char* delim, str_t* lhs, str_t* rhs)
     if (p != end)
         str_ncpy(rhs, p, (size_t)(end - p));
 
-    return 0;
-}
-
-MEM_INLINE char hex2char(char ch)
-{
-    if (ch >= '0' && ch <= '9')
-        return ch - '0';
-    if (ch >= 'a' && ch <= 'f')
-        return 10 + ch - 'a';
-    if (ch >= 'A' && ch <= 'F')
-        return 10 + ch - 'A';
-    return 0;
-}
-
-MEM_INLINE bool is_hex(char ch)
-{
-    return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') ||
-           (ch >= 'A' && ch <= 'F');
-}
-
-MEM_INLINE unsigned char hexpair2char(char a, char b)
-{
-    return (unsigned char)((hex2char(a) << 4) | hex2char(b));
-}
-
-MEM_INLINE int uuid_from_string(str_t* str, uint8_t* uuid)
-{
-    size_t index = 0;
-    size_t size = 0;
-    char* id_copy;
-    char value = 0;
-    bool firstDigit = true;
-
-    id_copy = _strdup(str_ptr(str));
-    size = strlen(id_copy);
-    if (size != 36)
-        return -1;
-
-    index = 0;
-
-    for (size_t i = 0; i < size; ++i)
-    {
-        if (id_copy[i] == '-')
-            continue;
-
-        if (index >= 16 || !is_hex(id_copy[i]))
-        {
-            return -2;
-        }
-
-        if (firstDigit)
-        {
-            value = id_copy[i];
-            firstDigit = false;
-        }
-        else
-        {
-            uuid[index++] = hexpair2char(value, id_copy[i]);
-            firstDigit = true;
-        }
-    }
-    if (index < 16)
-    {
-        return -3;
-    }
     return 0;
 }
 

--- a/include/openenclave/internal/str.h
+++ b/include/openenclave/internal/str.h
@@ -6,11 +6,16 @@
 
 #include <limits.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "mem.h"
+
+#ifndef _WIN32
+#define _strdup strdup
+#endif
 
 #define STR_NPOS ((size_t)-1)
 
@@ -421,6 +426,71 @@ MEM_INLINE int str_split(str_t* str, const char* delim, str_t* lhs, str_t* rhs)
     if (p != end)
         str_ncpy(rhs, p, (size_t)(end - p));
 
+    return 0;
+}
+
+MEM_INLINE char hex2char(char ch)
+{
+    if (ch >= '0' && ch <= '9')
+        return ch - '0';
+    if (ch >= 'a' && ch <= 'f')
+        return 10 + ch - 'a';
+    if (ch >= 'A' && ch <= 'F')
+        return 10 + ch - 'A';
+    return 0;
+}
+
+MEM_INLINE bool is_hex(char ch)
+{
+    return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') ||
+           (ch >= 'A' && ch <= 'F');
+}
+
+MEM_INLINE unsigned char hexpair2char(char a, char b)
+{
+    return (unsigned char)((hex2char(a) << 4) | hex2char(b));
+}
+
+MEM_INLINE int uuid_from_string(str_t* str, uint8_t* uuid)
+{
+    size_t index = 0;
+    size_t size = 0;
+    char* id_copy;
+    char value = 0;
+    bool firstDigit = true;
+
+    id_copy = _strdup(str_ptr(str));
+    size = strlen(id_copy);
+    if (size != 36)
+        return -1;
+
+    index = 0;
+
+    for (size_t i = 0; i < size; ++i)
+    {
+        if (id_copy[i] == '-')
+            continue;
+
+        if (index >= 16 || !is_hex(id_copy[i]))
+        {
+            return -2;
+        }
+
+        if (firstDigit)
+        {
+            value = id_copy[i];
+            firstDigit = false;
+        }
+        else
+        {
+            uuid[index++] = hexpair2char(value, id_copy[i]);
+            firstDigit = true;
+        }
+    }
+    if (index < 16)
+    {
+        return -3;
+    }
     return 0;
 }
 

--- a/tests/tools/oesign/test-enclave/enclave/enc.c
+++ b/tests/tools/oesign/test-enclave/enclave/enc.c
@@ -54,7 +54,7 @@ bool is_test_signed()
     return is_test_signed;
 }
 
-oe_result_t is_kss_extendedids_match(
+oe_result_t check_kss_extended_ids(
     oe_uuid_t* family_id,
     oe_uuid_t* ext_product_id)
 {

--- a/tests/tools/oesign/test-enclave/host/host.c
+++ b/tests/tools/oesign/test-enclave/host/host.c
@@ -61,8 +61,8 @@ int main(int argc, const char* argv[])
         if (!_is_kss_supported() &&
             properties.config.attributes & SGX_FLAGS_KSS)
         {
-            printf("Skipping Enclave creation with Kss feature
-                if hardware doesn't support .\n");
+            printf("Skipping Enclave creation with Kss feature \
+            if hardware doesn't support .\n");
             return 0;
         }
         oe_put_err("oe_create_crypto_enclave(): result=%u", result);

--- a/tests/tools/oesign/test-enclave/host/host.c
+++ b/tests/tools/oesign/test-enclave/host/host.c
@@ -3,14 +3,34 @@
 
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
+#include <openenclave/internal/load.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
+#include "../host/sgx/cpuid.h"
 
 #include "oesign_test_u.h"
+
+static bool _is_kss_supported()
+{
+    uint32_t eax, ebx, ecx, edx;
+    eax = ebx = ecx = edx = 0;
+
+    // Obtain feature information using CPUID
+    oe_get_cpuid(0x12, 0x1, &eax, &ebx, &ecx, &edx);
+
+    // Check if KSS  (bit 7) are supported in processor
+    if (!(eax & (1 << 7)))
+        return false;
+    else
+        return true;
+}
 
 int main(int argc, const char* argv[])
 {
     oe_result_t result;
+    oe_result_t ecall_result;
+    oe_enclave_image_t oeimage;
+    oe_sgx_enclave_properties_t properties;
     oe_enclave_t* enclave = NULL;
     bool is_signed = false;
 
@@ -19,12 +39,32 @@ int main(int argc, const char* argv[])
         oe_put_err("Usage: %s enclave_image_path\n", argv[0]);
     }
 
+    /* Load the ELF image */
+    if ((result = oe_load_enclave_image(argv[1], &oeimage)) != OE_OK)
+    {
+        oe_put_err("oe_load_enclave_image(): result=%u", result);
+    }
+
+    /* Load the SGX enclave properties */
+    if ((result = oe_sgx_load_enclave_properties(
+             &oeimage, OE_INFO_SECTION_NAME, &properties)) != OE_OK)
+    {
+        oe_put_err("oe_sgx_load_enclave_properties(): result=%u", result);
+    }
+
     // Create the enclave
     const uint32_t flags = oe_get_create_flags();
 
     if ((result = oe_create_oesign_test_enclave(
              argv[1], OE_ENCLAVE_TYPE_AUTO, flags, NULL, 0, &enclave)) != OE_OK)
     {
+        if (!_is_kss_supported() &&
+            properties.config.attributes & SGX_FLAGS_KSS)
+        {
+            printf("Skipping Enclave creation with Kss feature
+                if hardware doesn't support .\n");
+            return 0;
+        }
         oe_put_err("oe_create_crypto_enclave(): result=%u", result);
     }
 
@@ -47,6 +87,26 @@ int main(int argc, const char* argv[])
         {
             oe_put_err("%s is signed with a default debug signature", argv[1]);
         }
+    }
+
+    if (_is_kss_supported())
+    {
+        result = is_kss_extendedids_match(
+            enclave,
+            &ecall_result,
+            (oe_uuid_t*)properties.config.isv_family_id,
+            (oe_uuid_t*)properties.config.isv_ext_product_id);
+        if (result != OE_OK || ecall_result != OE_OK)
+        {
+            oe_put_err(
+                "verify_signed() failed: Enclave: %s, Host: %s\n",
+                oe_result_str(ecall_result),
+                oe_result_str(result));
+        }
+    }
+    else
+    {
+        OE_TEST(!(properties.config.attributes & OE_SGX_FLAGS_KSS));
     }
 
     if ((result = oe_terminate_enclave(enclave)) != OE_OK)

--- a/tests/tools/oesign/test-enclave/oesign_test.edl
+++ b/tests/tools/oesign/test-enclave/oesign_test.edl
@@ -12,5 +12,6 @@ enclave {
 
     trusted {
         public bool is_test_signed();
+        public oe_result_t is_kss_extendedids_match(oe_uuid_t* family_id, oe_uuid_t* ext_product_id);
     };
 };

--- a/tests/tools/oesign/test-enclave/oesign_test.edl
+++ b/tests/tools/oesign/test-enclave/oesign_test.edl
@@ -12,6 +12,6 @@ enclave {
 
     trusted {
         public bool is_test_signed();
-        public oe_result_t is_kss_extendedids_match(oe_uuid_t* family_id, oe_uuid_t* ext_product_id);
+        public oe_result_t check_kss_extended_ids(oe_uuid_t* family_id, oe_uuid_t* ext_product_id);
     };
 };

--- a/tests/tools/oesign/test-inputs/CMakeLists.txt
+++ b/tests/tools/oesign/test-inputs/CMakeLists.txt
@@ -74,6 +74,37 @@ add_custom_command(
   COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file new_security_version.conf --security_version 2)
 
+add_custom_command(
+  OUTPUT kss_valid.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+          --config_file kss_valid.conf --kss 1 --isv_ext_product_id 47183823-2574-4bfd-b411-99ed177d3e43 --isv_family_id 47183823-2574-4bfd-b411-99ed177d3e43)
+
+
+add_custom_command(
+  OUTPUT ext_prod_id_too_long.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+          --config_file ext_prod_id_too_long.conf --kss 1 --isv_ext_product_id 47183823-2574-4bfd-b411-99ed177d3e433)
+
+add_custom_command(
+  OUTPUT ext_prod_id_too_short.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+          --config_file ext_prod_id_too_short.conf --kss 1 --isv_ext_product_id 47183823-2574-4bfd-b411-99ed177d3e4)
+
+add_custom_command(
+  OUTPUT family_id_too_long.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+          --config_file family_id_too_long.conf --kss 1 --isv_family_id 47183823-2574-4bfd-b411-99ed177d3e433e433)
+
+add_custom_command(
+  OUTPUT family_id_too_short.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+          --config_file family_id_too_short.conf --kss 1 --isv_family_id 47183823-2574-4bfd-b411-99ed177d3e4)
+
 # Generate empty config file
 add_custom_command(
   OUTPUT empty.conf COMMAND cmake -E touch
@@ -97,6 +128,11 @@ add_custom_target(
           new_security_version.conf
           negative_num_heap_pages.conf
           non_debug.conf
+          kss_valid.conf
+          ext_prod_id_too_long.conf
+          ext_prod_id_too_short.conf
+          family_id_too_long.conf
+          family_id_too_short.conf
           valid.conf)
 
 # Generate a valid SGX signing key-pair and signing certificate

--- a/tests/tools/oesign/test-inputs/make-oesign-config.py
+++ b/tests/tools/oesign/test-inputs/make-oesign-config.py
@@ -15,6 +15,9 @@ if __name__ == "__main__":
     arg_parser.add_argument('--num_tcs', default="1", type=str, help="Value for the NumCS property. Defaults to 1.")
     arg_parser.add_argument('--product_id', default="1", type=str, help="Value for the ProductID property. Defaults to 1.")
     arg_parser.add_argument('--security_version', default="1", type=str, help="Value for the SecurityVersion property. Defaults to 1.")
+    arg_parser.add_argument('--kss', default="0", type=str, help="Value for the Debug property. Defaults to 0 (false).")
+    arg_parser.add_argument('--isv_ext_product_id', default=None, type=str, help="Value for the IsvExtProductID property. Defaults to empty string")
+    arg_parser.add_argument('--isv_family_id', default=None, type=str, help="Value for the IsvFamilyID property. Defaults to empty string.")
 
     args = arg_parser.parse_args()
     print("Generating {} ...".format(args.config_file))
@@ -27,4 +30,9 @@ if __name__ == "__main__":
     out_file.write("NumTCS={}\n".format(args.num_tcs))
     out_file.write("ProductID={}\n".format(args.product_id))
     out_file.write("SecurityVersion={}\n".format(args.security_version))
+    out_file.write("Kss={}\n".format(args.kss))
+    if args.isv_ext_product_id != None:
+        out_file.write("IsvExtProductID={}\n".format(args.isv_ext_product_id))
+    if args.isv_family_id != None:
+        out_file.write("IsvFamilyID={}\n".format(args.isv_family_id))
     out_file.close()

--- a/tests/tools/oesign/test-sign/CMakeLists.txt
+++ b/tests/tools/oesign/test-sign/CMakeLists.txt
@@ -203,3 +203,65 @@ add_test(
 
 set_tests_properties(tests/oesign-sign-lowercase-debug-property
                      PROPERTIES PASS_REGULAR_EXPRESSION "unknown setting")
+
+# Test valid kss properties argument
+set(OESIGN_SIGN_VALID_KSS
+    "[-c,${OESIGN_TEST_INPUTS_DIR}/kss_valid.conf,-k,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem]"
+)
+
+add_test(
+  NAME tests/oesign-sign-valid-kss
+  COMMAND
+    python sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
+    --enclave-path $<TARGET_FILE:oesign_test_enc> --oesign-path
+    $<TARGET_FILE:oesign> --oesign-args ${OESIGN_SIGN_VALID_KSS})
+
+set_tests_properties(
+  tests/oesign-sign-valid-kss
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "PASS: Launch of signed enclave succeeded")
+
+# Test invalid kss properties argument ExtProdID too long
+add_test(NAME tests/oesign-sign-extprodid-toolong
+         COMMAND oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+                 ${OESIGN_TEST_INPUTS_DIR}/ext_prod_id_too_long.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-extprodid-toolong
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "bad value for 'IsvExtProductID'")
+
+# Test invalid kss properties argument ExtProdID too short
+add_test(NAME tests/oesign-sign-extprodid-tooshort
+         COMMAND oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+                 ${OESIGN_TEST_INPUTS_DIR}/ext_prod_id_too_short.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-extprodid-tooshort
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "bad value for 'IsvExtProductID'")
+
+# Test invalid kss properties argument -ExtProdID too short
+add_test(NAME tests/oesign-sign-familyid-toolong
+         COMMAND oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+                 ${OESIGN_TEST_INPUTS_DIR}/family_id_too_long.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-familyid-toolong
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "bad value for 'IsvFamilyID'")
+
+
+# Test invalid kss properties argument -FamilyID too short
+add_test(NAME tests/oesign-sign-familyid-tooshort
+         COMMAND oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+                 ${OESIGN_TEST_INPUTS_DIR}/family_id_too_short.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-familyid-tooshort
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "bad value for 'IsvFamilyID'")

--- a/tools/oesgx/oesgx.c
+++ b/tools/oesgx/oesgx.c
@@ -13,6 +13,7 @@
 #define HAVE_FLC(regs) (((regs.ecx) >> 30) & 1)
 #define HAVE_SGX1(regs) (((regs.eax) & 1))
 #define HAVE_SGX2(regs) (((regs.eax) >> 1) & 1)
+#define HAVE_KSS(regs) (((regs.eax) >> 7) & 1)
 #define HAVE_EPC_SUBLEAF(regs) (((regs.eax) & 0x0f) == 0x01)
 
 typedef struct _regs
@@ -129,6 +130,22 @@ int main(int argc, const char* argv[])
             printf("SGX1\n");
         }
         printf("MaxEnclaveSize_64: 2^(%d)\n", (regs.edx >> 8) & 0xFF);
+    }
+
+    /* Enumeration of Intel SGX Capabilities: figure out whether CPU
+       supports KSS */
+    {
+        Regs regs = {SGX_CAPABILITY_ENUMERATION, 0, 0x1, 0};
+
+        result = _CPUID(&regs);
+        if (result)
+        {
+            printf("Read SGX_ATTRIBUTE_ENUMERATION failed:\n");
+            dump_regs(&regs);
+            return result;
+        }
+
+        printf("CPU supports KSS: %s\n", HAVE_KSS(regs) ? "true" : "false");
     }
 
     /* Enumeration of Intel SGX Capabilities: figure out EPC size */

--- a/tools/oesign/oesign.c
+++ b/tools/oesign/oesign.c
@@ -30,16 +30,25 @@ typedef struct _optional_uint16
     uint16_t value;
 } optional_uint16_t;
 
+typedef struct _optional_oe_uuid_t
+{
+    bool has_value;
+    oe_uuid_t value;
+} optional_oe_uuid_t;
+
 // Options loaded from .conf file. Uninitialized fields contain the maximum
 // integer value for the corresponding type.
 typedef struct _config_file_options
 {
     optional_bool_t debug;
+    optional_bool_t kss;
     optional_uint64_t num_heap_pages;
     optional_uint64_t num_stack_pages;
     optional_uint64_t num_tcs;
     optional_uint16_t product_id;
     optional_uint16_t security_version;
+    optional_oe_uuid_t isv_family_id;
+    optional_oe_uuid_t isv_ext_product_id;
 } config_file_options_t;
 
 static int _load_config_file(const char* path, config_file_options_t* options)
@@ -106,6 +115,26 @@ static int _load_config_file(const char* path, config_file_options_t* options)
 
             options->debug.value = (bool)value;
             options->debug.has_value = true;
+        }
+        else if (strcmp(str_ptr(&lhs), "Kss") == 0)
+        {
+            uint64_t value;
+
+            if (options->kss.has_value)
+            {
+                oe_err("%s(%zu): Duplicate 'Kss' value provided", path, line);
+                goto done;
+            }
+
+            // Debug must be 0 or 1
+            if (str_u64(&rhs, &value) != 0 || (value > 1))
+            {
+                oe_err("%s(%zu): 'Kss' value must be 0 or 1", path, line);
+                goto done;
+            }
+
+            options->kss.value = (bool)value;
+            options->kss.has_value = true;
         }
         else if (strcmp(str_ptr(&lhs), "NumHeapPages") == 0)
         {
@@ -240,6 +269,68 @@ static int _load_config_file(const char* path, config_file_options_t* options)
             options->security_version.value = n;
             options->security_version.has_value = true;
         }
+        else if (strcmp(str_ptr(&lhs), "IsvFamilyID") == 0)
+        {
+            oe_uuid_t id;
+
+            if (options->isv_family_id.has_value)
+            {
+                oe_err(
+                    "%s(%zu): Duplicate 'IsvFamilyID' value provided",
+                    path,
+                    line);
+                goto done;
+            }
+
+            if (str_len(&rhs) > 1)
+            {
+                int rc = uuid_from_string(&rhs, id.b);
+                if (rc != 0)
+                {
+                    oe_err(
+                        "%s(%zu): bad value for 'IsvFamilyID': %s, rc=%d",
+                        path,
+                        line,
+                        str_ptr(&rhs),
+                        rc);
+                    goto done;
+                }
+            }
+
+            memcpy(&options->isv_family_id.value, &id, 16);
+            options->isv_family_id.has_value = true;
+        }
+        else if (strcmp(str_ptr(&lhs), "IsvExtProductID") == 0)
+        {
+            oe_uuid_t id;
+
+            if (options->isv_ext_product_id.has_value)
+            {
+                oe_err(
+                    "%s(%zu): Duplicate 'IsvExtProductID' value provided",
+                    path,
+                    line);
+                goto done;
+            }
+
+            if (str_len(&rhs) > 1)
+            {
+                int rc = uuid_from_string(&rhs, id.b);
+                if (rc != 0)
+                {
+                    oe_err(
+                        "%s(%zu): bad value for 'IsvExtProductID': %s, rc=%d",
+                        path,
+                        line,
+                        str_ptr(&rhs),
+                        rc);
+                    goto done;
+                }
+            }
+
+            memcpy(&options->isv_ext_product_id.value, &id, 16);
+            options->isv_ext_product_id.has_value = true;
+        }
         else
         {
             oe_err("%s(%zu): unknown setting: %s", path, line, str_ptr(&rhs));
@@ -370,6 +461,15 @@ void _merge_config_file_options(
             properties->config.attributes &= ~SGX_FLAGS_DEBUG;
     }
 
+    /* Kss option is present */
+    if (options->kss.has_value)
+    {
+        if (options->kss.value)
+            properties->config.attributes |= SGX_FLAGS_KSS;
+        else
+            properties->config.attributes &= ~SGX_FLAGS_KSS;
+    }
+
     /* If ProductID option is present */
     if (options->product_id.has_value)
         properties->config.product_id = options->product_id.value;
@@ -377,6 +477,19 @@ void _merge_config_file_options(
     /* If SecurityVersion option is present */
     if (options->security_version.has_value)
         properties->config.security_version = options->security_version.value;
+
+    if (options->kss.has_value && options->kss.value)
+    {
+        if (options->isv_family_id.has_value)
+            memcpy(
+                properties->config.isv_family_id, &options->isv_family_id, 16);
+
+        if (options->isv_ext_product_id.has_value)
+            memcpy(
+                properties->config.isv_ext_product_id,
+                &options->isv_ext_product_id,
+                16);
+    }
 
     /* If NumHeapPages option is present */
     if (options->num_heap_pages.has_value)
@@ -542,6 +655,8 @@ int oesign(
                 engine_id,
                 engine_load_path,
                 key_id,
+                properties.config.isv_family_id,
+                properties.config.isv_ext_product_id,
                 (sgx_sigstruct_t*)properties.sigstruct),
             "oe_sgx_sign_enclave_from_engine() failed: result=%s (%#x)",
             oe_result_str(result),
@@ -613,6 +728,8 @@ int oesign(
                 properties.config.security_version,
                 pem_data,
                 pem_size,
+                properties.config.isv_family_id,
+                properties.config.isv_ext_product_id,
                 (sgx_sigstruct_t*)properties.sigstruct),
             "oe_sgx_sign_enclave() failed: result=%s (%#x)",
             oe_result_str(result),


### PR DESCRIPTION
Add the basic KSS support, the following changes are made in the OE SDK components:

SGX data structure definition to include KSS related fields.

Development tool to allow ISV to specify ISVFAMILYID, ISVEXTPRODID, and whether KSS feature is required by the Enclave through the KSS bit in SIGSTRUCT.ATTRIBUTES and SIGSTRUCT.ATTRIBUTEMASK, in SIGSTRUCT.

Enclave loader to detect whether the system support KSS