### PR TITLE
Clean up _add_segment_pages()

### DIFF
--- a/common/result.c
+++ b/common/result.c
@@ -136,6 +136,8 @@ const char* oe_result_str(oe_result_t result)
             return "OE_QUOTE_HASH_MISMATCH";
         case OE_INVALID_SGX_SIGNING_KEY:
             return "OE_INVALID_SGX_SIGNING_KEY";
+        case OE_INVALID_IMAGE:
+            return "OE_INVALID_IMAGE";
         case __OE_RESULT_MAX:
             break;
     }
@@ -207,6 +209,7 @@ bool oe_is_valid_result(uint32_t result)
         case OE_ALREADY_INITIALIZED:
         case OE_QUOTE_HASH_MISMATCH:
         case OE_INVALID_SGX_SIGNING_KEY:
+        case OE_INVALID_IMAGE:
         {
             return true;
         }

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -361,6 +361,11 @@ typedef enum _oe_result
      */
     OE_INVALID_SGX_SIGNING_KEY,
 
+    /**
+     * The binary image being loaded into the enclave could not be parsed.
+     */
+    OE_INVALID_IMAGE,
+
     __OE_RESULT_MAX = OE_ENUM_MAX,
 } oe_result_t;
 /**< typedef enum _oe_result oe_result_t*/

--- a/include/openenclave/internal/load.h
+++ b/include/openenclave/internal/load.h
@@ -25,12 +25,6 @@ typedef struct _oe_sgx_enclave_properties oe_sgx_enclave_properties_t;
 
 typedef struct _oe_elf_segment
 {
-    /* Pointer to segment from ELF file */
-    void* filedata;
-
-    /* Size of this segment in the ELF file */
-    size_t filesz;
-
     /* Size of this segment in memory */
     size_t memsz;
 


### PR DESCRIPTION
- Add OE_INVALID_IMAGE oe_result_t for _load_elf_image failures
- Fail early on unexpected ELF read during load instead of just asserting.
- Remove unused oe_elf_segment properties.

Signed-off-by: Simon Leet <simon.leet@microsoft.com>