### PR TITLE
Fix GCC errors about OE_RAISE jumping variable initialization

### DIFF
--- a/common/sgx/eeid.c
+++ b/common/sgx/eeid.c
@@ -132,12 +132,11 @@ done:
 oe_result_t oe_serialize_eeid(const oe_eeid_t* eeid, char* buf, size_t buf_size)
 {
     oe_result_t result = OE_UNEXPECTED;
+    char** position = &buf;
+    size_t remaining = buf_size;
 
     if (!eeid || !buf || !buf_size)
         OE_RAISE(OE_INVALID_PARAMETER);
-
-    char** position = &buf;
-    size_t remaining = buf_size;
 
     OE_CHECK(serialize_element(
         "version",
@@ -209,12 +208,11 @@ oe_result_t oe_deserialize_eeid(
     oe_eeid_t* eeid)
 {
     oe_result_t result = OE_UNEXPECTED;
+    const char** position = &buf;
+    size_t remaining = buf_size;
 
     if (!buf || !buf_size || !eeid)
         OE_RAISE(OE_INVALID_PARAMETER);
-
-    const char** position = &buf;
-    size_t remaining = buf_size;
 
     memset(eeid, 0, sizeof(oe_eeid_t));
 
@@ -385,7 +383,113 @@ static bool is_zero(const uint8_t* buf, size_t sz)
     return true;
 }
 
-static oe_result_t verify_base_image_signature(const sgx_sigstruct_t* sigstruct)
+#ifdef OE_BUILD_ENCLAVE
+static oe_result_t _verify_signature(
+    const OE_SHA256* msg_hsh,
+    const uint8_t* reversed_modulus,
+    const uint8_t* reversed_exponent,
+    const uint8_t* reversed_signature)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    oe_rsa_public_key_t pk;
+    mbedtls_pk_context pkctx;
+    mbedtls_rsa_context* rsa_ctx;
+    mbedtls_pk_context* ikey;
+    mbedtls_pk_init(&pkctx);
+    const mbedtls_pk_info_t* info;
+
+    info = mbedtls_pk_info_from_type(MBEDTLS_PK_RSA);
+    if (mbedtls_pk_setup(&pkctx, info) != 0)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    rsa_ctx = mbedtls_pk_rsa(pkctx);
+    mbedtls_rsa_init(rsa_ctx, 0, 0);
+    if (mbedtls_rsa_import_raw(
+            rsa_ctx,
+            reversed_modulus,
+            OE_KEY_SIZE, // N
+            NULL,
+            0,
+            NULL,
+            0,
+            NULL,
+            0, // P Q D
+            reversed_exponent,
+            OE_EXPONENT_SIZE) != 0)
+        OE_RAISE(OE_INVALID_PARAMETER);
+    if (mbedtls_rsa_check_pubkey(rsa_ctx) != 0)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    ikey = &pkctx;
+    oe_rsa_public_key_init(&pk, ikey);
+
+    OE_CHECK(oe_rsa_public_key_verify(
+        &pk,
+        OE_HASH_TYPE_SHA256,
+        msg_hsh->buf,
+        sizeof(msg_hsh->buf),
+        reversed_signature,
+        OE_KEY_SIZE));
+
+    OE_CHECK(oe_rsa_public_key_free(&pk));
+
+    mbedtls_pk_free(ikey);
+
+    result = OE_OK;
+
+done:
+    return result;
+}
+#else
+static oe_result_t _verify_signature(
+    const OE_SHA256* msg_hsh,
+    const uint8_t* reversed_modulus,
+    const uint8_t* reversed_exponent,
+    const uint8_t* reversed_signature)
+{
+#if OPENSSL_VERSION_NUMBER < 0x1010100fL
+#error OpenSSL 1.0.2 not supported
+#endif
+    oe_result_t result = OE_UNEXPECTED;
+    oe_rsa_public_key_t pk;
+    BIGNUM *rm, *re;
+    RSA* rsa;
+    EVP_PKEY* ikey;
+
+    rm = BN_bin2bn(reversed_modulus, OE_KEY_SIZE, 0);
+    re = BN_bin2bn(reversed_exponent, OE_EXPONENT_SIZE, 0);
+    rsa = RSA_new();
+    if (RSA_set0_key(rsa, rm, re, NULL) != 1)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    ikey = EVP_PKEY_new();
+    if (EVP_PKEY_assign_RSA(ikey, rsa) != 1)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    oe_rsa_public_key_init(&pk, ikey);
+
+    OE_CHECK(oe_rsa_public_key_verify(
+        &pk,
+        OE_HASH_TYPE_SHA256,
+        msg_hsh->buf,
+        sizeof(msg_hsh->buf),
+        reversed_signature,
+        OE_KEY_SIZE));
+
+    OE_CHECK(oe_rsa_public_key_free(&pk));
+
+    // The OpenSSL flavour of oe_rsa_public_key_init does not copy the key,
+    // so oe_rsa_public_key_free already freed it.
+
+    result = OE_OK;
+
+done:
+    return result;
+}
+#endif
+
+static oe_result_t _verify_base_image_signature(
+    const sgx_sigstruct_t* sigstruct)
 {
     oe_result_t result = OE_UNEXPECTED;
     unsigned char buf[sizeof(sgx_sigstruct_t)];
@@ -423,64 +527,8 @@ static oe_result_t verify_base_image_signature(const sgx_sigstruct_t* sigstruct)
     for (size_t i = 0; i < OE_KEY_SIZE; i++)
         reversed_signature[i] = sigstruct->signature[OE_KEY_SIZE - 1 - i];
 
-    oe_rsa_public_key_t pk;
-
-#ifdef WINDOWS_BUILD
-#error EEID is currently no supported on Windows
-#endif
-
-#ifdef OE_BUILD_ENCLAVE
-    mbedtls_pk_context pkctx;
-    mbedtls_pk_init(&pkctx);
-    const mbedtls_pk_info_t* info = mbedtls_pk_info_from_type(MBEDTLS_PK_RSA);
-    mbedtls_pk_setup(&pkctx, info);
-
-    mbedtls_rsa_context* rsa_ctx = mbedtls_pk_rsa(pkctx);
-    mbedtls_rsa_init(rsa_ctx, 0, 0);
-    mbedtls_rsa_import_raw(
-        rsa_ctx,
-        reversed_modulus,
-        OE_KEY_SIZE, // N
-        NULL,
-        0,
-        NULL,
-        0,
-        NULL,
-        0, // P Q D
-        reversed_exponent,
-        OE_EXPONENT_SIZE);
-    if (mbedtls_rsa_check_pubkey(rsa_ctx) != 0)
-        OE_RAISE(OE_INVALID_PARAMETER);
-    mbedtls_pk_context* ikey = &pkctx;
-#else
-#if OPENSSL_VERSION_NUMBER < 0x1010100fL
-#error OpenSSL 1.0.2 not supported
-#endif
-    BIGNUM* rm = BN_bin2bn(reversed_modulus, OE_KEY_SIZE, 0);
-    BIGNUM* re = BN_bin2bn(reversed_exponent, OE_EXPONENT_SIZE, 0);
-    RSA* rsa = RSA_new();
-    RSA_set0_key(rsa, rm, re, NULL);
-    EVP_PKEY* ikey = EVP_PKEY_new();
-    EVP_PKEY_assign_RSA(ikey, rsa);
-#endif
-    oe_rsa_public_key_init(&pk, ikey);
-
-    OE_CHECK(oe_rsa_public_key_verify(
-        &pk,
-        OE_HASH_TYPE_SHA256,
-        msg_hsh.buf,
-        sizeof(msg_hsh.buf),
-        reversed_signature,
-        OE_KEY_SIZE));
-
-    oe_rsa_public_key_free(&pk);
-
-#ifdef OE_BUILD_ENCLAVE
-    mbedtls_pk_free(ikey);
-#else
-    // The OpenSSL flavour of oe_rsa_public_key_init does not copy the key,
-    // so oe_rsa_public_key_free already freed it.
-#endif
+    OE_CHECK(_verify_signature(
+        &msg_hsh, reversed_modulus, reversed_exponent, reversed_signature));
 
     result = OE_OK;
 
@@ -498,6 +546,9 @@ oe_result_t verify_eeid(
     const oe_eeid_t* eeid)
 {
     oe_result_t result = OE_UNEXPECTED;
+    bool base_debug, extended_debug;
+    const sgx_sigstruct_t* sigstruct;
+    oe_eeid_t tmp_eeid;
 
     if (!eeid)
         OE_RAISE(OE_INVALID_PARAMETER);
@@ -520,13 +571,13 @@ oe_result_t verify_eeid(
         0)
         OE_RAISE(OE_VERIFY_FAILED);
 
-    const sgx_sigstruct_t* sigstruct =
+    sigstruct =
         (const sgx_sigstruct_t*)((uint8_t*)&eeid->data + eeid->data_size);
 
     // Compute and check base image hash
     *base_enclave_hash = sigstruct->enclavehash;
     OE_SHA256 computed_base_enclave_hash;
-    oe_eeid_t tmp_eeid = *eeid;
+    tmp_eeid = *eeid;
     // If we saved non-zero heap/stack sizes for the base image, we could
     // add them here.
     tmp_eeid.size_settings.num_heap_pages = 0;
@@ -541,8 +592,8 @@ oe_result_t verify_eeid(
         OE_RAISE(OE_VERIFY_FAILED);
 
     // Check other image properties have not changed
-    bool base_debug = sigstruct->attributes.flags & SGX_FLAGS_DEBUG;
-    bool extended_debug = reported_attributes & OE_REPORT_ATTRIBUTES_DEBUG;
+    base_debug = sigstruct->attributes.flags & SGX_FLAGS_DEBUG;
+    extended_debug = reported_attributes & OE_REPORT_ATTRIBUTES_DEBUG;
 
     if (base_debug != extended_debug ||
         sigstruct->isvprodid != reported_product_id ||
@@ -553,7 +604,7 @@ oe_result_t verify_eeid(
     if (base_debug && is_zero(sigstruct->signature, OE_KEY_SIZE))
         return OE_OK; // Unsigned debug image is ok.
     else
-        OE_CHECK(verify_base_image_signature(sigstruct));
+        OE_CHECK(_verify_base_image_signature(sigstruct));
 
     result = OE_OK;
 
@@ -673,13 +724,12 @@ oe_result_t oe_eeid_hton(
     size_t buffer_size)
 {
     oe_result_t result = OE_UNEXPECTED;
+    uint8_t* position = buffer;
+    size_t remaining = buffer_size;
 
     if (!eeid || !buffer || buffer_size == 0 ||
         eeid->version != OE_EEID_VERSION)
         OE_RAISE(OE_INVALID_PARAMETER);
-
-    uint8_t* position = buffer;
-    size_t remaining = buffer_size;
 
     OE_CHECK(_hton_uint32_t(eeid->version, &position, &remaining));
 
@@ -718,12 +768,11 @@ oe_result_t oe_eeid_ntoh(
     oe_eeid_t* eeid)
 {
     oe_result_t result = OE_UNEXPECTED;
+    const uint8_t* position = buffer;
+    size_t remaining = buffer_size;
 
     if (!buffer || buffer_size == 0 || !eeid)
         OE_RAISE(OE_INVALID_PARAMETER);
-
-    const uint8_t* position = buffer;
-    size_t remaining = buffer_size;
 
     OE_CHECK(_ntoh_uint32_t(&position, &remaining, &eeid->version));
 
@@ -765,12 +814,12 @@ oe_result_t oe_eeid_evidence_hton(
     size_t buffer_size)
 {
     oe_result_t result = OE_UNEXPECTED;
+    uint8_t* position = buffer;
+    size_t remaining = buffer_size;
+    size_t data_size = 0;
 
     if (!buffer || buffer_size == 0 || !evidence)
         OE_RAISE(OE_INVALID_PARAMETER);
-
-    uint8_t* position = buffer;
-    size_t remaining = buffer_size;
 
     OE_CHECK(
         _hton_uint64_t(evidence->sgx_evidence_size, &position, &remaining));
@@ -778,8 +827,8 @@ oe_result_t oe_eeid_evidence_hton(
         _hton_uint64_t(evidence->sgx_endorsements_size, &position, &remaining));
     OE_CHECK(_hton_uint64_t(evidence->eeid_size, &position, &remaining));
 
-    size_t data_size = evidence->sgx_evidence_size +
-                       evidence->sgx_endorsements_size + evidence->eeid_size;
+    data_size = evidence->sgx_evidence_size + evidence->sgx_endorsements_size +
+                evidence->eeid_size;
 
     OE_CHECK(_hton_buffer(evidence->data, data_size, &position, &remaining));
 
@@ -794,12 +843,12 @@ oe_result_t oe_eeid_evidence_ntoh(
     oe_eeid_evidence_t* evidence)
 {
     oe_result_t result = OE_UNEXPECTED;
+    const uint8_t* position = buffer;
+    size_t remaining = buffer_size;
+    size_t data_size = 0;
 
     if (!buffer || buffer_size == 0 || !evidence)
         OE_RAISE(OE_INVALID_PARAMETER);
-
-    const uint8_t* position = buffer;
-    size_t remaining = buffer_size;
 
     OE_CHECK(
         _ntoh_uint64_t(&position, &remaining, &evidence->sgx_evidence_size));
@@ -807,8 +856,8 @@ oe_result_t oe_eeid_evidence_ntoh(
         &position, &remaining, &evidence->sgx_endorsements_size));
     OE_CHECK(_ntoh_uint64_t(&position, &remaining, &evidence->eeid_size));
 
-    size_t data_size = evidence->sgx_evidence_size +
-                       evidence->sgx_endorsements_size + evidence->eeid_size;
+    data_size = evidence->sgx_evidence_size + evidence->sgx_endorsements_size +
+                evidence->eeid_size;
 
     OE_CHECK(_ntoh_buffer(
         &position, &remaining, (uint8_t*)&evidence->data, data_size));

--- a/common/sgx/eeid_verifier.c
+++ b/common/sgx/eeid_verifier.c
@@ -93,16 +93,16 @@ static oe_result_t _add_claims(
     size_t* claims_size_out)
 {
     oe_result_t result = OE_UNEXPECTED;
+    size_t claims_index = 0;
+    oe_claim_t* claims = NULL;
 
     if (!claims_out || !claims_size_out)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    oe_claim_t* claims = (oe_claim_t*)oe_malloc(
+    claims = (oe_claim_t*)oe_malloc(
         (OE_REQUIRED_CLAIMS_COUNT + 1) * sizeof(oe_claim_t));
     if (claims == NULL)
         return OE_OUT_OF_MEMORY;
-
-    size_t claims_index = 0;
 
     OE_CHECK(_add_claim(
         &claims[claims_index++],
@@ -186,6 +186,7 @@ static oe_result_t _verify_sgx_report(
     oe_datetime_t* time = NULL;
     oe_report_header_t* header = (oe_report_header_t*)report_buffer;
     oe_sgx_endorsements_t sgx_endorsements;
+    size_t sgx_claims_size = 0;
 
     for (size_t i = 0; i < policies_size; i++)
     {
@@ -204,8 +205,8 @@ static oe_result_t _verify_sgx_report(
     OE_CHECK(oe_verify_quote_with_sgx_endorsements(
         header->report, header->report_size, &sgx_endorsements, time));
 
-    size_t sgx_claims_size = sgx_evidence_buffer_size -
-                             (header->report_size + sizeof(oe_report_header_t));
+    sgx_claims_size = sgx_evidence_buffer_size -
+                      (header->report_size + sizeof(oe_report_header_t));
     *sgx_claims = oe_malloc(sgx_claims_size);
 
     OE_CHECK(oe_parse_report(
@@ -295,75 +296,78 @@ static oe_result_t _eeid_verify_evidence(
             OE_RAISE(OE_INVALID_PARAMETER);
     }
 
-    /* Verify SGX report */
-    oe_report_t parsed_report;
-    oe_claim_t* sgx_claims = NULL;
-    size_t sgx_claims_length = 0;
-    _verify_sgx_report(
-        context,
-        policies,
-        policies_size,
-        sgx_evidence_buffer,
-        sgx_evidence_buffer_size,
-        sgx_endorsements_buffer,
-        sgx_endorsements_buffer_size,
-        &sgx_claims,
-        &sgx_claims_length,
-        &parsed_report);
-
-    const uint8_t* r_enclave_hash = parsed_report.identity.unique_id;
-    const uint8_t* r_signer_id = parsed_report.identity.signer_id;
-    uint16_t r_product_id = *((uint16_t*)parsed_report.identity.product_id);
-    uint32_t r_security_version = parsed_report.identity.security_version;
-    uint64_t r_attributes = parsed_report.identity.attributes;
-    uint32_t r_id_version = parsed_report.identity.id_version;
-
-    /* EEID passed to the verifier */
-    if (endorsements_buffer)
     {
-        verifier_eeid =
-            oe_memalign(2 * sizeof(void*), endorsements_buffer_size);
-        if (!verifier_eeid)
-            OE_RAISE(OE_OUT_OF_MEMORY);
-        OE_CHECK(oe_eeid_ntoh(
-            endorsements_buffer, endorsements_buffer_size, verifier_eeid));
-    }
-
-    /* Check that the enclave-reported EEID data matches the verifier's
-     * expectation. */
-    if (verifier_eeid &&
-        (attester_eeid->data_size != verifier_eeid->data_size ||
-         attester_eeid->signature_size != verifier_eeid->signature_size ||
-         memcmp(
-             attester_eeid->data,
-             verifier_eeid->data,
-             verifier_eeid->data_size + verifier_eeid->signature_size) != 0))
-        OE_RAISE(OE_VERIFY_FAILED);
-
-    /* Verify EEID */
-    const uint8_t* r_enclave_base_hash;
-    OE_CHECK(verify_eeid(
-        r_enclave_hash,
-        r_signer_id,
-        r_product_id,
-        r_security_version,
-        r_attributes,
-        &r_enclave_base_hash,
-        attester_eeid));
-
-    /* Produce claims */
-    if (claims && claims_size)
-        _add_claims(
+        /* Verify SGX report */
+        oe_report_t parsed_report;
+        oe_claim_t* sgx_claims = NULL;
+        size_t sgx_claims_length = 0;
+        _verify_sgx_report(
             context,
+            policies,
+            policies_size,
+            sgx_evidence_buffer,
+            sgx_evidence_buffer_size,
+            sgx_endorsements_buffer,
+            sgx_endorsements_buffer_size,
+            &sgx_claims,
+            &sgx_claims_length,
+            &parsed_report);
+
+        const uint8_t* r_enclave_hash = parsed_report.identity.unique_id;
+        const uint8_t* r_signer_id = parsed_report.identity.signer_id;
+        uint16_t r_product_id = *((uint16_t*)parsed_report.identity.product_id);
+        uint32_t r_security_version = parsed_report.identity.security_version;
+        uint64_t r_attributes = parsed_report.identity.attributes;
+        uint32_t r_id_version = parsed_report.identity.id_version;
+
+        /* EEID passed to the verifier */
+        if (endorsements_buffer)
+        {
+            verifier_eeid =
+                oe_memalign(2 * sizeof(void*), endorsements_buffer_size);
+            if (!verifier_eeid)
+                OE_RAISE(OE_OUT_OF_MEMORY);
+            OE_CHECK(oe_eeid_ntoh(
+                endorsements_buffer, endorsements_buffer_size, verifier_eeid));
+        }
+
+        /* Check that the enclave-reported EEID data matches the verifier's
+         * expectation. */
+        if (verifier_eeid &&
+            (attester_eeid->data_size != verifier_eeid->data_size ||
+             attester_eeid->signature_size != verifier_eeid->signature_size ||
+             memcmp(
+                 attester_eeid->data,
+                 verifier_eeid->data,
+                 verifier_eeid->data_size + verifier_eeid->signature_size) !=
+                 0))
+            OE_RAISE(OE_VERIFY_FAILED);
+
+        /* Verify EEID */
+        const uint8_t* r_enclave_base_hash;
+        OE_CHECK(verify_eeid(
             r_enclave_hash,
             r_signer_id,
             r_product_id,
             r_security_version,
             r_attributes,
-            r_id_version,
-            r_enclave_base_hash,
-            claims,
-            claims_size);
+            &r_enclave_base_hash,
+            attester_eeid));
+
+        /* Produce claims */
+        if (claims && claims_size)
+            _add_claims(
+                context,
+                r_enclave_hash,
+                r_signer_id,
+                r_product_id,
+                r_security_version,
+                r_attributes,
+                r_id_version,
+                r_enclave_base_hash,
+                claims,
+                claims_size);
+    }
 
     result = OE_OK;
 

--- a/enclave/crypto/sha.c
+++ b/enclave/crypto/sha.c
@@ -121,7 +121,7 @@ oe_result_t oe_sha256_restore(
 
     uint64_t NB = ((((uint64_t)num_hashed[1]) << 32) + num_hashed[0]) / 8;
     impl->ctx.total[0] = NB & 0xFFFFFFFF;
-    impl->ctx.total[1] = (NB >> 32) & 0xFFFFFFFF;
+    impl->ctx.total[1] = ((uint32_t)(NB >> 32)) & 0xFFFFFFFF;
 
     result = OE_OK;
 

--- a/enclave/sgx/eeid_attester.c
+++ b/enclave/sgx/eeid_attester.c
@@ -123,6 +123,7 @@ static oe_result_t _eeid_get_evidence(
     uint8_t *sgx_evidence_buffer = NULL, *sgx_endorsements_buffer = NULL;
     size_t sgx_evidence_buffer_size = 0, sgx_endorsements_buffer_size = 0;
     const oe_eeid_t* eeid = __oe_get_eeid();
+    size_t eeid_size = 0;
 
     OE_UNUSED(context);
     if (!evidence_buffer || !evidence_buffer_size || !eeid)
@@ -146,7 +147,7 @@ static oe_result_t _eeid_get_evidence(
         eeid->signature_size != sizeof(sgx_sigstruct_t))
         OE_RAISE(OE_FAILURE);
 
-    size_t eeid_size = oe_eeid_byte_size(eeid);
+    eeid_size = oe_eeid_byte_size(eeid);
 
     // Get SGX evidence
     OE_CHECK(_get_sgx_evidence(

--- a/host/crypto/openssl/sha.c
+++ b/host/crypto/openssl/sha.c
@@ -78,11 +78,10 @@ oe_result_t oe_sha256_save(
     uint32_t* num_hashed)
 {
     oe_result_t result = OE_INVALID_PARAMETER;
+    oe_sha256_context_impl_t* impl = (oe_sha256_context_impl_t*)context;
 
     if (!context || !internal_hash || !num_hashed)
         OE_RAISE(OE_INVALID_PARAMETER);
-
-    oe_sha256_context_impl_t* impl = (oe_sha256_context_impl_t*)context;
 
     for (size_t i = 0; i < 8; i++)
         internal_hash[i] = impl->ctx.h[i];
@@ -102,11 +101,11 @@ oe_result_t oe_sha256_restore(
     const uint32_t* num_hashed)
 {
     oe_result_t result = OE_INVALID_PARAMETER;
+    oe_sha256_context_impl_t* impl = (oe_sha256_context_impl_t*)context;
 
     if (!context || !internal_hash || !num_hashed)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    oe_sha256_context_impl_t* impl = (oe_sha256_context_impl_t*)context;
     oe_sha256_init(context);
 
     for (size_t i = 0; i < 8; i++)


### PR DESCRIPTION
Fixes GCC errors about the `goto` in `OE_RAISE` jumping variable initializations (`-Werror=jump-misses-init`) in EEID code; no semantic changes.

Signed-off-by: Christoph M. Wintersteiger <cwinter@microsoft.com>