### PR TITLE
<WIP>: Add support for large thread-local data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - OE SDK Release packages can now be built on non-SGX and non-FLC machines.
+- Support for arbitrarily large thread-local data for SGX machines.
 
 ### Changed
 
@@ -46,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   application EDL. See [system EDL opt-in document](docs/DesignDocs/system_ocall_opt_in.md#how-to-port-your-application) for more information.
   - Note: SDK users would need to import logging.edl to enable logging. Logging is disabled by default.
   - See [System edls](docs/SystemEdls.md) for list of all edls and associated OCalls.
-  - A known issue is that different enclaves importing functions from System EDLs cannot be loaded by the same host app unless all of the functions were imported with exactly the same ordinals. See #3250 for details. This will be addressed in the next release based on design proposal #3086. 
+  - A known issue is that different enclaves importing functions from System EDLs cannot be loaded by the same host app unless all of the functions were imported with exactly the same ordinals. See #3250 for details. This will be addressed in the next release based on design proposal #3086.
   - A workaround for this issue in the meantime is to define a standard import EDL for any enclaves that need to be loaded into the same host app. Ensuring this shared EDL is then the first import in each enclave's EDL will result in the common imports being assigned the same ordinals in each resulting enclave.
 - Mark APIs in include/openenclave/attestation/sgx/attester.h and verifier.h as experimental.
 - Remove CRL_ISSUER_CHAIN_PCK_PROC_CA field from endorsement struct define in include/openenclave/bits/attestation.h.

--- a/enclave/core/sgx/asmdefs.h
+++ b/enclave/core/sgx/asmdefs.h
@@ -16,7 +16,6 @@
 #define PAGE_SIZE 4096
 #define STATIC_STACK_SIZE 8 * 100
 #define OE_WORD_SIZE 8
-#define TD_FROM_TCS (5 * PAGE_SIZE)
 
 #define CODE_ERET 0x200000000
 

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -47,7 +47,8 @@ oe_enter:
     // Upon first entry to the enclave, td->base.self in the td_t structure
     // is not yet initialized. However, the loader in host/sgx/create.c places
     // the td_t structure as a specific offset from TCS.
-    lea TD_FROM_TCS(%rbx), %r11
+    mov td_from_tcs_offset(%rip), %r11
+    add %rbx, %r11
 
 .save_host_registers:
     // Backup the current host rbp, rsp, and context to previous.

--- a/enclave/core/sgx/td.c
+++ b/enclave/core/sgx/td.c
@@ -38,8 +38,11 @@ OE_STATIC_ASSERT(
 // debugger/pythonExtension/gdb_sgx_plugin.py
 OE_STATIC_ASSERT(td_callsites == 0xf0);
 OE_STATIC_ASSERT(OE_OFFSETOF(Callsite, ocall_context) == 0x40);
-OE_STATIC_ASSERT(TD_FROM_TCS == 0x5000);
 OE_STATIC_ASSERT(sizeof(oe_ocall_context_t) == (2 * sizeof(uintptr_t)));
+
+// Offset of the td page from the tcs page in bytes. This varies depending on
+// the size of thread-local data.
+OE_EXPORT uint64_t td_from_tcs_offset;
 
 /*
 **==============================================================================
@@ -129,7 +132,7 @@ void td_push_callsite(oe_sgx_td_t* td, Callsite* callsite)
 
 oe_sgx_td_t* td_from_tcs(void* tcs)
 {
-    return (oe_sgx_td_t*)((uint8_t*)tcs + TD_FROM_TCS);
+    return (oe_sgx_td_t*)((uint8_t*)tcs + td_from_tcs_offset);
 }
 
 /*
@@ -144,7 +147,7 @@ oe_sgx_td_t* td_from_tcs(void* tcs)
 
 void* td_to_tcs(const oe_sgx_td_t* td)
 {
-    return (uint8_t*)td - TD_FROM_TCS;
+    return (uint8_t*)td - td_from_tcs_offset;
 }
 
 /*

--- a/host/sgx/sgxload.h
+++ b/host/sgx/sgxload.h
@@ -8,6 +8,8 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/sgxcreate.h>
 
+#define OE_SGX_NUM_CONTROL_PAGES 4
+
 OE_EXTERNC_BEGIN
 
 #define OE_SGX_NO_DEVICE_HANDLE -1

--- a/include/openenclave/internal/load.h
+++ b/include/openenclave/internal/load.h
@@ -99,7 +99,10 @@ struct _oe_enclave_image
         oe_enclave_t* enclave,
         uint64_t* vaddr);
 
-    oe_result_t (*patch)(oe_enclave_image_t* image, size_t enclave_size);
+    oe_result_t (*sgx_patch)(
+        oe_enclave_image_t* image,
+        oe_sgx_load_context_t* context,
+        size_t enclave_size);
 
     oe_result_t (*sgx_load_enclave_properties)(
         const oe_enclave_image_t* image,

--- a/include/openenclave/internal/sgxcreate.h
+++ b/include/openenclave/internal/sgxcreate.h
@@ -64,6 +64,9 @@ struct _oe_sgx_load_context
     /* Hash context used to measure enclave as it is loaded */
     oe_sha256_context_t hash_context;
 
+    /* Number of pages needed for thread-local data */
+    size_t num_tls_pages;
+
 #ifdef OE_WITH_EXPERIMENTAL_EEID
     /* EEID data needed during enclave creation */
     oe_eeid_t* eeid;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ if (UNIX
     add_subdirectory(thread)
     add_subdirectory(threadcxx)
     add_subdirectory(thread_local)
+    add_subdirectory(thread_local_large)
     add_subdirectory(thread_local_no_tdata)
     add_subdirectory(VectorException)
     add_subdirectory(stack_smashing_protector)

--- a/tests/thread_local_large/CMakeLists.txt
+++ b/tests/thread_local_large/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/thread_local_large thread_local_large_host
+                 thread_local_large_enc)

--- a/tests/thread_local_large/enc/CMakeLists.txt
+++ b/tests/thread_local_large/enc/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../thread_local_large.edl)
+
+add_custom_command(
+  OUTPUT thread_local_large_t.h thread_local_large_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(
+  TARGET
+  thread_local_large_enc
+  UUID
+  5bf1ee3d-0cf2-44f7-8120-6efb1de7c3ad
+  CXX
+  SOURCES
+  enc.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/thread_local_large_t.c)
+
+enclave_include_directories(thread_local_large_enc PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/thread_local_large/enc/enc.cpp
+++ b/tests/thread_local_large/enc/enc.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/tests.h>
+#include <array>
+#include <cstdint>
+#include "thread_local_large_t.h"
+
+using namespace std;
+
+void enc_test()
+{
+    static thread_local array<uint8_t, 9000> a;
+    for (auto& x : a)
+    {
+        OE_TEST(x == 0);
+        x = 2;
+    }
+
+    // Perform an ocall.
+    host_nop();
+
+    // Expect that TLS is the same as before the ocall.
+    for (const auto x : a)
+        OE_TEST(x == 2);
+}
+
+OE_SET_ENCLAVE_SGX(
+    0,    /* ProductID */
+    0,    /* SecurityVersion */
+    true, /* Debug */
+    64,   /* NumHeapPages */
+    16,   /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/thread_local_large/host/CMakeLists.txt
+++ b/tests/thread_local_large/host/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../thread_local_large.edl)
+
+add_custom_command(
+  OUTPUT thread_local_large_u.h thread_local_large_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(thread_local_large_host host.cpp thread_local_large_u.c)
+
+target_include_directories(thread_local_large_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(thread_local_large_host oehost)

--- a/tests/thread_local_large/host/host.cpp
+++ b/tests/thread_local_large/host/host.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include "thread_local_large_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+    if ((result = oe_create_thread_local_large_enclave(
+             argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    OE_TEST(enc_test(enclave) == OE_OK);
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (thread_local_large)\n");
+
+    return 0;
+}
+
+void host_nop()
+{
+}

--- a/tests/thread_local_large/thread_local_large.edl
+++ b/tests/thread_local_large/thread_local_large.edl
@@ -1,0 +1,20 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/fcntl.edl" import *;
+
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public void enc_test();
+    };
+
+    untrusted {
+        void host_nop();
+    };
+};


### PR DESCRIPTION
Calculate number of pages required for all TLS of the enclave image and
add them during enclave creation.

The distance between TCS and TD now depends on TLS size, so macro
TD_FROM_TCS is replaced by variable td_from_tcs_offset whose value is
patched during enclave creation.

Fix #1161

Signed-off-by: Thomas Tendyck <tt@edgeless.systems>

Add fcntl.edl necessary for code coverage build.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>