### PR TITLE
Remove HAS_QUOTE_PROVIDER from Jenkins files

### DIFF
--- a/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
@@ -50,7 +50,6 @@ def AArch64GNUTest(String version, String build_type) {
                                 -DCMAKE_BUILD_TYPE=${build_type}                                   \
                                 -DCMAKE_TOOLCHAIN_FILE=${WORKSPACE}/cmake/arm-cross.cmake          \
                                 -DOE_TA_DEV_KIT_DIR=/devkits/vexpress-qemu_armv8a/export-ta_arm64  \
-                                -DHAS_QUOTE_PROVIDER=OFF                                           \
                                 -Wdev
                             ninja -v
                             """
@@ -67,7 +66,7 @@ def checkDevFlows(String version) {
                 cleanWs()
                 checkout scm
                 def task = """
-                           cmake ${WORKSPACE} -G Ninja -DHAS_QUOTE_PROVIDER=OFF -Wdev --warn-uninitialized -Werror=dev
+                           cmake ${WORKSPACE} -G Ninja -Wdev --warn-uninitialized -Werror=dev
                            ninja -v
                            """
                 oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-7", task, "--cap-add=SYS_PTRACE")
@@ -110,19 +109,16 @@ try{
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
-                "Sim 1804 clang-7 SGX1 Debug":      { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 1804 clang-7 SGX1 Release":    { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 1804 clang-7 SGX1FLC Debug":   { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 1804 clang-7 SGX1FLC Release": { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) }
+                "Sim 1804 clang-7 SGX1 Debug":   { simulationContainerTest('18.04', 'Debug',   ['-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-7 SGX1 Release": { simulationContainerTest('18.04', 'Release', ['-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) }
             ]
             parallel testing_stages
         }
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "Sim 1804 clang-7 SGX1 Release":    { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "Sim 1804 clang-7 SGX1FLC Debug":   { simulationContainerTest('18.04', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "Sim 1804 clang-7 SGX1FLC Release": { simulationContainerTest('18.04', 'Release', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) }
+                "Sim 1804 clang-7 SGX1 Debug":   { simulationContainerTest('18.04', 'Debug',   ['-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "Sim 1804 clang-7 SGX1 Release": { simulationContainerTest('18.04', 'Release', ['-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) }
             ]
             parallel testing_stages
         }

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -97,7 +97,7 @@ def ACCGNUTest() {
                 cleanWs()
                 checkout scm
                 def task = """
-                           cmake ${WORKSPACE} -DHAS_QUOTE_PROVIDER=ON
+                           cmake ${WORKSPACE}
                            make
                            ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                            """
@@ -180,7 +180,7 @@ def ACCHostVerificationTest(String version, String build_type) {
 
                 println("Generating certificates and reports ...")
                 def task = """
-                           cmake ${WORKSPACE} -G Ninja -DHAS_QUOTE_PROVIDER=ON -DCMAKE_BUILD_TYPE=${build_type} -Wdev
+                           cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -Wdev
                            ninja -v
                            pushd tests/host_verify/host
                            openssl ecparam -name prime256v1 -genkey -noout -out keyec.pem
@@ -218,7 +218,7 @@ def ACCHostVerificationTest(String version, String build_type) {
         }
     }
 
