### PR TITLE
Support V3 tcbinfo parsing.

### DIFF
--- a/common/sgx/tcbinfo.h
+++ b/common/sgx/tcbinfo.h
@@ -15,6 +15,14 @@ OE_EXTERNC_BEGIN
 
 #define OE_TCB_LEVEL_STATUS_UNKNOWN (0)
 
+/*! \enum _oe_tcb_info_id
+ *  \brief TCB Info id (V3 only)
+ */
+typedef enum _oe_tcb_info_id
+{
+    TCB_INFO_ID_SGX,
+} oe_tcb_info_id_t;
+
 /*! \struct oe_tcb_level_status_t
  */
 typedef union _oe_tcb_level_status {
@@ -73,12 +81,19 @@ typedef struct _oe_parsed_tcb_info
     uint8_t signature[64];
 
     // V2 fields
+    // HW representation of CPUSVN for a given FMSPC is not architecturally
+    // defined to provide designers more flexibility. SW needs "tcbType" to
+    // determine how to decompose the CPUSVN. Each FMSPC has its own
+    // tcbType. For now, there is only one tcbType(0) has been defined.
     uint32_t tcb_type;
     uint32_t tcb_evaluation_data_number;
     oe_tcb_info_tcb_level_t tcb_level;
 
     const uint8_t* tcb_info_start;
     size_t tcb_info_size;
+
+    // V3 field
+    oe_tcb_info_id_t id;
 
 } oe_parsed_tcb_info_t;
 

