### PR TITLE
Add debug_malloc runtime options to improve tests/memory and tests/at…

### DIFF
--- a/enclave/core/debugmalloc.c
+++ b/enclave/core/debugmalloc.c
@@ -4,6 +4,7 @@
 #include "debugmalloc.h"
 #include <openenclave/advanced/allocator.h>
 #include <openenclave/corelibc/errno.h>
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/backtrace.h>
 #include <openenclave/internal/calls.h>
@@ -315,7 +316,10 @@ void* oe_debug_malloc(size_t size)
         return NULL;
 
     /* Fill block with 0xAA (Allocated) bytes */
-    oe_memset_s(block, block_size, 0xAA, block_size);
+    if (oe_use_debug_malloc_memset)
+    {
+        oe_memset_s(block, block_size, 0xAA, block_size);
+    }
 
     header_t* header = (header_t*)block;
     INIT_BLOCK(header, 0, size);

--- a/enclave/core/malloc.c
+++ b/enclave/core/malloc.c
@@ -40,9 +40,21 @@ void oe_set_allocation_failure_callback(
     _failure_callback = function;
 }
 
+bool oe_use_debug_malloc = true;
+
+bool oe_use_debug_malloc_memset = true;
+
 void* oe_malloc(size_t size)
 {
-    void* p = MALLOC(size);
+    void* p = NULL;
+    if (oe_use_debug_malloc)
+    {
+        p = MALLOC(size);
+    }
+    else
+    {
+        p = oe_allocator_malloc(size);
+    }
 
     if (!p && size)
     {
@@ -55,12 +67,27 @@ void* oe_malloc(size_t size)
 
 void oe_free(void* ptr)
 {
-    FREE(ptr);
+    if (oe_use_debug_malloc)
+    {
+        FREE(ptr);
+    }
+    else
+    {
+        oe_allocator_free(ptr);
+    }
 }
 
 void* oe_calloc(size_t nmemb, size_t size)
 {
-    void* p = CALLOC(nmemb, size);
+    void* p = NULL;
+    if (oe_use_debug_malloc)
+    {
+        p = CALLOC(nmemb, size);
+    }
+    else
+    {
+        p = oe_allocator_calloc(nmemb, size);
+    }
 
     if (!p && nmemb && size)
     {
@@ -73,7 +100,15 @@ void* oe_calloc(size_t nmemb, size_t size)
 
 void* oe_realloc(void* ptr, size_t size)
 {
-    void* p = REALLOC(ptr, size);
+    void* p = NULL;
+    if (oe_use_debug_malloc)
+    {
+        p = REALLOC(ptr, size);
+    }
+    else
+    {
+        p = oe_allocator_realloc(ptr, size);
+    }
 
     if (!p && size)
     {
@@ -112,5 +147,12 @@ int oe_posix_memalign(void** memptr, size_t alignment, size_t size)
 
 size_t oe_malloc_usable_size(void* ptr)
 {
-    return MALLOC_USABLE_SIZE(ptr);
+    if (oe_use_debug_malloc)
+    {
+        return MALLOC_USABLE_SIZE(ptr);
+    }
+    else
+    {
+        return oe_allocator_malloc_usable_size(ptr);
+    }
 }

--- a/include/openenclave/corelibc/stdlib.h
+++ b/include/openenclave/corelibc/stdlib.h
@@ -28,6 +28,10 @@ typedef struct _oe_syscall_path
     char buf[OE_PATH_MAX];
 } oe_syscall_path_t;
 
+extern bool oe_use_debug_malloc;
+
+extern bool oe_use_debug_malloc_memset;
+
 void* oe_malloc(size_t size);
 
 void oe_free(void* ptr);

--- a/tests/attestation_plugin/enc/enc.c
+++ b/tests/attestation_plugin/enc/enc.c
@@ -5,6 +5,7 @@
 #include <openenclave/attestation/sgx/evidence.h>
 #include <openenclave/attestation/verifier.h>
 #include <openenclave/bits/sgx/sgxtypes.h>
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/report.h>
 #include <openenclave/internal/sgx/plugin.h>
@@ -48,6 +49,8 @@ void unregister_sgx()
 
 static void _test_sgx_remote()
 {
+    oe_use_debug_malloc = false;
+
     printf("====== running _test_sgx_remote\n");
     uint8_t* evidence = NULL;
     size_t evidence_size = 0;
@@ -216,6 +219,8 @@ static void _test_sgx_remote()
     OE_TEST(oe_free_endorsements(endorsements) == OE_OK);
 
     printf("====== done _test_sgx_remote\n");
+
+    oe_use_debug_malloc = true;
 }
 
 static void _test_sgx_local()

--- a/tests/memory/enc/fragment.c
+++ b/tests/memory/enc/fragment.c
@@ -1,6 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/globals.h>
 #include <openenclave/internal/tests.h>
@@ -95,6 +96,8 @@ static int _malloc_free_random_size(int times, unsigned int seed)
 
 void test_malloc_fixed_size_fragment(void)
 {
+    oe_use_debug_malloc_memset = false;
+
     // get heap size before tests
     size_t heap_size_before_test = _get_heap_size();
     oe_host_printf(
@@ -109,10 +112,14 @@ void test_malloc_fixed_size_fragment(void)
         "[test_malloc_fixed_size_fragment]heap size after test : %zu.\n",
         heap_size_after_test);
     OE_TEST(heap_size_before_test == heap_size_after_test);
+
+    oe_use_debug_malloc_memset = true;
 }
 
 void test_malloc_random_size_fragment(unsigned int seed)
 {
+    oe_use_debug_malloc = false;
+
     // get heap size before tests
     size_t heap_size_before_test = _get_heap_size();
     oe_host_printf(
@@ -126,4 +133,6 @@ void test_malloc_random_size_fragment(unsigned int seed)
         "[test_malloc_random_size_fragment]heap size after test : %zu.\n",
         heap_size_after_test);
     OE_TEST(heap_size_before_test == heap_size_after_test);
+
+    oe_use_debug_malloc = true;
 }

--- a/tests/memory/host/host.cpp
+++ b/tests/memory/host/host.cpp
@@ -121,7 +121,6 @@ static void _malloc_boundary_test(oe_enclave_t* enclave, uint32_t flags)
     free(heapbuf);
 }
 
-#if !defined(OE_USE_DEBUG_MALLOC)
 static void _malloc_fixed_size_fragment_test(oe_enclave_t* enclave)
 {
     test_malloc_fixed_size_fragment(enclave);
@@ -141,7 +140,6 @@ static void _malloc_random_size_fragment_test(oe_enclave_t* enclave, int seed)
     }
     test_malloc_random_size_fragment(enclave, chosen_seed);
 }
-#endif
 
 int main(int argc, const char* argv[])
 {
@@ -171,7 +169,6 @@ int main(int argc, const char* argv[])
     printf("===Starting malloc boundary test.\n");
     _malloc_boundary_test(enclave, flags);
 
-#if !defined(OE_USE_DEBUG_MALLOC)
     printf("===Starting malloc fixed size fragment test.\n");
     _malloc_fixed_size_fragment_test(enclave);
 
@@ -190,7 +187,6 @@ int main(int argc, const char* argv[])
         }
     }
     _malloc_random_size_fragment_test(enclave, seed);
-#endif
 
     printf("===All tests pass.\n");
 


### PR DESCRIPTION
This is an internal patch for tests.
Due to debug_malloc's new feature of backtrace of allocation, the overhead makes it takes much longer walltime to finish some extreme cases.
By adding the runtime options use_debug_malloc and use_debug_malloc_memset, some tests are enabled or improved.

Signed-off-by: Alvin Chen <alvin@chen.asia>