### PR TITLE
Remove libsgx-enclave-common-dev

### DIFF
--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -14,7 +14,7 @@ set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 
 # CPack variables for Debian packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "libsgx-enclave-common (>=2.3.100.46354-1), libsgx-enclave-common-dev (>=2.3.100.0-1), libsgx-dcap-ql (>=1.0.100.46460-1.0), libsgx-dcap-ql-dev (>=1.0.100.46460-1.0)"
+    "libsgx-enclave-common (>=2.3.100.46354-1), libsgx-dcap-ql (>=1.0.100.46460-1.0), libsgx-dcap-ql-dev (>=1.0.100.46460-1.0)"
 )
 set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "pkg-config")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)

--- a/devex/vscode-extension/README.md
+++ b/devex/vscode-extension/README.md
@@ -259,7 +259,7 @@ system you run the extension on.
     build-essential clang-7 docker.io g++-aarch64-linux-gnu                  \
     gcc-aarch64-linux-gnu gdb gdb-multiarch libc6 libc6-dev:arm64 libfdt1    \
     libglib2.0-0 libpcre3 libpixman-1-0 libprotobuf10 libsgx-dcap-ql         \
-    libsgx-dcap-ql-dev libsgx-enclave-common libsgx-enclave-common-dev       \
+    libsgx-dcap-ql-dev libsgx-enclave-common                                 \
     libssl-dev libssl-dev:arm64 libstdc++6 open-enclave python python-crypto \
     python-pip qemu-user-static zlib1g
   ```

--- a/devex/vscode-extension/marketplace-homepage.md
+++ b/devex/vscode-extension/marketplace-homepage.md
@@ -259,7 +259,7 @@ system you run the extension on.
     build-essential clang-7 docker.io g++-aarch64-linux-gnu                  \
     gcc-aarch64-linux-gnu gdb gdb-multiarch libc6 libc6-dev:arm64 libfdt1    \
     libglib2.0-0 libpcre3 libpixman-1-0 libprotobuf10 libsgx-dcap-ql         \
-    libsgx-dcap-ql-dev libsgx-enclave-common libsgx-enclave-common-dev       \
+    libsgx-dcap-ql-dev libsgx-enclave-common                                 \
     libssl-dev libssl-dev:arm64 libstdc++6 open-enclave python python-crypto \
     python-pip qemu-user-static zlib1g
   ```

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
@@ -50,7 +50,7 @@ sudo ./sgx_linux_x64_driver.bin
 ### 3. Install the Intel and Open Enclave packages and dependencies
 
 ```bash
-sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf9v5 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave
+sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libprotobuf9v5 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave
 ```
 
 > This step also installs the [az-dcap-client](https://github.com/microsoft/azure-dcap-client)

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
@@ -47,7 +47,7 @@ sudo ./sgx_linux_x64_driver.bin
 
 ### 3. Install the Intel and Open Enclave packages and dependencies
 ```bash
-sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave
+sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave
 ```
 
 > This step also installs the [az-dcap-client](https://github.com/microsoft/azure-dcap-client)

--- a/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
@@ -5,7 +5,6 @@
 intel_sgx_packages:
   - "sgx-aesm-service"
   - "libsgx-enclave-common"
-  - "libsgx-enclave-common-devel"
   - "libsgx-ae-pce"
   - "libsgx-ae-qe3"
   - "libsgx-qe3-logic"
@@ -14,6 +13,6 @@ intel_sgx_packages:
 packages_validation_distribution_files:
   - "/usr/include/sgx_attributes.h"
   - "/usr/include/sgx_enclave_common.h"
-  - "/usr/lib64/libsgx_enclave_common.so"
+  - "/usr/lib64/libsgx_enclave_common.so.1"
   - "/usr/lib64/libsgx_pce.signed.so"
   - "/usr/lib64/libsgx_qe3.signed.so"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
@@ -4,7 +4,6 @@
 ---
 intel_sgx_packages:
   - "libsgx-enclave-common"
-  - "libsgx-enclave-common-dev"
   - "libsgx-ae-qve"
   - "libsgx-ae-pce"
   - "libsgx-ae-qe3"
@@ -17,7 +16,7 @@ intel_dcap_packages:
   - "libsgx-urts"
 
 packages_validation_distribution_files:
-  - "/usr/lib/x86_64-linux-gnu/libsgx_enclave_common.so"
+  - "/usr/lib/x86_64-linux-gnu/libsgx_enclave_common.so.1"
   - "/usr/lib/x86_64-linux-gnu/libsgx_pce_logic.so"
   - "/usr/lib/x86_64-linux-gnu/libsgx_qe3_logic.so"
   - "/usr/lib/x86_64-linux-gnu/libsgx_dcap_ql.so"


### PR DESCRIPTION
OE SDK no longer depends on libsgx-enclave-common-dev.
This package brought in sgx headers as well as the symbolic link
libsgx_enclave_common.so => libsgx_enclave_common.so.1

Since OE SDK dynamically loads SGX libraries, this dev package is no longer
needed.

This PR mainly involves removing references to libsgx-enclave-common-dev.
Additionally, ansible validation is changed to test existence of
libsgx_enclave_common.so.1.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>