### PR TITLE
Remove OE_HAS_SGX_DCAP_QL define.

### DIFF
--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -16,7 +16,7 @@
 #include "quote.h"
 #include "report.h"
 
-#if defined(OE_HAS_SGX_DCAP_QL) && !defined(OE_BUILD_ENCLAVE)
+#if !defined(OE_BUILD_ENCLAVE)
 #include "../../host/sgx/sgxquoteprovider.h"
 #endif
 
@@ -48,7 +48,7 @@ static oe_result_t _on_register(
     OE_UNUSED(configuration_data);
     OE_UNUSED(configuration_data_size);
 
-#if defined(OE_BUILD_ENCLAVE) || !defined(OE_HAS_SGX_DCAP_QL)
+#if defined(OE_BUILD_ENCLAVE)
     return OE_OK;
 #else
     return oe_initialize_quote_provider();

--- a/devex/vsextension/msbuild/open-enclave-cross.targets
+++ b/devex/vsextension/msbuild/open-enclave-cross.targets
@@ -292,8 +292,8 @@
     <ItemDefinitionGroup Condition="'$(OEType)' == 'Enclave'">
         <ClCompile>
             <!-- SGX Hardware and Simulation -->
-            <PreprocessorDefinitions Condition="$(OEIsSgx) == True And $(OEIsDebug) == True">OE_NO_SAL;OE_API_VERSION=2;OE_BUILD_ENCLAVE;OE_HAS_SGX_DCAP_QL;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-            <PreprocessorDefinitions Condition="$(OEIsSgx) == True And $(OEIsDebug) == False">OE_NO_SAL;OE_API_VERSION=2;OE_BUILD_ENCLAVE;OE_HAS_SGX_DCAP_QL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+            <PreprocessorDefinitions Condition="$(OEIsSgx) == True And $(OEIsDebug) == True">OE_NO_SAL;OE_API_VERSION=2;OE_BUILD_ENCLAVE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+            <PreprocessorDefinitions Condition="$(OEIsSgx) == True And $(OEIsDebug) == False">OE_NO_SAL;OE_API_VERSION=2;OE_BUILD_ENCLAVE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 
             <!-- OP-TEE Simulation -->
             <PreprocessorDefinitions Condition="$(OEIsTz) == True And $(OEIsSim) == True And $(OEIsDebug) == True">OE_SIMULATE_OPTEE;OE_API_VERSION=2;OE_BUILD_ENCLAVE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -271,7 +271,8 @@ if (OE_SGX)
     sgx/sgxquote.c
     sgx/sgxsign.c
     sgx/sgxtypes.c
-    sgx/switchless.c)
+    sgx/switchless.c
+    sgx/tests.c)
 
   # OS specific as well.
   if (UNIX)

--- a/host/sgx/tests.c
+++ b/host/sgx/tests.c
@@ -1,0 +1,21 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/sgx/tests.h>
+#include "../hostthread.h"
+#include "sgxquoteprovider.h"
+
+static bool _has_quote_provider = false;
+
+static void _check_quote_provider(void)
+{
+    _has_quote_provider = (oe_initialize_quote_provider() == OE_OK);
+}
+
+bool oe_has_sgx_quote_provider(void)
+{
+    static oe_once_type once = OE_H_ONCE_INITIALIZER;
+    oe_once(&once, _check_quote_provider);
+    return _has_quote_provider;
+}

--- a/include/openenclave/internal/sgx/tests.h
+++ b/include/openenclave/internal/sgx/tests.h
@@ -1,0 +1,18 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_INTERNAL_SGX_TESTS_H
+#define _OE_INTERNAL_SGX_TESTS_H
+
+#include <openenclave/bits/defs.h>
+
+OE_EXTERNC_BEGIN
+
+/*
+ * Return whether SGX quote provider libraries are available in the system.
+ */
+bool oe_has_sgx_quote_provider(void);
+
+OE_EXTERNC_END
+
+#endif // _OE_INTERNAL_SGX_TESTS_H

