### PR TITLE
Use enclave_* cmake macros for builds with EEID.

### DIFF
--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -75,5 +75,5 @@ install_enclaves(
   ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 
 if (WITH_EEID)
-  target_compile_definitions(oeenclave PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+  enclave_compile_definitions(oeenclave PRIVATE OE_WITH_EXPERIMENTAL_EEID)
 endif ()

--- a/enclave/crypto/CMakeLists.txt
+++ b/enclave/crypto/CMakeLists.txt
@@ -36,5 +36,5 @@ install_enclaves(
   ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 
 if (WITH_EEID)
-  target_compile_definitions(oecryptombed PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+  enclave_compile_definitions(oecryptombed PRIVATE OE_WITH_EXPERIMENTAL_EEID)
 endif ()

--- a/tests/eeid_plugin/CMakeLists.txt
+++ b/tests/eeid_plugin/CMakeLists.txt
@@ -8,4 +8,4 @@ if (BUILD_ENCLAVES)
 endif ()
 
 add_enclave_test(tests/eeid_plugin eeid_plugin_host eeid_plugin_enc_signed)
-set_tests_properties(tests/eeid_plugin PROPERTIES SKIP_RETURN_CODE 2)
+set_enclave_tests_properties(tests/eeid_plugin PROPERTIES SKIP_RETURN_CODE 2)

--- a/tests/eeid_plugin/enc/CMakeLists.txt
+++ b/tests/eeid_plugin/enc/CMakeLists.txt
@@ -22,6 +22,6 @@ add_enclave(
   ../test_helpers.c
   ${CMAKE_CURRENT_BINARY_DIR}/eeid_plugin_t.c)
 
-target_compile_definitions(eeid_plugin_enc PRIVATE OE_WITH_EXPERIMENTAL_EEID)
-target_include_directories(eeid_plugin_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(eeid_plugin_enc oeenclave oelibc)
+enclave_compile_definitions(eeid_plugin_enc PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+enclave_include_directories(eeid_plugin_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+enclave_link_libraries(eeid_plugin_enc oeenclave oelibc)


### PR DESCRIPTION
Fixes the build when both EEID and LVI mitigation are enabled. Fixes build failure in #3152.