### PR TITLE
Use relative paths to compilers when configuring LVI mitigations

### DIFF
--- a/cmake/configure_lvi_mitigation_build.cmake
+++ b/cmake/configure_lvi_mitigation_build.cmake
@@ -86,6 +86,6 @@ function (configure_lvi_mitigation_build)
         ${OE_BINDIR}/${CXX_COMPILER}
         PARENT_SCOPE)
   else ()
-    message(FATAL_ERROR "-- ${CXX_COMPILER} is not supported.")
+    message(FATAL_ERROR "-- ${OE_BINDIR}/${CXX_COMPILER} is not supported.")
   endif ()
 endfunction ()

--- a/cmake/configure_lvi_mitigation_build.cmake
+++ b/cmake/configure_lvi_mitigation_build.cmake
@@ -60,7 +60,7 @@ function (configure_lvi_mitigation_build)
   # Overwrite the default C compiler if CC is explicitly specified.
   # Otherwise, select the compiler based on the detection logic.
   if (DEFINED ENV{CC})
-    set(C_COMPILER $ENV{CC})
+    get_filename_component(C_COMPILER $ENV{CC} NAME)
   else ()
     detect_compiler(${OE_BINDIR} C)
   endif ()
@@ -70,13 +70,13 @@ function (configure_lvi_mitigation_build)
         ${OE_BINDIR}/${C_COMPILER}
         PARENT_SCOPE)
   else ()
-    message(FATAL_ERROR "-- ${C_COMPILER} is not found.")
+    message(FATAL_ERROR "-- ${OE_BINDIR}/${C_COMPILER} is not found.")
   endif ()
 
   # Overwrite the default C++ compiler if CXX is explicitly specified.
   # Otherwise, select the compiler based on the detection logic.
   if (DEFINED ENV{CXX})
-    set(CXX_COMPILER $ENV{CXX})
+    get_filename_component(CXX_COMPILER $ENV{CXX} NAME)
   else ()
     detect_compiler(${OE_BINDIR} CXX)
   endif ()


### PR DESCRIPTION
Trying to consume the LVI mitigated targets from an external project, I hit the following error:

```
CMake Error at /opt/openenclave/lib/openenclave/cmake/configure_lvi_mitigation_build.cmake:73 (message):
  -- /usr/bin/clang-8 is not found.
Call Stack (most recent call first):
  /opt/openenclave/lib/openenclave/cmake/openenclave-lvi-mitigation-config.cmake:43 (configure_lvi_mitigation_build)
  cmake/ccf_app.cmake:46 (find_package)
  cmake/common.cmake:108 (include)
  CMakeLists.txt:38 (include)


-- Configuring incomplete, errors occurred!
```

You will get the same error if `CC` or `CXX` are passed as environment variables when building OE with LVI, eg:

```
CC=/usr/bin/clang-8 cmake .. -GNinja -DUSE_SNMALLOC=ON -DLVI_MITIGATION=ControlFlow -DLVI_MITIGATION_BINDIR=/data/src/openenclave/build/lvi_mitigation_bin
```

The problem is this line in `configure_lvi_mitigation_build.cmake`:

```
  if (EXISTS "${OE_BINDIR}/${C_COMPILER}")
```

This path concatentation doesn't work if `C_COMPILER` is an absolute path, which it often is if its come from CC/CXX.

Not sure if this is the _right_ fix, but it seems to work.

Signed-off-by: Eddy Ashton <edashton@microsoft.com>