### PR TITLE
add overwrite action to host verification installation fixes #3351

### DIFF
--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -364,6 +364,7 @@ def ACCHostVerificationPackageTest(String version, String build_type) {
                         cpack -D CPACK_NUGET_COMPONENT_INSTALL=ON -DCPACK_COMPONENTS_ALL=OEHOSTVERIFY && \
                         copy tests\\host_verify\\host\\*.der ${WORKSPACE}\\samples\\host_verify && \
                         copy tests\\host_verify\\host\\*.bin ${WORKSPACE}\\samples\\host_verify && \
+                        if exist C:\\oe (rmdir C:\\oe) && \
                         nuget.exe install open-enclave.OEHOSTVERIFY -Source ${WORKSPACE}\\build -OutputDirectory C:\\oe -ExcludeVersion && \
                         xcopy /E C:\\oe\\open-enclave.OEHOSTVERIFY\\openenclave C:\\openenclave\\ && \
                         pushd ${WORKSPACE}\\samples\\host_verify && \


### PR DESCRIPTION
Add overwrite action to host verification installation. There is a bug in the CI where when a windows machine is reused the workspace is not being cleaned correctly. After an investigation into why this is, it has led nowhere. Patching for now by removing the directory before installation fixes #3351

Signed-off-by: Brett McLaren <brmclare@microsoft.com>