### PR TITLE
Update snmalloc to 0.5.0 release

### DIFF
--- a/3rdparty/snmalloc/allocator.cpp
+++ b/3rdparty/snmalloc/allocator.cpp
@@ -21,8 +21,7 @@ void* ThreadAllocUntyped::get()
 
 #define OPEN_ENCLAVE
 #define SNMALLOC_SGX
-#define USE_RESERVE_MULTIPLE 1
-#define IS_ADDRESS_SPACE_CONSTRAINED
+#define SNMALLOC_USE_SMALL_CHUNKS
 #define SNMALLOC_EXTERNAL_THREAD_ALLOC
 #define SNMALLOC_NAME_MANGLE(a) oe_allocator_##a
 


### PR DESCRIPTION
This updates snmalloc to the latest release, which brings a number of improvements (listed under https://github.com/microsoft/snmalloc/releases/tag/0.5.0), and in particular lowers initial allocation.

I've run all the Open Enclave tests locally, and they pass provided the initial allocation is adjusted to be at least 64 + 64 * NumTCS (in pages), which isn't the case currently (there are several cases that set 128 pages of heap but have 16 TCS). I've also moved CCF over to use the latest OE with snmalloc 0.5 using the pluggable allocator, and all tests are passing there too (https://github.com/microsoft/CCF/pull/1400).

I am preparing a follow up PR that allows switching the Open Enclave tests more easily (I used the USE_SNMALLOC flag with some exceptions for uses of dlmallinfo), adjusts enclave sizes and removes the USE_SNMALLOC flag, but I would like to get this merged in time for 0.10 if possible, so I will file that separately if that's ok.