### PR TITLE
System edl opt-in code clean up and add tests

### DIFF
--- a/enclave/core/hostcalls.c
+++ b/enclave/core/hostcalls.c
@@ -15,7 +15,7 @@
 
 #if !defined(OE_USE_BUILTIN_EDL)
 /**
- * Declare the protoype of the following functions to avoid the
+ * Declare the prototypes of the following functions to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_log_is_supported_ocall();
@@ -24,7 +24,7 @@ oe_result_t _oe_write_ocall(int device, const char* str, size_t maxlen);
 
 /**
  * Make the following OCALLs weak to support the system EDL opt-in.
- * When the user does not opt in (import) the EDL, the linker will pick
+ * When the user does not opt into (import) the EDL, the linker will pick
  * the following default implementations. If the user opts into the EDL,
  * the implementions (which are strong) in the oeedger8r-generated code will be
  * used.

--- a/enclave/core/sgx/backtrace.c
+++ b/enclave/core/sgx/backtrace.c
@@ -62,6 +62,7 @@ oe_result_t _oe_sgx_backtrace_symbols_ocall(
     return OE_UNSUPPORTED;
 }
 OE_WEAK_ALIAS(_oe_sgx_backtrace_symbols_ocall, oe_sgx_backtrace_symbols_ocall);
+
 #endif
 
 /* Return null if address is outside of the enclave; else return ptr. */

--- a/enclave/core/sgx/report.c
+++ b/enclave/core/sgx/report.c
@@ -27,7 +27,6 @@ oe_result_t _oe_get_qetarget_info_ocall(
     const void* opt_params,
     size_t opt_params_size,
     sgx_target_info_t* target_info);
