### PR TITLE
Remove -readnow from symbol load line in oegdb

### DIFF
--- a/debugger/pythonExtension/load_symbol_cmd.py
+++ b/debugger/pythonExtension/load_symbol_cmd.py
@@ -89,7 +89,7 @@ def GetLoadSymbolCommand(EnclaveFile, Base):
             # Write the GDB 'add-symbol-file' command with all the arguments to the setup GDB command file.
             # Note: The mandatory argument for the 'add-symbol-file' command is the .text section without a
             # '-s .SectionName'.  All other sections need the '-s .SectionName'.
-            gdbcmd = "add-symbol-file '" + EnclaveFile + "' " + '%(Location)#08x' % {'Location':int(Out[99][2])} + " -readnow "
+            gdbcmd = "add-symbol-file '" + EnclaveFile + "' " + '%(Location)#08x' % {'Location':int(Out[99][2])} + " "
             for j in range(i):
                 gdbcmd += Out[j][0] + " " + Out[j][1] + " " + '%(Location)#08x' % {'Location' : int(Out[j][2])} + " " + Out[j][3]
         else:


### PR DESCRIPTION
The using the -readnow flag can cause some performance issues when debugging very large enclaves with multiple symbol files. Remove the -readnow flag to allow lazy loading of symbols.