### PR TITLE
Remove dependency on sgx_dcap_ql_wrapper.h for building SDK.

### DIFF
--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -4,11 +4,11 @@
 
 #include "sgxquote.h"
 #include <openenclave/attestation/sgx/evidence.h>
+#include <openenclave/bits/sgx/sgxtypes.h>
 #include <openenclave/internal/defs.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/sgx/plugin.h>
 #include <openenclave/internal/trace.h>
-#include <sgx_dcap_ql_wrapper.h>
 #include <stdlib.h>
 #include <string.h>
 #include "../hostthread.h"

--- a/include/openenclave/bits/sgx/sgxtypes.h
+++ b/include/openenclave/bits/sgx/sgxtypes.h
@@ -1035,6 +1035,17 @@ typedef struct _sgx_key
 #define OE_SEALKEY_DEFAULT_MISCMASK (~SGX_MISC_NON_SECURITY_BITS)
 #define OE_SEALKEY_DEFAULT_XFRMMASK (0X0ULL)
 
+#define SGX_QL_MK_ERROR(x) (0x0000E000 | (x))
+
+// clang-format off
+/** Define quote3_error_t enumerations  used by OE attestation code. */
+typedef enum _quote3_error_t {
+    SGX_QL_SUCCESS = 0x0000,                                         ///< Success
+    SGX_QL_ERROR_UNEXPECTED = SGX_QL_MK_ERROR(0x0001),               ///< Unexpected error
+    SGX_QL_ERROR_MAX = SGX_QL_MK_ERROR(0x00FF),                      ///< Indicate max error to allow better translation.
+} quote3_error_t;
+// clang-format on
+
 OE_EXTERNC_END
 
 #endif /* _OE_SGXTYPES_H */


### PR DESCRIPTION
With this change, OE SDK with full attestation support,
can be built on a machine without any Intel SGX SDK headers.

This is a prerequisite for removing HAS_QUOTE_PROVIDER/OE_HAS_SGX_DCAP_QL
cmake option/define when building OE SDK.

See Meta-Issue: #3272 

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>