### PR TITLE
Weak symbols for two system ocalls.

### DIFF
--- a/docs/SystemEdls.md
+++ b/docs/SystemEdls.md
@@ -37,7 +37,7 @@ oe_write_ocall | N/A | Required by internal APIs/macros such as `oe_host_printf`
 ### memory.edl
 Ocall | Dependent Public APIs | Comments |
 :---|:---:|:---|
-oe_realloc_ocall | oe_host_realloc | Required by OP-TEE. |
+oe_realloc_ocall | oe_host_realloc | _ |
 
 ## Syscall system EDLs
 

--- a/enclave/core/hostcalls.c
+++ b/enclave/core/hostcalls.c
@@ -83,6 +83,16 @@ void* oe_host_calloc(size_t nmemb, size_t size)
     return ptr;
 }
 
+oe_result_t _oe_realloc_ocall(void** retval, void* ptr, size_t size)
+{
+    OE_UNUSED(retval);
+    OE_UNUSED(ptr);
+    OE_UNUSED(size);
+    return OE_UNEXPECTED;
+}
+
+OE_WEAK_ALIAS(_oe_realloc_ocall, oe_realloc_ocall);
+
 void* oe_host_realloc(void* ptr, size_t size)
 {
     void* retval = NULL;

--- a/enclave/core/sgx/thread.c
+++ b/enclave/core/sgx/thread.c
@@ -40,6 +40,20 @@ static int _thread_wake(oe_sgx_td_t* self)
     return 0;
 }
 
+oe_result_t _oe_sgx_thread_wake_wait_ocall(
+    oe_enclave_t* enclave,
+    uint64_t waiter_tcs,
+    uint64_t self_tcs)
+{
+    OE_UNUSED(enclave);
+    OE_UNUSED(waiter_tcs);
+    OE_UNUSED(self_tcs);
+
+    return OE_UNSUPPORTED;
+}
+
+OE_WEAK_ALIAS(_oe_sgx_thread_wake_wait_ocall, oe_sgx_thread_wake_wait_ocall);
+
 static int _thread_wake_wait(oe_sgx_td_t* waiter, oe_sgx_td_t* self)
 {
     int ret = -1;

--- a/include/openenclave/edl/optee/platform.edl
+++ b/include/openenclave/edl/optee/platform.edl
@@ -14,7 +14,6 @@
 
 enclave
 {
-    // Because OP-TEE enclaves are not linked with --gc-sections, they all
-    // depend on oe_host_realloc which is built into liboecore.
-    from "openenclave/edl/memory.edl" import *;
+    // OPTEE no longer has a hard requirement on memory.edl.
+    // This platform.edl can be removed in next release.
 };


### PR DESCRIPTION
Weak implementations for
oe_sgx_thread_wake_wait_ocall and
oe_realloc_ocall

fixes #3254
fixes #3255

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>