--- a/tests/attestation_cert_apis/host/host.cpp
+++ b/tests/attestation_cert_apis/host/host.cpp
@@ -5,6 +5,7 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -130,7 +131,13 @@ void run_test(oe_enclave_t* enclave, int test_type)
 
 int main(int argc, const char* argv[])
 {
-#ifdef OE_HAS_SGX_DCAP_QL
+    if (!oe_has_sgx_quote_provider())
+    {
+        // this test should not run on any platforms where DCAP libraries are
+        // not found.
+        OE_TRACE_INFO("=== tests skipped when DCAP libraries are not found.\n");
+        return SKIP_RETURN_CODE;
+    }
 
 #ifdef _WIN32
     /* This is a workaround for running in Visual Studio 2017 Test Explorer
@@ -195,12 +202,4 @@ int main(int argc, const char* argv[])
     OE_TEST(result == OE_OK);
     OE_TRACE_INFO("=== passed all tests (tls)\n");
     return 0;
-#else
-    // this test should not run on any platforms where HAS_QUOTE_PROVIDER is not
-    // defined
-    OE_UNUSED(argc);
-    OE_UNUSED(argv);
-    OE_TRACE_INFO("=== tests skipped when built with HAS_QUOTE_PROVIDER=OFF\n");
-    return SKIP_RETURN_CODE;
-#endif
 }

--- a/tests/attestation_plugin/host/host.c
+++ b/tests/attestation_plugin/host/host.c
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 #include <openenclave/host.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
 
@@ -38,7 +40,13 @@ void host_verify(
 
 int main(int argc, const char* argv[])
 {
-#ifdef OE_HAS_SGX_DCAP_QL
+    if (!oe_has_sgx_quote_provider())
+    {
+        // this test should not run on any platforms where DCAP libraries are
+        // not found.
+        OE_TRACE_INFO("=== tests skipped when DCAP libraries are not found.\n");
+        return SKIP_RETURN_CODE;
+    }
 
 #ifdef _WIN32
     /* This is a workaround for running in Visual Studio 2017 Test Explorer
@@ -113,12 +121,4 @@ int main(int argc, const char* argv[])
     // Unregister verifier.
     unregister_verifier();
     return 0;
-#else
-    // This test should not run on any platforms where HAS_QUOTE_PROVIDER is not
-    // defined.
-    OE_UNUSED(argc);
-    OE_UNUSED(argv);
-    printf("=== tests skipped when built with HAS_QUOTE_PROVIDER=OFF\n");
-    return SKIP_RETURN_CODE;
-#endif
 }

--- a/tests/debug-mode/host/host.c
+++ b/tests/debug-mode/host/host.c
@@ -4,6 +4,7 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/error.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -68,10 +69,11 @@ static void _test_debug_signed(const char* path)
 {
     /* Signed debug mode should always pass. */
     _launch_enclave_success(path, _create_flags(true));
-#ifdef OE_HAS_SGX_DCAP_QL
-    /* Only works with FLC */
-    _launch_enclave_success(path, _create_flags(false));
-#endif
+    if (oe_has_sgx_quote_provider())
+    {
+        /* Only works with FLC */
+        _launch_enclave_success(path, _create_flags(false));
+    }
 }
 
 static void _test_debug_unsigned(const char* path)
@@ -85,10 +87,11 @@ static void _test_non_debug_signed(const char* path)
 {
     /* Debug mode should fail. Non-debug mode should pass. */
     _launch_enclave_fail(path, _create_flags(true), OE_DEBUG_DOWNGRADE);
-#ifdef OE_HAS_SGX_DCAP_QL
-    /* Only works with FLC */
-    _launch_enclave_success(path, _create_flags(false));
-#endif
+    if (oe_has_sgx_quote_provider())
+    {
+        /* Only works with FLC */
+        _launch_enclave_success(path, _create_flags(false));
+    }
 }
 
 static void _test_non_debug_unsigned(const char* path)

--- a/tests/eeid_plugin/host/host.c
+++ b/tests/eeid_plugin/host/host.c
@@ -6,6 +6,8 @@
 #include <openenclave/attestation/sgx/eeid_verifier.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/plugin.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 
 #include "../../../common/sgx/endorsements.h"