--- a/tests/report/data_v3/tcbInfo.json
+++ b/tests/report/data_v3/tcbInfo.json
@@ -1,0 +1,175 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":8
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":7
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"SWHardeningNeeded"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"ConfigurationAndSWHardeningNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoAdvisoryIds.json
+++ b/tests/report/data_v3/tcbInfoAdvisoryIds.json
@@ -1,0 +1,131 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":8
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"UpToDate",
+        "advisoryIDs":["INTEL-SA-00079", "INTEL-SA-00076"]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "ConfigurationNeeded",
+        "advisoryIDs":["INTEL-SA-00079", "INTEL-SA-00076"]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeCompSvn.json
+++ b/tests/report/data_v3/tcbInfoNegativeCompSvn.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 257,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeFloat.json
+++ b/tests/report/data_v3/tcbInfoNegativeFloat.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 2.234,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeId.json
+++ b/tests/report/data_v3/tcbInfoNegativeId.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "sgx",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeIntegerOverflow.json
+++ b/tests/report/data_v3/tcbInfoNegativeIntegerOverflow.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 10000000000000000000000000000000000,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeIntegerWithSign.json
+++ b/tests/report/data_v3/tcbInfoNegativeIntegerWithSign.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": -1,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeInvalidIssueDate.json
+++ b/tests/report/data_v3/tcbInfoNegativeInvalidIssueDate.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-16-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeInvalidNextUpdate.json
+++ b/tests/report/data_v3/tcbInfoNegativeInvalidNextUpdate.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-16-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeMissingId.json
+++ b/tests/report/data_v3/tcbInfoNegativeMissingId.json
@@ -1,0 +1,128 @@
+{
+  "tcbInfo": {
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeMissingNextUpdate.json
+++ b/tests/report/data_v3/tcbInfoNegativeMissingNextUpdate.json
@@ -1,0 +1,128 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativePceSvn.json
+++ b/tests/report/data_v3/tcbInfoNegativePceSvn.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":65537
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativePropertyMissingLevel0.json
+++ b/tests/report/data_v3/tcbInfoNegativePropertyMissingLevel0.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "SIGNATURE": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativePropertyMissingLevel1.json
+++ b/tests/report/data_v3/tcbInfoNegativePropertyMissingLevel1.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "VERSION": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativePropertyMissingLevel2.json
+++ b/tests/report/data_v3/tcbInfoNegativePropertyMissingLevel2.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "TCBDATE":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativePropertyMissingLevel3.json
+++ b/tests/report/data_v3/tcbInfoNegativePropertyMissingLevel3.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "PCESVN":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativePropertyWrongTypeLevel0.json
+++ b/tests/report/data_v3/tcbInfoNegativePropertyWrongTypeLevel0.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": 123456
+}

--- a/tests/report/data_v3/tcbInfoNegativePropertyWrongTypeLevel1.json
+++ b/tests/report/data_v3/tcbInfoNegativePropertyWrongTypeLevel1.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": 90610000,
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativePropertyWrongTypeLevel2.json
+++ b/tests/report/data_v3/tcbInfoNegativePropertyWrongTypeLevel2.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":1
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativePropertyWrongTypeLevel3.json
+++ b/tests/report/data_v3/tcbInfoNegativePropertyWrongTypeLevel3.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": "128",
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeSignature.json
+++ b/tests/report/data_v3/tcbInfoNegativeSignature.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "1c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeStringEscape.json
+++ b/tests/report/data_v3/tcbInfoNegativeStringEscape.json
@@ -1,0 +1,129 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-\n06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2019-05-15T00:00:00Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T00:00:00Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfoNegativeTcbType.json
+++ b/tests/report/data_v3/tcbInfoNegativeTcbType.json
@@ -1,0 +1,175 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "tcbType": 1,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":8
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":7
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"SWHardeningNeeded"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"ConfigurationAndSWHardeningNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/data_v3/tcbInfo_with_pceid.json
+++ b/tests/report/data_v3/tcbInfo_with_pceid.json
@@ -1,0 +1,176 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "pceId":"0000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber":5,
+    "tcbLevels": [
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":8
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"UpToDate"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":7
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"SWHardeningNeeded"
+      },
+      {
+        "tcb":{
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn":6
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus":"ConfigurationAndSWHardeningNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "ConfigurationNeeded"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "tcbDate":"2018-01-04T01:02:03Z",
+        "tcbStatus": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -27,10 +27,18 @@
 extern void TestVerifyTCBInfo(
     oe_enclave_t* enclave,
     const char* test_file_name);
+extern void TestVerifyTCBInfo_Negative(
+    oe_enclave_t* enclave,
+    const char* file_names[],
+    size_t file_cnt);
 extern void TestVerifyTCBInfoV2(
     oe_enclave_t* enclave,
     const char* test_filename);
-extern void TestVerifyTCBInfoV2_AdvisoryIDs(
+extern void TestVerifyTCBInfo_AdvisoryIDs(
+    oe_enclave_t* enclave,
+    const char* test_filename,
+    uint32_t version);
+extern void TestVerifyTCBInfoV3(
     oe_enclave_t* enclave,
     const char* test_filename);
 extern int FileToBytes(const char* path, std::vector<uint8_t>* output);
@@ -201,11 +209,156 @@ int main(int argc, const char* argv[])
 
         TestVerifyTCBInfo(enclave, "./data/tcbInfo.json");
         TestVerifyTCBInfo(enclave, "./data/tcbInfo_with_pceid.json");
+        const char* negative_files[] = {
+            // In the following files, a property in corresponding level has
+            // been capitalized. JSON is case sensitive and therefore schema
+            // validation should fail.
+            "./data/tcbInfoNegativePropertyMissingLevel0.json",
+            "./data/tcbInfoNegativePropertyMissingLevel1.json",
+            "./data/tcbInfoNegativePropertyMissingLevel2.json",
+            "./data/tcbInfoNegativePropertyMissingLevel3.json",
+            // In the following files, a property in corresponding level has
+            // wrong type.
+            "./data/tcbInfoNegativePropertyWrongTypeLevel0.json",
+            "./data/tcbInfoNegativePropertyWrongTypeLevel1.json",
+            "./data/tcbInfoNegativePropertyWrongTypeLevel2.json",
+            "./data/tcbInfoNegativePropertyWrongTypeLevel3.json",
+
+            // Comp Svn greater than uint8_t
+            "./data/tcbInfoNegativeCompSvn.json",
+
+            // pce Svn greater than uint16_t
+            "./data/tcbInfoNegativePceSvn.json",
+
+            // Invalid issueDate field.
+            "./data/tcbInfoNegativeInvalidIssueDate.json",
+
+            // Invalid nextUpdate field.
+            "./data/tcbInfoNegativeInvalidNextUpdate.json",
+
+            // Missing nextUpdate field.
+            "./data/tcbInfoNegativeMissingNextUpdate.json",
+
+            // Signature != 64 bytes
+            "./data/tcbInfoNegativeSignature.json",
+
+            // Unsupported JSON constructs
+            "./data/tcbInfoNegativeStringEscape.json",
+            "./data/tcbInfoNegativeIntegerOverflow.json",
+            "./data/tcbInfoNegativeIntegerWithSign.json",
+            "./data/tcbInfoNegativeFloat.json",
+        };
+        TestVerifyTCBInfo_Negative(
+            enclave,
+            negative_files,
+            sizeof(negative_files) / sizeof(negative_files[0]));
 
         TestVerifyTCBInfoV2(enclave, "./data_v2/tcbInfo.json");
         TestVerifyTCBInfoV2(enclave, "./data_v2/tcbInfo_with_pceid.json");
-        TestVerifyTCBInfoV2_AdvisoryIDs(
-            enclave, "./data_v2/tcbInfoAdvisoryIds.json");
+        const char* negative_files_v2[] = {
+            // In the following files, a property in corresponding level has
+            // been capitalized. JSON is case sensitive and therefore schema
+            // validation should fail.
+            "./data_v2/tcbInfoNegativePropertyMissingLevel0.json",
+            "./data_v2/tcbInfoNegativePropertyMissingLevel1.json",
+            "./data_v2/tcbInfoNegativePropertyMissingLevel2.json",
+            "./data_v2/tcbInfoNegativePropertyMissingLevel3.json",
+
+            // In the following files, a property in corresponding level has
+            // wrong type.
+            "./data_v2/tcbInfoNegativePropertyWrongTypeLevel0.json",
+            "./data_v2/tcbInfoNegativePropertyWrongTypeLevel1.json",
+            "./data_v2/tcbInfoNegativePropertyWrongTypeLevel2.json",
+            "./data_v2/tcbInfoNegativePropertyWrongTypeLevel3.json",
+
+            // Comp Svn greater than uint8_t
+            "./data_v2/tcbInfoNegativeCompSvn.json",
+
+            // pce Svn greater than uint16_t
+            "./data_v2/tcbInfoNegativePceSvn.json",
+
+            // Invalid issueDate field.
+            "./data_v2/tcbInfoNegativeInvalidIssueDate.json",
+
+            // Invalid nextUpdate field.
+            "./data_v2/tcbInfoNegativeInvalidNextUpdate.json",
+
+            // Missing nextUpdate field.
+            "./data_v2/tcbInfoNegativeMissingNextUpdate.json",
+
+            // Signature != 64 bytes
+            "./data_v2/tcbInfoNegativeSignature.json",
+
+            // Unsupported JSON constructs
+            "./data_v2/tcbInfoNegativeStringEscape.json",
+            "./data_v2/tcbInfoNegativeIntegerOverflow.json",
+            "./data_v2/tcbInfoNegativeIntegerWithSign.json",
+            "./data_v2/tcbInfoNegativeFloat.json",
+            // TcbType != 0.
+            "./data_v2/tcbInfoNegativeTcbType.json",
+        };
+        TestVerifyTCBInfo_Negative(
+            enclave,
+            negative_files_v2,
+            sizeof(negative_files_v2) / sizeof(negative_files_v2[0]));
+        TestVerifyTCBInfo_AdvisoryIDs(
+            enclave, "./data_v2/tcbInfoAdvisoryIds.json", 2);
+
+        TestVerifyTCBInfoV3(enclave, "./data_v3/tcbInfo.json");
+        TestVerifyTCBInfoV3(enclave, "./data_v3/tcbInfo_with_pceid.json");
+        const char* negative_files_v3[] = {
+            // In the following files, id property is missing or has unsupported
+            // value.
+            "./data_v3/tcbInfoNegativeMissingId.json",
+            "./data_v3/tcbInfoNegativeId.json",
+
+            // In the following files, a property in corresponding level has
+            // been capitalized. JSON is case sensitive and therefore schema
+            // validation should fail.
+            "./data_v3/tcbInfoNegativePropertyMissingLevel0.json",
+            "./data_v3/tcbInfoNegativePropertyMissingLevel1.json",
+            "./data_v3/tcbInfoNegativePropertyMissingLevel2.json",
+            "./data_v3/tcbInfoNegativePropertyMissingLevel3.json",
+
+            // In the following files, a property in corresponding level has
+            // wrong type.
+            "./data_v3/tcbInfoNegativePropertyWrongTypeLevel0.json",
+            "./data_v3/tcbInfoNegativePropertyWrongTypeLevel1.json",
+            "./data_v3/tcbInfoNegativePropertyWrongTypeLevel2.json",
+            "./data_v3/tcbInfoNegativePropertyWrongTypeLevel3.json",
+
+            // Comp Svn greater than uint8_t
+            "./data_v3/tcbInfoNegativeCompSvn.json",
+
+            // pce Svn greater than uint16_t
+            "./data_v3/tcbInfoNegativePceSvn.json",
+
+            // Invalid issueDate field.
+            "./data_v3/tcbInfoNegativeInvalidIssueDate.json",
+
+            // Invalid nextUpdate field.
+            "./data_v3/tcbInfoNegativeInvalidNextUpdate.json",
+
+            // Missing nextUpdate field.
+            "./data_v3/tcbInfoNegativeMissingNextUpdate.json",
+
+            // Signature != 64 bytes
+            "./data_v3/tcbInfoNegativeSignature.json",
+
+            // Unsupported JSON constructs
+            "./data_v3/tcbInfoNegativeStringEscape.json",
+            "./data_v3/tcbInfoNegativeIntegerOverflow.json",
+            "./data_v3/tcbInfoNegativeIntegerWithSign.json",
+            "./data_v3/tcbInfoNegativeFloat.json",
+            // TcbType != 0.
+            "./data_v3/tcbInfoNegativeTcbType.json",
+        };
+        TestVerifyTCBInfo_Negative(
+            enclave,
+            negative_files_v3,
+            sizeof(negative_files_v3) / sizeof(negative_files_v3[0]));
+        TestVerifyTCBInfo_AdvisoryIDs(
+            enclave, "./data_v3/tcbInfoAdvisoryIds.json", 3);
     }
     else
     {

--- a/tests/report/host/tcbinfo.cpp
+++ b/tests/report/host/tcbinfo.cpp
@@ -198,53 +198,18 @@ void TestVerifyTCBInfo(oe_enclave_t* enclave, const char* test_filename)
     }
     printf("Unknown TCB Level determination test passed.\n");
 
-    printf("TestVerifyTCBInfo: Positive Tests passed\n");
+    printf("TestVerifyTCBInfo: Positive Tests %s passed\n", test_filename);
+}
 
-    const char* negative_files[] = {
-        // In the following files, a property in corresponding level has been
-        // capitalized. JSON is case sensitive and therefore schema validation
-        // should fail.
-        "./data/tcbInfoNegativePropertyMissingLevel0.json",
-        "./data/tcbInfoNegativePropertyMissingLevel1.json",
-        "./data/tcbInfoNegativePropertyMissingLevel2.json",
-        "./data/tcbInfoNegativePropertyMissingLevel3.json",
-        // In the following files, a property in corresponding level has wrong
-        // type.
-        "./data/tcbInfoNegativePropertyWrongTypeLevel0.json",
-        "./data/tcbInfoNegativePropertyWrongTypeLevel1.json",
-        "./data/tcbInfoNegativePropertyWrongTypeLevel2.json",
-        "./data/tcbInfoNegativePropertyWrongTypeLevel3.json",
-
-        // Comp Svn greater than uint8_t
-        "./data/tcbInfoNegativeCompSvn.json",
-
-        // pce Svn greater than uint16_t
-        "./data/tcbInfoNegativePceSvn.json",
-
-        // Invalid issueDate field.
-        "./data/tcbInfoNegativeInvalidIssueDate.json",
-
-        // Invalid nextUpdate field.
-        "./data/tcbInfoNegativeInvalidNextUpdate.json",
-
-        // Missing nextUpdate field.
-        "./data/tcbInfoNegativeMissingNextUpdate.json",
-
-        // Signature != 64 bytes
-        "./data/tcbInfoNegativeSignature.json",
-
-        // Unsupported JSON constructs
-        "./data/tcbInfoNegativeStringEscape.json",
-        "./data/tcbInfoNegativeIntegerOverflow.json",
-        "./data/tcbInfoNegativeIntegerWithSign.json",
-        "./data/tcbInfoNegativeFloat.json",
-    };
-
-    for (size_t i = 0; i < sizeof(negative_files) / sizeof(negative_files[0]);
-         ++i)
+void TestVerifyTCBInfo_Negative(
+    oe_enclave_t* enclave,
+    const char* file_names[],
+    size_t file_cnt)
+{
+    for (size_t i = 0; i < file_cnt; ++i)
     {
         std::vector<uint8_t> tcbInfo;
-        OE_TEST(FileToBytes(negative_files[i], &tcbInfo) == 0);
+        OE_TEST(FileToBytes(file_names[i], &tcbInfo) == 0);
 
         oe_parsed_tcb_info_t parsed_info = {0};
         oe_tcb_info_tcb_level_t platform_tcb_level = {{0}};
@@ -257,8 +222,7 @@ void TestVerifyTCBInfo(oe_enclave_t* enclave, const char* test_filename)
                 &platform_tcb_level,
                 &parsed_info) == OE_OK);
         OE_TEST(ecall_result == OE_JSON_INFO_PARSE_ERROR);
-        printf(
-            "TestVerifyTCBInfo: Negative Test %s passed\n", negative_files[i]);
+        printf("TestVerifyTCBInfo: Negative Test %s passed\n", file_names[i]);
     }
 }
 
