### PR TITLE
Enable oe_verify_evidence to retrieve sgx endorsements in claims.

### DIFF
--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -241,7 +241,8 @@ static oe_result_t _fill_with_known_claims(
 
     // Optional claims are needed for SGX quotes for remote attestation
     if (format_type != SGX_FORMAT_TYPE_LOCAL &&
-        claims_length < OE_REQUIRED_CLAIMS_COUNT + OE_OPTIONAL_CLAIMS_COUNT)
+        claims_length < OE_REQUIRED_CLAIMS_COUNT + OE_OPTIONAL_CLAIMS_COUNT +
+                            OE_SGX_CLAIMS_COUNT)
         OE_RAISE(OE_INVALID_PARAMETER);
 
     // ID version.
@@ -325,6 +326,73 @@ static oe_result_t _fill_with_known_claims(
             sizeof(OE_CLAIM_VALIDITY_UNTIL),
             &valid_until,
             sizeof(valid_until)));
+
+        // TCB info
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_SGX_TCB_INFO,
+            sizeof(OE_CLAIM_SGX_TCB_INFO),
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_TCB_INFO].data,
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_TCB_INFO].size));
+
+        // TCB issuer chain
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_SGX_TCB_ISSUER_CHAIN,
+            sizeof(OE_CLAIM_SGX_TCB_ISSUER_CHAIN),
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_TCB_ISSUER_CHAIN]
+                .data,
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_TCB_ISSUER_CHAIN]
+                .size));
+
+        // PCK CRL
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_SGX_PCK_CRL,
+            sizeof(OE_CLAIM_SGX_PCK_CRL),
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_CRL_PCK_CERT].data,
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_CRL_PCK_CERT]
+                .size));
+
+        // Root CA CRL
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_SGX_ROOT_CA_CRL,
+            sizeof(OE_CLAIM_SGX_ROOT_CA_CRL),
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_CRL_PCK_PROC_CA]
+                .data,
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_CRL_PCK_PROC_CA]
+                .size));
+
+        // CRL Issuer Chain
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_SGX_CRL_ISSUER_CHAIN,
+            sizeof(OE_CLAIM_SGX_CRL_ISSUER_CHAIN),
+            sgx_endorsements
+                ->items[OE_SGX_ENDORSEMENT_FIELD_CRL_ISSUER_CHAIN_PCK_CERT]
+                .data,
+            sgx_endorsements
+                ->items[OE_SGX_ENDORSEMENT_FIELD_CRL_ISSUER_CHAIN_PCK_CERT]
+                .size));
+
+        // QE ID info
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_SGX_QE_ID_INFO,
+            sizeof(OE_CLAIM_SGX_QE_ID_INFO),
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_QE_ID_INFO].data,
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_QE_ID_INFO].size));
+
+        // QE ID issuer chain
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_SGX_QE_ID_ISSUER_CHAIN,
+            sizeof(OE_CLAIM_SGX_QE_ID_ISSUER_CHAIN),
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_QE_ID_ISSUER_CHAIN]
+                .data,
+            sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_QE_ID_ISSUER_CHAIN]
+                .size));
     }
 
     *claims_added = claims_index;
@@ -415,7 +483,9 @@ oe_result_t oe_sgx_extract_claims(
     if (format_type != SGX_FORMAT_TYPE_LOCAL)
     {
         OE_CHECK(oe_safe_add_u64(
-            claims_length, OE_OPTIONAL_CLAIMS_COUNT, &claims_length));
+            claims_length,
+            OE_OPTIONAL_CLAIMS_COUNT + OE_SGX_CLAIMS_COUNT,
+            &claims_length));
     }
 
     OE_CHECK(oe_safe_mul_u64(claims_length, sizeof(oe_claim_t), &claims_size));

--- a/include/openenclave/attestation/sgx/evidence.h
+++ b/include/openenclave/attestation/sgx/evidence.h
@@ -64,7 +64,19 @@ OE_EXTERNC_BEGIN
     }
 
 /**
- * SGX specific claim: for the report data embedded in the SGX quote.
+ * SGX specific claim: SGX Quote verification collateral.
+ */
+#define OE_CLAIM_SGX_TCB_INFO "sgx_tcb_info"
+#define OE_CLAIM_SGX_TCB_ISSUER_CHAIN "sgx_tcb_issuer_chain"
+#define OE_CLAIM_SGX_PCK_CRL "sgx_pck_crl"
+#define OE_CLAIM_SGX_ROOT_CA_CRL "sgx_root_ca_crl"
+#define OE_CLAIM_SGX_CRL_ISSUER_CHAIN "sgx_crl_issuer_chain"
+#define OE_CLAIM_SGX_QE_ID_INFO "sgx_qe_id_info"
+#define OE_CLAIM_SGX_QE_ID_ISSUER_CHAIN "sgx_qe_id_issuer_chain"
+#define OE_SGX_CLAIMS_COUNT 7
+
+/**
+ * Additional SGX specific claim: for the report data embedded in the SGX quote.
  */
 #define OE_CLAIM_SGX_REPORT_DATA "sgx_report_data"
 

--- a/tests/attestation_plugin/enc/enc.c
+++ b/tests/attestation_plugin/enc/enc.c
@@ -58,7 +58,7 @@ static void _test_sgx_remote()
     OE_TEST_CODE(
         oe_attester_select_format(&_ecdsa_uuid, 1, &selected_format), OE_OK);
 
