### PR TITLE
Install oesnmalloc

### DIFF
--- a/3rdparty/snmalloc/CMakeLists.txt
+++ b/3rdparty/snmalloc/CMakeLists.txt
@@ -24,8 +24,12 @@ add_custom_command(
           ${CMAKE_CURRENT_BINARY_DIR}/__config.h
   DEPENDS musl_includes libcxx_includes)
 
+# Create snmalloc_obj OBJECT library to allow snmalloc to be used as
+# the default allocator. See DEFAULT_ALLOCATOR in enclave/core/CMakeLists.txt.
+# Note: This scenario is possible only with the experimental USE_SNMALLOC
+# cmake option.
 add_enclave_library(
-  oesnmalloc
+  oesnmalloc_obj
   OBJECT
   allocator.cpp
   # List the following as sources of oesnmalloc in order to ensure that
@@ -35,14 +39,14 @@ add_enclave_library(
   __config.h)
 
 if (OE_TRUSTZONE)
-  enclave_link_libraries(oesnmalloc PUBLIC oelibutee_includes)
+  enclave_link_libraries(oesnmalloc_obj PUBLIC oelibutee_includes)
   set(TEE_C_FLAGS ${OE_TZ_TA_C_FLAGS})
 else ()
   set(TEE_C_FLAGS -mcx16)
 endif ()
 
 enclave_compile_options(
-  oesnmalloc
+  oesnmalloc_obj
   PRIVATE
   -I${CMAKE_CURRENT_SOURCE_DIR}/snmalloc/src
   -I${PROJECT_SOURCE_DIR}/include
@@ -64,4 +68,18 @@ enclave_compile_options(
 # other std specification.
 set_source_files_properties(allocator.cpp COMPILE_FLAGS -std=c++17)
 
+maybe_build_using_clangw(oesnmalloc_obj)
+
+# Create snmalloc library to make snmalloc available to the user
+# as a pluggable allocator.
+add_enclave_library(oesnmalloc $<TARGET_OBJECTS:oesnmalloc_obj>)
 maybe_build_using_clangw(oesnmalloc)
+
+install_enclaves(
+  TARGETS
+  oesnmalloc
+  EXPORT
+  openenclave-targets
+  ARCHIVE
+  DESTINATION
+  ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -163,7 +163,7 @@ if (OE_TRUSTZONE OR (OE_SGX AND (UNIX OR USE_CLANGW)))
 endif ()
 
 if (USE_SNMALLOC)
-  set(DEFAULT_ALLOCATOR oesnmalloc)
+  set(DEFAULT_ALLOCATOR oesnmalloc_obj)
 else ()
   set(DEFAULT_ALLOCATOR oedlmalloc)
 endif ()

--- a/tests/snmalloc/enc/CMakeLists.txt
+++ b/tests/snmalloc/enc/CMakeLists.txt
@@ -10,8 +10,6 @@ add_custom_command(
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
     ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_enclave_library(snmalloc_test_lib $<TARGET_OBJECTS:oesnmalloc>)
-
 add_enclave(
   TARGET
   snmalloc_enc
@@ -22,7 +20,7 @@ add_enclave(
   ${CMAKE_CURRENT_BINARY_DIR}/snmalloc_t.c)
 
 enclave_include_directories(snmalloc_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-enclave_link_libraries(snmalloc_enc snmalloc_test_lib oelibc)
+enclave_link_libraries(snmalloc_enc oesnmalloc oelibc)
 
 add_enclave(
   TARGET


### PR DESCRIPTION
oesnmalloc will be installed when make install is done.
To retain the USE_SNMALLOC feature, oesnmalloc_obj cmake target
refers to the objects whereas oesnmalloc cmake target refers to
the library.

Note: This PR does not change the release package.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>