### PR TITLE
Pass segfault address from host to OE exception handler

### DIFF
--- a/enclave/core/sgx/exception.c
+++ b/enclave/core/sgx/exception.c
@@ -317,7 +317,7 @@ void oe_real_exception_dispatcher(oe_context_t* oe_context)
     oe_exception_record_t oe_exception_record = {0};
     oe_exception_record.code = td->exception_code;
     oe_exception_record.flags = td->exception_flags;
-    oe_exception_record.address = td->exception_address;
+    oe_exception_record.address = td->exception_host_address;
     oe_exception_record.context = oe_context;
 
     // Refer to oe_enter in host/sgx/enter.c. The contract we defined for EENTER
@@ -395,9 +395,11 @@ void oe_virtual_exception_dispatcher(
         {
             td->exception_address = ssa_gpr->rip;
 
-            /* TODO PRP: We need to read the exception information from
+            /* TODO We need to read the exception information from
              * oe_exception_record instead */
             td->exception_code = OE_EXCEPTION_PAGE_FAULT;
+            // Store the accessed address that caused the page fault from host
+            td->exception_host_address = oe_exception_record->address;
             td->exception_flags |= OE_EXCEPTION_FLAGS_HARDWARE;
         }
         else

--- a/host/sgx/exception.c
+++ b/host/sgx/exception.c
@@ -21,6 +21,7 @@ uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
 {
     uint64_t exit_code = context->rax;
     uint64_t tcs_address = context->rbx;
+    uint64_t host_address = context->address;
     uint64_t exit_address = context->rip;
 
     // Check if the signal happens inside the enclave.
@@ -46,8 +47,9 @@ uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
 
         oe_exception_record_t oe_exception_record = {0};
 
-        /* TODO PRP: We need to save the exception information in
+        /* TODO: We need to save the complete exception information in
          * oe_exception_record */
+        oe_exception_record.address = host_address;
 
         // Call into enclave first pass exception handler.
         uint64_t arg_out = 0;

--- a/host/sgx/exception.h
+++ b/host/sgx/exception.h
@@ -11,6 +11,7 @@ typedef struct _host_exception_context
 {
     uint64_t rax;
     uint64_t rbx;
+    uint64_t address;
     uint64_t rip;
 } oe_host_exception_context_t;
 

--- a/host/sgx/linux/exception.c
+++ b/host/sgx/linux/exception.c
@@ -36,6 +36,7 @@ static void _host_signal_handler(
     oe_host_exception_context_t host_context = {0};
     host_context.rax = (uint64_t)context->uc_mcontext.gregs[REG_RAX];
     host_context.rbx = (uint64_t)context->uc_mcontext.gregs[REG_RBX];
+    host_context.address = (uint64_t) sig_info->si_addr;
     host_context.rip = (uint64_t)context->uc_mcontext.gregs[REG_RIP];
 
     // Call platform neutral handler.

--- a/include/openenclave/internal/sgx/td.h
+++ b/include/openenclave/internal/sgx/td.h
@@ -81,7 +81,7 @@ oe_thread_data_t* oe_get_thread_data(void);
  * Due to the inability to use OE_OFFSETOF on a struct while defining its
  * members, this value is computed and hard-coded.
  */
-#define OE_THREAD_SPECIFIC_DATA_SIZE (3744)
+#define OE_THREAD_SPECIFIC_DATA_SIZE (3736)
 
 typedef struct _callsite Callsite;
 
@@ -148,6 +148,8 @@ typedef struct _td
     uint32_t exception_flags;
     // The rip when exception happened.
     uint64_t exception_address;
+    // The memory address accessed when exception happened (reported by host).
+    uint64_t exception_host_address;
 
     /* The threads implementations uses this to put threads on queues */
     struct _td* next;


### PR DESCRIPTION
This commit takes the address that caused a segfault, as reported in the
host signal handler, and passes it to the in-enclave OE exception
handler. This is needed so that an application signal handler can
obtain the faulting address inside the enclave.

The current implementation should be generalised to handle arbitrary
synchronous signals correctly. Note that SGX2 permits the exception
information to be obtained in-enclave, making this untrusted mechanism
unnecessary.

This is needed by PR https://github.com/lsds/sgx-lkl/pull/646 to fix https://github.com/lsds/sgx-lkl/issues/645.