### PR TITLE
issue:3309 add missing header file in OE SDK

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -29,6 +29,7 @@ install(
   FILES openenclave/attestation/sgx/eeid_attester.h
         openenclave/attestation/sgx/eeid_plugin.h
         openenclave/attestation/sgx/eeid_verifier.h
+        openenclave/attestation/sgx/evidence.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/attestation/sgx)
 install(
   FILES openenclave/attestation/verifier.h


### PR DESCRIPTION
Add missing include/openenclave/attestation/sgx/evidence.h in OE SDK package.

fixes #3309 

Signed-off-by: Shantanu Sharma <shanshar@microsoft.com>