### PR TITLE
Remove compaction bit from OE_XSAVE_INITIAL_STATE

### DIFF
--- a/enclave/core/sgx/asmdefs.c
+++ b/enclave/core/sgx/asmdefs.c
@@ -35,9 +35,10 @@ OE_XSAVE_INITIAL_STATE[MINIMAL_XSTATE_AREA_LENGTH/sizeof(uint32_t)] = {
     0, 0, 0, 0, 0, 0, 0, 0,
 
     /* XSAVE Header */
-    /* Clear XSTATE_BV, set XCOMP_BV[63] = 1 to support compaction mode;
-     * SGX-capable systems should support it */
-    0, 0, 0, 0x80000000,
+    /* Clear XSTATE_BV. Note that this means we don't support
+     * compaction mode (XCOMP_BV[63]) to accommodate running
+     * the same code in simulation mode on older CPUs. */
+    0, 0, 0, 0,
 
     /* Reserved XSAVE header bits */
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
Fixes #3350

Signed-off-by: Simon Leet <simon.leet@microsoft.com>