### PR TITLE
Enable tests with snmalloc

### DIFF
--- a/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
@@ -110,19 +110,22 @@ try{
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
-                "Sim 1804 clang-7 SGX1 Debug":      { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 1804 clang-7 SGX1 Release":    { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 1804 clang-7 SGX1FLC Debug":   { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 1804 clang-7 SGX1FLC Release": { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) }
+                "Sim 1804 clang-7 SGX1 Debug":               { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-7 SGX1 Release":             { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-7 SGX1FLC Debug":            { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-7 SGX1FLC Release":          { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-7 SGX1FLC Debug snmalloc":   { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+                "Sim 1804 clang-7 SGX1FLC Release snmalloc": { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
             ]
             parallel testing_stages
         }
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "Sim 1804 clang-7 SGX1 Release":    { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "Sim 1804 clang-7 SGX1FLC Debug":   { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "Sim 1804 clang-7 SGX1FLC Release": { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) }
+                "Sim 1804 clang-7 SGX1 Release":             { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "Sim 1804 clang-7 SGX1FLC Debug":            { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "Sim 1804 clang-7 SGX1FLC Release":          { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "Sim 1804 clang-7 SGX1FLC Release snmalloc": { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON', '-DUSE_SNMALLOC=ON']) },
             ]
             parallel testing_stages
         }

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -422,7 +422,10 @@ try{
         "ACC1804 gcc Debug LVI e2e":                     { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) },
     
         "RHEL-8 clang-8 simulation Release e2e":         { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1'], true) },
-        "RHEL-8 ACC clang-8 SGX1 Release e2e":           { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], [], true) }
+        "RHEL-8 ACC clang-8 SGX1 Release e2e":           { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], [], true) },
+
+        "RHEL-8 ACC clang-8 SGX1 Release snmalloc":      { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF', '-DUSE_SNMALLOC=ON']) },
+        "RHEL-8 ACC gcc-8 SGX1 Release snmalloc":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF', '-DUSE_SNMALLOC=ON']) },
     ]
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
@@ -482,28 +485,43 @@ try{
                 "ACC1604 gcc Release LVI e2e":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04-vanilla"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) },
                 "ACC1804 clang-7 Debug LVI e2e":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) },
                 "ACC1804 clang-7 Release LVI e2e":        { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) },
-                "ACC1804 gcc Release LVI e2e":            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) }
+                "ACC1804 gcc Release LVI e2e":            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) },
+
+                "ACC1604 Package RelWithDebInfo LVI snmalloc":     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+                "ACC1804 Package RelWithDebInfo LVI snmalloc":     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF',  '-DUSE_SNMALLOC=ON']) },
+
+                "ACC1604 clang-7 Release LVI e2e snmalloc":        { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04-vanilla"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
+                "ACC1604 gcc Debug LVI e2e snmalloc":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04-vanilla"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
+                "ACC1604 gcc Release LVI e2e snmalloc":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04-vanilla"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
+                "ACC1804 clang-7 Debug LVI e2e snmalloc":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
+                "ACC1804 clang-7 Release LVI e2e snmalloc":        { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
+                "ACC1804 gcc Release LVI e2e snmalloc":            { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
+                "ACC1604 clang-7 Release LVI snmalloc":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
             ]
             parallel testing_stages
         }
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "ACC1604 Package RelWithDebInfo LVI":     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 Package RelWithDebInfo LVI":     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1604 Package RelWithDebInfo LVI":              { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 Package RelWithDebInfo LVI":              { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
 
-                "ACC1604 Container RelWithDebInfo LVI":   { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 Container RelWithDebInfo LVI":   { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1604 Container RelWithDebInfo LVI":            { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 Container RelWithDebInfo LVI":            { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
 
-                "ACC1604 clang-7 Debug LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1604 clang-7 Release LVI":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1604 gcc Debug LVI":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1604 gcc Release LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 clang-7 Debug LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 clang-7 Release LVI FULL Tests": { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC1804 gcc Debug LVI":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 gcc Release LVI":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 Code Coverage Test" :            { ACCCodeCoverageTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug') }
+                "ACC1604 clang-7 Debug LVI":                       { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1604 clang-7 Release LVI":                     { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1604 gcc Debug LVI":                           { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1604 gcc Release LVI":                         { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 clang-7 Debug LVI":                       { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 clang-7 Release LVI FULL Tests":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 gcc Debug LVI":                           { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 gcc Release LVI":                         { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 Code Coverage Test" :                     { ACCCodeCoverageTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug') },
+
+                "ACC1604 clang-7 Release LVI snmalloc":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON', '-DUSE_SNMALLOC=ON']) },
+                "ACC1804 clang-7 Release LVI FULL Tests snmalloc": { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+                "ACC1804 gcc Release LVI snmalloc":                { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON', '-DUSE_SNMALLOC=ON']) },
                 ]
             parallel testing_stages
         }

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -17,7 +17,7 @@ AGENTS_LABELS = [
     "acc-win2019-dcap": env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP"
 ]
 
-def windowsLinuxElfBuild(String label, String version, String compiler, String build_type, String lvi_mitigation = 'None', String lvi_mitigation_skip_tests = 'OFF') {
+def windowsLinuxElfBuild(String label, String version, String compiler, String build_type, String lvi_mitigation = 'None', String lvi_mitigation_skip_tests = 'OFF', List extra_cmake_args = []) {
     stage("Ubuntu ${version} SGX1 ${compiler} ${build_type} LVI_MITIGATION=${lvi_mitigation}") {
         node(AGENTS_LABELS["ubuntu-nonsgx"]) {
             timeout(GLOBAL_TIMEOUT_MINUTES) {
@@ -31,7 +31,8 @@ def windowsLinuxElfBuild(String label, String version, String compiler, String b
                                -DLVI_MITIGATION=${lvi_mitigation}                       \
                                -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
                                -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} \
-                               -Wdev
+                               -Wdev                                                    \
+                               ${extra_cmake_args.join(' ')}
                            ninja -v
                            """
                 oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", compiler, task, "--cap-add=SYS_PTRACE")
@@ -59,7 +60,7 @@ def windowsLinuxElfBuild(String label, String version, String compiler, String b
     }
 }
 
-def windowsCrossCompile(String label, String build_type, String has_quote_provider = 'OFF', String lvi_mitigation = 'None', String OE_SIMULATION = "0", String lvi_mitigation_skip_tests = 'OFF') {
+def windowsCrossCompile(String label, String build_type, String has_quote_provider = 'OFF', String lvi_mitigation = 'None', String OE_SIMULATION = "0", String lvi_mitigation_skip_tests = 'OFF', List extra_cmake_args = []) {
     def node_label = AGENTS_LABELS[label]
     if (has_quote_provider == "ON") {
         node_label = AGENTS_LABELS["${label}-dcap"]
@@ -68,7 +69,7 @@ def windowsCrossCompile(String label, String build_type, String has_quote_provid
         node(node_label) {
             withEnv(["OE_SIMULATION=${OE_SIMULATION}"]) {
                 timeout(GLOBAL_TIMEOUT_MINUTES) {
-                    oe.WinCompilePackageTest("build/X64-${build_type}", build_type, has_quote_provider, CTEST_TIMEOUT_SECONDS, lvi_mitigation, lvi_mitigation_skip_tests)
+                    oe.WinCompilePackageTest("build/X64-${build_type}", build_type, has_quote_provider, CTEST_TIMEOUT_SECONDS, lvi_mitigation, lvi_mitigation_skip_tests, extra_cmake_args)
                 }
             }
         }
@@ -122,21 +123,27 @@ try{
                 "Win2019 Debug Cross Compile with DCAP libs":             { windowsCrossCompile('acc-win2019', 'Debug', 'ON') },
                 "Win2019 Release Cross Compile with DCAP libs":           { windowsCrossCompile('acc-win2019', 'Release', 'ON') },
                 "Win2019 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow') },
-                "Win2019 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow') }
+                "Win2019 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow') },
+
+                "Win2016 Sim Release Cross Compile LVI snmalloc":         { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
+                "Win2016 Release Cross Compile DCAP LVI snmalloc":        { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) },
+                "Win2019 Sim Debug Cross Compile LVI snmalloc":           { windowsCrossCompile('acc-win2019', 'Debug', 'OFF', 'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
+                "Win2019 Release Cross Compile DCAP LVI snmalloc":        { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) }
             ]
             parallel testing_stages
         }
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow', 'ON') },
-                "Win2016 Sim Release Cross Compile LVI ":                 { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
-                "Win2016 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
-                "Win2016 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow', '0', 'ON') },
-                "Win2019 Ubuntu1804 clang-7 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow', 'ON') },
-                "Win2019 Sim Release Cross Compile LVI ":                 { windowsCrossCompile('acc-win2019', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
-                "Win2019 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
-                "Win2019 Release Cross Compile DCAP LVI FULL Tests":      { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow') }
+                "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build LVI":          { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow', 'ON') },
+                "Win2016 Sim Release Cross Compile LVI ":                          { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
+                "Win2016 Debug Cross Compile DCAP LVI":                            { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
+                "Win2016 Release Cross Compile DCAP LVI":                          { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow', '0', 'ON') },
+                "Win2019 Ubuntu1804 clang-7 Release Linux-Elf-build LVI":          { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-7', 'Release', 'ControlFlow', 'ON') },
+                "Win2019 Sim Release Cross Compile LVI ":                          { windowsCrossCompile('acc-win2019', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
+                "Win2019 Debug Cross Compile DCAP LVI":                            { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
+                "Win2019 Release Cross Compile DCAP LVI FULL Tests":               { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow') },
+                "Win2019 Release Cross Compile DCAP LVI FULL Tests snmalloc":      { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) }
             ]
             parallel testing_stages
         }

--- a/include/openenclave/internal/tests.h
+++ b/include/openenclave/internal/tests.h
@@ -66,6 +66,20 @@ OE_EXTERNC_BEGIN
 
 #define OE_TEST_IGNORE(COND) OE_TEST_IF(COND, false)
 
+/* Multi-threaded test cases may need a specific base allocation
+ * when using allocators that make use of thread-local storage, such
+ * as tcmalloc or snmalloc.
+ *
+ * The formula below applies to snmalloc when SNMALLOC_USE_SMALL_CHUNKS
+ * is set, which it is in Open Enclave. It corresponds to 256Kb for meta-data,
+ * and an intial 256Kb allocation per thread. Not all of that memory may be
+ * used, in particular if fewer threads than TCS are actually spawned, but it is
+ * a safe mininum value. Setting the enclave size to less than this value runs
+ * the risk of an abort being triggered by a thread creation unable to allocate
+ * its initial amount successfully.
+ */
+#define OE_TEST_MT_HEAP_SIZE(NUM_TCS) 64 + 64 * NUM_TCS
+
 /*
  * Return flags to pass to oe_create_enclave() based on the OE_SIMULATION
  * environment variable.

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -229,9 +229,10 @@ endif ()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oehost-gcc.pc
                ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-gcc.pc @ONLY)
 
-install(FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-gcc.pc
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
-        COMPONENT OEHOSTVERIFY)
+install(
+  FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-gcc.pc
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+  COMPONENT OEHOSTVERIFY)
 
 ##==============================================================================
 ##
@@ -242,9 +243,10 @@ install(FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-gcc.pc
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oehost-g++.pc
                ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-g++.pc @ONLY)
 
-install(FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-g++.pc
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
-        COMPONENT OEHOSTVERIFY)
+install(
+  FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-g++.pc
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+  COMPONENT OEHOSTVERIFY)
 
 ##==============================================================================
 ##
@@ -345,9 +347,10 @@ endif ()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oehost-clang.pc
                ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang.pc @ONLY)
 
-install(FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang.pc
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
-        COMPONENT OEHOSTVERIFY)
+install(
+  FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang.pc
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+  COMPONENT OEHOSTVERIFY)
 
 ##==============================================================================
 ##
@@ -359,9 +362,10 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/oehost-clang++.pc
   ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang++.pc @ONLY)
 
-install(FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang++.pc
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
-        COMPONENT OEHOSTVERIFY)
+install(
+  FILES ${CMAKE_BINARY_DIR}/output/share/pkgconfig/oehost-clang++.pc
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+  COMPONENT OEHOSTVERIFY)
 
 ##==============================================================================
 ##

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,7 +49,8 @@ if (OE_SGX)
   add_subdirectory(switchless_worksleep)
   add_subdirectory(switchless_one_tcs)
 
-  if (COMPILER_SUPPORTS_SNMALLOC)
+  if (COMPILER_SUPPORTS_SNMALLOC AND NOT USE_SNMALLOC)
+    # Do not build that test if we are already using snmalloc for all other tests
     add_subdirectory(snmalloc)
   else ()
     message("The C++ compiler cannot compile snmalloc. Skipping snmalloc test.")
@@ -67,7 +68,10 @@ if (UNIX
     if (BUILD_ENCLAVES)
       # Disable the memory test for the scenario of building the enclave in Linux and running
       # it on Windows because of the mismatch on the enclave heap size configuration.
-      add_subdirectory(memory)
+      # Also disable the memory test with snmalloc for now because it calls dlmallinfo
+      if (NOT USE_SNMALLOC)
+        add_subdirectory(memory)
+      endif ()
       add_subdirectory(tls_e2e)
     endif ()
 

--- a/tests/attestation_cert_apis/enc/enc.cpp
+++ b/tests/attestation_cert_apis/enc/enc.cpp
@@ -373,6 +373,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    128,  /* NumHeapPages */
+    256,  /* NumHeapPages */
     128,  /* NumStackPages */
     1);   /* NumTCS */

--- a/tests/attestation_plugin/enc/enc.c
+++ b/tests/attestation_plugin/enc/enc.c
@@ -459,6 +459,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    128,  /* NumHeapPages */
+    320,  /* NumHeapPages */
     128,  /* NumStackPages */
     1);   /* NumTCS */

--- a/tests/attestation_plugin_cert/enc/enc.cpp
+++ b/tests/attestation_plugin_cert/enc/enc.cpp
@@ -335,6 +335,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    128,  /* NumHeapPages */
+    192,  /* NumHeapPages */
     128,  /* NumStackPages */
     1);   /* NumTCS */

--- a/tests/create-rapid/enc/enc.cpp
+++ b/tests/create-rapid/enc/enc.cpp
@@ -13,7 +13,7 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    8,    /* NumHeapPages */
+    128,  /* NumHeapPages */
     8,    /* NumStackPages */
     1);   /* NumTCS */
 

--- a/tests/ecall_ocall/enc/enc.cpp
+++ b/tests/ecall_ocall/enc/enc.cpp
@@ -145,10 +145,12 @@ void enc_make_ocall(int n)
     host_ocall_pointer(&n);
 }
 
+#define NUM_TCS 5
+
 OE_SET_ENCLAVE_SGX(
-    1,    /* ProductID */
-    1,    /* SecurityVersion */
-    true, /* Debug */
-    256,  /* NumHeapPages */
-    16,   /* NumStackPages */
-    5);   /* NumTCS */
+    1,                             /* ProductID */
+    1,                             /* SecurityVersion */
+    true,                          /* Debug */
+    OE_TEST_MT_HEAP_SIZE(NUM_TCS), /* NumHeapPages */
+    16,                            /* NumStackPages */
+    NUM_TCS);                      /* NumTCS */

--- a/tests/stress/CMakeLists.txt
+++ b/tests/stress/CMakeLists.txt
@@ -18,10 +18,14 @@ set(ECALL_STRESS_TEST 0)
 set(OCALL_STRESS_TEST 1)
 set(ECALL_OCALL_STRESS_TEST 2)
 
-add_enclave_test(tests/stress_ecall_1 stress_host stress_enc ${ECALL_STRESS_TEST} 1 10000)
-add_enclave_test(tests/stress_ecall_2 stress_host stress_enc ${ECALL_STRESS_TEST} 10 100)
+add_enclave_test(tests/stress_ecall_1 stress_host stress_enc
+                 ${ECALL_STRESS_TEST} 1 10000)
+add_enclave_test(tests/stress_ecall_2 stress_host stress_enc
+                 ${ECALL_STRESS_TEST} 10 100)
 
 if (ENABLE_FULL_STRESS_TESTS)
-  add_enclave_test(tests/stress_ecall_3 stress_host stress_enc ${ECALL_STRESS_TEST} 1 1000000)
-  add_enclave_test(tests/stress_ecall_4 stress_host stress_enc ${ECALL_STRESS_TEST} 100 10000)
-endif()
+  add_enclave_test(tests/stress_ecall_3 stress_host stress_enc
+                   ${ECALL_STRESS_TEST} 1 1000000)
+  add_enclave_test(tests/stress_ecall_4 stress_host stress_enc
+                   ${ECALL_STRESS_TEST} 100 10000)
+endif ()

--- a/tests/switchless/enc/enc.c
+++ b/tests/switchless/enc/enc.c
@@ -106,9 +106,9 @@ int enc_echo_regular(
 }
 
 OE_SET_ENCLAVE_SGX(
-    1,        /* ProductID */
-    1,        /* SecurityVersion */
-    true,     /* Debug */
-    64,       /* NumHeapPages */
-    64,       /* NumStackPages */
-    NUM_TCS); /* NumTCS */
+    1,                             /* ProductID */
+    1,                             /* SecurityVersion */
+    true,                          /* Debug */
+    OE_TEST_MT_HEAP_SIZE(NUM_TCS), /* NumHeapPages */
+    64,                            /* NumStackPages */
+    NUM_TCS);                      /* NumTCS */

--- a/tests/switchless_nestedcalls/enc/enc.c
+++ b/tests/switchless_nestedcalls/enc/enc.c
@@ -4,6 +4,7 @@
 #include <openenclave/corelibc/string.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/print.h>
+#include <openenclave/internal/tests.h>
 #include "switchless_nestedcalls_t.h"
 
 void enc_ecall1_switchless(void)
@@ -17,9 +18,9 @@ void enc_ecall2_switchless(void)
 }
 
 OE_SET_ENCLAVE_SGX(
-    1,        /* ProductID */
-    1,        /* SecurityVersion */
-    true,     /* Debug */
-    64,       /* NumHeapPages */
-    64,       /* NumStackPages */
-    NUM_TCS); /* NumTCS */
+    1,                             /* ProductID */
+    1,                             /* SecurityVersion */
+    true,                          /* Debug */
+    OE_TEST_MT_HEAP_SIZE(NUM_TCS), /* NumHeapPages */
+    64,                            /* NumStackPages */
+    NUM_TCS);                      /* NumTCS */

--- a/tests/switchless_one_tcs/enc/enc.c
+++ b/tests/switchless_one_tcs/enc/enc.c
@@ -4,6 +4,7 @@
 #include <openenclave/corelibc/string.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/print.h>
+#include <openenclave/internal/tests.h>
 #include "switchless_one_tcs_t.h"
 
 void enc_empty_regular(void)
@@ -23,9 +24,9 @@ void enc_empty_switchless(status_e* status)
 }
 
 OE_SET_ENCLAVE_SGX(
-    1,        /* ProductID */
-    1,        /* SecurityVersion */
-    true,     /* AllowDebug */
-    64,       /* HeapPageCount */
-    64,       /* StackPageCount */
-    NUM_TCS); /* TCSCount */
+    1,                             /* ProductID */
+    1,                             /* SecurityVersion */
+    true,                          /* AllowDebug */
+    OE_TEST_MT_HEAP_SIZE(NUM_TCS), /* HeapPageCount */
+    64,                            /* StackPageCount */
+    NUM_TCS);                      /* TCSCount */

--- a/tests/switchless_threads/enc/enc.c
+++ b/tests/switchless_threads/enc/enc.c
@@ -4,6 +4,7 @@
 #include <openenclave/corelibc/string.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/print.h>
+#include <openenclave/internal/tests.h>
 #include "switchless_threads_t.h"
 
 #define STRING_LEN 100
@@ -66,10 +67,12 @@ int enc_echo_multiple(char* in, char out[STRING_LEN], int repeats)
     return 0;
 }
 
+#define NUM_TCS 8
+
 OE_SET_ENCLAVE_SGX(
-    1,    /* ProductID */
-    1,    /* SecurityVersion */
-    true, /* Debug */
-    128,  /* NumHeapPages */
-    128,  /* NumStackPages */
-    8);   /* NumTCS */
+    1,                             /* ProductID */
+    1,                             /* SecurityVersion */
+    true,                          /* Debug */
+    OE_TEST_MT_HEAP_SIZE(NUM_TCS), /* NumHeapPages */
+    128,                           /* NumStackPages */
+    NUM_TCS);                      /* NumTCS */

--- a/tests/switchless_worksleep/enc/enc.cpp
+++ b/tests/switchless_worksleep/enc/enc.cpp
@@ -4,6 +4,7 @@
 #include <openenclave/corelibc/string.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/print.h>
+#include <openenclave/internal/tests.h>
 #include "switchless_worksleep_t.h"
 
 void enc_ecall1_switchless(void)
@@ -17,9 +18,9 @@ void enc_ecall2_switchless(void)
 }
 
 OE_SET_ENCLAVE_SGX(
-    1,        /* ProductID */
-    1,        /* SecurityVersion */
-    true,     /* Debug */
-    64,       /* NumHeapPages */
-    64,       /* NumStackPages */
-    NUM_TCS); /* NumTCS */
+    1,                             /* ProductID */
+    1,                             /* SecurityVersion */
+    true,                          /* Debug */
+    OE_TEST_MT_HEAP_SIZE(NUM_TCS), /* NumHeapPages */
+    64,                            /* NumStackPages */
+    NUM_TCS);                      /* NumTCS */

--- a/tests/thread/enc/enc.cpp
+++ b/tests/thread/enc/enc.cpp
@@ -289,10 +289,12 @@ size_t enc_tcs_used_thread_count()
     return g_tcs_used_thread_count;
 }
 
+#define NUM_TCS 16
+
 OE_SET_ENCLAVE_SGX(
-    1,    /* ProductID */
-    1,    /* SecurityVersion */
-    true, /* Debug */
-    128,  /* NumHeapPages */
-    16,   /* NumStackPages */
-    16);  /* NumTCS */
+    1,                                  /* ProductID */
+    1,                                  /* SecurityVersion */
+    true,                               /* Debug */
+    OE_TEST_MT_HEAP_SIZE(NUM_TCS) + 64, /* NumHeapPages */
+    16,                                 /* NumStackPages */
+    NUM_TCS);                           /* NumTCS */

--- a/tests/thread_local/enc/enc.cpp
+++ b/tests/thread_local/enc/enc.cpp
@@ -175,10 +175,12 @@ void enclave_thread(int thread_num, int iters, int step)
     wait_for_test_completion();
 }
 
+#define NUM_TCS 16
+
 OE_SET_ENCLAVE_SGX(
-    0,    /* ProductID */
-    0,    /* SecurityVersion */
-    true, /* Debug */
-    64,   /* NumHeapPages */
-    16,   /* NumStackPages */
-    16);  /* NumTCS */
+    0,                                  /* ProductID */
+    0,                                  /* SecurityVersion */
+    true,                               /* Debug */
+    OE_TEST_MT_HEAP_SIZE(NUM_TCS) + 64, /* NumHeapPages */
+    16,                                 /* NumStackPages */
+    NUM_TCS);                           /* NumTCS */

--- a/tests/thread_local_large/enc/enc.cpp
+++ b/tests/thread_local_large/enc/enc.cpp
@@ -29,6 +29,6 @@ OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
     true, /* Debug */
-    64,   /* NumHeapPages */
-    16,   /* NumStackPages */
+    128,  /* NumHeapPages */
+    32,   /* NumStackPages */
     1);   /* NumTCS */

--- a/tests/thread_local_no_tdata/enc/enc.cpp
+++ b/tests/thread_local_no_tdata/enc/enc.cpp
@@ -35,10 +35,12 @@ uint64_t enc_get_value()
     return _local_foo.bar;
 }
 
+#define NUM_TCS 16
+
 OE_SET_ENCLAVE_SGX(
-    0,    /* ProductID */
-    0,    /* SecurityVersion */
-    true, /* Debug */
-    64,   /* NumHeapPages */
-    16,   /* NumStackPages */
-    16);  /* NumTCS */
+    0,                             /* ProductID */
+    0,                             /* SecurityVersion */
+    true,                          /* Debug */
+    OE_TEST_MT_HEAP_SIZE(NUM_TCS), /* NumHeapPages */
+    16,                            /* NumStackPages */
+    NUM_TCS);                      /* NumTCS */

--- a/tests/threadcxx/enc/enc.cpp
+++ b/tests/threadcxx/enc/enc.cpp
@@ -294,10 +294,12 @@ void enc_lock_and_unlock_mutexes_cxx(const char* mutexes)
     }
 }
 
+#define NUM_TCS 16
+
 OE_SET_ENCLAVE_SGX(
-    1,    /* ProductID */
-    1,    /* SecurityVersion */
-    true, /* Debug */
-    128,  /* NumHeapPages */
-    16,   /* NumStackPages */
-    16);  /* NumTCS */
+    1,                                  /* ProductID */
+    1,                                  /* SecurityVersion */
+    true,                               /* Debug */
+    OE_TEST_MT_HEAP_SIZE(NUM_TCS) + 64, /* NumHeapPages */
+    16,                                 /* NumStackPages */
+    NUM_TCS);                           /* NumTCS */

--- a/tests/tls_e2e/client_enc/client.cpp
+++ b/tests/tls_e2e/client_enc/client.cpp
@@ -397,6 +397,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    128,  /* NumHeapPages */
+    512,  /* NumHeapPages */
     128,  /* NumStackPages */
     1);   /* NumTCS */

--- a/tests/tls_e2e/server_enc/server.cpp
+++ b/tests/tls_e2e/server_enc/server.cpp
@@ -438,6 +438,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    128,  /* NumHeapPages */
+    512,  /* NumHeapPages */
     128,  /* NumStackPages */
     1);   /* NumTCS */


### PR DESCRIPTION
Follow-up to #3256 and to the previous effort #2730. This PR contains two sets of changes:

1. Enclave size adjustments, to fit snmalloc's initial memory requirements. These changes are much smaller than in #2730.
2. Enable a subset of CI configurations for Linux and Windows (PR and Full). I'd appreciate a review of these configuration choices, to ensure they are completely judicious.

There's an open question under #3262, which I am planning to address separately from this PR because it needs a design proposal.