### PR TITLE
Use enclave_link_libraries instead of TARGET_OBJECTS

### DIFF
--- a/3rdparty/dlmalloc/CMakeLists.txt
+++ b/3rdparty/dlmalloc/CMakeLists.txt
@@ -1,18 +1,20 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-add_enclave_library(oedlmalloc OBJECT allocator.c)
+add_enclave_library(oedlmalloc_obj OBJECT allocator.c)
 
-enclave_link_libraries(oedlmalloc PRIVATE oe_includes oelibc_includes)
+enclave_link_libraries(oedlmalloc_obj PRIVATE oe_includes oelibc_includes)
 
 if (OE_TRUSTZONE)
-    enclave_link_libraries(oedlmalloc PUBLIC oelibutee_includes)
-    set(TEE_C_FLAGS ${OE_TZ_TA_C_FLAGS})
-else()
-    set(TEE_C_FLAGS "")
-endif()
+  enclave_link_libraries(oedlmalloc_obj PUBLIC oelibutee_includes)
+  set(TEE_C_FLAGS ${OE_TZ_TA_C_FLAGS})
+else ()
+  set(TEE_C_FLAGS "")
+endif ()
 
-enclave_compile_options(oedlmalloc PRIVATE
+enclave_compile_options(
+  oedlmalloc_obj
+  PRIVATE
   -ftls-model=local-exec
   -nostdinc
   -fPIE
@@ -23,7 +25,17 @@ enclave_compile_options(oedlmalloc PRIVATE
 # Specify the warning options as source files properties so that
 # they will appear last in the compiler command line and supercede
 # other warning options.
-set_source_files_properties(allocator.c PROPERTIES
-  COMPILE_FLAGS "-Wno-conversion -Wno-null-pointer-arithmetic")
+set_source_files_properties(
+  allocator.c PROPERTIES COMPILE_FLAGS
+                         "-Wno-conversion -Wno-null-pointer-arithmetic")
 
-maybe_build_using_clangw(oedlmalloc)
+maybe_build_using_clangw(oedlmalloc_obj)
+
+install_enclaves(
+  TARGETS
+  oedlmalloc_obj
+  EXPORT
+  openenclave-targets
+  ARCHIVE
+  DESTINATION
+  ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/3rdparty/snmalloc/CMakeLists.txt
+++ b/3rdparty/snmalloc/CMakeLists.txt
@@ -72,11 +72,13 @@ maybe_build_using_clangw(oesnmalloc_obj)
 
 # Create snmalloc library to make snmalloc available to the user
 # as a pluggable allocator.
-add_enclave_library(oesnmalloc $<TARGET_OBJECTS:oesnmalloc_obj>)
+add_enclave_library(oesnmalloc STATIC)
+enclave_link_libraries(oesnmalloc oesnmalloc_obj)
 maybe_build_using_clangw(oesnmalloc)
 
 install_enclaves(
   TARGETS
+  oesnmalloc_obj
   oesnmalloc
   EXPORT
   openenclave-targets

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -164,9 +164,9 @@ if (OE_TRUSTZONE OR (OE_SGX AND (UNIX OR USE_CLANGW)))
 endif ()
 
 if (USE_SNMALLOC)
-  set(DEFAULT_ALLOCATOR oesnmalloc_obj)
+  set(DEFAULT_ALLOCATOR_LIB oesnmalloc_obj)
 else ()
-  set(DEFAULT_ALLOCATOR oedlmalloc)
+  set(DEFAULT_ALLOCATOR_LIB oedlmalloc_obj)
 endif ()
 
 add_enclave_library(
@@ -200,7 +200,6 @@ add_enclave_library(
   time.c
   tracee.c
   wchar.c
-  $<TARGET_OBJECTS:${DEFAULT_ALLOCATOR}>
   ${PLATFORM_SRC})
 
 # Some files in oecore come directly from the musl source. For these files,
@@ -241,7 +240,7 @@ if (OE_TRUSTZONE)
     oecore PRIVATE ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 endif ()
 
-enclave_link_libraries(oecore PUBLIC oe_includes)
+enclave_link_libraries(oecore PUBLIC oe_includes ${DEFAULT_ALLOCATOR_LIB})
 
 if (CMAKE_C_COMPILER_ID MATCHES GNU)
   enclave_compile_options(oecore PRIVATE -Wjump-misses-init)


### PR DESCRIPTION
This ensures that lvi-mitigated objects are picked up from object libraries.

Fixes #3315 

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>