### PR TITLE
Win Docs Cleanup: Remove EnclaveCommonAPI reference

### DIFF
--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
@@ -51,19 +51,9 @@ After unpacking the self-extracting ZIP executable, you can refer to the *Intel 
 for more details on how to install the contents of the package.
 
 Note that Windows Server 2019 should have this package installed by default via Windows Update.
-In that case, it is only necessary to set the registry key to allow the LC_driver to run, and install the
-DCAP nuget packages if you want to build the OE SDK.
+In that case, it is only necessary to set the registry key to allow the LC_driver to run.
 
 The following summary will assume that the contents were extracted to `C:\Intel SGX DCAP for Windows v1.7.100.2`:
-
-### Install the Intel DCAP nuget packages
-
-The standalone `nuget.exe` [CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) can be used to do this from the command prompt:
-
-```cmd
-nuget.exe install DCAP_Components -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.7.100.2\nuget" -OutputDirectory c:\oe_prereqs
-nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.7.100.2\nuget" -OutputDirectory c:\oe_prereqs
-```
 
 ### Install the Intel DCAP driver
 
@@ -92,12 +82,4 @@ nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP fo
       ```cmd
       devcon.exe update base\WindowsServer2019_Windows10\sgx_base.inf *INT0E0C
       devcon.exe update dcap\WindowsServer2019_Windows10\sgx_dcap.inf "SWC\VEN_INT&DEV_0E0C_DCAP"
-      ```
-
-3. Install the DCAP nuget packages:
-    - The standalone `nuget.exe` [CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) can be used to do this from the command prompt:
-
-      ```cmd
-      nuget.exe install DCAP_Components -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.7.100.2\nuget" -OutputDirectory c:\oe_prereqs
-      nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.7.100.2\nuget" -OutputDirectory c:\oe_prereqs
       ```

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
@@ -49,20 +49,3 @@ using the following command from Powershell.
 ```powershell
 Start-Service "AESMService"
 ```
-
-## [Intel Data Center Attestation Primitives (DCAP) Libraries v1.6](http://registrationcenter-download.intel.com/akdlm/irc_nas/16620/Intel%20SGX%20DCAP%20for%20Windows%20v1.6.100.2.exe)
-
-While SGX1 machines without FLC support do not support DCAP quoting and attestation, the DCAP libraries package
-contains the **Intel Enclave Common API library** as well. This library is necessary for creating, initializing, and deleting enclaves.
-
-After unpacking the self-extracting ZIP executable, you will need to install the nuget package for the Enclave
-Common API library if you want to build OE SDK on the target device. To do so, make sure you have the [nuget CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) installed and its location in your `PATH`.
-
-The following example will assume that the contents were extracted to `C:\Intel SGX DCAP for Windows v1.6.100.2`
-and that `C:\oe_prereqs` is where you would like the prerequisites to be installed:
-
-```cmd
-nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.6.100.2\nuget" -OutputDirectory c:\oe_prereqs
-```
-
-You can verify that the library is installed properly by checking whether `sgx_enclave_common.lib` exists in the folder `C:\oe_prereqs`.


### PR DESCRIPTION
All SGX dlls exist in the system32 directory, and
they are dynamically loaded. There is no need anymore for
SGX nuget packages (DCAP, EnclaveCommonAPI) while building the
SDK.

The NUGET_PACKAGE_PATH cmake parameter is almost useless,
since no nuget packages are needed for building the SDK.
The sole use of NUGET_PACKAGE_PATH that cannot be removed
is in add_dcap_client_target.cmake where the it is used to
locate dcap_quoteprove.dll via:
```
 # Define the DCAP provider path
  set(AZURE_DCAP_QUOTEPROV
      ${NUGET_PACKAGE_PATH}/Microsoft.Azure.DCAP/build/native/dcap_quoteprov.dll
  )
```

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>