### PR TITLE
Update the EEID design doc to reflect the current implementation and to clarify certain design choices

### DIFF
--- a/docs/DesignDocs/ExtendedEnclaveInitializationData.md
+++ b/docs/DesignDocs/ExtendedEnclaveInitializationData.md
@@ -7,7 +7,6 @@ Our extension uses TEE evidence (e.g. MRENCLAVE in SGX) as a platform configurat
 We introduce a new OE evidence type that holds extended enclave initialization data (EEID).
 Recipients of such evidence must be able to recover and verify the original enclave identity information (including the original evidence, like MRENCLAVE and MRSIGNER in the case of SGX), based on the knowledge of the EEID, which is transmitted alongside the evidence as a new type of endorsement.
 
-
 Motivations
 -----------
 
@@ -25,8 +24,7 @@ User Experience
 
 The new API is experimental and details are subject to change, but the examples given here give an idea of the added functionality.
 
-We recommend that all parameters specified at enclave signing time should be set to a value that would prevent the enclave from loading, typically 0. In the case of SGX that means `NumStackPages=0`, `NumHeapPages=0`, and `NumTCS=0`.
-This guarantees that enclave images meant to be used with EEID cannot be accidentally initialized with traditional attestation.
+We recommend that all parameters specified at enclave signing time should be set to a value that would prevent the enclave from loading, typically 0. This guarantees that enclave images meant to be used with EEID cannot be accidentally initialized with traditional attestation. In the case of SGX that means `NumStackPages=0`, `NumHeapPages=0`, and `NumTCS=1`. `NumTCS=0` would be a more obvious choice than `NumTCS=1`, and simplify the EEID report verification implementation, but based on the specific existing implementation of TCS page initialization in OE SDK, `NumTCS=1` is chosen for a security consideration. The rational is discussed in later section about EEID reports verification.
 
 To launch an EEID enclave, the user uses a new type of `oe_enclave_setting_t` called to be passed to `oe_create_enclave` API:
 
@@ -59,27 +57,27 @@ The additional union member is of type `oe_eeid_t`, which contains the following
 #ifdef EXPERIMENTAL_EEID
 typedef struct oe_eeid_t_
 {
+    uint32_t version;        /* version number of the structure */
     uint32_t hash_state[10]; /* internal state of the hash computation at the end of the enclave base image */
-    uint8_t *signature_size; /* size of signature */
-    uint8_t *signature;      /* base-image signature and associated data (for SGX, the complete sigstruct of the base image) */
+    uint64_t signature_size; /* size of signature */
     oe_enclave_size_settings_t size_settings; /* heap, stack and thread configuration for this instance */
     uint64_t vaddr;          /* location of the added data pages in enclave memory; EEID follows immediately thereafter */
-    uint64_t entry_point;    /* entry point of the image */
+    uint64_t entry_point;    /* entry point of the image, for SGX, matches TCS.OENTRY */
     uint64_t data_size;      /* size of application EEID */
-    uint8_t data[];          /* actual application EEID */
+    uint8_t data[];          /* Buffer holding EEID data followed by the signature */
 } oe_eeid_t;
 #endif
 ```
 
-Once an enclave has been started with EEID, it can use `oe_get_report` as usual to obtain evidence, except that this evidence will not be verifiable by verifiers built without EEID support, e.g. based on the Intel SGX SDK.
-However, enclaves built with OE can appraise this evidence, using `oe_verify_report` as usual, regardless of whether they themselves use EEID, as long as their version of OE supports EEID.
+Once an enclave has been started with EEID, it can use `oe_get_evidence` as usual to obtain evidence, except that this evidence will not be verifiable by verifiers built without EEID support, e.g. based on the Intel SGX SDK.
+However, enclaves built with OE can appraise this evidence, using `oe_verify_evidence` as usual, regardless of whether they themselves use EEID, as long as their version of OE supports EEID.
 
 Specification
 -------------
 
 ![Design Overview](eeid.png "EEID Design Overview")
 
-The changes introduced by EEID are mostly internal to the enclave initialization function (`oe_create_enclave_eeid`) and the attestation functions (`oe_get_report`/`oe_verify_report`).
+The changes introduced by EEID are mostly internal to the enclave initialization function (`oe_create_enclave`) and the attestation functions (`oe_get_evidence`/`oe_verify_evidence`).
 
 First, before an enclave image with EEID is loaded, we patch the size settings from the signed image with instance-specific settings, for instance as in the following SGX-based example (the symbols for other TEEs may have different structure):
 
@@ -90,7 +88,7 @@ First, before an enclave image with EEID is loaded, we patch the size settings f
         // image was intended to be used with EEID.
         if (props.header.size_settings.num_heap_pages != 0 ||
             props.header.size_settings.num_stack_pages != 0 ||
-            props.header.size_settings.num_tcs != 0)
+            props.header.size_settings.num_tcs != 1)
             OE_RAISE(OE_INVALID_PARAMETER);
 
         props.header.size_settings.num_heap_pages =
@@ -116,6 +114,8 @@ First, before an enclave image with EEID is loaded, we patch the size settings f
 ```
 
 This alters the computation of the enclave hash (e.g. `MRENCLAVE` on SGX) as the sequence of protected memory pages (e.g. via `EADD/EEXTEND`) is modified with EEID after signing. Thus, we save the state of the hash computation before adding these pages, as it will be needed to verify EEID evidence. This also requires minor additions to `oesign`, such that the extended metadata (base image `hash_state`, `vaddr`, and `signature`) can be dumped from signed enclave images, to enable the prediction of hashes before an enclave is started.
