### PR TITLE
Fix oe_log_message() and time functions.

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -163,16 +163,11 @@ if (UNIX)
     crypto/openssl/key.c
     crypto/openssl/rsa.c
     crypto/openssl/sha.c
-    linux/hostthread.c)
-
-  list(
-    APPEND
-    PLATFORM_SDK_ONLY_SRC
-    ../common/asn1.c
-    crypto/openssl/hmac.c
-    crypto/openssl/random.c
-    linux/syscall.c
+    linux/hostthread.c
     linux/time.c)
+
+  list(APPEND PLATFORM_SDK_ONLY_SRC ../common/asn1.c crypto/openssl/hmac.c
+       crypto/openssl/random.c linux/syscall.c)
 elseif (WIN32)
   list(
     APPEND
@@ -186,7 +181,8 @@ elseif (WIN32)
     crypto/bcrypt/sha.c
     crypto/bcrypt/pem.c
     crypto/bcrypt/util.c
-    windows/hostthread.c)
+    windows/hostthread.c
+    windows/time.c)
 
   list(
     APPEND
@@ -205,8 +201,7 @@ elseif (WIN32)
     crypto/bcrypt/rsa.c
     crypto/bcrypt/sha.c
     windows/hostthread.c
-    windows/syscall.c
-    windows/time.c)
+    windows/syscall.c)
 else ()
   message(
     FATAL_ERROR "Unknown OS. The only supported OSes are Linux and Windows")

--- a/host/linux/time.c
+++ b/host/linux/time.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <errno.h>
+#include <openenclave/internal/localtime.h>
 #include <openenclave/internal/time.h>
 #include <time.h>
 #include "../ocalls.h"
@@ -27,4 +28,9 @@ void oe_handle_get_time(uint64_t arg_in, uint64_t* arg_out)
 
     if (arg_out)
         *arg_out = _time();
+}
+
+int oe_localtime(time_t* timep, struct tm* result)
+{
+    return !localtime_r(timep, result);
 }

--- a/host/measure/CMakeLists.txt
+++ b/host/measure/CMakeLists.txt
@@ -11,7 +11,8 @@ if (UNIX)
       crypto/openssl/key.c
       crypto/openssl/rsa.c
       crypto/openssl/sha.c
-      linux/hostthread.c)
+      linux/hostthread.c
+      linux/time.c)
 elseif (WIN32)
   set(PLATFORM_HOST_MR_SRC
       crypto/bcrypt/key.c

--- a/host/sgx/sgxsign.c
+++ b/host/sgx/sgxsign.c
@@ -6,6 +6,7 @@
 #include <openenclave/internal/crypto/cert.h>
 #include <openenclave/internal/elf.h>
 #include <openenclave/internal/error.h>
+#include <openenclave/internal/localtime.h>
 #include <openenclave/internal/mem.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/rsa.h>
@@ -47,13 +48,9 @@ static oe_result_t _get_date(unsigned int* date)
 
     t = time(NULL);
 
-#if defined(_MSC_VER)
-    if (localtime_s(&tm, &t) != 0)
+    if (oe_localtime(&t, &tm))
         OE_RAISE(OE_FAILURE);
-#else
-    if (localtime_r(&t, &tm) == NULL)
-        OE_RAISE(OE_FAILURE);
-#endif
+
     {
         char s[9];
         unsigned char b[8];

--- a/include/openenclave/internal/localtime.h
+++ b/include/openenclave/internal/localtime.h
@@ -1,0 +1,21 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_INTERNAL_LOCALTIME_H
+#define _OE_INTERNAL_LOCALTIME_H
+
+#include <openenclave/bits/defs.h>
+#include <openenclave/bits/result.h>
+#include <openenclave/bits/types.h>
+#include <time.h>
+
+OE_EXTERNC_BEGIN
+
+/**
+ * Return the current system time in local time.
+ */
+extern int oe_localtime(time_t* timep, struct tm* result);
+
+OE_EXTERNC_END
+
+#endif /* _OE_INTERNAL_DATETIME_H */

--- a/include/openenclave/internal/time.h
+++ b/include/openenclave/internal/time.h
@@ -22,6 +22,20 @@ OE_EXTERNC_BEGIN
 
 uint64_t oe_get_time(void);
 
+#ifdef _WIN32
+/*
+**==============================================================================
+**
+** gettimeofday()
+**
+**     Get seconds and useconds elapsed since the Epoch.
+**
+**==============================================================================
+*/
+
+int gettimeofday(struct timeval* tv, struct timezone* tz);
+#endif
+
 OE_EXTERNC_END
 
 #endif /* _OE_INCLUDE_TIME_H */

--- a/include/openenclave/internal/trace.h
+++ b/include/openenclave/internal/trace.h
@@ -34,6 +34,7 @@ typedef void (*oe_log_callback_t)(
     const char* time,
     long int usecs,
     oe_log_level_t level,
+    uint64_t host_thread_id,
     const char* message);
 oe_result_t oe_log_set_callback(void* context, oe_log_callback_t callback);
 extern void* oe_log_context;


### PR DESCRIPTION
Fix oe_log_message().
1. Initialize usecs on Both Linux and Windows.
2. Add host thread id to callback function type.

Fix several time functions:
1. Implement equivalent gettimeofday() on Windows.
2. Add oe_localtime().

Signed-off-by: Alvin Chen <alvin@chen.asia>