@@ -402,76 +366,13 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
     }
     printf("Unknown TCB Level determination test passed.\n");
 
-    printf("TestVerifyTCBInfo V2: Positive Tests passed\n");
-
-    const char* negative_files[] = {
-        // In the following files, a property in corresponding level has been
-        // capitalized. JSON is case sensitive and therefore schema validation
-        // should fail.
-        "./data_v2/tcbInfoNegativePropertyMissingLevel0.json",
-        "./data_v2/tcbInfoNegativePropertyMissingLevel1.json",
-        "./data_v2/tcbInfoNegativePropertyMissingLevel2.json",
-        "./data_v2/tcbInfoNegativePropertyMissingLevel3.json",
-        // In the following files, a property in corresponding level has wrong
-        // type.
-        "./data_v2/tcbInfoNegativePropertyWrongTypeLevel0.json",
-        "./data_v2/tcbInfoNegativePropertyWrongTypeLevel1.json",
-        "./data_v2/tcbInfoNegativePropertyWrongTypeLevel2.json",
-        "./data_v2/tcbInfoNegativePropertyWrongTypeLevel3.json",
-
-        // Comp Svn greater than uint8_t
-        "./data_v2/tcbInfoNegativeCompSvn.json",
-
-        // pce Svn greater than uint16_t
-        "./data_v2/tcbInfoNegativePceSvn.json",
-
-        // Invalid issueDate field.
-        "./data_v2/tcbInfoNegativeInvalidIssueDate.json",
-
-        // Invalid nextUpdate field.
-        "./data_v2/tcbInfoNegativeInvalidNextUpdate.json",
-
-        // Missing nextUpdate field.
-        "./data_v2/tcbInfoNegativeMissingNextUpdate.json",
-
-        // Signature != 64 bytes
-        "./data_v2/tcbInfoNegativeSignature.json",
-
-        // Unsupported JSON constructs
-        "./data_v2/tcbInfoNegativeStringEscape.json",
-        "./data_v2/tcbInfoNegativeIntegerOverflow.json",
-        "./data_v2/tcbInfoNegativeIntegerWithSign.json",
-        "./data_v2/tcbInfoNegativeFloat.json",
-        // TcbType != 0.
-        "./data_v2/tcbInfoNegativeTcbType.json",
-    };
-
-    for (size_t i = 0; i < sizeof(negative_files) / sizeof(negative_files[0]);
-         ++i)
-    {
-        std::vector<uint8_t> tcbInfo;
-        OE_TEST(FileToBytes(negative_files[i], &tcbInfo) == 0);
-
-        oe_parsed_tcb_info_t parsed_info = {0};
-        oe_tcb_info_tcb_level_t platform_tcb_level = {{0}};
-        oe_result_t ecall_result = OE_FAILURE;
-        OE_TEST(
-            test_verify_tcb_info(
-                enclave,
-                &ecall_result,
-                (const char*)&tcbInfo[0],
-                &platform_tcb_level,
-                &parsed_info) == OE_OK);
-        OE_TEST(ecall_result == OE_JSON_INFO_PARSE_ERROR);
-        printf(
-            "TestVerifyTCBInfoV2: Negative Test %s passed\n",
-            negative_files[i]);
-    }
+    printf("TestVerifyTCBInfo: Positive Tests %s passed\n", test_filename);
 }
 