+
+For SGX enclaves, the enclave linear address space size in `SECS` is measured at the beginning of the hashing process, impacting the enclave measurement value. Adjusting the enclave linear address space size based on instance-specific settings would alter the base image measurement. Therefore, the enclave linear address space size of the base image is set to a large fixed value, for example 64GB. If the instance-specific heap/stack/tcs setting does not fill the enclave linear address space, the enclave pages at the end of the enclave are not committed. If enclave code attempts to access those pages, page fault will be triggered, same as when enclave code attempts to access "guard" pages.
 
 Then, after the enclave image is loaded but before it is initialized, we add the additional memory pages containing the contents of the `oe_eeid_t` struct (for instance with an SGX `sigstruct` signature):
 
@@ -170,12 +170,15 @@ Verification of EEID reports
 Verification of reports with EEID requires a fully populated `oe_eeid_t` and it performs the following steps (not necessarily in this order):
 
 - Create a SHA256 context and restore the internal state to `hash_state`,
-- re-measure the addition of heap, stack, and TCS pages with the settings from `size_settings` (starting at address `vaddr` and with `entry_point` in the TCS control pages),
+- re-measure the addition of heap, and thread sections with stacks (number of thread section is decided by the number of TCS pages) with the settings from `size_settings` (starting at address `vaddr` and with `entry_point` in the TCS control pages),
 - measure the additional page containing the `oe_eeid_t` (filled with the entire `oe_eeid_t`, including `data`),
 - check that the final hash matches the hash reported in the extended report (e.g. MRENCLAVE),
 - check the identity of the signer of the extended image (e.g. public key corresponding to `OE_DEBUG_SIGN_KEY`),
-- check that the base image properties (e.g. debug flag, product version) match the ones in the extended report, and finally
+- check that the base image properties (e.g. debug flag, product version) match the ones in the extended report,
+- restore the SHA256 internal state to `hash_state` again, re-measure the addition of one thread section with no stack page, check that the final hash matches the base image hash (e.g. `sigstruct.EnclaveHash` in the case of SGX), and finally
 - check the signature of the base image (e.g. `sigstruct` in the case of SGX; note this is integrity-protected by the hardware because of it's inclusion in the EEID pages).
+  
+Essentially, the verification process confirms that heap, thread sections with stacks and theEEID pages were added exactly according to the SW convention, after the base image. For SGX, the content of heap and thread sections to be added are predetermined by the SW convention, expect TCS.OENTRY. To make sure TCS.OENTRY is set as expected when the TCS control pages were added, one thread section (containing a TCS control page) is included in the base image and measured, with the measurement reflected in the base image `sigstruct`. If TCS.OENTRY was not set as expected (matching the value used to produce the measurement in the base image `sigstruct`, and truthfully recorded in `entry_point` in `oe_eeid_t` ) when the TCS control pages were added, the base image measurement check or the MRENCLAVE check will detect the attack.  
 
 Authors
 -------


### PR DESCRIPTION
The current implementation of the EEID feature deviates from the design doc in multiple areas. Update the design doc to reflect the current implementation, and add clarification for certain design choices.

CC @ad-l @sylvanc @wintersteiger @CodeMonkeyLeet @dthaler 