### PR TITLE
Docs:App cannot consume an OE SDK and an Intel SDK enclave

### DIFF
--- a/docs/GettingStartedDocs/APIs_and_Libs.md
+++ b/docs/GettingStartedDocs/APIs_and_Libs.md
@@ -25,3 +25,5 @@ The subset of [mbedtls](https://tls.mbed.org/) functionality for use inside an e
 ## [System EDL files](/docs/SystemEdls.md)
 
 The list of system EDL files that allow for user opt-in.
+
+Note: At this time, a single application consuming both an OE SDK enclave and an Intel SGX SDK enclave is an unsupported scenario. Issue #3174 tracks this scenario.


### PR DESCRIPTION
#3174 tracks validating that an application can consume both an Intel SGX SDK enclave and an OE SDK enclave. At this time, this scenario is untested. Adding a note to this effect per discussion in triage.