### PR TITLE
Explicitly load libsgx_enclave_common.so.1

### DIFF
--- a/host/sgx/sgx_enclave_common_wrapper.c
+++ b/host/sgx/sgx_enclave_common_wrapper.c
@@ -63,7 +63,9 @@ static bool (*_enclave_set_information)(
 
 #include <dlfcn.h>
 
-#define LIBRARY_NAME "libsgx_enclave_common.so"
+// Explicitly choose the version of libsgx_enclave_common.so (currently 1)
+// that OE is compatible with.
+#define LIBRARY_NAME "libsgx_enclave_common.so.1"
 
 // Use best practices
 // - RTLD_NOW  Bind all undefined symbols before dlopen returns.


### PR DESCRIPTION
libsgx_enclave_common.so is an abi versioned library:

$ ls -la /usr/lib/x86_64-linux-gnu | grep libsgx_enclave_common
lrwxrwxrwx  1 root root       26 Jun 30 09:25 libsgx_enclave_common.so -> libsgx_enclave_common.so.1
lrwxrwxrwx  1 root root       34 Jun 30 09:25 libsgx_enclave_common.so.1 -> libsgx_enclave_common.so.1.0.111.2
-rw-r--r--  1 root root    26448 Jun 30 09:25 libsgx_enclave_common.so.1.0.111.2

libsgx_enclave_common.so symlink is created by the libsgx-enclave-common-dev.
It points to the current major version of available (happens to be libsgx_enclave_common.so.1)
in the build system.

When the GNU linker is supplied a versioned library, it actually creates a symlink to the major version:
$ gcc -fPIC -m64 foo.c -lsgx_enclave_common
$ ldd ./a.out
    ...
    libsgx_enclave_common.so.1 => /usr/lib/x86_64-linux-gnu/libsgx_enclave_common.so.1 (0x00007efcde21a000)
    ...
The application does not need libsgx_enclave_common.so; rather it needs libsgx_enclave_common.so.1
to be present in the target system to successfully run.

Since production systems may not have libsgx_enclave_common.so (i.e a production system may
not install a development package like libsgx-enclave-common-dev), and to be consistent with
the GNU linker behavior, we now load libsgx_enclave_common.so.1 (i.e the major version of the library)
instead of libsgx_enclave_common.so.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>