### PR TITLE
Clear xstates on enclave entry to prevent ABI poisoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed oehostapp and the appendent "-rdynamic" compiling option. Please use oehost instead and add the option back manually if necessary.
 - Removed dependencies on nodejs and esy, which were previously used to build Ocaml compiler and oeedger8r.
 
+### Security
+- Fix [ABI poisoning vulnerability for x87 FPU operations in enclaves](
+https://github.com/openenclave/openenclave/security/advisories/GHSA-7wjx-wcwg-w999).
+
 [0.9.0][v0.9.0_log]
 ------------
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ supported versions of Open Enclave:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.7.x   | :white_check_mark: |
-| 0.7.0   | :white_check_mark: |
-| < 0.7   | :x:                |
+| 0.10.x  | :white_check_mark: |
+| 0.10.0  | :white_check_mark: |
+| < 0.10  | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -78,6 +78,7 @@ if (OE_SGX)
     ../../common/sgx/endorsements.c
     ../../common/sgx/rand.S
     sgx/arena.c
+    sgx/asmdefs.c
     sgx/backtrace.c
     sgx/calls.c
     sgx/cpuid.c

--- a/enclave/core/sgx/asmcommon.inc
+++ b/enclave/core/sgx/asmcommon.inc
@@ -6,31 +6,56 @@
 
 //==============================================================================
 //
-// This macro is used to cleanup the enclave Registers. Following registers will be scrubbed:
-// 1. General Purpose registers excluding RAX, RBX, RCX, RDI, RSI, RBP, and RSP
-//     RAX and RBX are input registers of EEXIT.
-//     RCX is output register of EEXIT.
-//     RDI and RSI is output parameters defined by SDK.
-//     RBP and RSP will be set to host rbp and rsp right before EEXIT is executed.
+// This macro is used to reset all XSAVE supported state components to a
+// clean initial state. This includes:
 //
-// 2. Legacy SSE.
-// 3. Extended XState components.
+//  - The legacy SSE state:
+//    - Initializes the FPU control word to ABI-specified value 0x037F
+//    - Initializes MXCSR to ABI-specified value 0x1F80 and MXCSR_MASK to 0xFFFF
+//    - Clears FPU Status, Tag, OpCode, and FIP words
+//    - Clears all FDP bits
+//    - Clears all MMX/FPU registers
+//    - Clears all XMM registers
+//
+//  - The extended XSAVE state components:
+//    - Clears all XSTATE_BV bits
+//    - Sets XCOMP_BV bit-63 to support compaction mode
+//    - Clears all other XCOMP_BV bits
+//
+//==============================================================================
+.macro oe_cleanup_xstates
+    // Preserve registers being used
+    push %rax
+    push %rdx
+
+    // Set the XSAVE_MASK
+    mov $0xFFFFFFFF, %eax
+    mov $0xFFFFFFFF, %edx
+
+    // Restore initial enclave XSAVE state
+    xrstor64 OE_XSAVE_INITIAL_STATE(%rip)
+
+    // Restore the registers
+    pop %rdx
+    pop %rax
+.endm
+
+//==============================================================================
+//
+// This macro is used to clean up the enclave registers in addition to the
+// extended states (see oe_cleanup_xstates).
+//
+// It scrubs all general purpose registers excluding:
+//  - RAX and RBX, which are used as input registers of EEXIT.
+//  - RCX, which is used as the output register of EEXIT.
+//  - RDI and RSI, which are used as output parameters defined by SDK.
+//  - RBP and RSP, which will be set to host values of RBP & RSP right before
+//      EEXIT is executed.
+//
 //==============================================================================
 .macro oe_cleanup_registers
     // Scrub both Legacy SSE and extended XSTATEs.
-    // Save the rax, rcx, rdi and rsi.
-    mov %rax, %r12
-    mov %rcx, %r13
-    mov %rdi, %r14
-    mov %rsi, %r15
-
-    call oe_cleanup_xstates
-
-    // Restore the rax, rcx, rdi and rsi.
-    mov %r12, %rax
-    mov %r13, %rcx
-    mov %r14, %rdi
-    mov %r15, %rsi
+    oe_cleanup_xstates
 
     // Zero out GPRs.
     // Retain r11 since it is used as a reference to the td structure.

--- a/enclave/core/sgx/asmdefs.c
+++ b/enclave/core/sgx/asmdefs.c
@@ -1,0 +1,45 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/bits/types.h>
+#include <openenclave/internal/constants_x64.h>
+
+/*
+ * Initialization state for XSAVE area in the enclave.
+ */
+/* clang-format off */
+OE_ALIGNED(XSAVE_ALIGNMENT) const uint32_t
+OE_XSAVE_INITIAL_STATE[MINIMAL_XSTATE_AREA_LENGTH/sizeof(uint32_t)] = {
+
+    /* LEGACY_XSAVE_AREA */
+    /* Set FPU Control Word to ABI init value of 0x037F,
+     * clear Status, Tag, OpCode, FIP words */
+    0x037F, 0, 0, 0,
+
+    /* Clear FDP bits, set MXCSR to ABI init value of 0x1F80
+     * and MXCSR_MASK to all bits (0XFFFF) */
+    0, 0, 0x1F80, 0xFFFF,
+
+    /* Clear ST/MM0-7 */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+    /* Clear XMM0-15 */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+    /* Reserved bits up to end of LEGACY_XSAVE_AREA */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+
+    /* XSAVE Header */
+    /* Clear XSTATE_BV, set XCOMP_BV[63] = 1 to support compaction mode;
+     * SGX-capable systems should support it */
+    0, 0, 0, 0x80000000,
+
+    /* Reserved XSAVE header bits */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+};
+/* clang-format on */

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -133,18 +133,6 @@ oe_enter:
     mov %rsp, %rbp
 
 .call_function:
-    // Set the MXCSR according to the Linux x86_64 ABI
-    mov $ABI_MXCSR_INIT, %r10
-    push %r10
-    ldmxcsr (%rsp)
-    pop %r10
-
-    // Set the FPU Control Word according to the Linux x86_64 ABI
-    mov $ABI_FPUCW_INIT, %r10
-    push %r10
-    fldcw (%rsp)
-    pop %r10
-
     // Initialize the RFLAGS prior to calling enclave functions
     // This only clears the DF and state flag bits since
     // the system flags and reserved bits are not writable here
@@ -188,6 +176,9 @@ oe_enter:
 
     // Save reference to the td structure to enclave stack.
     mov %r11, OM_ENC_TD
+
+    // Clear the XSTATE so that enclave has clean legacy SSE and extended states
+    oe_cleanup_xstates
 
     // Call __oe_handle_main(ARG1=RDI, ARG2=RSI, CSSA=RDX, TCS=RCX, OUTPUTARG1=R8, OUTPUTARG2=R9)
     mov %rax, %rdx

--- a/include/openenclave/internal/constants_x64.h
+++ b/include/openenclave/internal/constants_x64.h
@@ -60,9 +60,7 @@
 #define XSAVE_ALIGNMENT 0x40
 #define LEGACY_XSAVE_AREA 0X200
 #define XSAVE_HEADER_LENGTH 0X40
-//#define MINIMAL_XSTATE_AREA_LENGTH  (LEGACY_XSAVE_AREA + XSAVE_HEADER_LENGTH)
-// Workaround for #144 xrstor64 fault - Increasing from 0x240 to 0x1000
-#define MINIMAL_XSTATE_AREA_LENGTH 0x1000
+#define MINIMAL_XSTATE_AREA_LENGTH (LEGACY_XSAVE_AREA + XSAVE_HEADER_LENGTH)
 
 //
 //  AMD64 ABI related constants.
@@ -70,11 +68,5 @@
 
 //  AMD64 ABI needs a 128 bytes red zone.
 #define ABI_REDZONE_BYTE_SIZE 0x80
-
-// MXCSR initialization value for Linux x86_64 ABI in enclave
-#define ABI_MXCSR_INIT 0x1F80
-
-// x87 FPU control word initialization value for Linux x86_64 ABI in enclave
-#define ABI_FPUCW_INIT 0x037F
 
 #endif /* _OE_INTERNAL_CONSTANTS_X64_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ if (UNIX
       add_subdirectory(tls_e2e)
     endif ()
 
+    add_subdirectory(abi)
     add_subdirectory(abortStatus)
     add_subdirectory(argv)
     add_subdirectory(atexit)

--- a/tests/abi/CMakeLists.txt
+++ b/tests/abi/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/abi abi_host abi_enc)

