### PR TITLE
Update to lvi mitigation toolchain to 2.10 and fix a bug in the installation script

### DIFF
--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/lvi-setup.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/lvi-setup.yml
@@ -41,25 +41,25 @@
 
 - name: Download as/ld tarball
   get_url:
-    url: 'https://download.01.org/intel-sgx/sgx-linux/2.9/as.ld.objdump.gold.r1.tar.gz'
-    dest: '/tmp/as.ld.objdump.gold.r1.tar.gz'
+    url: 'https://download.01.org/intel-sgx/sgx-linux/2.10/as.ld.objdump.gold.r2.tar.gz'
+    dest: '/tmp/as.ld.objdump.gold.r2.tar.gz'
 
 - name: Extract as and ld binaries
   unarchive:
-    src: '/tmp/as.ld.objdump.gold.r1.tar.gz'
+    src: '/tmp/as.ld.objdump.gold.r2.tar.gz'
     dest: '{{ local_lvi_directory }}/'
     remote_src: yes
 
 - name: Create symbolic link to as
   file:
-    src: '{{ local_lvi_directory }}/external/toolset/as'
+    src: '{{ local_lvi_directory }}/external/toolset/ubuntu18.04/as'
     dest: '{{ local_lvi_directory }}/bin/as'
     state: link
     force: yes
 
 - name: Create symbolic link to ld
   file:
-    src: '{{ local_lvi_directory }}/external/toolset/ld'
+    src: '{{ local_lvi_directory }}/external/toolset/ubuntu18.04/ld'
     dest: '{{ local_lvi_directory }}/bin/ld'
     state: link
     force: yes

--- a/scripts/lvi-mitigation/install_lvi_mitigation_bindir
+++ b/scripts/lvi-mitigation/install_lvi_mitigation_bindir
@@ -2,7 +2,15 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-set -o errexit
+# Exit on error.
+set -e
+
+# shellcheck disable=SC2154
+# Keep track of the last executed command.
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# shellcheck disable=SC2154
+# Echo an error message upon a trap.
+trap 'echo "\"${last_command}\" command filed with exit code $?."' ERR
 
 script=$(readlink -f "$0")
 script_path=$(dirname "$script")
@@ -29,6 +37,9 @@ cp "$script_path"/invoke_compiler "$bin_path"/invoke_compiler
 clang_versions=("" "-7" "-8" "-9")
 for version in "${clang_versions[@]}"; do
   clang="clang$version"
+  if ! [ -x "$(command -v "$clang")" ]; then
+    continue
+  fi
   clangcpp="clang++$version"
   clang_path=$(which "$clang")
   clangcpp_path=$(which "$clangcpp")
@@ -55,12 +66,12 @@ fi
 
 # Obtain `as` and `ld` from Intel site.
 intel_site="https://download.01.org/intel-sgx/sgx-linux/"
-intel_tool_version="2.9"
-intel_tarball="as.ld.objdump.gold.r1.tar.gz"
+intel_tool_version="2.10"
+intel_tarball="as.ld.objdump.gold.r2.tar.gz"
 wget "$intel_site"/"$intel_tool_version"/"$intel_tarball" -O /tmp/"$intel_tarball"
 tar -xf /tmp/"$intel_tarball" -C /tmp
 
-intel_extract_path=external/toolset
+intel_extract_path=external/toolset/ubuntu18.04
 rm -f "$bin_path"/as
 cp /tmp/"$intel_extract_path"/as "$bin_path"/as
 # The `ld` depends on glibc version 2.27.


### PR DESCRIPTION
Update the toolchain of lvi mitigation to 2.10 that reflects the recent update from Intel.

Also, fixing a bug that causing the installation script exit if any of `clang`, `clang-7`, `clang-8`, `clang-9` is not installed.

Fixes #3307 

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>