-    /* Compile the tests with HAS_QUOTE_PROVIDER=OFF and unstash the certs over for verification.  */
+    /* Compile the tests and unstash the certs over for verification.  */
     stage("Linux nonSGX Verify Quote") {
         node(AGENTS_LABELS["ubuntu-nonsgx"]) {
             timeout(GLOBAL_TIMEOUT_MINUTES) {
@@ -226,7 +226,7 @@ def ACCHostVerificationTest(String version, String build_type) {
                 checkout scm
                 unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
                 def task = """
-                           cmake ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=OFF -DCMAKE_BUILD_TYPE=${build_type} -Wdev
+                           cmake ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -Wdev
                            ninja -v
                            ctest -R host_verify --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                            """
@@ -246,7 +246,7 @@ def ACCHostVerificationTest(String version, String build_type) {
                 dir('build') {
                     bat """
                         vcvars64.bat x64 && \
-                        cmake.exe ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=OFF -DCMAKE_BUILD_TYPE=${build_type} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
+                        cmake.exe ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
                         ninja -v && \
                         ctest.exe -V -C ${build_type} -R host_verify --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                         """
@@ -271,20 +271,16 @@ try{
 
         "ACC1804 GNU gcc SGX1FLC":                { ACCGNUTest() },
 
-        "RHEL-8 clang-8 simulation Release":      { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
-        "RHEL-8 clang-8 simulation Debug":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
-        "RHEL-8 gcc-8 simulation Release":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
-        "RHEL-8 gcc-8 simulation Debug":          { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1']) },
-        "RHEL-8 ACC clang-8 SGX1 Release":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF']) },
-        "RHEL-8 ACC clang-8 SGX1 Debug":          { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF']) },
-        "RHEL-8 ACC gcc-8 SGX1 Release":          { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF']) },
-        "RHEL-8 ACC gcc-8 SGX1 Debug":            { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF']) },
+        "RHEL-8 clang-8 simulation Release":      { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', [], ['OE_SIMULATION=1']) },
+        "RHEL-8 clang-8 simulation Debug":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   [], ['OE_SIMULATION=1']) },
+        "RHEL-8 gcc-8 simulation Release":        { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', [], ['OE_SIMULATION=1']) },
+        "RHEL-8 gcc-8 simulation Debug":          { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   [], ['OE_SIMULATION=1']) },
 
         "ACC1604 clang-7 Debug LVI e2e":          { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04-vanilla"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) },
         "ACC1804 gcc Debug LVI e2e":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) },
     
-        "RHEL-8 clang-8 simulation Release e2e":  { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1'], true) },
-        "RHEL-8 ACC clang-8 SGX1 Release e2e":    { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], [], true) }
+        "RHEL-8 clang-8 simulation Release e2e":  { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', [], ['OE_SIMULATION=1'], true) },
+        "RHEL-8 ACC clang-8 SGX1 Release e2e":    { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', [], [], true) }
     ]
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
@@ -302,22 +298,18 @@ try{
                 "ACC1804 Container RelWithDebInfo":       { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
                 "ACC1804 Container RelWithDebInfo LVI":   { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
 
-                "RHEL-8 ACC clang-8 SGX1FLC Release":     { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=ON']) },
-                "RHEL-8 ACC clang-8 SGX1FLC Debug":       { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON']) },
-                "RHEL-8 ACC gcc-8 SGX1FLC Release":       { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=ON']) },
-                "RHEL-8 ACC gcc-8 SGX1FLC Debug":         { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=ON']) },
+                "RHEL-8 ACC clang-8 SGX1FLC Release":     { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Release', []) },
+                "RHEL-8 ACC clang-8 SGX1FLC Debug":       { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'clang', 'Debug',   []) },
+                "RHEL-8 ACC gcc-8 SGX1FLC Release":       { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Release', []) },
+                "RHEL-8 ACC gcc-8 SGX1FLC Debug":         { ACCTest(AGENTS_LABELS['acc-rhel-8'], 'gcc',   'Debug',   []) },
 
-                "RHEL-8 ACC clang-8 SGX1FLC Release e2e": { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=ON'], [], true) },
-                "RHEL-8 ACC clang-8 SGX1FLC Debug e2e":   { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=ON'], [], true) },
-                "RHEL-8 ACC gcc-8 SGX1FLC Release e2e":   { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=ON'], [], true) },
-                "RHEL-8 ACC gcc-8 SGX1FLC Debug e2e":     { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=ON'], [], true) },
-                "RHEL-8 clang-8 simulation Debug e2e":    { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1'], true) },
-                "RHEL-8 gcc-8 simulation Release e2e":    { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1'], true) },
-                "RHEL-8 gcc-8 simulation Debug e2e":      { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], ['OE_SIMULATION=1'], true) },
-                "RHEL-8 ACC clang-8 SGX1 Release e2e":    { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], [], true) },
-                "RHEL-8 ACC clang-8 SGX1 Debug e2e":      { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], [], true) },
-                "RHEL-8 ACC gcc-8 SGX1 Release e2e":      { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'gcc',   'Release', ['-DHAS_QUOTE_PROVIDER=OFF'], [], true) },
-                "RHEL-8 ACC gcc-8 SGX1 Debug e2e":        { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'gcc',   'Debug',   ['-DHAS_QUOTE_PROVIDER=OFF'], [], true) },
+                "RHEL-8 ACC clang-8 SGX1FLC Release e2e": { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Release', [], [], true) },
+                "RHEL-8 ACC clang-8 SGX1FLC Debug e2e":   { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Debug',   [], [], true) },
+                "RHEL-8 ACC gcc-8 SGX1FLC Release e2e":   { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'gcc',   'Release', [], [], true) },
+                "RHEL-8 ACC gcc-8 SGX1FLC Debug e2e":     { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'gcc',   'Debug',   [], [], true) },
+                "RHEL-8 clang-8 simulation Debug e2e":    { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'clang', 'Debug',   [], ['OE_SIMULATION=1'], true) },
+                "RHEL-8 gcc-8 simulation Release e2e":    { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'gcc',   'Release', [], ['OE_SIMULATION=1'], true) },
+                "RHEL-8 gcc-8 simulation Debug e2e":      { ACCTest(AGENTS_LABELS['acc-rhel-8-vanilla'], 'gcc',   'Debug',   [], ['OE_SIMULATION=1'], true) },
 
                 "ACC1604 clang-7 Debug":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Debug',   ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
                 "ACC1604 clang-7 Release":                { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },

--- a/.jenkins/pipelines/Azure/Nightly/libcxx_tests.Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Nightly/libcxx_tests.Jenkinsfile
@@ -18,7 +18,7 @@ def ACCLibcxxTest(String label, String compiler, String build_type) {
                 cleanWs()
                 checkout scm
                 def task = """
-                           cmake .. -DCMAKE_BUILD_TYPE=${build_type} -DHAS_QUOTE_PROVIDER=ON -DENABLE_FULL_LIBCXX_TESTS=ON
+                           cmake .. -DCMAKE_BUILD_TYPE=${build_type} -DENABLE_FULL_LIBCXX_TESTS=ON
                            make
                            ctest -VV -debug --timeout ${CTEST_TIMEOUT_SECONDS}
                            """

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -27,7 +27,6 @@ def windowsLinuxElfBuild(String label, String version, String compiler, String b
                            cmake ${WORKSPACE}                                           \
                                -G Ninja                                                 \
                                -DCMAKE_BUILD_TYPE=${build_type}                         \
-                               -DHAS_QUOTE_PROVIDER=ON                                  \
                                -DLVI_MITIGATION=${lvi_mitigation}                       \
                                -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
                                -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} \
@@ -49,7 +48,7 @@ def windowsLinuxElfBuild(String label, String version, String compiler, String b
                 dir('build') {
                   bat """
                       vcvars64.bat x64 && \
-                      cmake.exe ${WORKSPACE} -G Ninja -DADD_WINDOWS_ENCLAVE_TESTS=ON -DBUILD_ENCLAVES=OFF -DHAS_QUOTE_PROVIDER=ON -DCMAKE_BUILD_TYPE=${build_type} -DLINUX_BIN_DIR=${WORKSPACE}\\linuxbin\\tests -DLVI_MITIGATION=${lvi_mitigation} -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
+                      cmake.exe ${WORKSPACE} -G Ninja -DADD_WINDOWS_ENCLAVE_TESTS=ON -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -DLINUX_BIN_DIR=${WORKSPACE}\\linuxbin\\tests -DLVI_MITIGATION=${lvi_mitigation} -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
                       ninja -v && \
                       ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT_SECONDS}
                       """


### PR DESCRIPTION
- .jenkins/pipelines/Azure/Nightly/libcxx_tests.Jenkinsfile
  Remove HAS_QUOTE_PROVIDER=on from cmake args

- .jenkins/pipelines/Agnostic/Linux/Jenkinsfile
  - Remove HAS_QUOTE_PROVIDER in AArch64GNUTest, checkDevFlows and testing stages.
  - Removed SGX1FLC stages since FLC does not matter for Simulation Mode testing

-  pipelines/Azure/Windows/Jenkinsfile

- .jenkins/pipelines/Azure/Linux/Jenkinsfile
   - Removed HAS_QUOTE_PROVIDER cmake option in ACCGNUTest, ACCHostVerificationTest
   - Removed duplicate pipelines resultant from removal of HAS_QUOTE_PROVIDER

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>