### PR TITLE
Support request for multiple SGX quote collateral providers.

### DIFF
--- a/enclave/sgx/collateralinfo.c
+++ b/enclave/sgx/collateralinfo.c
@@ -20,6 +20,7 @@
 oe_result_t _oe_get_quote_verification_collateral_ocall(
     oe_result_t* _retval,
     uint8_t fmspc[6],
+    uint8_t collateral_provider,
     void* tcb_info,
     size_t tcb_info_size,
     size_t* tcb_info_size_out,
@@ -52,6 +53,7 @@ oe_result_t _oe_get_quote_verification_collateral_ocall(
 oe_result_t _oe_get_quote_verification_collateral_ocall(
     oe_result_t* _retval,
     uint8_t fmspc[6],
+    uint8_t collateral_provider,
     void* tcb_info,
     size_t tcb_info_size,
     size_t* tcb_info_size_out,
@@ -75,6 +77,7 @@ oe_result_t _oe_get_quote_verification_collateral_ocall(
     size_t* qe_identity_issuer_chain_size_out)
 {
     OE_UNUSED(fmspc);
+    OE_UNUSED(collateral_provider);
     OE_UNUSED(tcb_info);
     OE_UNUSED(tcb_info_size);
     OE_UNUSED(tcb_info_size_out);
@@ -160,6 +163,7 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
         0,
         {0},
         0,
+        0,
         TCBINFO_DEFAULT_SIZE,
         0,
         ALL_ISSUER_CHAIN_DEFAULT_SIZE,
@@ -182,6 +186,8 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
 
     /* fmspc */
     memcpy(in.fmspc, args->fmspc, sizeof(in.fmspc));
+    /* collateral_provider */
+    in.collateral_provider = args->collateral_provider;
     oe_prealloc_quote_verification_collateral_args(&in, &default_arg_size);
 
     for (;;)
@@ -191,6 +197,7 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
         OE_CHECK(oe_get_quote_verification_collateral_ocall(
             &retval,
             out.fmspc,
+            out.collateral_provider,
             out.tcb_info,
             out.tcb_info_size,
             &out.tcb_info_size,

--- a/host/sgx/ocalls.c
+++ b/host/sgx/ocalls.c
@@ -118,8 +118,6 @@ oe_result_t oe_get_quote_ocall(
     return result;
 }
 
-#if defined(OE_LINK_SGX_DCAP_QL)
-
 /* Copy the source array to an output buffer. */
 static oe_result_t _copy_output_buffer(
     void* dest,
@@ -149,6 +147,7 @@ done:
 
 oe_result_t oe_get_quote_verification_collateral_ocall(
     uint8_t fmspc[6],
+    uint8_t collateral_provider,
     void* tcb_info,
     size_t tcb_info_size,
     size_t* tcb_info_size_out,
@@ -177,6 +176,9 @@ oe_result_t oe_get_quote_verification_collateral_ocall(
 
     /* fmspc */
     memcpy(args.fmspc, fmspc, sizeof(args.fmspc));
+
+    /* collateral_provider */
+    args.collateral_provider = collateral_provider;
 
     /* Populate the output fields. */
     OE_CHECK(oe_get_sgx_quote_verification_collateral(&args));
@@ -266,60 +268,6 @@ done:
 
     return result;
 }
-
-#else /* !defined(OE_LINK_SGX_DCAP_QL) */
-
-oe_result_t oe_get_quote_verification_collateral_ocall(
-    uint8_t fmspc[6],
-    void* tcb_info,
-    size_t tcb_info_size,
-    size_t* tcb_info_size_out,
-    void* tcb_info_issuer_chain,
-    size_t tcb_info_issuer_chain_size,
-    size_t* tcb_info_issuer_chain_size_out,
-    void* pck_crl,
-    size_t pck_crl_size,
-    size_t* pck_crl_size_out,
-    void* root_ca_crl,
-    size_t root_ca_crl_size,
-    size_t* root_ca_crl_size_out,
-    void* pck_crl_issuer_chain,
-    size_t pck_crl_issuer_chain_size,
-    size_t* pck_crl_issuer_chain_size_out,
-    void* qe_identity,
-    size_t qe_identity_size,
-    size_t* qe_identity_size_out,
-    void* qe_identity_issuer_chain,
-    size_t qe_identity_issuer_chain_size,
-    size_t* qe_identity_issuer_chain_size_out)
-{
-    OE_UNUSED(fmspc);
-    OE_UNUSED(tcb_info);
-    OE_UNUSED(tcb_info_size);
-    OE_UNUSED(tcb_info_size_out);
-    OE_UNUSED(tcb_info_issuer_chain);
-    OE_UNUSED(tcb_info_issuer_chain_size);
-    OE_UNUSED(tcb_info_issuer_chain_size_out);
-    OE_UNUSED(pck_crl);
-    OE_UNUSED(pck_crl_size);
-    OE_UNUSED(pck_crl_size_out);
-    OE_UNUSED(root_ca_crl);
-    OE_UNUSED(root_ca_crl_size);
-    OE_UNUSED(root_ca_crl_size_out);
-    OE_UNUSED(pck_crl_issuer_chain);
-    OE_UNUSED(pck_crl_issuer_chain_size);
-    OE_UNUSED(pck_crl_issuer_chain_size_out);
-    OE_UNUSED(qe_identity);
-    OE_UNUSED(qe_identity_size);
-    OE_UNUSED(qe_identity_size_out);
-    OE_UNUSED(qe_identity_issuer_chain);
-    OE_UNUSED(qe_identity_issuer_chain_size);
-    OE_UNUSED(qe_identity_issuer_chain_size_out);
-
-    return OE_UNSUPPORTED;
-}
-
-#endif /* !defined(OE_LINK_SGX_DCAP_QL) */
 
 oe_result_t oe_get_qetarget_info_ocall(
     const oe_uuid_t* format_id,

--- a/host/sgx/sgxquoteprovider.c
+++ b/host/sgx/sgxquoteprovider.c
@@ -12,9 +12,6 @@
 #include "../hostthread.h"
 #include "sgxquoteprovider.h"
 
-// Define the name of CA
-static uint8_t CRL_CA_PROCESSOR[] = "processor";
-
 /**
  * This file manages the dcap_quoteprov shared library.
  * It loads the library during program startup and keeps it loaded until the
@@ -59,6 +56,7 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
     oe_result_t result = OE_FAILURE;
     sgx_plat_error_t r = SGX_PLAT_ERROR_OUT_OF_MEMORY;
     sgx_ql_qve_collateral_t* collateral = NULL;
+    char* ca_type = NULL;
     uint32_t host_buffer_size = 0;
     uint8_t* p = 0;
     uint8_t* p_end = 0;
@@ -66,6 +64,13 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
 
     uint8_t* fmspc = args->fmspc;
     uint16_t fmspc_size = sizeof(args->fmspc);
+
+    if (args->collateral_provider == CRL_CA_PROCESSOR)
+        ca_type = "processor";
+    else if (args->collateral_provider == CRL_CA_PLATFORM)
+        ca_type = "platform";
+    else
+        OE_RAISE_MSG(OE_INVALID_ENDORSEMENT, "invalid CA type", NULL);
 
     OE_CHECK(oe_initialize_quote_provider());
 
@@ -80,7 +85,7 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
 
     // fetch collateral information
     r = provider.get_sgx_quote_verification_collateral(
-        fmspc, fmspc_size, (char*)CRL_CA_PROCESSOR, &collateral);
+        fmspc, fmspc_size, ca_type, &collateral);
     if (r != SGX_PLAT_ERROR_OK || collateral == NULL)
     {
         OE_RAISE(OE_QUOTE_PROVIDER_CALL_ERROR);

--- a/include/openenclave/edl/sgx/attestation.edl
+++ b/include/openenclave/edl/sgx/attestation.edl
@@ -71,6 +71,7 @@ enclave
 
         oe_result_t oe_get_quote_verification_collateral_ocall(
             [in] uint8_t fmspc[6],
+            uint8_t collateral_provider,
             [out, size=tcb_info_size] void* tcb_info,
             size_t tcb_info_size,
             [out] size_t* tcb_info_size_out,

--- a/include/openenclave/internal/report.h
+++ b/include/openenclave/internal/report.h
@@ -23,6 +23,7 @@ typedef struct _oe_get_sgx_quote_verification_collateral_args
 {
     oe_result_t result;                   /* out */
     uint8_t fmspc[6];                     /* in */
+    uint8_t collateral_provider;          /* in */
     uint8_t* tcb_info;                    /* out */
     size_t tcb_info_size;                 /* out */
     uint8_t* tcb_info_issuer_chain;       /* out */
@@ -39,6 +40,10 @@ typedef struct _oe_get_sgx_quote_verification_collateral_args
     size_t qe_identity_issuer_chain_size; /* out */
     uint8_t* host_out_buffer;             /* out */
 } oe_get_sgx_quote_verification_collateral_args_t;
+
+// Collateral provider for sgx quote verification
+#define CRL_CA_PROCESSOR (1)
+#define CRL_CA_PLATFORM (2)
 
 /*
 **==============================================================================

--- a/tests/edl_opt_out/enc/enc.c
+++ b/tests/edl_opt_out/enc/enc.c
@@ -138,6 +138,7 @@ void enc_edl_opt_out()
             oe_get_quote_verification_collateral_ocall(
                 &result,
                 NULL,
+                0,
                 NULL,
                 0,
                 NULL,


### PR DESCRIPTION
In current implementation, [common/sgx/collateral.c](https://github.com/openenclave/openenclave/blob/master/common/sgx/collateral.c#L185-L212) calls into host to fetch collateral given the PCK certificate. There was only one provider(certificate issuer) "Intel SGX PCK Processor CA" so [host/sgx/sgxquoteprovider.c](https://github.com/openenclave/openenclave/blob/master/host/sgx/sgxquoteprovider.c#L16) hardcoded CA as "processor".
Now with the introducing of new platform like icelake, there could be multiple collateral providers. e.g., the provider name for icelake machine should be "platform". This PR is to support multiple collateral providers request.

Collateral is fetched by `fmpsc` extracted from PCK certificate. But as disscussed above, now we also need to know which CA issued that certificate (PCK Processor CA or PCK Platform CA). That's not provided in PCK certificate. But according to the [spec](https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_PCK_Certificate_CRL_Spec-1.4.pdf), we can tell it by "Platform Instance ID" field in SGX extension. It's a 16 bytes id that certificates issued by PCK Platform CA must contain this
field but certificates issued by PCK Processor CA do not contain this field. So that the `opt_platform_instance_id[16]` will be [an array of 0](https://github.com/openenclave/openenclave/blob/master/common/sgx/collateral.c#L193) when certificate is provided by PCK Processor CA, and a 16 bytes id when certificate is provided by PCK Platform CA. So we can use this information to detemine the collateral provider.

A new field `collateral_provider` is added in `oe_get_sgx_quote_verification_collateral_args_t` to indicate the collateral provider, which now is either CRL_CA_PROCESSOR(1) or CRL_CA_PLATFORM(2).

Tests have been run and passed in both coffeelake machine and icelake machine.