-    // Get a remote attestation report.
+    // Get evidence.
     printf("====== running _test_sgx_remote #1: Just evidence\n");
     OE_TEST_CODE(
         oe_get_evidence(
@@ -77,11 +77,20 @@ static void _test_sgx_remote()
     printf("    ====== evidence_size=%d\n", evidence_size);
 
     verify_sgx_evidence(
-        &selected_format, true, evidence, evidence_size, NULL, 0, NULL, 0);
+        &selected_format,
+        true,
+        evidence,
+        evidence_size,
+        NULL,
+        0,
+        NULL,
+        0,
+        NULL,
+        0);
 
     OE_TEST(oe_free_evidence(evidence) == OE_OK);
 
-    // Get a remote report with endorsements.
+    // Get evidence with endorsements.
     printf("====== running _test_sgx_remote #2: + Endorsements\n");
     OE_TEST_CODE(
         oe_get_evidence(
@@ -102,12 +111,28 @@ static void _test_sgx_remote()
         evidence_size,
         endorsements_size);
 
+    printf("====== verify evidence by passing NULL endorsements\n");
+    verify_sgx_evidence(
+        &selected_format,
+        true,
+        evidence,
+        evidence_size,
+        NULL, // endorsements
+        0,
+        endorsements, // expected_endorsements
+        endorsements_size,
+        NULL,
+        0);
+
+    printf("====== verify evidence by passing non-NULL endorsements\n");
     verify_sgx_evidence(
         &selected_format,
         true,
         evidence,
         evidence_size,
         endorsements,
+        endorsements_size,
+        endorsements, // expected_endorsements
         endorsements_size,
         NULL,
         0);
@@ -142,6 +167,8 @@ static void _test_sgx_remote()
         true,
         evidence,
         evidence_size,
+        endorsements,
+        endorsements_size,
         endorsements,
         endorsements_size,
         test_claims,
@@ -183,6 +210,8 @@ static void _test_sgx_remote()
         evidence_size,
         endorsements,
         endorsements_size,
+        endorsements,
+        endorsements_size,
         NULL,
         0);
     OE_TEST(oe_free_evidence(evidence) == OE_OK);
@@ -208,6 +237,8 @@ static void _test_sgx_remote()
         false,
         evidence,
         evidence_size,
+        endorsements,
+        endorsements_size,
         endorsements,
         endorsements_size,
         NULL,
@@ -252,7 +283,16 @@ static void _test_sgx_local()
             0) == OE_OK);
 
     verify_sgx_evidence(
-        &selected_format, true, evidence, evidence_size, NULL, 0, NULL, 0);
+        &selected_format,
+        true,
+        evidence,
+        evidence_size,
+        NULL,
+        0,
+        NULL,
+        0,
+        NULL,
+        0);
 
     OE_TEST(oe_free_evidence(evidence) == OE_OK);
 
@@ -276,6 +316,8 @@ static void _test_sgx_local()
         true,
         evidence,
         evidence_size,
+        NULL,
+        0,
         NULL,
         0,
         test_claims,

--- a/tests/attestation_plugin/host/host.c
+++ b/tests/attestation_plugin/host/host.c
@@ -34,6 +34,8 @@ void host_verify(
         evidence_size,
         endorsements,
         endorsements_size,
+        endorsements,
+        endorsements_size,
         test_claims,
         TEST_CLAIMS_SIZE);
 }

--- a/tests/attestation_plugin/plugin/tests.h
+++ b/tests/attestation_plugin/plugin/tests.h
@@ -22,6 +22,9 @@ void verify_sgx_evidence(
     size_t evidence_size,
     const uint8_t* endorsements,
     size_t endorsements_size,
+    const uint8_t*
+        expected_endorsements, // validate endorsements related claims
+    size_t expected_endorsements_size,
     const uint8_t* custom_claims,
     size_t custom_claims_size);
 


### PR DESCRIPTION
Fixes issue #2976 
The caller of verifier might need endorsements information such as TCB info, QE id, CRL for their own extra verification. So this PR enabled `oe_verify_evidence()` to retrieve endorsements information in new oe claims entries:
```
OE_CLAIM_SGX_TCB_INFO:           oe_sgx_endorsements[OE_SGX_ENDORSEMENT_FIELD_TCB_INFO]
OE_CLAIM_SGX_TCB_ISSUER_CHAIN:   oe_sgx_endorsements[OE_SGX_ENDORSEMENT_FIELD_TCB_ISSUER_CHAIN]
OE_CLAIM_SGX_PCK_CRL:            oe_sgx_endorsements[OE_SGX_ENDORSEMENT_FIELD_CRL_PCK_CERT]
OE_CLAIM_SGX_ROOT_CA_CRL:        oe_sgx_endorsements[OE_SGX_ENDORSEMENT_FIELD_CRL_PCK_PROC_CA]
OE_CLAIM_SGX_CRL_ISSUER_CHAIN:   oe_sgx_endorsements[OE_SGX_ENDORSEMENT_FIELD_CRL_ISSUER_CHAIN_PCK_CERT]
OE_CLAIM_SGX_QE_ID_INFO:         oe_sgx_endorsements[OE_SGX_ENDORSEMENT_FIELD_QE_ID_INFO]
OE_CLAIM_SGX_QE_ID_ISSUER_CHAIN: oe_sgx_endorsements[OE_SGX_ENDORSEMENT_FIELD_QE_ID_ISSUER_CHAIN]
```

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>