### PR TITLE
Remove suppressing of mscompatibility flags.

### DIFF
--- a/scripts/clangw
+++ b/scripts/clangw
@@ -49,14 +49,6 @@ function call_clang {
         [ "$a" == "/W4" ]           && continue
         [ "$a" == "/WX" ]           && continue
 
-        # Ignore specific clang flags for the MSVC compatibility.
-        # See http://clang.llvm.org/docs/UsersManual.html#microsoft-extensions for more detail.
-        [ "$a" == "-fms-compatibility" ]            && continue
-        [ "$a" == "-fms-extension" ]                && continue
-        [ "$a" == "-fdelayed-template-parsing" ]    && continue
-        # Use regex to match the value-passing flag.
-        [[ "$a" =~ "-fms-compatibility-version=" ]] && continue
-
         # Ignore warnings for specific error codes
         if [[ "$a" =~ /[wW][dD][0-9]* ]]; then
             continue


### PR DESCRIPTION
It turns out the user in fact needs the compatibility flags since
code written for windows is being compiled for enclaves, and uses msvc constructs.

The original scenario that caused us to add the supression is not relevant anymore.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>