### PR TITLE
Integrate with SGX quote-ex library for EPID evidence generation

### DIFF
--- a/enclave/core/sgx/report.c
+++ b/enclave/core/sgx/report.c
@@ -271,11 +271,6 @@ oe_result_t oe_get_remote_report(
     size_t sgx_report_size = sizeof(sgx_report);
     sgx_quote_t* sgx_quote = NULL;
 
-    // For remote attestation, the Quoting Enclave's target info is used.
-    // opt_params must not be supplied.
-    if (opt_params != NULL || opt_params_size != 0)
-        OE_RAISE(OE_INVALID_PARAMETER);
-
     /*
      * OCall: Get target info from Quoting Enclave.
      * This involves a call to host. The target provided by targetinfo does not

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -275,7 +275,8 @@ if (OE_SGX)
 
   # OS specific as well.
   if (UNIX)
-    list(APPEND PLATFORM_HOST_ONLY_SRC sgx/linux/sgxquoteproviderloader.c)
+    list(APPEND PLATFORM_HOST_ONLY_SRC sgx/linux/sgxquoteproviderloader.c
+         sgx/linux/sgxquoteexloader.c)
 
     list(
       APPEND
@@ -287,7 +288,8 @@ if (OE_SGX)
       sgx/linux/switchless.c
       sgx/linux/xstate.c)
   else ()
-    list(APPEND PLATFORM_HOST_ONLY_SRC sgx/windows/sgxquoteproviderloader.c)
+    list(APPEND PLATFORM_HOST_ONLY_SRC sgx/windows/sgxquoteproviderloader.c
+         sgx/windows/sgxquoteexloader.c)
 
     list(
       APPEND
@@ -487,6 +489,21 @@ if (OE_SGX)
     endif ()
     # turn on 'OE_LINK_SGX_DCAP_QL' for the preprocessor
     target_compile_definitions(oehost PUBLIC OE_LINK_SGX_DCAP_QL)
+    # If Intel SGX SDK is installed in SGX_SDK_PATH, add it to include path
+    if (NOT SGX_SDK_PATH)
+      set(SGX_SDK_PATH "/opt/intel/sgxsdk")
+    endif ()
+    find_file(
+      SGX_SDK_INSTALLED
+      NAMES "sgx_urts.h"
+      PATHS ${SGX_SDK_PATH}/include
+      NO_DEFAULT_PATH)
+    if (SGX_SDK_INSTALLED)
+      message("-- Looking for Intel SGX SDK - found")
+      target_include_directories(oehost PRIVATE ${SGX_SDK_PATH}/include)
+    else ()
+      message("-- Looking for Intel SGX SDK - not found")
+    endif ()
   endif ()
 endif ()
 

--- a/host/sgx/linux/sgxquoteexloader.c
+++ b/host/sgx/linux/sgxquoteexloader.c
@@ -1,0 +1,140 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#if defined(OE_LINK_SGX_DCAP_QL)
+
+#if __has_include(<sgx_uae_quote_ex.h>) && __has_include(<sgx_urts.h>)
+#define OE_LINK_SGX_QUOTE_EX
+#include <dlfcn.h>
+#include <openenclave/internal/defs.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/trace.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../../../common/oe_host_stdlib.h"
+#include "../sgxquote_ex.h"
+#endif
+
+#ifdef OE_LINK_SGX_QUOTE_EX
+
+static const char* _quote_ex_library_file_name = "libsgx_quote_ex.so";
+
+static oe_sgx_quote_ex_library_t* _quote_ex_library = NULL;
+
+static void _unload_quote_ex_library(void)
+{
+    if (_quote_ex_library && _quote_ex_library->handle)
+    {
+        OE_TRACE_INFO(
+            "_unload_quote_ex_library() %s\n", _quote_ex_library_file_name);
+        dlclose(_quote_ex_library->handle);
+        _quote_ex_library->handle = 0;
+        if (_quote_ex_library->mapped)
+        {
+            oe_free(_quote_ex_library->mapped);
+            _quote_ex_library->mapped = NULL;
+        }
+        if (_quote_ex_library->uuid)
+        {
+            oe_free(_quote_ex_library->uuid);
+            _quote_ex_library->uuid = NULL;
+        }
+        if (_quote_ex_library->sgx_key_id)
+        {
+            oe_free(_quote_ex_library->sgx_key_id);
+            _quote_ex_library->sgx_key_id = NULL;
+        }
+    }
+}
+
+void oe_load_quote_ex_library(oe_sgx_quote_ex_library_t* library)
+{
+    oe_result_t result = OE_UNEXPECTED;
+
+    if (!library)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    _quote_ex_library = library;
+
+    if (library->handle == 0)
+    {
+        void* _handle = 0;
+        OE_TRACE_INFO(
+            "oe_load_quote_ex_library() %s\n", _quote_ex_library_file_name);
+        _handle = dlopen(_quote_ex_library_file_name, RTLD_LAZY | RTLD_LOCAL);
+
+        if (_handle != 0)
+        {
+            library->sgx_select_att_key_id =
+                dlsym(_handle, SGX_SELECT_ATT_KEY_ID_NAME);
+            if (!library->sgx_select_att_key_id)
+            {
+                OE_TRACE_ERROR(
+                    "sgxquoteexprovider: sgx_select_att_key_id not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+            library->sgx_init_quote_ex = dlsym(_handle, SGX_INIT_QUOTE_EX_NAME);
+            if (!library->sgx_init_quote_ex)
+            {
+                OE_TRACE_ERROR(
+                    "sgxquoteexprovider: sgx_init_quote_ex not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+            library->sgx_get_quote_size_ex =
+                dlsym(_handle, SGX_GET_QUOTE_SIZE_NAME);
+            if (!library->sgx_get_quote_size_ex)
+            {
+                OE_TRACE_ERROR(
+                    "sgxquoteexprovider: sgx_get_quote_size_ex not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+            library->sgx_get_quote_ex = dlsym(_handle, SGX_GET_QUOTE_EX_NAME);
+            if (!library->sgx_get_quote_ex)
+            {
+                OE_TRACE_ERROR(
+                    "sgxquoteexprovider: sgx_get_quote_ex not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+            library->sgx_get_supported_att_key_id_num =
+                dlsym(_handle, SGX_GET_SUPPORTED_ATT_KEY_ID_NUM_NAME);
+            if (!library->sgx_get_supported_att_key_id_num)
+            {
+                OE_TRACE_ERROR("sgxquoteexprovider: "
+                               "sgx_get_supported_att_key_id_num not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+            library->sgx_get_supported_att_key_ids =
+                dlsym(_handle, SGX_GET_SUPPORTED_ATT_KEY_IDS_NAME);
+            if (!library->sgx_get_supported_att_key_ids)
+            {
+                OE_TRACE_ERROR("sgxquoteexprovider: "
+                               "sgx_get_supported_att_key_ids not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+
+            atexit(_unload_quote_ex_library);
+
+            library->handle = _handle;
+            result = OE_OK;
+        }
+        else
+        {
+            OE_TRACE_ERROR(
+                "sgxquoteexprovider: failed to load %s: %s\n",
+                _quote_ex_library_file_name,
+                dlerror());
+
+            library->handle = 0;
+            result = OE_NOT_FOUND;
+        }
+    }
+
+done:
+    library->load_result = result;
+    if (result != OE_OK)
+        _unload_quote_ex_library();
+}
+
+#endif // OE_LINK_SGX_QUOTE_EX
+
+#endif // OE_LINK_SGX_DCAP_QL

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -5,18 +5,107 @@
 #include "sgxquote.h"
 #include <openenclave/attestation/sgx/evidence.h>
 #include <openenclave/internal/defs.h>
+#include <openenclave/internal/hexdump.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/sgx/plugin.h>
+#include <openenclave/internal/tests.h>
 #include <openenclave/internal/trace.h>
 #include <sgx_dcap_ql_wrapper.h>
+#include <sgx_quote_3.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../../common/oe_host_stdlib.h"
 #include "../hostthread.h"
+
+#if __has_include(<sgx_uae_quote_ex.h>) && __has_include(<sgx_urts.h>)
+#define OE_LINK_SGX_QUOTE_EX
+#include <sgx_uae_quote_ex.h>
+#include "sgxquote_ex.h"
+#endif
 
 // Check consistency with OE definition.
 OE_STATIC_ASSERT(sizeof(sgx_target_info_t) == 512);
 OE_STATIC_ASSERT(sizeof(sgx_report_t) == 432);
 
+static const oe_uuid_t _ecdsa_p256_uuid = {OE_FORMAT_UUID_SGX_ECDSA_P256};
+
+#ifdef OE_LINK_SGX_QUOTE_EX
+
+OE_STATIC_ASSERT(sizeof(sgx_att_key_id_ext_t) == sizeof(sgx_att_key_id_t));
+
+// Redefine some constants in <sgx_quote_3.h> to be more meaningful
+#define SGX_QL_ALG_EPID_UNLINKABLE SGX_QL_ALG_EPID
+#define SGX_QL_ALG_EPID_LINKABLE SGX_QL_ALG_RESERVED_1
+
+static oe_sgx_quote_ex_library_t _quote_ex_library = {0};
+static const oe_uuid_t _unknown_uuid = {OE_FORMAT_UUID_SGX_UNKNOWN};
+static const oe_uuid_t _ecdsa_p384_uuid = {OE_FORMAT_UUID_SGX_ECDSA_P384};
+static const oe_uuid_t _epid_linkable_uuid = {OE_FORMAT_UUID_SGX_EPID_LINKABLE};
+static const oe_uuid_t _epid_unlinkable_uuid = {
+    OE_FORMAT_UUID_SGX_EPID_UNLINKABLE};
+
+static sgx_att_key_id_ext_t* _format_id_to_key_id(const oe_uuid_t* format_id)
+{
+    if (!format_id)
+        return NULL;
+
+    for (size_t i = 0; i < _quote_ex_library.key_id_count; i++)
+    {
+        if (!_quote_ex_library.mapped[i])
+            continue;
+
+        if (!memcmp(format_id, _quote_ex_library.uuid + i, sizeof(oe_uuid_t)))
+            return _quote_ex_library.sgx_key_id + i;
+    }
+
+    return NULL;
+}
+
+static void _print_hex_buf_tail(
+    const char* title,
+    const uint8_t* buf,
+    size_t size,
+    size_t tail)
+{
+    const int max_size = 64;
+    size_t offset = 0;
+    char* str = NULL;
+
+    // Adjust for printing only the tail
+    if (tail && size > tail)
+    {
+        offset = size - tail;
+        size = tail;
+    }
+
+    str = (char*)oe_malloc(max_size * 2 + 1);
+    if (!str)
+    {
+        OE_TRACE_ERROR("Out of memory for _print_hex_buf()");
+        return;
+    }
+
+    if (offset)
+        OE_TRACE_INFO(
+            "%s[%d ->tail %d]:", title, (int)(size + offset), (int)size);
+    else
+        OE_TRACE_INFO("%s[%d]:", title, (int)size);
+
+    while (size > 0)
+    {
+        size_t seg_size = size;
+        if (seg_size > max_size)
+            seg_size = max_size;
+        oe_hex_string(str, seg_size * 2 + 1, buf + offset, seg_size);
+        str[seg_size * 2] = '\0';
+        OE_TRACE_INFO("%s\n", str);
+        size -= seg_size;
+        offset += seg_size;
+    }
+    oe_free(str);
+}
+
+#endif // OE_LINK_SGX_QUOTE_EX
 static quote3_error_t (*_sgx_qe_get_target_info)(
     sgx_target_info_t* p_qe_target_info);
 
@@ -132,12 +221,76 @@ oe_result_t oe_sgx_qe_get_target_info(
     size_t opt_params_size,
     uint8_t* target_info)
 {
-    oe_result_t result = OE_FAILURE;
+    oe_result_t result = OE_UNEXPECTED;
     quote3_error_t err = SGX_QL_ERROR_UNEXPECTED;
 
-    OE_UNUSED(format_id);
+    if (!format_id || !target_info)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+#ifdef OE_LINK_SGX_QUOTE_EX
+
+    if (oe_initialize_quote_ex_library() == OE_OK)
+    {
+        sgx_status_t status = SGX_ERROR_UNEXPECTED;
+        sgx_att_key_id_ext_t updated_key_id = {{0}};
+        size_t tmp_size = 0;
+        uint8_t* tmp_buffer = NULL;
+        sgx_target_info_t tmp_target_info;
+
+        sgx_att_key_id_ext_t* key_id = _format_id_to_key_id(format_id);
+        if (!key_id)
+            OE_RAISE(OE_UNSUPPORTED);
+
+        // Update key ID with input SP ID for EPID quoting
+        memcpy(&updated_key_id, key_id, sizeof(*key_id));
+        if (key_id->base.algorithm_id == SGX_QL_ALG_EPID_LINKABLE ||
+            key_id->base.algorithm_id == SGX_QL_ALG_EPID_UNLINKABLE)
+        {
+            if (opt_params && opt_params_size == sizeof(key_id->spid))
+                memcpy(updated_key_id.spid, opt_params, opt_params_size);
+        }
+
+        status = _quote_ex_library.sgx_init_quote_ex(
+            (sgx_att_key_id_t*)&updated_key_id,
+            &tmp_target_info,
+            &tmp_size,
+            NULL);
+
+        if (status != SGX_SUCCESS)
+            OE_RAISE_MSG(
+                OE_PLATFORM_ERROR,
+                "sgx_init_quote_ex(NULL) returned 0x%x\n",
+                status);
+
+        tmp_buffer = (uint8_t*)oe_malloc(tmp_size);
+        OE_TEST(tmp_buffer);
+
+        status = _quote_ex_library.sgx_init_quote_ex(
+            (sgx_att_key_id_t*)&updated_key_id,
+            &tmp_target_info,
+            &tmp_size,
+            tmp_buffer);
+        oe_free(tmp_buffer);
+
+        if (status != SGX_SUCCESS)
+            OE_RAISE_MSG(
+                OE_PLATFORM_ERROR,
+                "sgx_init_quote_ex(tmp_buffer) returned 0x%x\n",
+                status);
+
+        memcpy(target_info, &tmp_target_info, sizeof(sgx_target_info_t));
+
+        result = OE_OK;
+        goto done;
+    }
+
+#else // OE_LINK_SGX_QUOTE_EX
+
     OE_UNUSED(opt_params);
     OE_UNUSED(opt_params_size);
+
+#endif // OE_LINK_SGX_QUOTE_EX
+
     _load_sgx_dcap_ql();
     err = _sgx_qe_get_target_info((sgx_target_info_t*)target_info);
 
@@ -155,19 +308,63 @@ oe_result_t oe_sgx_qe_get_quote_size(
     size_t opt_params_size,
     size_t* quote_size)
 {
-    oe_result_t result = OE_FAILURE;
-    uint32_t* local_quote_size = (uint32_t*)quote_size;
+    oe_result_t result = OE_UNEXPECTED;
+    uint32_t local_quote_size = (uint32_t)*quote_size;
     quote3_error_t err = SGX_QL_ERROR_UNEXPECTED;
 
-    OE_UNUSED(format_id);
+    if (!format_id || !quote_size)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+#ifdef OE_LINK_SGX_QUOTE_EX
+
+    if (oe_initialize_quote_ex_library() == OE_OK)
+    {
+        sgx_status_t status = SGX_ERROR_UNEXPECTED;
+        sgx_att_key_id_ext_t updated_key_id = {{0}};
+
+        sgx_att_key_id_ext_t* key_id = _format_id_to_key_id(format_id);
+        if (!key_id)
+            OE_RAISE(OE_UNSUPPORTED);
+
+        // Update key ID with input SP ID for EPID quoting
+        memcpy(&updated_key_id, key_id, sizeof(*key_id));
+        if (key_id->base.algorithm_id == SGX_QL_ALG_EPID_LINKABLE ||
+            key_id->base.algorithm_id == SGX_QL_ALG_EPID_UNLINKABLE)
+        {
+            if (opt_params && opt_params_size == sizeof(key_id->spid))
+                memcpy(updated_key_id.spid, opt_params, opt_params_size);
+        }
+
+        status = _quote_ex_library.sgx_get_quote_size_ex(
+            (const sgx_att_key_id_t*)&updated_key_id, &local_quote_size);
+
+        if (status != SGX_SUCCESS)
+            OE_RAISE_MSG(
+                OE_PLATFORM_ERROR,
+                "sgx_get_quote_size_ex() returned 0x%x\n",
+                status);
+
+        OE_TRACE_INFO("local_quote_size = %lu\n", local_quote_size);
+
+        *quote_size = local_quote_size;
+        result = OE_OK;
+        goto done;
+    }
+
+#else // OE_LINK_SGX_QUOTE_EX
+
     OE_UNUSED(opt_params);
     OE_UNUSED(opt_params_size);
+
+#endif // OE_LINK_SGX_QUOTE_EX
+
     _load_sgx_dcap_ql();
-    err = _sgx_qe_get_quote_size(local_quote_size);
+    err = _sgx_qe_get_quote_size(&local_quote_size);
 
     if (err != SGX_QL_SUCCESS)
         OE_RAISE_MSG(OE_PLATFORM_ERROR, "quote3_error_t=0x%x\n", err);
 
+    *quote_size = local_quote_size;
     result = OE_OK;
 done:
     return result;
@@ -181,14 +378,77 @@ oe_result_t oe_sgx_qe_get_quote(
     size_t quote_size,
     uint8_t* quote)
 {
-    oe_result_t result = OE_FAILURE;
-    uint32_t local_quote_size = 0;
+    oe_result_t result = OE_UNEXPECTED;
+    uint32_t local_quote_size = (uint32_t)quote_size;
     quote3_error_t err = SGX_QL_ERROR_UNEXPECTED;
 
-    OE_UNUSED(format_id);
-    OE_UNUSED(opt_params);
-    OE_UNUSED(opt_params_size);
+    if (!format_id || !report || !quote || !quote_size ||
+        quote_size > OE_MAX_UINT32)
+        OE_RAISE(OE_INVALID_PARAMETER);
 
+#ifdef OE_LINK_SGX_QUOTE_EX
+
+    if (oe_initialize_quote_ex_library() == OE_OK)
+    {
+        sgx_status_t status = SGX_ERROR_UNEXPECTED;
+        sgx_att_key_id_ext_t updated_key_id = {{0}};
+
+        sgx_att_key_id_ext_t* key_id = _format_id_to_key_id(format_id);
+        if (!key_id)
+            OE_RAISE(OE_UNSUPPORTED);
+
+        // Update key ID with input SP ID for EPID quoting
+        memcpy(&updated_key_id, key_id, sizeof(*key_id));
+        if (key_id->base.algorithm_id == SGX_QL_ALG_EPID_LINKABLE ||
+            key_id->base.algorithm_id == SGX_QL_ALG_EPID_UNLINKABLE)
+        {
+            if (opt_params)
+            {
+                if (opt_params_size == sizeof(key_id->spid))
+                    memcpy(updated_key_id.spid, opt_params, opt_params_size);
+                else
+                {
+                    OE_TRACE_INFO(
+                        "EPID requires opt_params to be 16-byte SPID");
+                    OE_RAISE(OE_INVALID_PARAMETER);
+                }
+            }
+        }
+        else // ECDSA
+        {
+            // For EPID, no opt_params is taken.
+            if (opt_params || opt_params_size)
+                OE_RAISE(OE_INVALID_PARAMETER);
+        }
+
+        status = _quote_ex_library.sgx_get_quote_ex(
+            (const sgx_report_t*)report,
+            (const sgx_att_key_id_t*)&updated_key_id,
+            NULL,
+            quote,
+            local_quote_size);
+
+        if (status != SGX_SUCCESS)
+            OE_RAISE_MSG(
+                OE_PLATFORM_ERROR,
+                "sgx_get_quote_ex() returned 0x%x\n",
+                status);
+
+        OE_TRACE_INFO(
+            "quote_ex got quote for algorithm_id=%d\n",
+            key_id->base.algorithm_id);
+
+        result = OE_OK;
+        goto done;
+    }
+
+#else // OE_LINK_SGX_QUOTE_EX
+
+    // For EPID, no opt_params is taken.
+    if (opt_params || opt_params_size)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+#endif // OE_LINK_SGX_QUOTE_EX
     if (quote_size > OE_MAX_UINT32)
         OE_RAISE(OE_INVALID_PARAMETER);
 
@@ -209,11 +469,55 @@ oe_result_t oe_sgx_get_supported_attester_format_ids(
     void* format_ids,
     size_t* format_ids_size)
 {
-    const oe_uuid_t _ecdsa_uuid = {OE_FORMAT_UUID_SGX_ECDSA_P256};
-    oe_result_t result = OE_FAILURE;
+    oe_result_t result = OE_UNEXPECTED;
 
     if (!format_ids_size)
         OE_RAISE(OE_INVALID_PARAMETER);
+
+#ifdef OE_LINK_SGX_QUOTE_EX
+
+    if (oe_initialize_quote_ex_library() == OE_OK)
+    {
+        size_t count = _quote_ex_library.mapped_key_id_count;
+        size_t index = 0;
+
+        if (count &&
+            (!format_ids || *format_ids_size < sizeof(oe_uuid_t) * count))
+        {
+            *format_ids_size = sizeof(oe_uuid_t) * count;
+            OE_RAISE(OE_BUFFER_TOO_SMALL);
+        }
+
+        for (size_t i = 0; i < _quote_ex_library.key_id_count; i++)
+        {
+            // Skip the entry if it was not mapped.
+            if (!_quote_ex_library.mapped[i])
+                continue;
+
+            memcpy(
+                ((uint8_t*)format_ids) + sizeof(oe_uuid_t) * index,
+                _quote_ex_library.uuid + i,
+                sizeof(oe_uuid_t));
+            index++;
+        }
+
+        OE_TEST(index == count);
+
+        *format_ids_size = sizeof(oe_uuid_t) * count;
+
+        OE_TRACE_INFO("quote_ex got %lu format IDs\n", count);
+        _print_hex_buf_tail("format_ids: ", format_ids, *format_ids_size, 0);
+        _print_hex_buf_tail(
+            "_quote_ex_library.uuid: ",
+            (uint8_t*)_quote_ex_library.uuid,
+            *format_ids_size,
+            0);
+
+        result = OE_OK;
+        goto done;
+    }
+
+#endif // OE_LINK_SGX_QUOTE_EX
 
     // Case when DCAP is used
     if (!format_ids && *format_ids_size == 0)
@@ -226,14 +530,154 @@ oe_result_t oe_sgx_get_supported_attester_format_ids(
         *format_ids_size = sizeof(oe_uuid_t);
         OE_RAISE(OE_BUFFER_TOO_SMALL);
     }
-
-    memcpy(format_ids, &_ecdsa_uuid, sizeof(oe_uuid_t));
+    memcpy(format_ids, &_ecdsa_p256_uuid, sizeof(oe_uuid_t));
     *format_ids_size = sizeof(oe_uuid_t);
 
+    OE_TRACE_INFO("DCAP only supports ECDSA_P256\n");
     result = OE_OK;
 
 done:
     return result;
 }
 
-#endif
+#ifdef OE_LINK_SGX_QUOTE_EX
+
+static void _load_quote_ex_library_once(void)
+{
+    bool* tmp_mapped = NULL;
+    oe_uuid_t* tmp_uuid = NULL;
+    sgx_att_key_id_ext_t* tmp_key_id = NULL;
+    oe_result_t result = OE_UNEXPECTED;
+
+    if (_quote_ex_library.handle && _quote_ex_library.load_result == OE_OK)
+        return;
+
+    oe_load_quote_ex_library(&_quote_ex_library);
+    if (_quote_ex_library.load_result == OE_OK)
+    {
+        uint32_t att_key_id_num = 0;
+        uint32_t mapped_key_id_count = 0;
+        sgx_status_t status = SGX_ERROR_UNEXPECTED;
+        status =
+            _quote_ex_library.sgx_get_supported_att_key_id_num(&att_key_id_num);
+        if (status != SGX_SUCCESS || att_key_id_num == 0)
+        {
+            OE_TRACE_ERROR(
+                "_load_quote_ex_library_once() "
+                "sgx_get_supported_att_key_id_num() status=%d num=%d\n",
+                status,
+                att_key_id_num);
+            OE_RAISE(OE_QUOTE_PROVIDER_CALL_ERROR);
+        }
+
+        tmp_mapped = (bool*)oe_malloc(att_key_id_num * sizeof(bool));
+        tmp_uuid = (oe_uuid_t*)oe_malloc(att_key_id_num * sizeof(oe_uuid_t));
+        tmp_key_id = (sgx_att_key_id_ext_t*)oe_malloc(
+            att_key_id_num * sizeof(sgx_att_key_id_ext_t));
+
+        if (!tmp_mapped || !tmp_uuid || !tmp_key_id)
+            OE_RAISE(OE_OUT_OF_MEMORY);
+
+        status = _quote_ex_library.sgx_get_supported_att_key_ids(
+            tmp_key_id, att_key_id_num);
+        if (status != SGX_SUCCESS)
+            OE_RAISE_MSG(
+                OE_PLATFORM_ERROR,
+                "_load_quote_ex_library_once() "
+                "sgx_get_supported_att_key_ids() status=%d\n",
+                status);
+
+        for (uint32_t i = 0; i < att_key_id_num; i++)
+        {
+            sgx_att_key_id_ext_t* key = tmp_key_id + i;
+            const oe_uuid_t* uuid = NULL;
+
+            OE_TRACE_INFO("algorithm_id=%d", key->base.algorithm_id);
+
+            switch (key->base.algorithm_id)
+            {
+                case SGX_QL_ALG_EPID_UNLINKABLE:
+                    uuid = &_epid_unlinkable_uuid;
+                    tmp_mapped[i] = true;
+                    mapped_key_id_count++;
+                    break;
+                case SGX_QL_ALG_EPID_LINKABLE:
+                    uuid = &_epid_linkable_uuid;
+                    tmp_mapped[i] = true;
+                    mapped_key_id_count++;
+                    break;
+                case SGX_QL_ALG_ECDSA_P256:
+                    uuid = &_ecdsa_p256_uuid;
+                    tmp_mapped[i] = true;
+                    mapped_key_id_count++;
+                    break;
+                case SGX_QL_ALG_ECDSA_P384:
+                    uuid = &_ecdsa_p384_uuid;
+                    tmp_mapped[i] = true;
+                    mapped_key_id_count++;
+                    break;
+                default:
+                    uuid = &_unknown_uuid;
+                    tmp_mapped[i] = false;
+                    OE_TRACE_ERROR(
+                        "algorithm_id=%d maps to no uuid",
+                        key->base.algorithm_id);
+                    break;
+            }
+            memcpy(tmp_uuid + i, uuid, sizeof(oe_uuid_t));
+        }
+
+        _quote_ex_library.key_id_count = att_key_id_num;
+        _quote_ex_library.mapped_key_id_count = mapped_key_id_count;
+        _quote_ex_library.mapped = tmp_mapped;
+        _quote_ex_library.uuid = tmp_uuid;
+        _quote_ex_library.sgx_key_id = tmp_key_id;
+        tmp_mapped = NULL;
+        tmp_uuid = NULL;
+        tmp_key_id = NULL;
+
+        OE_TRACE_INFO(
+            "key_id_count=%lu mapped=%lu\n",
+            att_key_id_num,
+            mapped_key_id_count);
+
+        result = OE_OK;
+    }
+
+done:
+    if (tmp_mapped)
+    {
+        oe_free(tmp_mapped);
+        tmp_mapped = NULL;
+    }
+    if (tmp_uuid)
+    {
+        oe_free(tmp_uuid);
+        tmp_uuid = NULL;
+    }
+    if (tmp_key_id)
+    {
+        oe_free(tmp_key_id);
+        tmp_key_id = NULL;
+    }
+    if (_quote_ex_library.load_result == OE_OK)
+        _quote_ex_library.load_result = result;
+
+    OE_TRACE_INFO(
+        "_load_quote_ex_library_once() result=%s\n",
+        oe_result_str(_quote_ex_library.load_result));
+
+    return;
+}
+
+oe_result_t oe_initialize_quote_ex_library(void)
+{
+    static oe_once_type once = OE_H_ONCE_INITIALIZER;
+    oe_once(&once, _load_quote_ex_library_once);
+
+    return _quote_ex_library.load_result;
+}
+
+#endif // OE_LINK_SGX_QUOTE_EX
+
+#endif // OE_LINK_SGX_DCAP_QL

--- a/host/sgx/sgxquote_ex.h
+++ b/host/sgx/sgxquote_ex.h
@@ -1,0 +1,108 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_SGXQUOTE_EX_H
+#define _OE_SGXQUOTE_EX_H
+
+#if defined(OE_LINK_SGX_DCAP_QL)
+
+#include <openenclave/bits/evidence.h>
+#include <openenclave/bits/result.h>
+#include <openenclave/bits/types.h>
+
+OE_EXTERNC_BEGIN
+
+// Declarations for quote_ex integration
+// Note: the quote_ex library entry points are based on declarations in
+// https://github.com/intel/linux-sgx/blob/master/common/inc/sgx_uae_quote_ex.h
+
+enum _status_t;
+typedef enum _status_t sgx_status_t;
+
+struct _quote_t;
+typedef struct _quote_t sgx_quote_t;
+
+struct _att_key_id_t;
+typedef struct _att_key_id_t sgx_att_key_id_t;
+
+struct _sgx_ql_att_key_id_t;
+typedef struct _sgx_ql_att_key_id_t sgx_ql_att_key_id_t;
+
+struct _sgx_att_key_id_ext_t;
+typedef struct _sgx_att_key_id_ext_t sgx_att_key_id_ext_t;
+
+struct _qe_report_info_t;
+typedef struct _qe_report_info_t sgx_qe_report_info_t;
+
+struct _target_info_t;
+typedef struct _target_info_t sgx_target_info_t;
+
+struct _report_t;
+typedef struct _report_t sgx_report_t;
+
+typedef sgx_status_t (*sgx_select_att_key_id_t)(
+    const uint8_t* p_att_key_id_list,
+    uint32_t att_key_id_list_size,
+    sgx_att_key_id_t* p_selected_key_id);
+
+typedef sgx_status_t (*sgx_init_quote_ex_t)(
+    const sgx_att_key_id_t* p_att_key_id,
+    sgx_target_info_t* p_qe_target_info,
+    size_t* p_pub_key_id_size,
+    uint8_t* p_pub_key_id);
+
+typedef sgx_status_t (*sgx_get_quote_size_ex_t)(
+    const sgx_att_key_id_t* p_att_key_id,
+    uint32_t* p_quote_size);
+
+typedef sgx_status_t (*sgx_get_quote_ex_t)(
+    const sgx_report_t* p_app_report,
+    const sgx_att_key_id_t* p_att_key_id,
+    sgx_qe_report_info_t* p_qe_report_info,
+    uint8_t* p_quote,
+    uint32_t quote_size);
+
+typedef sgx_status_t (*sgx_get_supported_att_key_id_num_t)(
+    uint32_t* p_att_key_id_num);
+
+typedef sgx_status_t (*sgx_get_supported_att_key_ids_t)(
+    sgx_att_key_id_ext_t* p_att_key_id_list,
+    uint32_t att_key_id_num);
+
+typedef struct _oe_sgx_quote_ex_library_t
+{
+    void* handle;
+    oe_result_t load_result;
+
+    // quote_ex shared library entry points
+    sgx_select_att_key_id_t sgx_select_att_key_id;
+    sgx_init_quote_ex_t sgx_init_quote_ex;
+    sgx_get_quote_size_ex_t sgx_get_quote_size_ex;
+    sgx_get_quote_ex_t sgx_get_quote_ex;
+    sgx_get_supported_att_key_id_num_t sgx_get_supported_att_key_id_num;
+    sgx_get_supported_att_key_ids_t sgx_get_supported_att_key_ids;
+
+    // Map between OE uuid and SGX key ID
+    size_t key_id_count;
+    size_t mapped_key_id_count;
+    bool* mapped;
+    oe_uuid_t* uuid;
+    sgx_att_key_id_ext_t* sgx_key_id;
+} oe_sgx_quote_ex_library_t;
+
+oe_result_t oe_initialize_quote_ex_library(void);
+
+void oe_load_quote_ex_library(oe_sgx_quote_ex_library_t* library);
+
+#define SGX_SELECT_ATT_KEY_ID_NAME "sgx_select_att_key_id"
+#define SGX_INIT_QUOTE_EX_NAME "sgx_init_quote_ex"
+#define SGX_GET_QUOTE_SIZE_NAME "sgx_get_quote_size_ex"
+#define SGX_GET_QUOTE_EX_NAME "sgx_get_quote_ex"
+#define SGX_GET_SUPPORTED_ATT_KEY_ID_NUM_NAME "sgx_get_supported_att_key_id_num"
+#define SGX_GET_SUPPORTED_ATT_KEY_IDS_NAME "sgx_get_supported_att_key_ids"
+
+OE_EXTERNC_END
+
+#endif // OE_LINK_SGX_DCAP_QL
+
+#endif // _OE_SGXQUOTE_EX_H

--- a/host/sgx/windows/sgxquoteexloader.c
+++ b/host/sgx/windows/sgxquoteexloader.c
@@ -1,0 +1,146 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#if defined(OE_LINK_SGX_DCAP_QL)
+
+#if __has_include(<sgx_uae_quote_ex.h>) && __has_include(<sgx_urts.h>)
+#define OE_LINK_SGX_QUOTE_EX
+#include <Windows.h>
+#include <openenclave/internal/defs.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/trace.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../../../common/oe_host_stdlib.h"
+#include "../sgxquote_ex.h"
+#endif
+
+#ifdef OE_LINK_SGX_QUOTE_EX
+
+static const char* _quote_ex_library_file_name = "libsgx_quote_ex.dll";
+
+static oe_sgx_quote_ex_library_t* _quote_ex_library = NULL;
+
+static void _unload_quote_ex_library(void)
+{
+    if (_quote_ex_library && _quote_ex_library->handle)
+    {
+        OE_TRACE_INFO(
+            "_unload_quote_ex_library() %s\n", _quote_ex_library_file_name);
+        FreeLibrary((HMODULE)_quote_ex_library->handle);
+        _quote_ex_library->handle = 0;
+        if (_quote_ex_library->mapped)
+        {
+            oe_free(_quote_ex_library->mapped);
+            _quote_ex_library->mapped = NULL;
+        }
+        if (_quote_ex_library->uuid)
+        {
+            oe_free(_quote_ex_library->uuid);
+            _quote_ex_library->uuid = NULL;
+        }
+        if (_quote_ex_library->sgx_key_id)
+        {
+            oe_free(_quote_ex_library->sgx_key_id);
+            _quote_ex_library->sgx_key_id = NULL;
+        }
+    }
+}
+
+void oe_load_quote_ex_library(oe_sgx_quote_ex_library_t* library)
+{
+    oe_result_t result = OE_UNEXPECTED;
+
+    if (!library)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    _quote_ex_library = library;
+
+    if (library->handle == 0)
+    {
+        HMODULE _handle = 0;
+        OE_TRACE_INFO(
+            "oe_load_quote_ex_library() %s", _quote_ex_library_file_name);
+        _handle = LoadLibraryEx(_quote_ex_library_file_name, NULL, 0);
+
+        if (_handle != 0)
+        {
+            library->sgx_select_att_key_id =
+                (sgx_select_att_key_id_t)GetProcAddress(
+                    _handle, SGX_SELECT_ATT_KEY_ID_NAME);
+            if (!library->sgx_select_att_key_id)
+            {
+                OE_TRACE_ERROR(
+                    "sgxquoteexprovider: sgx_select_att_key_id not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+            library->sgx_init_quote_ex = (sgx_init_quote_ex_t)GetProcAddress(
+                _handle, SGX_INIT_QUOTE_EX_NAME);
+            if (!library->sgx_init_quote_ex)
+            {
+                OE_TRACE_ERROR(
+                    "sgxquoteexprovider: sgx_init_quote_ex not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+            library->sgx_get_quote_size_ex =
+                (sgx_get_quote_size_ex_t)GetProcAddress(
+                    _handle, SGX_GET_QUOTE_SIZE_NAME);
+            if (!library->sgx_get_quote_size_ex)
+            {
+                OE_TRACE_ERROR(
+                    "sgxquoteexprovider: sgx_get_quote_size_ex not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+            library->sgx_get_quote_ex = (sgx_get_quote_ex_t)GetProcAddress(
+                _handle, SGX_GET_QUOTE_EX_NAME);
+            if (!library->sgx_get_quote_ex)
+            {
+                OE_TRACE_ERROR(
+                    "sgxquoteexprovider: sgx_get_quote_ex not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+            library->sgx_get_supported_att_key_id_num =
+                (sgx_get_supported_att_key_id_num_t)GetProcAddress(
+                    _handle, SGX_GET_SUPPORTED_ATT_KEY_ID_NUM_NAME);
+            if (!library->sgx_get_supported_att_key_id_num)
+            {
+                OE_TRACE_ERROR("sgxquoteexprovider: "
+                               "sgx_get_supported_att_key_id_num not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+            library->sgx_get_supported_att_key_ids =
+                (sgx_get_supported_att_key_ids_t)GetProcAddress(
+                    _handle, SGX_GET_SUPPORTED_ATT_KEY_IDS_NAME);
+            if (!library->sgx_get_supported_att_key_ids)
+            {
+                OE_TRACE_ERROR("sgxquoteexprovider: "
+                               "sgx_get_supported_att_key_ids not fuond\n");
+                OE_RAISE(OE_PLATFORM_ERROR);
+            }
+
+            atexit(_unload_quote_ex_library);
+
+            library->handle = _handle;
+            result = OE_OK;
+        }
+        else
+        {
+            OE_TRACE_ERROR(
+                "sgxquoteexprovider: failed to load %s: error=%#x\n",
+                _quote_ex_library_file_name,
+                GetLastError());
+
+            library->handle = 0;
+            result = OE_NOT_FOUND;
+        }
+    }
+
+done:
+    library->load_result = result;
+    if (result != OE_OK)
+        _unload_quote_ex_library();
+}
+
+#endif // OE_LINK_SGX_QUOTE_EX
+
+#endif // OE_LINK_SGX_DCAP_QL

--- a/tests/attestation_plugin/enc/enc.c
+++ b/tests/attestation_plugin/enc/enc.c
@@ -23,6 +23,9 @@ static const oe_uuid_t _ecdsa_report_uuid = {
     OE_FORMAT_UUID_SGX_ECDSA_P256_REPORT};
 static const oe_uuid_t _ecdsa_quote_uuid = {
     OE_FORMAT_UUID_SGX_ECDSA_P256_QUOTE};
+static const oe_uuid_t _epid_linkable_uuid = {OE_FORMAT_UUID_SGX_EPID_LINKABLE};
+static const oe_uuid_t _epid_unlinkable_uuid = {
+    OE_FORMAT_UUID_SGX_EPID_UNLINKABLE};
 
 void run_runtime_test()
 {
@@ -214,6 +217,62 @@ static void _test_sgx_remote()
         0);
     OE_TEST(oe_free_evidence(evidence) == OE_OK);
     OE_TEST(oe_free_endorsements(endorsements) == OE_OK);
+
+    if (oe_attester_select_format(&_epid_linkable_uuid, 1, &selected_format) ==
+        OE_OK)
+    {
+        uint8_t spid[16] = "SPID";
+
+        printf("====== running _test_sgx_remote #6: get EPID evidence\n");
+
+        OE_TEST_CODE(
+            oe_get_evidence(
+                &_epid_linkable_uuid,
+                0,
+                NULL,
+                0,
+                NULL,
+                0,
+                &evidence,
+                &evidence_size,
+                &endorsements,
+                &endorsements_size),
+            OE_OK);
+        OE_TEST(oe_free_evidence(evidence) == OE_OK);
+        OE_TEST(oe_free_endorsements(endorsements) == OE_OK);
+
+        OE_TEST_CODE(
+            oe_get_evidence(
+                &_epid_unlinkable_uuid,
+                0,
+                NULL,
+                0,
+                spid,
+                sizeof(spid),
+                &evidence,
+                &evidence_size,
+                &endorsements,
+                &endorsements_size),
+            OE_OK);
+        OE_TEST(oe_free_evidence(evidence) == OE_OK);
+        OE_TEST(oe_free_endorsements(endorsements) == OE_OK);
+
+        OE_TEST_CODE(
+            oe_get_evidence(
+                &_epid_unlinkable_uuid,
+                0,
+                NULL,
+                0,
+                spid,
+                1,
+                &evidence,
+                &evidence_size,
+                &endorsements,
+                &endorsements_size),
+            OE_INVALID_PARAMETER);
+    }
+    else
+        printf("====== note: _test_sgx_remote #6: EPID not supported\n");
 
     printf("====== done _test_sgx_remote\n");
 }


### PR DESCRIPTION
The quote-ex library is detected and loaded at run-time.

Compilation of the host-side library depends on the installation of the Intel SGX SDK in its default directory.
