### PR TITLE
Update docs to reflect support for socket and netdb

### DIFF
--- a/docs/LibcSupport.md
+++ b/docs/LibcSupport.md
@@ -15,8 +15,10 @@ limits.h | Yes | - |
 locale.h | Partial | Only basic support for C/POSIX locale |
 malloc.h | Partial | - |
 math.h | Partial | **Unsupported functions:** fmal(), tgamma() |
+netdb.h | Partial | Functions implicitly call out to untrusted host. **Supported functions:** getaddrinfo(), freeaddrinfo(), getnameinfo() |
 setjmp.h | Yes | - |
 signal.h | No | - |
+socket.h | Partial | Functions implicitly call out to untrusted host. <br> Full support available on Linux hosts. <br> **Unsupported functions on Windows hosts:**  recvmsg(), sendmsg(), socketpair() |
 stdalign.h | No | - |
 stdarg.h | Yes | - |
 stdatomic.h | No | - |


### PR DESCRIPTION
Signed-off-by: Radhika Jandhyala <radhikaj@microsoft.com>

Fixes #2847

Please note that there are still missings docs around other syscalls. Documentation for these is in progress. This is tracked by https://github.com/openenclave/openenclave/issues/3278. 