### PR TITLE
Fix memory leaks in EEID plugins and tests.

### DIFF
--- a/common/sgx/eeid_verifier.c
+++ b/common/sgx/eeid_verifier.c
@@ -182,7 +182,6 @@ static oe_result_t _verify_sgx_report(
     oe_report_t* parsed_report)
 {
     oe_result_t result = OE_UNEXPECTED;
-    OE_UNUSED(sgx_evidence_buffer_size);
     const uint8_t* report_buffer = sgx_evidence_buffer;
     oe_datetime_t* time = NULL;
     oe_report_header_t* header = (oe_report_header_t*)report_buffer;
@@ -208,7 +207,7 @@ static oe_result_t _verify_sgx_report(
 
     sgx_claims_size = sgx_evidence_buffer_size -
                       (header->report_size + sizeof(oe_report_header_t));
-    *sgx_claims = oe_malloc(sgx_claims_size);
+    *sgx_claims = NULL;
 
     OE_CHECK(oe_parse_report(
         sgx_evidence_buffer,
@@ -324,6 +323,8 @@ static oe_result_t _eeid_verify_evidence(
         uint64_t r_attributes = parsed_report.identity.attributes;
         uint32_t r_id_version = parsed_report.identity.id_version;
 
+        oe_free_claims(sgx_claims, sgx_claims_length);
+
         /* EEID passed to the verifier */
         if (endorsements_buffer)
         {
@@ -393,7 +394,12 @@ static oe_result_t _eeid_free_claims_list(
 {
     OE_UNUSED(context);
     OE_UNUSED(claims_size);
-    free(claims);
+    for (size_t i = 0; i < claims_size; i++)
+    {
+        oe_free(claims[i].name);
+        oe_free(claims[i].value);
+    }
+    oe_free(claims);
     return OE_OK;
 }
 

--- a/common/sgx/eeid_verifier.c
+++ b/common/sgx/eeid_verifier.c
@@ -393,7 +393,6 @@ static oe_result_t _eeid_free_claims_list(
     size_t claims_size)
 {
     OE_UNUSED(context);
-    OE_UNUSED(claims_size);
     for (size_t i = 0; i < claims_size; i++)
     {
         oe_free(claims[i].name);

--- a/common/sgx/eeid_verifier.c
+++ b/common/sgx/eeid_verifier.c
@@ -7,6 +7,7 @@
 
 #ifdef OE_BUILD_ENCLAVE
 #include <openenclave/enclave.h>
+#define oe_memalign_free oe_free
 #else
 #include <openenclave/host.h>
 #include "../../host/memalign.h"

--- a/common/sgx/eeid_verifier.c
+++ b/common/sgx/eeid_verifier.c
@@ -378,10 +378,10 @@ static oe_result_t _eeid_verify_evidence(
 
 done:
 
-    oe_free(sgx_evidence_buffer);
-    oe_free(sgx_endorsements_buffer);
-    oe_free(attester_eeid);
-    oe_free(verifier_eeid);
+    oe_memalign_free(sgx_evidence_buffer);
+    oe_memalign_free(sgx_endorsements_buffer);
+    oe_memalign_free(attester_eeid);
+    oe_memalign_free(verifier_eeid);
     oe_free(evidence);
 
     return result;

--- a/common/sgx/eeid_verifier.c
+++ b/common/sgx/eeid_verifier.c
@@ -388,21 +388,6 @@ done:
     return result;
 }
 
-static oe_result_t _eeid_free_claims_list(
-    oe_verifier_t* context,
-    oe_claim_t* claims,
-    size_t claims_size)
-{
-    OE_UNUSED(context);
-    for (size_t i = 0; i < claims_size; i++)
-    {
-        oe_free(claims[i].name);
-        oe_free(claims[i].value);
-    }
-    oe_free(claims);
-    return OE_OK;
-}
-
 static oe_verifier_t _eeid_verifier = {
     .base =
         {
@@ -411,7 +396,7 @@ static oe_verifier_t _eeid_verifier = {
             .on_unregister = &_eeid_verifier_on_unregister,
         },
     .verify_evidence = &_eeid_verify_evidence,
-    .free_claims = &_eeid_free_claims_list};
+    .free_claims = &sgx_attestation_plugin_free_claims_list};
 
 oe_result_t oe_sgx_eeid_verifier_initialize(void)
 {

--- a/common/sgx/eeid_verifier.c
+++ b/common/sgx/eeid_verifier.c
@@ -304,7 +304,7 @@ static oe_result_t _eeid_verify_evidence(
         oe_report_t parsed_report;
         oe_claim_t* sgx_claims = NULL;
         size_t sgx_claims_length = 0;
-        _verify_sgx_report(
+        OE_CHECK(_verify_sgx_report(
             context,
             policies,
             policies_size,
@@ -314,7 +314,7 @@ static oe_result_t _eeid_verify_evidence(
             sgx_endorsements_buffer_size,
             &sgx_claims,
             &sgx_claims_length,
-            &parsed_report);
+            &parsed_report));
 
         const uint8_t* r_enclave_hash = parsed_report.identity.unique_id;
         const uint8_t* r_signer_id = parsed_report.identity.signer_id;

--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -66,7 +66,7 @@ static void _free_claim(oe_claim_t* claim)
     oe_free(claim->value);
 }
 
-static oe_result_t _free_claims(
+oe_result_t sgx_attestation_plugin_free_claims_list(
     oe_verifier_t* context,
     oe_claim_t* claims,
     size_t claims_length)
@@ -539,7 +539,7 @@ oe_result_t oe_sgx_extract_claims(
 
 done:
     if (claims)
-        _free_claims(NULL, claims, claims_length);
+        sgx_attestation_plugin_free_claims_list(NULL, claims, claims_length);
     return result;
 }
 
@@ -858,7 +858,7 @@ static oe_result_t _get_verifier_plugins(
         plugin->get_format_settings = &_get_format_settings;
         plugin->verify_evidence = &_verify_evidence;
         plugin->verify_report = &_verify_report;
-        plugin->free_claims = &_free_claims;
+        plugin->free_claims = &sgx_attestation_plugin_free_claims_list;
     }
     *verifiers_length = uuid_count;
     result = OE_OK;

--- a/enclave/sgx/eeid_attester.c
+++ b/enclave/sgx/eeid_attester.c
@@ -95,6 +95,9 @@ static oe_result_t _get_sgx_evidence(
     result = OE_OK;
 
 done:
+
+    oe_free(report);
+
     return result;
 }
 

--- a/enclave/sgx/eeid_attester.c
+++ b/enclave/sgx/eeid_attester.c
@@ -96,7 +96,7 @@ static oe_result_t _get_sgx_evidence(
 
 done:
 
-    oe_free(report);
+    oe_free_report(report);
 
     return result;
 }

--- a/include/openenclave/internal/sgx/plugin.h
+++ b/include/openenclave/internal/sgx/plugin.h
@@ -6,6 +6,7 @@
 
 #include <openenclave/bits/report.h>
 #include <openenclave/internal/crypto/sha.h>
+#include <openenclave/internal/plugin.h>
 
 OE_EXTERNC_BEGIN
 
@@ -76,6 +77,21 @@ oe_result_t oe_sgx_hash_custom_claims(
     const void* custom_claims,
     size_t custom_claims_size,
     OE_SHA256* hash_out);
+
+/**
+ * sgx_attestation_plugin_free_claims_list
+ *
+ * Free a claims list produced by the SGX verifier plugin.
+ *
+ * @param[in] context Plugin context (may be NULL).
+ * @param[in] claims List of claims.
+ * @param[in] claims_length The length of claims.
+ * @retval OE_OK on success, otherwise an appropriate error code.
+ */
+oe_result_t sgx_attestation_plugin_free_claims_list(
+    oe_verifier_t* context,
+    oe_claim_t* claims,
+    size_t claims_length);
 
 OE_EXTERNC_END
 

--- a/tests/eeid_plugin/enc/enc.c
+++ b/tests/eeid_plugin/enc/enc.c
@@ -279,8 +279,8 @@ oe_result_t get_eeid_evidence(
 
     OE_TEST_CODE(oe_sgx_eeid_attester_shutdown(), OE_OK);
 
-    free(local_evidence);
-    free(local_endorsements);
+    oe_free_evidence(local_evidence);
+    oe_free_endorsements(local_endorsements);
 
     return OE_OK;
 }

--- a/tests/eeid_plugin/enc/enc.c
+++ b/tests/eeid_plugin/enc/enc.c
@@ -11,6 +11,7 @@
 #include <openenclave/internal/report.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "../../../common/sgx/quote.h"
@@ -277,6 +278,9 @@ oe_result_t get_eeid_evidence(
     memcpy(endorsements, local_endorsements, local_endorsements_size);
 
     OE_TEST_CODE(oe_sgx_eeid_attester_shutdown(), OE_OK);
+
+    free(local_evidence);
+    free(local_endorsements);
 
     return OE_OK;
 }

--- a/tests/eeid_plugin/test_helpers.c
+++ b/tests/eeid_plugin/test_helpers.c
@@ -24,7 +24,7 @@ oe_result_t make_test_eeid(oe_eeid_t** eeid, size_t data_size)
     for (size_t i = 0; i < data_size; i++)
         (*eeid)->data[i] = 'a' + (i % 26);
     (*eeid)->data[data_size - 1] = 0;
-    (*eeid)->size_settings.num_heap_pages = 100 + (data_size / OE_PAGE_SIZE);
+    (*eeid)->size_settings.num_heap_pages = 110 + (data_size / OE_PAGE_SIZE);
     (*eeid)->size_settings.num_stack_pages = 50;
     (*eeid)->size_settings.num_tcs = 2;
 


### PR DESCRIPTION
This fixes memory leaks in the EEID code. 

Fixes #3368.

Signed-off-by: Christoph M. Wintersteiger <cwinter@microsoft.com>