--- a/tests/abi/abi.edl
+++ b/tests/abi/abi.edl
@@ -1,0 +1,16 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public double enclave_add_float();
+    };
+};

--- a/tests/abi/enc/CMakeLists.txt
+++ b/tests/abi/enc/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../abi.edl)
+
+add_custom_command(
+  OUTPUT abi_t.h abi_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(
+  TARGET
+  abi_enc
+  UUID
+  7B7FB79E-2B73-46C5-8C30-3A71C014BD85
+  SOURCES
+  enc.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/abi_t.c)
+
+enclave_include_directories(abi_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+                            ${CMAKE_CURRENT_SOURCE_DIR})
+enclave_link_libraries(abi_enc oelibc)

--- a/tests/abi/enc/enc.cpp
+++ b/tests/abi/enc/enc.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "abi_t.h"
+
+double enclave_add_float()
+{
+    double my_res = 0;
+    volatile double my_num = 0.12345678899;
+
+    asm("fldl %1\n\t"
+        "fadd %%st, %%st\n\t"
+        "fstl %0\n\t"
+        : "=m"(my_res)
+        : "m"(my_num)
+        :);
+
+    return my_res;
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/abi/host/CMakeLists.txt
+++ b/tests/abi/host/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../abi.edl)
+
+add_custom_command(
+  OUTPUT abi_u.h abi_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+list(APPEND ABI_HOST_SRC host.cpp abi_u.c)
+if (WIN32)
+  list(APPEND ABI_HOST_SRC abi.asm)
+endif ()
+
+add_executable(abi_host ${ABI_HOST_SRC})
+
+target_include_directories(abi_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(abi_host oehost)

--- a/tests/abi/host/abi.asm
+++ b/tests/abi/host/abi.asm
@@ -1,0 +1,29 @@
+;; Copyright (c) Open Enclave SDK contributors.
+;; Licensed under the MIT License.
+.CODE
+
+PUBLIC oe_dummy_mmx_add
+oe_dummy_mmx_add PROC
+
+    pxor mm0, mm0
+    paddd mm0, mm0
+    ret
+
+oe_dummy_mmx_add ENDP
+
+PUBLIC oe_dummy_fpu_loads
+oe_dummy_fpu_loads PROC
+
+    fldz
+    fldz
+    fldz
+    fldz
+    fldz
+    fldz
+    fldz
+    fldz
+    ret
+
+oe_dummy_fpu_loads ENDP
+
+END

--- a/tests/abi/host/host.cpp
+++ b/tests/abi/host/host.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <cmath>
+
+#include "abi_u.h"
+
+#ifdef _WIN32
+extern "C"
+{
+    void oe_dummy_mmx_add();
+    void oe_dummy_fpu_loads();
+}
+#endif
+
+OE_NO_OPTIMIZE_BEGIN
+void test_mmx_abi_poison(oe_enclave_t* enclave)
+{
+    double float_result = 0;
+    uint64_t dummy = 0;
+
+    printf("=== test_mmx_abi_poison()\n");
+
+#ifdef _WIN32
+    oe_dummy_mmx_add();
+#else
+    asm("movq %0, %%mm0\n\t"
+        "paddd %%mm0, %%mm0\n\t" ::"m"(dummy)
+        :);
+#endif
+
+    OE_TEST(enclave_add_float(enclave, &float_result) == OE_OK);
+
+    printf("x87 FPU result = %f\n", float_result);
+    OE_TEST(!std::isnan(float_result));
+}
+
+void test_fpu_stack_overflow(oe_enclave_t* enclave)
+{
+    double float_result = 0;
+    uint64_t dummy = 0;
+
+    printf("=== test_fpu_stack_overflow()\n");
+
+#ifdef _WIN32
+    oe_dummy_fpu_loads();
+#else
+    asm("fldl %0\n\t"
+        "fldl %0\n\t"
+        "fldl %0\n\t"
+        "fldl %0\n\t"
+        "fldl %0\n\t"
+        "fldl %0\n\t"
+        "fldl %0\n\t"
+        "fldl %0\n\t" ::"m"(dummy)
+        :);
+#endif
+
+    OE_TEST(enclave_add_float(enclave, &float_result) == OE_OK);
+
+    printf("x87 FPU result = %f\n", float_result);
+    OE_TEST(!std::isnan(float_result));
+}
+OE_NO_OPTIMIZE_END
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE\n", argv[0]);
+        exit(1);
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    result = oe_create_abi_enclave(
+        argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);
+    if (result != OE_OK)
+    {
+        oe_put_err("oe_create_abi_enclave(): result=%u", result);
+    }
+
+    test_mmx_abi_poison(enclave);
+    test_fpu_stack_overflow(enclave);
+
+    if ((result = oe_terminate_enclave(enclave)) != OE_OK)
+    {
+        oe_put_err("oe_terminate_enclave(): result=%u", result);
+    }
+
+    printf("=== passed all tests (%s)\n", argv[0]);
+
+    return 0;
+}


### PR DESCRIPTION
- Refactor oe_cleanup_xstates() out of exception.c as a macro in asmcommon.inc
   - Remove workaround for #144
- Add OE_XSAVE_INITIAL_STATE definition in new asmdefs.c file
   - oe_cleanup_xstates now does an xrstor to OE_XSAVE_INITIAL_STATE
- oe_enter now also calls oe_cleanup_xstates as part of .call_function
- Remove workaround for #144

See https://github.com/openenclave/openenclave/security/advisories/GHSA-7wjx-wcwg-w999