### PR TITLE
Enable to build and install host-verify package and run host-verify sample on CI/CD

### DIFF
--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -256,6 +256,137 @@ def ACCHostVerificationTest(String version, String build_type) {
     }
 }
 
+def ACCHostVerificationPackageTest(String version, String build_type) {
+    /* Generate an SGX report and two SGX certificates for the host_verify sample.
+    * Also generate and install the host_verify package. Then run the host_verify sample.
+    */
+    stage("ACC-1804 Generate Quote") {
+        node(AGENTS_LABELS["acc-ubuntu-18.04"]) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+
+                println("Generating certificates and reports ...")
+                def task = """
+                           cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -Wdev
+                           ninja -v
+                           pushd tests/host_verify/host
+                           openssl ecparam -name prime256v1 -genkey -noout -out keyec.pem
+                           openssl ec -in keyec.pem -pubout -out publicec.pem
+                           openssl genrsa -out keyrsa.pem 2048
+                           openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
+                           ../../tools/oecert/host/oecert ../../tools/oecert/enc/oecert_enc --cert keyec.pem publicec.pem --out sgx_cert_ec.der
+                           ../../tools/oecert/host/oecert ../../tools/oecert/enc/oecert_enc --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der
+                           ../../tools/oecert/host/oecert ../../tools/oecert/enc/oecert_enc --report --out sgx_report.bin
+                           popd
+                           """
+                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-7", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx")
+
+                def ec_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_ec.der'
+                def rsa_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_rsa.der'
+                def report_created = fileExists 'build/tests/host_verify/host/sgx_report.bin'
+                if (ec_cert_created) {
+                    println("EC cert file created successfully!")
+                } else {
+                    error("Failed to create EC cert file.")
+                }
+                if (rsa_cert_created) {
+                    println("RSA cert file created successfully!")
+                } else {
+                    error("Failed to create RSA cert file.")
+                }
+                if (report_created) {
+                    println("SGX report file created successfully!")
+                } else {
+                    error("Failed to create SGX report file.")
+                }
+
+                stash includes: 'build/tests/host_verify/host/*.der,build/tests/host_verify/host/*.bin', name: "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+            }
+        }
+    }
+
+    /* Linux nonSGX stage. */
+    stage("Linux nonSGX Verify Quote") {
+        node(AGENTS_LABELS["ubuntu-nonsgx"]) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+                def task = """
+                           cmake ${WORKSPACE} \
+                             -DBUILD_ENCLAVES=OFF \
+                             -DCMAKE_BUILD_TYPE=${build_type} \
+                             -DCMAKE_INSTALL_PREFIX=/opt/openenclave \
+                             -DCOMPONENT=OEHOSTVERIFY \
+                             -Wdev
+                           make VERBOSE=1
+                           cpack -G DEB -D CPACK_DEB_COMPONENT_INSTALL=ON -D CPACK_COMPONENTS_ALL=OEHOSTVERIFY
+                           if [ -d /opt/openenclave ]; then sudo rm -r /opt/openenclave; fi
+                           sudo dpkg -i open-enclave-hostverify*.deb
+                           cp tests/host_verify/host/*.der ${WORKSPACE}/samples/host_verify
+                           cp tests/host_verify/host/*.bin ${WORKSPACE}/samples/host_verify
+                           pushd ${WORKSPACE}/samples/host_verify
+                           if [ ! -d build ]; then mkdir build; fi
+                           cd build
+                           cmake ..  -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -Wdev
+                           make VERBOSE=1
+                           ./host_verify -r ../sgx_report.bin
+                           ./host_verify -c ../sgx_cert_ec.der
+                           ./host_verify -c ../sgx_cert_rsa.der
+                           popd
+                           """
+                // Note: Include the commands to build and run the quote verification test above
+                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-7", task, "--cap-add=SYS_PTRACE")
+            }
+        }
+    }
+
+    /* Windows nonSGX stage. */
+    stage("Windows nonSGX Verify Quote") {
+        node(AGENTS_LABELS["windows-nonsgx"]) {
+            timeout(GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+                dir('build') {
+                    bat """
+                        vcvars64.bat x64 && \
+                        cmake.exe ${WORKSPACE} \
+                          -G Ninja \
+                          -DBUILD_ENCLAVES=OFF \
+                          -DCMAKE_BUILD_TYPE=${build_type} \
+                          -DCOMPONENT=OEHOSTVERIFY \
+                          -DCPACK_GENERATOR=NuGet \
+                          -DNUGET_PACKAGE_PATH=C:/oe_prereqs \
+                          -Wdev && \
+                        ninja -v && \
+                        cpack -D CPACK_NUGET_COMPONENT_INSTALL=ON -DCPACK_COMPONENTS_ALL=OEHOSTVERIFY && \
+                        copy tests\\host_verify\\host\\*.der ${WORKSPACE}\\samples\\host_verify && \
+                        copy tests\\host_verify\\host\\*.bin ${WORKSPACE}\\samples\\host_verify && \
+                        nuget.exe install open-enclave.OEHOSTVERIFY -Source ${WORKSPACE}\\build -OutputDirectory C:\\oe -ExcludeVersion && \
+                        xcopy /E C:\\oe\\open-enclave.OEHOSTVERIFY\\openenclave C:\\openenclave\\ && \
+                        pushd ${WORKSPACE}\\samples\\host_verify && \
+                        if not exist build\\ (mkdir build) && \
+                        cd build && \
+                        cmake.exe .. \
+                          -G Ninja \
+                          -DBUILD_ENCLAVES=OFF \
+                          -DCMAKE_BUILD_TYPE=${build_type} \
+                          -DCMAKE_PREFIX_PATH=C:/openenclave/lib/openenclave/cmake \
+                          -DNUGET_PACKAGE_PATH=C:/oe_prereqs \
+                          -Wdev && \
+                        ninja -v && \
+                        host_verify.exe -r ../sgx_report.bin && \
+                        host_verify.exe -c ../sgx_cert_ec.der && \
+                        host_verify.exe -c ../sgx_cert_rsa.der && \
+                        popd
+                        """
+                }
+            }
+        }
+    }
+}
 
 properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
                                       artifactNumToKeepStr: '180',