-void TestVerifyTCBInfoV2_AdvisoryIDs(
+void TestVerifyTCBInfo_AdvisoryIDs(
     oe_enclave_t* enclave,
-    const char* test_filename)
+    const char* test_filename,
+    uint32_t version)
 {
     std::vector<uint8_t> tcbInfo;
     oe_result_t ecall_result = OE_FAILURE;
@@ -499,7 +400,7 @@ void TestVerifyTCBInfoV2_AdvisoryIDs(
     OE_TEST(ecall_result == OE_OK);
     OE_TEST(platform_tcb_level.status.fields.up_to_date == 1);
 
-    AssertParsedValues(parsed_info, 2);
+    AssertParsedValues(parsed_info, version);
     oe_datetime_t nextUpdate = {2019, 6, 6, 10, 12, 17};
     OE_TEST(oe_datetime_compare(&parsed_info.next_update, &nextUpdate) == 0);
 
@@ -536,5 +437,152 @@ void TestVerifyTCBInfoV2_AdvisoryIDs(
                 expectedAdvisoryIDs[i],
                 advisoryIDs_length[i]) == 0);
     }
-    printf("TCB Info V2 positive test, with advisoryIDs. PASSED\n");
+    printf("TestVerifyTCBInfo: Positive Tests %s passed\n", test_filename);
+}
+
+void TestVerifyTCBInfoV3(oe_enclave_t* enclave, const char* test_filename)
+{
+    const uint32_t version = 3;
+    oe_tcb_info_tcb_level_t platform_tcb_level = {
+        {4, 4, 2, 4, 1, 128, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 8};
+    oe_parsed_tcb_info_t parsed_info = {0};
+
+    printf("TCB Info Version 3 tests:\n");
+    // ./data_v2/tcbInfo.json contains 7 tcb levels.
+    // The first level with pce svn = 8 is up to date.
+    // The second level with pce svn = 7 is SWHardeningNeeded.
+    // The third level with pce svn = 6 is ConfigurationAndSWHardeningNeeded.
+    // The fourth level with pce svn = 5 is OutOfDateConfigurationNeeded
+    // The fifth level with pce svn = 4 needs configuration.
+    // The sixth level with pce svn = 3 is out of date.
+    // The seventh level with pce svn = 2 is revoked.
+
+    // Set platform pce svn to 9 and assert that
+    // the determined status is up to date.
+    platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+    platform_tcb_level.pce_svn = 9;
+    TestVerifyTCBInfo(
+        enclave,
+        test_filename,
+        &platform_tcb_level,
+        &parsed_info,
+        OE_OK,
+        version);
+
+    OE_TEST(parsed_info.id == TCB_INFO_ID_SGX);
+    printf("TCB Info id test passed.\n");
+
+    OE_TEST(platform_tcb_level.status.fields.up_to_date == 1);
+    printf("UptoDate TCB Level determination test passed.\n");
+
+    // Set platform pce svn to 7 and assert that
+    // the determined status is SWHardeningNeeded.
+    platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+    platform_tcb_level.pce_svn = 7;
+    TestVerifyTCBInfo(
+        enclave,
+        test_filename,
+        &platform_tcb_level,
+        &parsed_info,
+        OE_OK,
+        version);
+    OE_TEST(platform_tcb_level.status.fields.up_to_date == 1);
+    OE_TEST(platform_tcb_level.status.fields.sw_hardening_needed == 1);
+    printf("SWHardeningNeeded TCB Level determination test passed.\n");
+
+    // Set platform pce svn to 6 and assert that
+    // the determined status is ConfigurationAndSWHardeningNeeded.
+    platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+    platform_tcb_level.pce_svn = 6;
+    TestVerifyTCBInfo(
+        enclave,
+        test_filename,
+        &platform_tcb_level,
+        &parsed_info,
+        OE_TCB_LEVEL_INVALID,
+        version);
+    OE_TEST(platform_tcb_level.status.fields.configuration_needed == 1);
+    OE_TEST(platform_tcb_level.status.fields.sw_hardening_needed == 1);
+    printf("ConfigurationAndSWHardeningNeeded TCB Level determination test "
+           "passed.\n");
+
+    // Set platform pce svn to 5 and assert that
+    // the determined status is out of date configuration needed.
+    platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+    platform_tcb_level.pce_svn = 5;
+    TestVerifyTCBInfo(
+        enclave,
+        test_filename,
+        &platform_tcb_level,
+        &parsed_info,
+        OE_TCB_LEVEL_INVALID,
+        version);
+    OE_TEST(platform_tcb_level.status.fields.qe_identity_out_of_date == 1);
+    OE_TEST(platform_tcb_level.status.fields.configuration_needed == 1);
+    printf(
+        "OutOfDateConfigurationNeeded TCB Level determination test passed.\n");
+
+    // Set platform pce svn to 4 and assert that
+    // the determined status is configuration needed.
+    platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+    platform_tcb_level.pce_svn = 4;
+    TestVerifyTCBInfo(
+        enclave,
+        test_filename,
+        &platform_tcb_level,
+        &parsed_info,
+        OE_TCB_LEVEL_INVALID,
+        version);
+    OE_TEST(platform_tcb_level.status.fields.configuration_needed == 1);
+    printf("ConfigurationNeeded TCB Level determination test passed.\n");
+
+    // Set platform pce svn to 3 and assert that
+    // the determined status is out of date.
+    platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+    platform_tcb_level.pce_svn = 3;
+    TestVerifyTCBInfo(
+        enclave,
+        test_filename,
+        &platform_tcb_level,
+        &parsed_info,
+        OE_TCB_LEVEL_INVALID,
+        version);
+    OE_TEST(platform_tcb_level.status.fields.outofdate == 1);
+    printf("OutOfDate TCB Level determination test passed.\n");
+
+    // Set platform pce svn to 2 and assert that
+    // the determined status is revoked.
+    platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+    platform_tcb_level.pce_svn = 2;
+    TestVerifyTCBInfo(
+        enclave,
+        test_filename,
+        &platform_tcb_level,
+        &parsed_info,
+        OE_TCB_LEVEL_INVALID,
+        version);
+    OE_TEST(platform_tcb_level.status.fields.revoked == 1);
+    printf("Revoked TCB Level determination test passed.\n");
+
+    // Set each of the fields to a value not listed in the json and
+    // test that the determined status is OE_TCB_LEVEL_INVALID
+    for (uint32_t i = 0; i < OE_COUNTOF(platform_tcb_level.sgx_tcb_comp_svn);
+         ++i)
+    {
+        platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+        platform_tcb_level.sgx_tcb_comp_svn[i] = 0;
+        TestVerifyTCBInfo(
+            enclave,
+            test_filename,
+            &platform_tcb_level,
+            &parsed_info,
+            OE_TCB_LEVEL_INVALID,
+            version);
+        OE_TEST(
+            platform_tcb_level.status.AsUINT32 == OE_TCB_LEVEL_STATUS_UNKNOWN);
+        platform_tcb_level.sgx_tcb_comp_svn[i] = 2;
+    }
+    printf("Unknown TCB Level determination test passed.\n");
+
+    printf("TestVerifyTCBInfo: Positive Tests %s passed\n", test_filename);
 }


### PR DESCRIPTION
Fixes issue #3375 
SGX attestation V3 spec was released and [new property `id` was added to tcbinfo](https://sbx.api.portal.trustedservices.intel.com/documentation#pcs-tcb-info-v3).
This PR is to support V3 tcbinfo:
1. An enum type field `oe_tcb_info_id_t id` was added to `oe_parsed_tcb_info_t` struct, which to be consistent with the `id` field in `qe_identity_info`.
2. Logic check `(value > 2) != has_id)` was added, assuming the `tcbinfo` which has the property `id`, should have version higher than `2`, and that doesn't have the property `id` should have a version lower than `3`.
3. V3 tcbinfo test case files were added under `tests/report/data_v3`.
4. The negative tests were isolated from the positive test function so that those negative tests do not need to be repeated in the `tcbInfo_with_pceid.json` positive test after the `tcbInfo.json` positive test was tested.


Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>