@@ -286,11 +288,18 @@ void multiple_enclaves_tests(const char* filename, uint32_t flags)
 
 int main(int argc, const char* argv[])
 {
-#ifdef OE_HAS_SGX_DCAP_QL
     if (argc != 2)
     {
         fprintf(stderr, "Usage: %s ENCLAVE\n", argv[0]);
         exit(1);
+    }
+
+    if (!oe_has_sgx_quote_provider())
+    {
+        // this test should not run on any platforms where DCAP libraries are
+        // not found.
+        OE_TRACE_INFO("=== tests skipped when DCAP libraries are not found.\n");
+        return SKIP_RETURN_CODE;
     }
 
     // Skip test in simulation mode because of memory alignment issues, same as
@@ -307,12 +316,4 @@ int main(int argc, const char* argv[])
     oe_sgx_eeid_verifier_shutdown();
 
     return 0;
-#else
-    // This test should not run on any platforms where HAS_QUOTE_PROVIDER is not
-    // defined.
-    OE_UNUSED(argc);
-    OE_UNUSED(argv);
-    printf("=== tests skipped when built with HAS_QUOTE_PROVIDER=OFF\n");
-    return SKIP_RETURN_CODE;
-#endif
 }

--- a/tests/qeidentity/enc/CMakeLists.txt
+++ b/tests/qeidentity/enc/CMakeLists.txt
@@ -19,10 +19,6 @@ add_enclave(
   enc.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/tests_t.c)
 
-if (HAS_QUOTE_PROVIDER)
-  enclave_compile_definitions(qeidentity_enc PRIVATE OE_HAS_SGX_DCAP_QL)
-endif ()
-
 enclave_include_directories(qeidentity_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                             ${CMAKE_CURRENT_SOURCE_DIR}/../common)
 enclave_link_libraries(qeidentity_enc oelibc)

--- a/tests/qeidentity/enc/enc.cpp
+++ b/tests/qeidentity/enc/enc.cpp
@@ -17,18 +17,11 @@ oe_result_t test_verify_qe_identity_info(
     oe_qe_identity_info_tcb_level_t* platform_tcb_level,
     oe_parsed_qe_identity_info_t* parsed_info)
 {
-#ifdef OE_HAS_SGX_DCAP_QL
     return oe_parse_qe_identity_info_json(
         (const uint8_t*)info_json,
         strlen(info_json) + 1,
         platform_tcb_level,
         parsed_info);
-#else
-    OE_UNUSED(info_json);
-    OE_UNUSED(platform_tcb_level);
-    OE_UNUSED(parsed_info);
-    return OE_OK;
-#endif
 }
 
 OE_SET_ENCLAVE_SGX(

--- a/tests/qeidentity/host/CMakeLists.txt
+++ b/tests/qeidentity/host/CMakeLists.txt
@@ -12,10 +12,6 @@ add_custom_command(
 
 add_executable(qeidentity_host host.cpp qeidentifyinfo.cpp tests_u.c)
 
-if (HAS_QUOTE_PROVIDER)
-  target_compile_definitions(qeidentity_host PRIVATE OE_HAS_SGX_DCAP_QL)
-endif ()
-
 add_custom_command(
   TARGET qeidentity_host
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/../data

--- a/tests/qeidentity/host/host.cpp
+++ b/tests/qeidentity/host/host.cpp
@@ -4,6 +4,7 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/hexdump.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <openenclave/internal/utils.h>
 #include <ctime>
@@ -47,13 +48,12 @@ int main(int argc, const char* argv[])
         oe_put_err("oe_create_enclave(): result=%u", result);
     }
 
-#ifdef OE_HAS_SGX_DCAP_QL
-
-    run_parse_advisoryids_json_test();
-    run_qe_identity_test_cases(enclave);
-    run_qe_identity_v2_test_cases(enclave);
-
-#endif
+    if (oe_has_sgx_quote_provider())
+    {
+        run_parse_advisoryids_json_test();
+        run_qe_identity_test_cases(enclave);
+        run_qe_identity_v2_test_cases(enclave);
+    }
 
     /* Terminate the enclave */
     if ((result = oe_terminate_enclave(enclave)) != OE_OK)

--- a/tests/qeidentity/host/qeidentifyinfo.cpp
+++ b/tests/qeidentity/host/qeidentifyinfo.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
-#ifdef OE_HAS_SGX_DCAP_QL
 
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
@@ -393,5 +392,3 @@ void run_qe_identity_v2_test_cases(oe_enclave_t* enclave)
         printf("passed\n");
     }
 }
-
-#endif

