### PR TITLE
Make install_lvi_mitigation_bindir exit on errors

### DIFF
--- a/scripts/lvi-mitigation/install_lvi_mitigation_bindir
+++ b/scripts/lvi-mitigation/install_lvi_mitigation_bindir
@@ -2,6 +2,8 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
+set -o errexit
+
 script=$(readlink -f "$0")
 script_path=$(dirname "$script")
 curr_path=$(pwd)


### PR DESCRIPTION
`install_lvi_mitigation_bindir` will print error messages but continue to execute, and doesn't set any exit codes to indicate errors. As such its awkward to use in any automation, or call from any script. This PR sets `-o errexit` (this seems to be the preferred style over `set -e`?) so errors are more easily detected.

Signed-off-by: Eddy Ashton <edashton@microsoft.com>