### PR TITLE
Remove use of OE_LINK_SGX_DCAP_QL when building SDK libraries.

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -320,10 +320,6 @@ enclave_compile_definitions(
   # package.
   $<BUILD_INTERFACE:OE_API_VERSION=2>)
 
-if (HAS_QUOTE_PROVIDER)
-  enclave_compile_definitions(oecore PUBLIC OE_HAS_SGX_DCAP_QL)
-endif ()
-
 if (USE_DEBUG_MALLOC)
   enclave_compile_definitions(oecore PRIVATE OE_USE_DEBUG_MALLOC)
   message(

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -485,8 +485,6 @@ if (OE_SGX)
     if (WIN32)
       target_include_directories(oehost PRIVATE ${INCPATHS})
     endif ()
-    # turn on 'OE_HAS_SGX_DCAP_QL' for the preprocessor
-    target_compile_definitions(oehost PUBLIC OE_HAS_SGX_DCAP_QL)
   endif ()
 endif ()
 

--- a/host/sgx/ocalls.c
+++ b/host/sgx/ocalls.c
@@ -118,8 +118,6 @@ oe_result_t oe_get_quote_ocall(
     return result;
 }
 
-#if defined(OE_HAS_SGX_DCAP_QL)
-
 /* Copy the source array to an output buffer. */
 static oe_result_t _copy_output_buffer(
     void* dest,
@@ -266,60 +264,6 @@ done:
 
     return result;
 }
-
-#else /* !defined(OE_HAS_SGX_DCAP_QL) */
-
-oe_result_t oe_get_quote_verification_collateral_ocall(
-    uint8_t fmspc[6],
-    void* tcb_info,
-    size_t tcb_info_size,
-    size_t* tcb_info_size_out,
-    void* tcb_info_issuer_chain,
-    size_t tcb_info_issuer_chain_size,
-    size_t* tcb_info_issuer_chain_size_out,
-    void* pck_crl,
-    size_t pck_crl_size,
-    size_t* pck_crl_size_out,
-    void* root_ca_crl,
-    size_t root_ca_crl_size,
-    size_t* root_ca_crl_size_out,
-    void* pck_crl_issuer_chain,
-    size_t pck_crl_issuer_chain_size,
-    size_t* pck_crl_issuer_chain_size_out,
-    void* qe_identity,
-    size_t qe_identity_size,
-    size_t* qe_identity_size_out,
-    void* qe_identity_issuer_chain,
-    size_t qe_identity_issuer_chain_size,
-    size_t* qe_identity_issuer_chain_size_out)
-{
-    OE_UNUSED(fmspc);
-    OE_UNUSED(tcb_info);
-    OE_UNUSED(tcb_info_size);
-    OE_UNUSED(tcb_info_size_out);
-    OE_UNUSED(tcb_info_issuer_chain);
-    OE_UNUSED(tcb_info_issuer_chain_size);
-    OE_UNUSED(tcb_info_issuer_chain_size_out);
-    OE_UNUSED(pck_crl);
-    OE_UNUSED(pck_crl_size);
-    OE_UNUSED(pck_crl_size_out);
-    OE_UNUSED(root_ca_crl);
-    OE_UNUSED(root_ca_crl_size);
-    OE_UNUSED(root_ca_crl_size_out);
-    OE_UNUSED(pck_crl_issuer_chain);
-    OE_UNUSED(pck_crl_issuer_chain_size);
-    OE_UNUSED(pck_crl_issuer_chain_size_out);
-    OE_UNUSED(qe_identity);
-    OE_UNUSED(qe_identity_size);
-    OE_UNUSED(qe_identity_size_out);
-    OE_UNUSED(qe_identity_issuer_chain);
-    OE_UNUSED(qe_identity_issuer_chain_size);
-    OE_UNUSED(qe_identity_issuer_chain_size_out);
-
-    return OE_UNSUPPORTED;
-}
-
-#endif /* !defined(OE_HAS_SGX_DCAP_QL) */
 
 oe_result_t oe_get_qetarget_info_ocall(
     const oe_uuid_t* format_id,

--- a/host/sgx/quote.c
+++ b/host/sgx/quote.c
@@ -10,10 +10,8 @@
 #include <openenclave/internal/safecrt.h>
 #include <openenclave/internal/utils.h>
 
-#if defined(OE_HAS_SGX_DCAP_QL)
 #include "sgxquote.h"
 #include "sgxquoteprovider.h"
-#endif
 
 oe_result_t sgx_get_qetarget_info(
     const oe_uuid_t* format_id,
@@ -28,7 +26,6 @@ oe_result_t sgx_get_qetarget_info(
 
     memset(target_info, 0, sizeof(sgx_target_info_t));
 
-#if defined(OE_HAS_SGX_DCAP_QL)
     // Quote workflow always begins with obtaining the target info. Therefore
     // initializing the quote provider here ensures that that we can control its
     // life time rather than Intel's attestation libraries.
@@ -39,9 +36,6 @@ oe_result_t sgx_get_qetarget_info(
     OE_CHECK(oe_sgx_qe_get_target_info(
         format_id, opt_params, opt_params_size, (uint8_t*)target_info));
     result = OE_OK;
-#else
-    result = OE_UNSUPPORTED;
-#endif
 done:
     return result;
 }
@@ -63,12 +57,8 @@ oe_result_t sgx_get_quote_size(
     if (!quote_size)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-#if defined(OE_HAS_SGX_DCAP_QL)
     result = oe_sgx_qe_get_quote_size(
         format_id, opt_params, opt_params_size, quote_size);
-#else
-    result = OE_UNSUPPORTED;
-#endif
 
 done:
     return result;
@@ -111,8 +101,6 @@ oe_result_t sgx_get_quote(
     memset(quote, 0, *quote_size);
 
     /* Get the quote from the AESM service */
-
-#if defined(OE_HAS_SGX_DCAP_QL)
     result = oe_sgx_qe_get_quote(
         format_id,
         opt_params,
@@ -120,9 +108,6 @@ oe_result_t sgx_get_quote(
         (uint8_t*)report,
         *quote_size,
         quote);
-#else
-    result = OE_UNSUPPORTED;
-#endif
 
 done:
 
@@ -138,14 +123,8 @@ oe_result_t sgx_get_supported_attester_format_ids(
     if (!format_ids && !format_ids_size)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-#if defined(OE_HAS_SGX_DCAP_QL)
     result =
         oe_sgx_get_supported_attester_format_ids(format_ids, format_ids_size);
-#else
-    // No supported format ID
-    *format_ids_size = 0;
-    result = OE_OK;
-#endif
 
 done:
     return result;

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -242,9 +242,8 @@ oe_result_t oe_verify_report_internal(
     if (header->report_type == OE_REPORT_TYPE_SGX_REMOTE)
     {
         // Intialize the quote provider if we want to verify a remote quote.
-        // Note that we don't have the OE_HAS_SGX_DCAP_QL guard here since we
-        // don't need the sgx libraries to verify the quote. All we need is the
-        // quote provider.
+        // Note that we don't need the sgx libraries to verify the quote. All we
+        // need is the quote provider.
         OE_CHECK(oe_initialize_quote_provider());
 
         // Quote attestation can be done entirely on the host side.

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -1,6 +1,5 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
-#if defined(OE_HAS_SGX_DCAP_QL)
 
 #include "sgxquote.h"
 #include <openenclave/attestation/sgx/evidence.h>
@@ -235,5 +234,3 @@ oe_result_t oe_sgx_get_supported_attester_format_ids(
 done:
     return result;
 }
-
-#endif

--- a/tests/qeidentity/enc/CMakeLists.txt
+++ b/tests/qeidentity/enc/CMakeLists.txt
@@ -20,7 +20,7 @@ add_enclave(
   ${CMAKE_CURRENT_BINARY_DIR}/tests_t.c)
 
 if (HAS_QUOTE_PROVIDER)
-  enclave_compile_definitions(qeidentity_enc PRIVATE HAS_QUOTE_PROVIDER)
+  enclave_compile_definitions(qeidentity_enc PRIVATE OE_HAS_SGX_DCAP_QL)
 endif ()
 
 enclave_include_directories(qeidentity_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}

--- a/tests/report/enc/CMakeLists.txt
+++ b/tests/report/enc/CMakeLists.txt
@@ -21,6 +21,10 @@ add_enclave(
   ../common/tests.cpp
   tests_t.c)
 
+if (HAS_QUOTE_PROVIDER)
+  enclave_compile_definitions(report_enc PRIVATE OE_HAS_SGX_DCAP_QL)
+endif ()
+
 enclave_include_directories(report_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                             ${CMAKE_CURRENT_SOURCE_DIR}/../common)
 

--- a/tests/tools/oecert/host/CMakeLists.txt
+++ b/tests/tools/oecert/host/CMakeLists.txt
@@ -9,5 +9,9 @@ add_custom_command(
 
 add_executable(oecert host.cpp ${CMAKE_CURRENT_BINARY_DIR}/oecert_u.c)
 
+if (HAS_QUOTE_PROVIDER)
+  target_compile_definitions(oecert PRIVATE OE_HAS_SGX_DCAP_QL)
+endif ()
+
 target_include_directories(oecert PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(oecert oehost)


### PR DESCRIPTION
This ensures that the same library is produced irrespective of
the value of HAS_QUOTE_PROVIDER cmake option.

Tests still use OE_LINK_SGX_DCAP_QL; such uses will be evaluated
and replaced in future PRs.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>