--- a/tests/report/common/tests.cpp
+++ b/tests/report/common/tests.cpp
@@ -175,9 +175,6 @@ static oe_result_t oe_verify_report_with_collaterals(
     {
 #ifndef OE_BUILD_ENCLAVE
         // Intialize the quote provider if we want to verify a remote quote.
-        // Note that we don't have the OE_HAS_SGX_DCAP_QL guard here since we
-        // don't need the sgx libraries to verify the quote. All we need is the
-        // quote provider.
         OE_CHECK(oe_initialize_quote_provider());
 #endif
 
@@ -285,9 +282,6 @@ static oe_result_t oe_get_quote_validity_with_collaterals(
     {
 #ifndef OE_BUILD_ENCLAVE
         // Intialize the quote provider if we want to verify a remote quote.
-        // Note that we don't have the OE_HAS_SGX_DCAP_QL guard here since we
-        // don't need the sgx libraries to verify the quote. All we need is the
-        // quote provider.
         OE_CHECK(oe_initialize_quote_provider());
 #endif
 

--- a/tests/report/enc/CMakeLists.txt
+++ b/tests/report/enc/CMakeLists.txt
@@ -21,10 +21,6 @@ add_enclave(
   ../common/tests.cpp
   tests_t.c)
 
-if (HAS_QUOTE_PROVIDER)
-  enclave_compile_definitions(report_enc PRIVATE OE_HAS_SGX_DCAP_QL)
-endif ()
-
 enclave_include_directories(report_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                             ${CMAKE_CURRENT_SOURCE_DIR}/../common)
 

--- a/tests/report/enc/enc.cpp
+++ b/tests/report/enc/enc.cpp
@@ -17,23 +17,15 @@ oe_result_t test_verify_tcb_info(
     oe_tcb_info_tcb_level_t* platform_tcb_level,
     oe_parsed_tcb_info_t* parsed_tcb_info)
 {
-#ifdef OE_HAS_SGX_DCAP_QL
     return oe_parse_tcb_info_json(
         (const uint8_t*)tcb_info,
         strlen(tcb_info) + 1,
         platform_tcb_level,
         parsed_tcb_info);
-#else
-    OE_UNUSED(tcb_info);
-    OE_UNUSED(platform_tcb_level);
-    OE_UNUSED(parsed_tcb_info);
-    return OE_OK;
-#endif
 }
 
 void test_minimum_issue_date(oe_datetime_t now)
 {
-#ifdef OE_HAS_SGX_DCAP_QL
     static uint8_t* report;
     size_t report_size = 0;
     static uint8_t* report_v2;
@@ -102,9 +94,6 @@ void test_minimum_issue_date(oe_datetime_t now)
     oe_free_report(report_v2);
 
     printf("test_minimum_issue_date passed.\n");
-#else
-    OE_UNUSED(now);
-#endif
 }
 
 void enclave_test_local_report(sgx_target_info_t* target_info)

--- a/tests/report/host/CMakeLists.txt
+++ b/tests/report/host/CMakeLists.txt
@@ -14,10 +14,6 @@ add_custom_command(
 
 add_executable(report_host host.cpp tcbinfo.cpp ../common/tests.cpp tests_u.c)
 
-if (HAS_QUOTE_PROVIDER)
-  target_compile_definitions(report_host PRIVATE OE_HAS_SGX_DCAP_QL)
-endif ()
-
 add_custom_command(
   TARGET report_host
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/../data

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -7,6 +7,7 @@
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/hexdump.h>
 #include <openenclave/internal/sgx/plugin.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <openenclave/internal/utils.h>
 #include <ctime>
@@ -36,7 +37,9 @@ extern int FileToBytes(const char* path, std::vector<uint8_t>* output);
 
 void generate_and_save_report(oe_enclave_t* enclave)
 {
-#ifdef OE_HAS_SGX_DCAP_QL
+    if (!oe_has_sgx_quote_provider())
+        return;
+
     static uint8_t* report;
     size_t report_size;
     OE_TEST_CODE(
@@ -57,9 +60,6 @@ void generate_and_save_report(oe_enclave_t* enclave)
     fwrite(report, 1, report_size, file);
     fclose(file);
     oe_free_report(report);
-#else
-    OE_UNUSED(enclave);
-#endif
 }
 
 int load_and_verify_report()
@@ -159,64 +159,67 @@ int main(int argc, const char* argv[])
      */
     g_enclave = enclave;
 
-#ifdef OE_HAS_SGX_DCAP_QL
-
-    static oe_uuid_t sgx_ecdsa_uuid = {OE_FORMAT_UUID_SGX_ECDSA_P256};
-
-    /* Initialize the target info */
+    if (oe_has_sgx_quote_provider())
     {
-        if ((result = sgx_get_qetarget_info(
-                 &sgx_ecdsa_uuid, NULL, 0, &target_info)) != OE_OK)
+        static oe_uuid_t sgx_ecdsa_uuid = {OE_FORMAT_UUID_SGX_ECDSA_P256};
+
+        /* Initialize the target info */
         {
-            oe_put_err("sgx_get_qetarget_info(): result=%u", result);
+            if ((result = sgx_get_qetarget_info(
+                     &sgx_ecdsa_uuid, NULL, 0, &target_info)) != OE_OK)
+            {
+                oe_put_err("sgx_get_qetarget_info(): result=%u", result);
+            }
         }
+
+        test_local_report(&target_info);
+        test_remote_report();
+        test_parse_report_negative();
+        test_local_verify_report();
+
+        test_remote_verify_report();
+
+        test_verify_report_with_collaterals();
+
+        OE_TEST(test_iso8601_time(enclave) == OE_OK);
+        OE_TEST(test_iso8601_time_negative(enclave) == OE_OK);
+
+        /*
+         * Enclave API tests.
+         */
+        OE_TEST_CODE(enclave_test_local_report(enclave, &target_info), OE_OK);
+        OE_TEST_CODE(enclave_test_remote_report(enclave), OE_OK);
+
+        OE_TEST_CODE(enclave_test_parse_report_negative(enclave), OE_OK);
+
+        OE_TEST_CODE(enclave_test_local_verify_report(enclave), OE_OK);
+
+        OE_TEST_CODE(enclave_test_remote_verify_report(enclave), OE_OK);
+
+        OE_TEST_CODE(
+            enclave_test_verify_report_with_collaterals(enclave), OE_OK);
+
+        TestVerifyTCBInfo(enclave, "./data/tcbInfo.json");
+        TestVerifyTCBInfo(enclave, "./data/tcbInfo_with_pceid.json");
+
+        TestVerifyTCBInfoV2(enclave, "./data_v2/tcbInfo.json");
+        TestVerifyTCBInfoV2(enclave, "./data_v2/tcbInfo_with_pceid.json");
+        TestVerifyTCBInfoV2_AdvisoryIDs(
+            enclave, "./data_v2/tcbInfoAdvisoryIds.json");
     }
+    else
+    {
+        test_local_report(&target_info);
+        test_parse_report_negative();
+        test_local_verify_report();
 
-    test_local_report(&target_info);
-    test_remote_report();
-    test_parse_report_negative();
-    test_local_verify_report();
+        OE_TEST(test_iso8601_time(enclave) == OE_OK);
+        OE_TEST(test_iso8601_time_negative(enclave) == OE_OK);
 
-    test_remote_verify_report();
-
-    test_verify_report_with_collaterals();
-
-    OE_TEST(test_iso8601_time(enclave) == OE_OK);
-    OE_TEST(test_iso8601_time_negative(enclave) == OE_OK);
-
-    /*
-     * Enclave API tests.
-     */
-    OE_TEST_CODE(enclave_test_local_report(enclave, &target_info), OE_OK);
-    OE_TEST_CODE(enclave_test_remote_report(enclave), OE_OK);
-
-    OE_TEST_CODE(enclave_test_parse_report_negative(enclave), OE_OK);
-
-    OE_TEST_CODE(enclave_test_local_verify_report(enclave), OE_OK);
-
-    OE_TEST_CODE(enclave_test_remote_verify_report(enclave), OE_OK);
-
-    OE_TEST_CODE(enclave_test_verify_report_with_collaterals(enclave), OE_OK);
-
-    TestVerifyTCBInfo(enclave, "./data/tcbInfo.json");
-    TestVerifyTCBInfo(enclave, "./data/tcbInfo_with_pceid.json");
-
-    TestVerifyTCBInfoV2(enclave, "./data_v2/tcbInfo.json");
-    TestVerifyTCBInfoV2(enclave, "./data_v2/tcbInfo_with_pceid.json");
-    TestVerifyTCBInfoV2_AdvisoryIDs(
-        enclave, "./data_v2/tcbInfoAdvisoryIds.json");
-#else
-    test_local_report(&target_info);
-    test_parse_report_negative();
-    test_local_verify_report();
-
-    OE_TEST(test_iso8601_time(enclave) == OE_OK);
-    OE_TEST(test_iso8601_time_negative(enclave) == OE_OK);
-
-    OE_TEST(enclave_test_local_report(enclave, &target_info) == OE_OK);
-    OE_TEST(enclave_test_parse_report_negative(enclave) == OE_OK);
-    OE_TEST(enclave_test_local_verify_report(enclave) == OE_OK);
-#endif
+        OE_TEST(enclave_test_local_report(enclave, &target_info) == OE_OK);
+        OE_TEST(enclave_test_parse_report_negative(enclave) == OE_OK);
+        OE_TEST(enclave_test_local_verify_report(enclave) == OE_OK);
+    }
 
     test_get_signer_id_from_public_key();
     OE_TEST(enclave_test_get_signer_id_from_public_key(enclave) == OE_OK);

--- a/tests/tls_e2e/client_enc/CMakeLists.txt
+++ b/tests/tls_e2e/client_enc/CMakeLists.txt
@@ -19,10 +19,6 @@ add_enclave(
   ../common/utility.cpp
   tls_e2e_t.c)
 
-if (HAS_QUOTE_PROVIDER)
-  enclave_compile_definitions(tls_client_enc PRIVATE OE_HAS_SGX_DCAP_QL)
-endif ()
-
 set_source_files_properties(tls_e2e_t.c PROPERTIES COMPILE_FLAGS
                                                    "-Wno-conversion")
 

--- a/tests/tls_e2e/host/host.cpp
+++ b/tests/tls_e2e/host/host.cpp
@@ -5,6 +5,7 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <signal.h>
 #include <stdio.h>
@@ -346,7 +347,14 @@ done:
 
 int main(int argc, const char* argv[])
 {
-#ifdef OE_HAS_SGX_DCAP_QL
+    if (!oe_has_sgx_quote_provider())
+    {
+        // this test should not run on any platforms where DCAP libraries are
+        // not found.
+        OE_TRACE_INFO("=== tests skipped when DCAP libraries are not found.\n");
+        return SKIP_RETURN_CODE;
+    }
+
     oe_result_t result = OE_FAILURE;
     uint32_t flags = OE_ENCLAVE_FLAG_DEBUG;
     int ret = 0;
@@ -401,12 +409,4 @@ done:
     OE_TRACE_INFO("=== passed all tests (tls)\n");
 
     return 0;
-#else
-    // this test should not run on any platforms where OE_HAS_SGX_DCAP_QL is
-    // not defined
-    OE_UNUSED(argc);
-    OE_UNUSED(argv);
-    OE_TRACE_INFO("=== tests skipped when built with OE_HAS_SGX_DCAP_QL=OFF\n");
-    return SKIP_RETURN_CODE;
-#endif
 }

--- a/tests/tls_e2e/server_enc/CMakeLists.txt
+++ b/tests/tls_e2e/server_enc/CMakeLists.txt
@@ -12,9 +12,6 @@ add_custom_command(
 
 add_enclave(TARGET tls_server_enc SOURCES server.cpp ../common/utility.cpp
             ${CMAKE_CURRENT_BINARY_DIR}/tls_e2e_t.c)
-if (HAS_QUOTE_PROVIDER)
-  enclave_compile_definitions(tls_server_enc PRIVATE OE_HAS_SGX_DCAP_QL)
-endif ()
 
 set_source_files_properties(tls_e2e_t.c PROPERTIES COMPILE_FLAGS
                                                    "-Wno-conversion")

--- a/tests/tools/oecert/host/CMakeLists.txt
+++ b/tests/tools/oecert/host/CMakeLists.txt
@@ -9,9 +9,5 @@ add_custom_command(
 
 add_executable(oecert host.cpp ${CMAKE_CURRENT_BINARY_DIR}/oecert_u.c)
 
-if (HAS_QUOTE_PROVIDER)
-  target_compile_definitions(oecert PRIVATE OE_HAS_SGX_DCAP_QL)
-endif ()
-
 target_include_directories(oecert PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(oecert oehost)

--- a/tests/tools/oecert/host/host.cpp
+++ b/tests/tools/oecert/host/host.cpp
@@ -4,6 +4,7 @@
 #include <limits.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/report.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,8 +12,6 @@
 #include "oecert_u.h"
 
 #include "../../../../common/sgx/endorsements.h"
-
-#ifdef OE_HAS_SGX_DCAP_QL
 
 #define INPUT_PARAM_OPTION_CERT "--cert"
 #define INPUT_PARAM_OPTION_REPORT "--report"
@@ -472,13 +471,17 @@ static oe_result_t _process_params(oe_enclave_t* enclave)
     return result;
 }
 
-#endif // OE_HAS_SGX_DCAP_QL
-
 int main(int argc, const char* argv[])
 {
     int ret = 0;
 
-#ifdef OE_HAS_SGX_DCAP_QL
+    if (!oe_has_sgx_quote_provider())
+    {
+        fprintf(
+            stderr, "FAILURE: DCAP libraries must be present for this test.\n");
+        return -1;
+    }
+
     oe_result_t result;
     oe_enclave_t* enclave = NULL;
 
@@ -513,11 +516,6 @@ int main(int argc, const char* argv[])
 
     result = oe_terminate_enclave(enclave);
 exit:
-#else
-#pragma message( \
-    "OE_HAS_SGX_DCAP_QL is not set to ON.  This tool requires DCAP libraries.")
-    OE_UNUSED(argc);
-    OE_UNUSED(argv);
-#endif
+
     return ret;
 }

--- a/tests/tools/oecertdump/host/CMakeLists.txt
+++ b/tests/tools/oecertdump/host/CMakeLists.txt
@@ -17,10 +17,6 @@ target_include_directories(oecertdump PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
 
 target_link_libraries(oecertdump oehost OpenSSL::SSL)
 
-if (HAS_QUOTE_PROVIDER)
-  target_compile_definitions(oecertdump PRIVATE OE_HAS_SGX_DCAP_QL)
-endif ()
-
 # The X509_print_ex_fp function in OpenSSL requires to include applink.c, which
 # glues OpenSSL BIO and Win32 compiler run-time. But applink.c uses fopen() that
 # raises a W3 warning and triggers error C2220 (warning treated as error).

--- a/tests/tools/oecertdump/host/host.cpp
+++ b/tests/tools/oecertdump/host/host.cpp
@@ -4,6 +4,7 @@
 #include <limits.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/report.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/sgxcertextensions.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
@@ -12,8 +13,6 @@
 #include "oecertdump_u.h"
 
 #include "sgx_quote.h"
-
-#ifdef OE_HAS_SGX_DCAP_QL
 
 #define INPUT_PARAM_USAGE "--help"
 #define INPUT_PARAM_OUT_FILE "--out"
@@ -272,13 +271,17 @@ static oe_result_t _process_params(oe_enclave_t* enclave)
     return result;
 }
 
-#endif // OE_HAS_SGX_DCAP_QL
-
 int main(int argc, const char* argv[])
 {
     int ret = 0;
 
-#ifdef OE_HAS_SGX_DCAP_QL
+    if (!oe_has_sgx_quote_provider())
+    {
+        fprintf(
+            stderr, "FAILURE: DCAP libraries must be present for this test.\n");
+        return -1;
+    }
+
     oe_result_t result;
     oe_enclave_t* enclave = nullptr;
 
@@ -347,12 +350,5 @@ exit:
         fclose(log_file);
     }
 
-#else
-#pragma message( \
-    "OE_HAS_SGX_DCAP_QL is not set to ON.  This tool requires DCAP libraries.")
-    OE_UNUSED(argc);
-    OE_UNUSED(argv);
-    printf("oecertdump requires DCAP libraries.\n");
-#endif
     return ret;
 }

--- a/tests/tools/oecertdump/host/sgx_quote.cpp
+++ b/tests/tools/oecertdump/host/sgx_quote.cpp
@@ -28,8 +28,6 @@
 #include "../../../../common/sgx/quote.h"
 #include "../../../../host/sgx/sgxquoteprovider.h"
 
-#ifdef OE_HAS_SGX_DCAP_QL
-
 extern FILE* log_file;
 
 #define OE_PEM_BEGIN_CERTIFICATE "-----BEGIN CERTIFICATE-----"
@@ -573,5 +571,3 @@ oe_result_t get_sgx_report_from_certificate(
 
     return result;
 }
-
-#endif // OE_HAS_SGX_DCAP_QL


### PR DESCRIPTION
 Remove OE_HAS_SGX_DCAP_QL define

- Use runtime check for quote provider instead of compile time check.
- Remove use of HAS_QUOTE_PROVIDER and OE_HAS_SGX_DCAP_QL from tests.
- Remove use of OE_HAS_SGX_DCAP_QL from common/sgx/verifier.c
  that was missed in an earlier PR
- Remove OE_HAS_SGX_DCAP_QL from VS extension

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>