### PR TITLE
Cleanup: OE_LINK_SGX_DCAP_QL -> OE_HAS_SGX_DCAP_QL

### DIFF
--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -16,7 +16,7 @@
 #include "quote.h"
 #include "report.h"
 
-#if defined(OE_LINK_SGX_DCAP_QL) && !defined(OE_BUILD_ENCLAVE)
+#if defined(OE_HAS_SGX_DCAP_QL) && !defined(OE_BUILD_ENCLAVE)
 #include "../../host/sgx/sgxquoteprovider.h"
 #endif
 
@@ -48,7 +48,7 @@ static oe_result_t _on_register(
     OE_UNUSED(configuration_data);
     OE_UNUSED(configuration_data_size);
 
-#if defined(OE_BUILD_ENCLAVE) || !defined(OE_LINK_SGX_DCAP_QL)
+#if defined(OE_BUILD_ENCLAVE) || !defined(OE_HAS_SGX_DCAP_QL)
     return OE_OK;
 #else
     return oe_initialize_quote_provider();

--- a/devex/vsextension/msbuild/open-enclave-cross.targets
+++ b/devex/vsextension/msbuild/open-enclave-cross.targets
@@ -292,8 +292,8 @@
     <ItemDefinitionGroup Condition="'$(OEType)' == 'Enclave'">
         <ClCompile>
             <!-- SGX Hardware and Simulation -->
-            <PreprocessorDefinitions Condition="$(OEIsSgx) == True And $(OEIsDebug) == True">OE_NO_SAL;OE_API_VERSION=2;OE_BUILD_ENCLAVE;OE_LINK_SGX_DCAP_QL;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-            <PreprocessorDefinitions Condition="$(OEIsSgx) == True And $(OEIsDebug) == False">OE_NO_SAL;OE_API_VERSION=2;OE_BUILD_ENCLAVE;OE_LINK_SGX_DCAP_QL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+            <PreprocessorDefinitions Condition="$(OEIsSgx) == True And $(OEIsDebug) == True">OE_NO_SAL;OE_API_VERSION=2;OE_BUILD_ENCLAVE;OE_HAS_SGX_DCAP_QL;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+            <PreprocessorDefinitions Condition="$(OEIsSgx) == True And $(OEIsDebug) == False">OE_NO_SAL;OE_API_VERSION=2;OE_BUILD_ENCLAVE;OE_HAS_SGX_DCAP_QL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 
             <!-- OP-TEE Simulation -->
             <PreprocessorDefinitions Condition="$(OEIsTz) == True And $(OEIsSim) == True And $(OEIsDebug) == True">OE_SIMULATE_OPTEE;OE_API_VERSION=2;OE_BUILD_ENCLAVE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -321,7 +321,7 @@ enclave_compile_definitions(
   $<BUILD_INTERFACE:OE_API_VERSION=2>)
 
 if (HAS_QUOTE_PROVIDER)
-  enclave_compile_definitions(oecore PUBLIC OE_LINK_SGX_DCAP_QL)
+  enclave_compile_definitions(oecore PUBLIC OE_HAS_SGX_DCAP_QL)
 endif ()
 
 if (USE_DEBUG_MALLOC)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -485,8 +485,8 @@ if (OE_SGX)
     if (WIN32)
       target_include_directories(oehost PRIVATE ${INCPATHS})
     endif ()
-    # turn on 'OE_LINK_SGX_DCAP_QL' for the preprocessor
-    target_compile_definitions(oehost PUBLIC OE_LINK_SGX_DCAP_QL)
+    # turn on 'OE_HAS_SGX_DCAP_QL' for the preprocessor
+    target_compile_definitions(oehost PUBLIC OE_HAS_SGX_DCAP_QL)
   endif ()
 endif ()
 

--- a/host/sgx/ocalls.c
+++ b/host/sgx/ocalls.c
@@ -118,7 +118,7 @@ oe_result_t oe_get_quote_ocall(
     return result;
 }
 
-#if defined(OE_LINK_SGX_DCAP_QL)
+#if defined(OE_HAS_SGX_DCAP_QL)
 
 /* Copy the source array to an output buffer. */
 static oe_result_t _copy_output_buffer(
@@ -267,7 +267,7 @@ done:
     return result;
 }
 
-#else /* !defined(OE_LINK_SGX_DCAP_QL) */
+#else /* !defined(OE_HAS_SGX_DCAP_QL) */
 
 oe_result_t oe_get_quote_verification_collateral_ocall(
     uint8_t fmspc[6],
@@ -319,7 +319,7 @@ oe_result_t oe_get_quote_verification_collateral_ocall(
     return OE_UNSUPPORTED;
 }
 
-#endif /* !defined(OE_LINK_SGX_DCAP_QL) */
+#endif /* !defined(OE_HAS_SGX_DCAP_QL) */
 
 oe_result_t oe_get_qetarget_info_ocall(
     const oe_uuid_t* format_id,

--- a/host/sgx/quote.c
+++ b/host/sgx/quote.c
@@ -10,7 +10,7 @@
 #include <openenclave/internal/safecrt.h>
 #include <openenclave/internal/utils.h>
 
-#if defined(OE_LINK_SGX_DCAP_QL)
+#if defined(OE_HAS_SGX_DCAP_QL)
 #include "sgxquote.h"
 #include "sgxquoteprovider.h"
 #endif
@@ -28,7 +28,7 @@ oe_result_t sgx_get_qetarget_info(
 
     memset(target_info, 0, sizeof(sgx_target_info_t));
 
-#if defined(OE_LINK_SGX_DCAP_QL)
+#if defined(OE_HAS_SGX_DCAP_QL)
     // Quote workflow always begins with obtaining the target info. Therefore
     // initializing the quote provider here ensures that that we can control its
     // life time rather than Intel's attestation libraries.
@@ -63,7 +63,7 @@ oe_result_t sgx_get_quote_size(
     if (!quote_size)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-#if defined(OE_LINK_SGX_DCAP_QL)
+#if defined(OE_HAS_SGX_DCAP_QL)
     result = oe_sgx_qe_get_quote_size(
         format_id, opt_params, opt_params_size, quote_size);
 #else
@@ -112,7 +112,7 @@ oe_result_t sgx_get_quote(
 
     /* Get the quote from the AESM service */
 
-#if defined(OE_LINK_SGX_DCAP_QL)
+#if defined(OE_HAS_SGX_DCAP_QL)
     result = oe_sgx_qe_get_quote(
         format_id,
         opt_params,
@@ -138,7 +138,7 @@ oe_result_t sgx_get_supported_attester_format_ids(
     if (!format_ids && !format_ids_size)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-#if defined(OE_LINK_SGX_DCAP_QL)
+#if defined(OE_HAS_SGX_DCAP_QL)
     result =
         oe_sgx_get_supported_attester_format_ids(format_ids, format_ids_size);
 #else

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -242,7 +242,7 @@ oe_result_t oe_verify_report_internal(
     if (header->report_type == OE_REPORT_TYPE_SGX_REMOTE)
     {
         // Intialize the quote provider if we want to verify a remote quote.
-        // Note that we don't have the OE_LINK_SGX_DCAP_QL guard here since we
+        // Note that we don't have the OE_HAS_SGX_DCAP_QL guard here since we
         // don't need the sgx libraries to verify the quote. All we need is the
         // quote provider.
         OE_CHECK(oe_initialize_quote_provider());

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -1,6 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
-#if defined(OE_LINK_SGX_DCAP_QL)
+#if defined(OE_HAS_SGX_DCAP_QL)
 
 #include "sgxquote.h"
 #include <openenclave/attestation/sgx/evidence.h>

--- a/tests/attestation_cert_apis/host/host.cpp
+++ b/tests/attestation_cert_apis/host/host.cpp
@@ -130,7 +130,7 @@ void run_test(oe_enclave_t* enclave, int test_type)
 
 int main(int argc, const char* argv[])
 {
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
 
 #ifdef _WIN32
     /* This is a workaround for running in Visual Studio 2017 Test Explorer

--- a/tests/attestation_plugin/host/host.c
+++ b/tests/attestation_plugin/host/host.c
@@ -38,7 +38,7 @@ void host_verify(
 
 int main(int argc, const char* argv[])
 {
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
 
 #ifdef _WIN32
     /* This is a workaround for running in Visual Studio 2017 Test Explorer

--- a/tests/debug-mode/host/host.c
+++ b/tests/debug-mode/host/host.c
@@ -68,7 +68,7 @@ static void _test_debug_signed(const char* path)
 {
     /* Signed debug mode should always pass. */
     _launch_enclave_success(path, _create_flags(true));
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
     /* Only works with FLC */
     _launch_enclave_success(path, _create_flags(false));
 #endif
@@ -85,7 +85,7 @@ static void _test_non_debug_signed(const char* path)
 {
     /* Debug mode should fail. Non-debug mode should pass. */
     _launch_enclave_fail(path, _create_flags(true), OE_DEBUG_DOWNGRADE);
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
     /* Only works with FLC */
     _launch_enclave_success(path, _create_flags(false));
 #endif

--- a/tests/eeid_plugin/host/host.c
+++ b/tests/eeid_plugin/host/host.c
@@ -286,7 +286,7 @@ void multiple_enclaves_tests(const char* filename, uint32_t flags)
 
 int main(int argc, const char* argv[])
 {
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
     if (argc != 2)
     {
         fprintf(stderr, "Usage: %s ENCLAVE\n", argv[0]);

--- a/tests/qeidentity/enc/enc.cpp
+++ b/tests/qeidentity/enc/enc.cpp
@@ -17,7 +17,7 @@ oe_result_t test_verify_qe_identity_info(
     oe_qe_identity_info_tcb_level_t* platform_tcb_level,
     oe_parsed_qe_identity_info_t* parsed_info)
 {
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
     return oe_parse_qe_identity_info_json(
         (const uint8_t*)info_json,
         strlen(info_json) + 1,

--- a/tests/qeidentity/host/CMakeLists.txt
+++ b/tests/qeidentity/host/CMakeLists.txt
@@ -13,7 +13,7 @@ add_custom_command(
 add_executable(qeidentity_host host.cpp qeidentifyinfo.cpp tests_u.c)
 
 if (HAS_QUOTE_PROVIDER)
-  target_compile_definitions(qeidentity_host PRIVATE OE_LINK_SGX_DCAP_QL)
+  target_compile_definitions(qeidentity_host PRIVATE OE_HAS_SGX_DCAP_QL)
 endif ()
 
 add_custom_command(

--- a/tests/qeidentity/host/host.cpp
+++ b/tests/qeidentity/host/host.cpp
@@ -47,7 +47,7 @@ int main(int argc, const char* argv[])
         oe_put_err("oe_create_enclave(): result=%u", result);
     }
 
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
 
     run_parse_advisoryids_json_test();
     run_qe_identity_test_cases(enclave);

--- a/tests/qeidentity/host/qeidentifyinfo.cpp
+++ b/tests/qeidentity/host/qeidentifyinfo.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
 
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>

--- a/tests/report/common/tests.cpp
+++ b/tests/report/common/tests.cpp
@@ -175,7 +175,7 @@ static oe_result_t oe_verify_report_with_collaterals(
     {
 #ifndef OE_BUILD_ENCLAVE
         // Intialize the quote provider if we want to verify a remote quote.
-        // Note that we don't have the OE_LINK_SGX_DCAP_QL guard here since we
+        // Note that we don't have the OE_HAS_SGX_DCAP_QL guard here since we
         // don't need the sgx libraries to verify the quote. All we need is the
         // quote provider.
         OE_CHECK(oe_initialize_quote_provider());
@@ -285,7 +285,7 @@ static oe_result_t oe_get_quote_validity_with_collaterals(
     {
 #ifndef OE_BUILD_ENCLAVE
         // Intialize the quote provider if we want to verify a remote quote.
-        // Note that we don't have the OE_LINK_SGX_DCAP_QL guard here since we
+        // Note that we don't have the OE_HAS_SGX_DCAP_QL guard here since we
         // don't need the sgx libraries to verify the quote. All we need is the
         // quote provider.
         OE_CHECK(oe_initialize_quote_provider());

--- a/tests/report/enc/enc.cpp
+++ b/tests/report/enc/enc.cpp
@@ -17,7 +17,7 @@ oe_result_t test_verify_tcb_info(
     oe_tcb_info_tcb_level_t* platform_tcb_level,
     oe_parsed_tcb_info_t* parsed_tcb_info)
 {
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
     return oe_parse_tcb_info_json(
         (const uint8_t*)tcb_info,
         strlen(tcb_info) + 1,
@@ -33,7 +33,7 @@ oe_result_t test_verify_tcb_info(
 
 void test_minimum_issue_date(oe_datetime_t now)
 {
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
     static uint8_t* report;
     size_t report_size = 0;
     static uint8_t* report_v2;

--- a/tests/report/host/CMakeLists.txt
+++ b/tests/report/host/CMakeLists.txt
@@ -15,7 +15,7 @@ add_custom_command(
 add_executable(report_host host.cpp tcbinfo.cpp ../common/tests.cpp tests_u.c)
 
 if (HAS_QUOTE_PROVIDER)
-  target_compile_definitions(report_host PRIVATE OE_LINK_SGX_DCAP_QL)
+  target_compile_definitions(report_host PRIVATE OE_HAS_SGX_DCAP_QL)
 endif ()
 
 add_custom_command(

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -36,7 +36,7 @@ extern int FileToBytes(const char* path, std::vector<uint8_t>* output);
 
 void generate_and_save_report(oe_enclave_t* enclave)
 {
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
     static uint8_t* report;
     size_t report_size;
     OE_TEST_CODE(
@@ -159,7 +159,7 @@ int main(int argc, const char* argv[])
      */
     g_enclave = enclave;
 
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
 
     static oe_uuid_t sgx_ecdsa_uuid = {OE_FORMAT_UUID_SGX_ECDSA_P256};
 

--- a/tests/tls_e2e/client_enc/CMakeLists.txt
+++ b/tests/tls_e2e/client_enc/CMakeLists.txt
@@ -20,7 +20,7 @@ add_enclave(
   tls_e2e_t.c)
 
 if (HAS_QUOTE_PROVIDER)
-  enclave_compile_definitions(tls_client_enc PRIVATE OE_LINK_SGX_DCAP_QL)
+  enclave_compile_definitions(tls_client_enc PRIVATE OE_HAS_SGX_DCAP_QL)
 endif ()
 
 set_source_files_properties(tls_e2e_t.c PROPERTIES COMPILE_FLAGS

--- a/tests/tls_e2e/host/host.cpp
+++ b/tests/tls_e2e/host/host.cpp
@@ -346,7 +346,7 @@ done:
 
 int main(int argc, const char* argv[])
 {
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
     oe_result_t result = OE_FAILURE;
     uint32_t flags = OE_ENCLAVE_FLAG_DEBUG;
     int ret = 0;
@@ -402,12 +402,11 @@ done:
 
     return 0;
 #else
-    // this test should not run on any platforms where OE_LINK_SGX_DCAP_QL is
+    // this test should not run on any platforms where OE_HAS_SGX_DCAP_QL is
     // not defined
     OE_UNUSED(argc);
     OE_UNUSED(argv);
-    OE_TRACE_INFO(
-        "=== tests skipped when built with OE_LINK_SGX_DCAP_QL=OFF\n");
+    OE_TRACE_INFO("=== tests skipped when built with OE_HAS_SGX_DCAP_QL=OFF\n");
     return SKIP_RETURN_CODE;
 #endif
 }

--- a/tests/tls_e2e/server_enc/CMakeLists.txt
+++ b/tests/tls_e2e/server_enc/CMakeLists.txt
@@ -13,7 +13,7 @@ add_custom_command(
 add_enclave(TARGET tls_server_enc SOURCES server.cpp ../common/utility.cpp
             ${CMAKE_CURRENT_BINARY_DIR}/tls_e2e_t.c)
 if (HAS_QUOTE_PROVIDER)
-  enclave_compile_definitions(tls_server_enc PRIVATE OE_LINK_SGX_DCAP_QL)
+  enclave_compile_definitions(tls_server_enc PRIVATE OE_HAS_SGX_DCAP_QL)
 endif ()
 
 set_source_files_properties(tls_e2e_t.c PROPERTIES COMPILE_FLAGS

--- a/tests/tools/oecert/host/host.cpp
+++ b/tests/tools/oecert/host/host.cpp
@@ -12,7 +12,7 @@
 
 #include "../../../../common/sgx/endorsements.h"
 
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
 
 #define INPUT_PARAM_OPTION_CERT "--cert"
 #define INPUT_PARAM_OPTION_REPORT "--report"
@@ -472,13 +472,13 @@ static oe_result_t _process_params(oe_enclave_t* enclave)
     return result;
 }
 
-#endif // OE_LINK_SGX_DCAP_QL
+#endif // OE_HAS_SGX_DCAP_QL
 
 int main(int argc, const char* argv[])
 {
     int ret = 0;
 
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
     oe_result_t result;
     oe_enclave_t* enclave = NULL;
 
@@ -515,7 +515,7 @@ int main(int argc, const char* argv[])
 exit:
 #else
 #pragma message( \
-    "OE_LINK_SGX_DCAP_QL is not set to ON.  This tool requires DCAP libraries.")
+    "OE_HAS_SGX_DCAP_QL is not set to ON.  This tool requires DCAP libraries.")
     OE_UNUSED(argc);
     OE_UNUSED(argv);
 #endif

--- a/tests/tools/oecertdump/host/CMakeLists.txt
+++ b/tests/tools/oecertdump/host/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(oecertdump PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
 target_link_libraries(oecertdump oehost OpenSSL::SSL)
 
 if (HAS_QUOTE_PROVIDER)
-  target_compile_definitions(oecertdump PRIVATE OE_LINK_SGX_DCAP_QL)
+  target_compile_definitions(oecertdump PRIVATE OE_HAS_SGX_DCAP_QL)
 endif ()
 
 # The X509_print_ex_fp function in OpenSSL requires to include applink.c, which

--- a/tests/tools/oecertdump/host/host.cpp
+++ b/tests/tools/oecertdump/host/host.cpp
@@ -13,7 +13,7 @@
 
 #include "sgx_quote.h"
 
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
 
 #define INPUT_PARAM_USAGE "--help"
 #define INPUT_PARAM_OUT_FILE "--out"
@@ -272,13 +272,13 @@ static oe_result_t _process_params(oe_enclave_t* enclave)
     return result;
 }
 
-#endif // OE_LINK_SGX_DCAP_QL
+#endif // OE_HAS_SGX_DCAP_QL
 
 int main(int argc, const char* argv[])
 {
     int ret = 0;
 
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
     oe_result_t result;
     oe_enclave_t* enclave = nullptr;
 
@@ -349,7 +349,7 @@ exit:
 
 #else
 #pragma message( \
-    "OE_LINK_SGX_DCAP_QL is not set to ON.  This tool requires DCAP libraries.")
+    "OE_HAS_SGX_DCAP_QL is not set to ON.  This tool requires DCAP libraries.")
     OE_UNUSED(argc);
     OE_UNUSED(argv);
     printf("oecertdump requires DCAP libraries.\n");

--- a/tests/tools/oecertdump/host/sgx_quote.cpp
+++ b/tests/tools/oecertdump/host/sgx_quote.cpp
@@ -28,7 +28,7 @@
 #include "../../../../common/sgx/quote.h"
 #include "../../../../host/sgx/sgxquoteprovider.h"
 
-#ifdef OE_LINK_SGX_DCAP_QL
+#ifdef OE_HAS_SGX_DCAP_QL
 
 extern FILE* log_file;
 
@@ -574,4 +574,4 @@ oe_result_t get_sgx_report_from_certificate(
     return result;
 }
 
-#endif // OE_LINK_SGX_DCAP_QL
+#endif // OE_HAS_SGX_DCAP_QL


### PR DESCRIPTION
The SDK no longer links against sgx_dcap_ql.so; instead
it is dynamically loaded.

Refer to #3272 for the bigger picture.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>