-
 oe_result_t _oe_get_quote_ocall(
     oe_result_t* _retval,
     const oe_uuid_t* format_id,

--- a/enclave/core/sgx/switchlesscalls.c
+++ b/enclave/core/sgx/switchlesscalls.c
@@ -31,6 +31,45 @@ static bool _is_switchless_initialized = false;
  * */
 static int64_t _switchless_init_in_progress = 0;
 
+#if !defined(OE_USE_BUILTIN_EDL)
+/**
+ * Declare the prototypes of the following functions to avoid the
+ * missing-prototypes warning.
+ */
+oe_result_t _oe_sgx_wake_switchless_worker_ocall(
+    oe_host_worker_context_t* context);
+oe_result_t _oe_sgx_sleep_switchless_worker_ocall(
+    oe_enclave_worker_context_t* context);
+
+/**
+ * Make the following OCALLs weak to support the system EDL opt-in.
+ * When the user does not opt into (import) the EDL, the linker will pick
+ * the following default implementations. If the user opts into the EDL,
+ * the implementations (which are strong) in the oeedger8r-generated code will
+ * be used.
+ */
+oe_result_t _oe_sgx_wake_switchless_worker_ocall(
+    oe_host_worker_context_t* context)
+{
+    OE_UNUSED(context);
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(
+    _oe_sgx_wake_switchless_worker_ocall,
+    oe_sgx_wake_switchless_worker_ocall);
+
+oe_result_t _oe_sgx_sleep_switchless_worker_ocall(
+    oe_enclave_worker_context_t* context)
+{
+    OE_UNUSED(context);
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(
+    _oe_sgx_sleep_switchless_worker_ocall,
+    oe_sgx_sleep_switchless_worker_ocall);
+
+#endif
+
 /*
 **==============================================================================
 **
@@ -261,23 +300,6 @@ void oe_sgx_switchless_enclave_worker_thread_ecall(
             asm volatile("pause");
         }
     }
-}
-
-/*
- * Stubs for ocalls in the event they are not included
- */
-OE_WEAK oe_result_t
-oe_sgx_wake_switchless_worker_ocall(oe_host_worker_context_t* context)
-{
-    OE_UNUSED(context);
-    return OE_UNSUPPORTED;
-}
-
-OE_WEAK oe_result_t
-oe_sgx_sleep_switchless_worker_ocall(oe_enclave_worker_context_t* context)
-{
-    OE_UNUSED(context);
-    return OE_UNSUPPORTED;
 }
 
 // Function used by oeedger8r for allocating switchless ocall buffers.

--- a/enclave/sgx/collateralinfo.c
+++ b/enclave/sgx/collateralinfo.c
@@ -101,7 +101,7 @@ oe_result_t _oe_get_quote_verification_collateral_ocall(
     if (_retval)
         *_retval = OE_UNSUPPORTED;
 
-    return OE_OK;
+    return OE_UNSUPPORTED;
 }
 OE_WEAK_ALIAS(
     _oe_get_quote_verification_collateral_ocall,

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -32,13 +32,17 @@ oe_result_t _oe_get_report_v2_ecall(
     size_t opt_params_size,
     uint8_t** report_buffer,
     size_t* report_buffer_size);
-
 oe_result_t _oe_verify_local_report_ecall(
     oe_enclave_t* enclave,
     oe_result_t* _retval,
     const uint8_t* report,
     size_t report_size,
     oe_report_t* parsed_report);
+oe_result_t _oe_verify_report_ecall(
+    oe_enclave_t* enclave,
+    oe_result_t* _retval,
+    const void* report,
+    size_t report_size);
 
 /**
  * Make the following ECALLs weak to support the system EDL opt-in.
@@ -89,6 +93,23 @@ oe_result_t _oe_verify_local_report_ecall(
     return OE_UNSUPPORTED;
 }
 OE_WEAK_ALIAS(_oe_verify_local_report_ecall, oe_verify_local_report_ecall);
+
+oe_result_t _oe_verify_report_ecall(
+    oe_enclave_t* enclave,
+    oe_result_t* _retval,
+    const void* report,
+    size_t report_size)
+{
+    OE_UNUSED(enclave);
+    OE_UNUSED(report);
+    OE_UNUSED(report_size);
+
+    if (_retval)
+        *_retval = OE_UNSUPPORTED;
+
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_verify_report_ecall, oe_verify_report_ecall);
 
 #endif
 
@@ -250,5 +271,12 @@ oe_result_t oe_verify_report_internal(
 
     result = OE_OK;
 done:
+    if (result == OE_UNSUPPORTED)
+        OE_TRACE_WARNING("oe_verify_report_ecall is not supported. To "
+                         "enable, please add\n\n"
+                         "from \"openenclave/edl/attestation.edl\" import "
+                         "oe_verify_report_ecall;\n\n"
+                         "in the edl file.\n");
+
     return result;
 }

--- a/host/traceh_enclave.c
+++ b/host/traceh_enclave.c
@@ -20,7 +20,7 @@
 
 #if !defined(OE_USE_BUILTIN_EDL)
 /**
- * Declare the protoype of the following functions to avoid the
+ * Declare the prototype of the following function to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_log_init_ecall(
@@ -30,9 +30,9 @@ oe_result_t _oe_log_init_ecall(
 
 /**
  * Make the following ECALL weak to support the system EDL opt-in.
- * When the user does not opt in (import) the EDL, the linker will pick
+ * When the user does not opt into (import) the EDL, the linker will pick
  * the following default implementation. If the user opts into the EDL,
- * the implementions (which are also weak) in the oeedger8r-generated code will
+ * the implemention (which is also weak) in the oeedger8r-generated code will
  * be used. This behavior is guaranteed by the linker; i.e., the linker will
  * pick the symbols defined in the object before those in the library.
  */
@@ -46,8 +46,8 @@ oe_result_t _oe_log_init_ecall(
     OE_UNUSED(log_level);
     return OE_UNSUPPORTED;
 }
-
 OE_WEAK_ALIAS(_oe_log_init_ecall, oe_log_init_ecall);
+
 #endif
 
 /*

--- a/syscall/hostcalls.c
+++ b/syscall/hostcalls.c
@@ -37,7 +37,7 @@
 */
 
 /**
- * Declare the prototype of the following functions to avoid the
+ * Declare the prototypes of the following functions to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_syscall_epoll_create1_ocall(oe_host_fd_t* _retval, int flags);
@@ -124,7 +124,7 @@ OE_WEAK_ALIAS(_oe_syscall_epoll_close_ocall, oe_syscall_epoll_close_ocall);
 */
 
 /**
- * Declare the prototype of the following functions to avoid the
+ * Declare the prototypes of the following functions to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_syscall_open_ocall(
@@ -516,7 +516,7 @@ OE_WEAK_ALIAS(_oe_syscall_fcntl_ocall, oe_syscall_fcntl_ocall);
 */
 
 /**
- * Declare the prototype of the following functions to avoid the
+ * Declare the prototypes of the following functions to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_syscall_ioctl_ocall(
@@ -558,7 +558,7 @@ OE_WEAK_ALIAS(_oe_syscall_ioctl_ocall, oe_syscall_ioctl_ocall);
 */
 
 /**
- * Declare the prototype of the following functions to avoid the
+ * Declare the prototypes of the following functions to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_syscall_kill_ocall(int* _retval, int pid, int signum);
@@ -585,7 +585,7 @@ OE_WEAK_ALIAS(_oe_syscall_kill_ocall, oe_syscall_kill_ocall);
 */
 
 /**
- * Declare the prototype of the following functions to avoid the
+ * Declare the prototypes of the following functions to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_syscall_close_socket_ocall(int* _retval, oe_host_fd_t sockfd);
@@ -1194,7 +1194,7 @@ OE_WEAK_ALIAS(_oe_syscall_getnameinfo_ocall, oe_syscall_getnameinfo_ocall);
 */
 
 /**
- * Declare the prototype of the following functions to avoid the
+ * Declare the prototypes of the following functions to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_syscall_poll_ocall(
@@ -1230,7 +1230,7 @@ OE_WEAK_ALIAS(_oe_syscall_poll_ocall, oe_syscall_poll_ocall);
 */
 
 /**
- * Declare the prototype of the following functions to avoid the
+ * Declare the prototypes of the following functions to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_syscall_nanosleep_ocall(
@@ -1263,7 +1263,7 @@ OE_WEAK_ALIAS(_oe_syscall_nanosleep_ocall, oe_syscall_nanosleep_ocall);
 */
 
 /**
- * Declare the prototype of the following functions to avoid the
+ * Declare the prototypes of the following functions to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_syscall_getpid_ocall(int* _retval);
@@ -1361,7 +1361,7 @@ OE_WEAK_ALIAS(_oe_syscall_getgroups_ocall, oe_syscall_getgroups_ocall);
 */
 
 /**
- * Declare the prototype of the following functions to avoid the
+ * Declare the prototypes of the following functions to avoid the
  * missing-prototypes warning.
  */
 oe_result_t _oe_syscall_uname_ocall(int* _retval, struct oe_utsname* buf);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -128,6 +128,7 @@ if (UNIX
   add_subdirectory(c99_compliant)
   add_subdirectory(create-errors)
   add_subdirectory(crypto)
+  add_subdirectory(edl_opt_out)
   add_subdirectory(hexdump)
   add_subdirectory(hostcalls)
   add_subdirectory(initializers)

--- a/tests/edl_opt_out/CMakeLists.txt
+++ b/tests/edl_opt_out/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/edl_opt_out edl_opt_out_host edl_opt_out_enc)

--- a/tests/edl_opt_out/edl/edl_opt_out.edl
+++ b/tests/edl_opt_out/edl/edl_opt_out.edl
@@ -1,0 +1,23 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall; // Support OE_TEST
+    from "openenclave/edl/fcntl.edl" import // Support code coverage analysis
+        oe_syscall_open_ocall,
+        oe_syscall_close_ocall,
+        oe_syscall_readv_ocall,
+        oe_syscall_writev_ocall,
+        oe_syscall_lseek_ocall,
+        oe_syscall_dup_ocall,
+        oe_syscall_flock_ocall;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/cpu.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public void enc_edl_opt_out();
+    };
+};

--- a/tests/edl_opt_out/edl/header.edl
+++ b/tests/edl_opt_out/edl/header.edl
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+    from "openenclave/edl/core.edl" import *;
+    from "openenclave/edl/syscall.edl" import *;
+};

--- a/tests/edl_opt_out/enc/CMakeLists.txt
+++ b/tests/edl_opt_out/enc/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../edl/edl_opt_out.edl)
+
+add_custom_command(
+  OUTPUT edl_opt_out_t.h edl_opt_out_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(PLATFORM_EDL_FILE ../edl/header.edl)
+add_custom_command(
+  OUTPUT header_t.h
+  DEPENDS ${PLATFORM_EDL_FILE} edger8r
+  COMMAND
+    edger8r --header-only --trusted ${PLATFORM_EDL_FILE} --search-path
+    ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR})
+add_custom_target(trusted_header DEPENDS header_t.h)
+
+add_enclave(
+  TARGET
+  edl_opt_out_enc
+  UUID
+  892e7f65-5da1-45d0-8209-53795ce5be8f
+  SOURCES
+  enc.c
+  ${CMAKE_CURRENT_BINARY_DIR}/edl_opt_out_t.c)
+add_enclave_dependencies(edl_opt_out_host trusted_header)
+
+enclave_include_directories(edl_opt_out_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+enclave_link_libraries(edl_opt_out_enc oelibc)

--- a/tests/edl_opt_out/enc/enc.c
+++ b/tests/edl_opt_out/enc/enc.c
@@ -1,0 +1,194 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/corelibc/string.h>
+#include <openenclave/enclave.h>
+#include <openenclave/internal/tests.h>
+#include "edl_opt_out_t.h"
+#include "header_t.h"
+
+void enc_edl_opt_out()
+{
+    /* logging.edl */
+    OE_TEST(oe_log_ocall(0, NULL) == OE_UNSUPPORTED);
+
+    /* epoll.edl */
+    OE_TEST(oe_syscall_epoll_create1_ocall(NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_epoll_wait_ocall(NULL, 0, NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_epoll_wake_ocall(NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_epoll_ctl_ocall(NULL, 0, 0, 0, NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_epoll_close_ocall(NULL, 0) == OE_UNSUPPORTED);
+
+    /* fcntl.edl */
+    OE_TEST(oe_syscall_read_ocall(NULL, 0, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_write_ocall(NULL, 0, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_pread_ocall(NULL, 0, NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_pwrite_ocall(NULL, 0, NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_opendir_ocall(NULL, NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_readdir_ocall(NULL, 0, NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_rewinddir_ocall(0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_closedir_ocall(NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_stat_ocall(NULL, NULL, NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_access_ocall(NULL, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_link_ocall(NULL, NULL, NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_unlink_ocall(NULL, NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_rename_ocall(NULL, NULL, NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_truncate_ocall(NULL, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_mkdir_ocall(NULL, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_rmdir_ocall(NULL, NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_fcntl_ocall(NULL, 0, 0, 0, 0, NULL) == OE_UNSUPPORTED);
+
+    /* ioctl.edl */
+    OE_TEST(oe_syscall_ioctl_ocall(NULL, 0, 0, 0, 0, NULL) == OE_UNSUPPORTED);
+
+    /* signal.edl */
+    OE_TEST(oe_syscall_kill_ocall(NULL, 0, 0) == OE_UNSUPPORTED);
+
+    /* socket.edl */
+    OE_TEST(oe_syscall_close_socket_ocall(NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_socket_ocall(NULL, 0, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_shutdown_sockets_device_ocall(NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_socketpair_ocall(NULL, 0, 0, 0, NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_connect_ocall(NULL, 0, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_accept_ocall(NULL, 0, NULL, 0, NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_bind_ocall(NULL, 0, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_listen_ocall(NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_recvmsg_ocall(
+            NULL, 0, NULL, 0, NULL, NULL, 0, 0, NULL, 0, NULL, 0) ==
+        OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_sendmsg_ocall(NULL, 0, NULL, 0, NULL, 0, 0, NULL, 0, 0) ==
+        OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_recv_ocall(NULL, 0, NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_recvfrom_ocall(NULL, 0, NULL, 0, 0, NULL, 0, NULL) ==
+        OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_send_ocall(NULL, 0, NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_sendto_ocall(NULL, 0, NULL, 0, 0, NULL, 0) ==
+        OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_recvv_ocall(NULL, 0, NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_sendv_ocall(NULL, 0, NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_shutdown_ocall(NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_setsockopt_ocall(NULL, 0, 0, 0, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_getsockname_ocall(NULL, 0, NULL, 0, NULL) == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_getpeername_ocall(NULL, 0, NULL, 0, NULL) == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_getaddrinfo_open_ocall(NULL, NULL, NULL, NULL, NULL) ==
+        OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_getaddrinfo_read_ocall(
+            NULL, 0, NULL, NULL, NULL, NULL, 0, NULL, NULL, 0, NULL, NULL) ==
+        OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_getaddrinfo_close_ocall(NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_getnameinfo_ocall(NULL, NULL, 0, NULL, 0, NULL, 0, 0) ==
+        OE_UNSUPPORTED);
+
+    /* poll.edl */
+    OE_TEST(oe_syscall_poll_ocall(NULL, NULL, 0, 0) == OE_UNSUPPORTED);
+
+    /* time.edl */
+    OE_TEST(oe_syscall_nanosleep_ocall(NULL, NULL, NULL) == OE_UNSUPPORTED);
+
+    /* unistd.edl */
+    OE_TEST(oe_syscall_getpid_ocall(NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_getppid_ocall(NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_getpgrp_ocall(NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_getuid_ocall(NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_geteuid_ocall(NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_getgid_ocall(NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_getegid_ocall(NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_getpgid_ocall(NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_getgroups_ocall(NULL, 0, NULL) == OE_UNSUPPORTED);
+
+    /* utsname.edl */
+    OE_TEST(oe_syscall_uname_ocall(NULL, NULL) == OE_UNSUPPORTED);
+
+#if __x86_64__ || _M_X64
+    /* debug.edl */
+    OE_TEST(
+        oe_sgx_backtrace_symbols_ocall(NULL, NULL, NULL, 0, NULL, 0, NULL) ==
+        OE_UNSUPPORTED);
+
+    /* sgx/switchless.edl*/
+    OE_TEST(oe_sgx_sleep_switchless_worker_ocall(NULL) == OE_UNSUPPORTED);
+    OE_TEST(oe_sgx_wake_switchless_worker_ocall(NULL) == OE_UNSUPPORTED);
+
+    /* sgx/attestation */
+    {
+        oe_result_t result = OE_OK;
+
+        OE_TEST(
+            oe_get_supported_attester_format_ids_ocall(
+                &result, NULL, 0, NULL) == OE_UNSUPPORTED);
+        OE_TEST(result == OE_UNSUPPORTED);
+        result = OE_OK;
+        OE_TEST(
+            oe_get_supported_attester_format_ids_ocall(
+                &result, NULL, 0, NULL) == OE_UNSUPPORTED);
+        OE_TEST(result == OE_UNSUPPORTED);
+        result = OE_OK;
+        OE_TEST(
+            oe_get_quote_verification_collateral_ocall(
+                &result,
+                NULL,
+                NULL,
+                0,
+                NULL,
+                NULL,
+                0,
+                NULL,
+                NULL,
+                0,
+                NULL,
+                NULL,
+                0,
+                NULL,
+                NULL,
+                0,
+                NULL,
+                NULL,
+                0,
+                NULL,
+                NULL,
+                0,
+                NULL) == OE_UNSUPPORTED);
+        OE_TEST(result == OE_UNSUPPORTED);
+        result = OE_OK;
+        OE_TEST(
+            oe_get_qetarget_info_ocall(&result, NULL, NULL, 0, NULL) ==
+            OE_UNSUPPORTED);
+        OE_TEST(result == OE_UNSUPPORTED);
+    }
+#endif
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    1);   /* NumTCS */
+
+#define TA_UUID                                            \
+    { /* 892e7f65-5da1-45d0-8209-53795ce5be8f */           \
+        0x892e7f65, 0x5da1, 0x45d0,                        \
+        {                                                  \
+            0x82, 0x09, 0x53, 0x79, 0x5c, 0xe5, 0xbe, 0x8e \
+        }                                                  \
+    }
+
+OE_SET_ENCLAVE_OPTEE(
+    TA_UUID,
+    1 * 1024 * 1024,
+    12 * 1024,
+    0,
+    "1.0.0",
+    "edl_opt_out test")

--- a/tests/edl_opt_out/host/CMakeLists.txt
+++ b/tests/edl_opt_out/host/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../edl/edl_opt_out.edl)
+
+add_custom_command(
+  OUTPUT edl_opt_out_u.h edl_opt_out_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(PLATFORM_EDL_FILE ../edl/header.edl)
+add_custom_command(
+  OUTPUT header_u.h
+  DEPENDS ${PLATFORM_EDL_FILE} edger8r
+  COMMAND
+    edger8r --header-only --untrusted ${PLATFORM_EDL_FILE} --search-path
+    ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR})
+add_custom_target(untrusted_header DEPENDS header_u.h)
+
+add_executable(edl_opt_out_host host.c edl_opt_out_u.c)
+
+add_dependencies(edl_opt_out_host untrusted_header)
+
+target_include_directories(edl_opt_out_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(edl_opt_out_host oehost)

--- a/tests/edl_opt_out/host/host.c
+++ b/tests/edl_opt_out/host/host.c
@@ -1,0 +1,83 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <limits.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "edl_opt_out_u.h"
+#include "header_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    if ((result = oe_create_edl_opt_out_enclave(
+             argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    result = enc_edl_opt_out(enclave);
+
+    if (result != OE_OK)
+        oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+    /* logging.edl */
+    OE_TEST(oe_log_init_ecall(NULL, NULL, 0) == OE_UNSUPPORTED);
+
+#if __x86_64__ || _M_X64
+#if defined(_WIN32)
+    /*
+     * On Windows, explicitly invoking the function so the attestation-related
+     * ecalls are pulled in by the linker. On Linux, we currently do not build
+     * the host with --gc-sections so this is not needed.
+     */
+    oe_verify_report(enclave, NULL, 0, NULL);
+#endif
+
+    /* attestation.edl */
+    result = OE_OK;
+    OE_TEST(oe_verify_report_ecall(NULL, &result, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(result == OE_UNSUPPORTED);
+
+    /* sgx/attestation.edl */
+    result = OE_OK;
+    OE_TEST(
+        oe_get_report_v2_ecall(NULL, &result, 0, NULL, 0, NULL, NULL) ==
+        OE_UNSUPPORTED);
+    OE_TEST(result == OE_UNSUPPORTED);
+    result = OE_OK;
+    OE_TEST(
+        oe_verify_local_report_ecall(NULL, &result, NULL, 0, NULL) ==
+        OE_UNSUPPORTED);
+    OE_TEST(result == OE_UNSUPPORTED);
+
+    /* sgx/switchless.edl */
+    result = OE_OK;
+    OE_TEST(
+        oe_sgx_init_context_switchless_ecall(NULL, &result, NULL, 0) ==
+        OE_UNSUPPORTED);
+    OE_TEST(result == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_sgx_switchless_enclave_worker_thread_ecall(NULL, NULL) ==
+        OE_UNSUPPORTED);
+#endif
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (edl_opt_out)\n");
+
+    return 0;
+}


### PR DESCRIPTION
This PR cleans up the code related to system edl opt-in to make it consistent, which include
- Fix typos in the comments
- Use the same pattern for all the weak alias implementations of ecall/ocall

Also, adding a test to lock down the scenario with using the minimal set of system edls. The test invokes the unimported ecalls/ocalls and verifies the return value against `OE_UNSUPPORTED`.