@@ -266,32 +397,37 @@ properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
 try{
     oe.emailJobStatus('STARTED')
     def testing_stages = [
-        "Host verification 1604 Release":         { ACCHostVerificationTest('16.04', 'Release') },
-        "Host verification 1804 Release":         { ACCHostVerificationTest('18.04', 'Release') },
+        "Host verification 1604 Release":                { ACCHostVerificationTest('16.04', 'Release') },
+        "Host verification 1804 Release":                { ACCHostVerificationTest('18.04', 'Release') },
 
-        "ACC1804 GNU gcc SGX1FLC":                { ACCGNUTest() },
-        "ACC1804 clang-7 Release Experimental LVI FULL Tests": { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DWITH_EEID=on ']) },
-                
-        "RHEL-8 clang-8 simulation Release":      { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
-        "RHEL-8 clang-8 simulation Debug":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
-        "RHEL-8 gcc-8 simulation Release":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
-        "RHEL-8 gcc-8 simulation Debug":          { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
-        "RHEL-8 ACC clang-8 SGX1 Release":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF']) },
-        "RHEL-8 ACC clang-8 SGX1 Debug":          { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF']) },
-        "RHEL-8 ACC gcc-8 SGX1 Release":          { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF']) },
-        "RHEL-8 ACC gcc-8 SGX1 Debug":            { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF']) },
+        "Host verification package 1604 RelWithDebInfo": { ACCHostVerificationPackageTest('16.04', 'RelWithDebInfo') },
+        "Host verification package 1804 RelWithDebInfo": { ACCHostVerificationPackageTest('18.04', 'RelWithDebInfo') },
 
-        "ACC1604 clang-7 Debug LVI e2e":          { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04-vanilla"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) },
-        "ACC1804 gcc Debug LVI e2e":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) },
+        "ACC1804 GNU gcc SGX1FLC":                       { ACCGNUTest() },
+
+        "RHEL-8 clang-8 simulation Release":             { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
+        "RHEL-8 clang-8 simulation Debug":               { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
+        "RHEL-8 gcc-8 simulation Release":               { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
+        "RHEL-8 gcc-8 simulation Debug":                 { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
+        "RHEL-8 ACC clang-8 SGX1 Release":               { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF']) },
+        "RHEL-8 ACC clang-8 SGX1 Debug":                 { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF']) },
+        "RHEL-8 ACC gcc-8 SGX1 Release":                 { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF']) },
+        "RHEL-8 ACC gcc-8 SGX1 Debug":                   { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF']) },
+
+        "ACC1604 clang-7 Debug LVI e2e":                 { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04-vanilla"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) },
+        "ACC1804 gcc Debug LVI e2e":                     { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) },
     
-        "RHEL-8 clang-8 simulation Release e2e":  { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1'], true) },
-        "RHEL-8 ACC clang-8 SGX1 Release e2e":    { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], [], true) }
+        "RHEL-8 clang-8 simulation Release e2e":         { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1'], true) },
+        "RHEL-8 ACC clang-8 SGX1 Release e2e":           { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], [], true) }
     ]
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
                 "Host verification 1604 Debug":           { ACCHostVerificationTest('16.04', 'Debug') },
                 "Host verification 1804 Debug":           { ACCHostVerificationTest('18.04', 'Debug') },
+
+                "Host verification package 1604 Debug":   { ACCHostVerificationPackageTest('16.04', 'Debug') },
+                "Host verification package 1804 Debug":   { ACCHostVerificationPackageTest('18.04', 'Debug') },
 
                 "ACC1604 Package RelWithDebInfo":         { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
                 "ACC1604 Package RelWithDebInfo LVI":     { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-16.04"], '16.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },


### PR DESCRIPTION
Enable testing of `host-verify` package and sample on `Azure-Linux` pipeline of CI/CD. 

After SGX certificates and an SGX report are generated, they will be copied to a non-SGX Ubuntu Linux machine and a non-SGX Windows machine.

On a non-SGX machine, regardless of the operating system installed, it will build a `open-enclave-hostverify` package, install it, and run the `host-verify` sample. ~Note that package installation is not included in this pull request.~

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>