### PR TITLE
Use dynamic symbols for loading enclaves

### DIFF
--- a/enclave/core/sgx/globals.c
+++ b/enclave/core/sgx/globals.c
@@ -7,7 +7,8 @@
 
 /* Note: The variables below are initialized during enclave loading */
 
-extern volatile const oe_sgx_enclave_properties_t oe_enclave_properties_sgx;
+OE_EXPORT extern volatile const oe_sgx_enclave_properties_t
+    oe_enclave_properties_sgx;
 
 /**
  *****************************************************************************
@@ -124,9 +125,9 @@ extern volatile const oe_sgx_enclave_properties_t oe_enclave_properties_sgx;
  *
  **/
 
-static volatile uint64_t _enclave_rva;
-static volatile uint64_t _reloc_rva;
-static volatile uint64_t _reloc_size;
+OE_EXPORT volatile uint64_t _enclave_rva;
+OE_EXPORT volatile uint64_t _reloc_rva;
+OE_EXPORT volatile uint64_t _reloc_size;
 
 #ifdef OE_WITH_EXPERIMENTAL_EEID
 oe_eeid_t* oe_eeid = NULL;

--- a/enclave/core/sgx/threadlocal.c
+++ b/enclave/core/sgx/threadlocal.c
@@ -193,12 +193,12 @@
  * the loader fetches the symbol's sh-value and stores it in the r_addend field
  * (r_added field is otherwise zero for R_X86_64_TPOFF64).
  */
-static volatile uint64_t _tdata_rva = 0;
-static volatile uint64_t _tdata_size = 0;
-static volatile uint64_t _tdata_align = 1;
+OE_EXPORT volatile uint64_t _tdata_rva = 0;
+OE_EXPORT volatile uint64_t _tdata_size = 0;
+OE_EXPORT volatile uint64_t _tdata_align = 1;
 
-static volatile uint64_t _tbss_size = 0;
-static volatile uint64_t _tbss_align = 1;
+OE_EXPORT volatile uint64_t _tbss_size = 0;
+OE_EXPORT volatile uint64_t _tbss_align = 1;
 
 // Number of thread-local relocations.
 static volatile bool _thread_locals_relocated = false;

--- a/tests/thread_local/CMakeLists.txt
+++ b/tests/thread_local/CMakeLists.txt
@@ -13,3 +13,9 @@ add_enclave_test(tests/thread_local thread_local_host thread_local_enc)
 # Test enclaves with exported thread-locals.
 add_enclave_test(tests/thread_local_exported thread_local_host
                  thread_local_enc_exported --exported-thread-locals)
+
+# Repeat above tests, but with stripped enclaves.
+add_enclave_test(tests/thread_local_stripped thread_local_host
+                 thread_local_enc_stripped)
+add_enclave_test(tests/thread_local_exported_stripped thread_local_host
+                 thread_local_enc_exported_stripped --exported-thread-locals)

--- a/tests/thread_local/enc/CMakeLists.txt
+++ b/tests/thread_local/enc/CMakeLists.txt
@@ -42,3 +42,40 @@ enclave_compile_definitions(thread_local_enc_exported PRIVATE
 
 enclave_include_directories(thread_local_enc_exported PRIVATE
                             ${CMAKE_CURRENT_BINARY_DIR})
+
+# Build stripped enclave without exported thread-locals.
+add_enclave(
+  TARGET
+  thread_local_enc_stripped
+  UUID
+  0eee03ee-0f93-4c24-8da7-6d00176c8e78
+  CXX
+  SOURCES
+  enc.cpp
+  externs.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/thread_local_t.c)
+
+enclave_include_directories(thread_local_enc_stripped PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})
+
+enclave_link_libraries(thread_local_enc_stripped "-s")
+
+# Build enclave with exported thread-locals.
+add_enclave(
+  TARGET
+  thread_local_enc_exported_stripped
+  UUID
+  6dd12df2-ba89-4718-b7f4-1be7845c33e8
+  CXX
+  SOURCES
+  enc.cpp
+  externs.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/thread_local_t.c)
+
+enclave_compile_definitions(thread_local_enc_exported_stripped PRIVATE
+                            -DEXPORT_THREAD_LOCALS=1)
+
+enclave_include_directories(thread_local_enc_exported_stripped PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})
+
+enclave_link_libraries(thread_local_enc_exported_stripped "-s")


### PR DESCRIPTION
The following symbols are needed to load an enclave
- _start This is the enclave entry-point that calls __oe_handle_main
- oe_call_link_enclave This is used to force dependency on report/attestation functions
- _enclave_rva This is critical for the enclave to securely figure out the base-address
- _reloc_rva This points to the relocation entries of the enclave. This is critical for the
  enclave to function correctly. Relocations are performed as one of the first actions upon
  enclave initialization.
- _reloc_size This is the size in bytes of _reloc_rva entries.
- _tdata_rva This is the pointer to thread-local-data template.
- _tdata_size This is the size of the thread-local-data template.
- _tdata_align This is the alignment of thread-local-data template.
- _tbss_size This tis the size of zero initialized thread-local-data. (tbss section).
- _tbss_align This is the alignment of the tbss section.

All the above symbols must be visible to correctly load an enclave.

When an enclave is built using `-s` linker flag (as is often the case with release builds)
or if the enclave binary is stripped using the strip command, then these symbols will be
eliminated from the enclave binary and there would be no way to load them.

In order to perform dynamic linking/program loading, necessary symbols are always preserved
in the dynamic symbols section.

To make enclaves loading work without symbols, all of the above symbols must be exported
(earlier we were only exporting _start). Additionally the loader must rely on dynamic symbols.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>