### PR TITLE
Fix host-verify sample make run failure

### DIFF
--- a/samples/host_verify/Makefile
+++ b/samples/host_verify/Makefile
@@ -11,17 +11,17 @@ EXISTS_SGX_CERT_EC=0
 EXISTS_SGX_CERT_RSA=0
 EXISTS_SGX_REPORT=0
 
-ifneq ($(wildcard, sgx_cert_ec.der), "")
+ifneq ($(wildcard sgx_cert_ec.der),)
 	EXISTS_SGX_CERT_EC=1
 	EXISTS_FILE=1
 endif
 
-ifneq ($(wildcard, sgx_cert_rsa.der), "")
+ifneq ($(wildcard sgx_cert_rsa.der),)
 	EXISTS_SGX_CERT_RSA=1
 	EXISTS_FILE=1
 endif
 
-ifneq ($(wildcard, sgx_report.bin), "")
+ifneq ($(wildcard sgx_report.bin),)
 	EXISTS_SGX_REPORT=1
 	EXISTS_FILE=1
 endif
@@ -39,15 +39,15 @@ clean:
 	rm -f host_verify host.o
 
 run:
-ifeq (EXISTS_FILE, 0)
+ifeq ($(EXISTS_FILE), 0)
 	./host_verify -h
 endif
-ifeq (EXISTS_SGX_CERT_EC, 1)
+ifeq ($(EXISTS_SGX_CERT_EC), 1)
 	./host_verify -c sgx_cert_ec.der
 endif
-ifeq (EXISTS_SGX_CERT_RSA, 1)
+ifeq ($(EXISTS_SGX_CERT_RSA), 1)
 	./host_verify -c sgx_cert_rsa.der
 endif
-ifeq (EXISTS_SGX_REPORT, 1)
+ifeq ($(EXISTS_SGX_REPORT), 1)
 	./host_verify -r sgx_report.bin
 endif


### PR DESCRIPTION
Signed-off-by: Yen Lee <yenlee@microsoft.com>

Fixed host-verify sample 'make run' failure as described in issue 3300.