### PR TITLE
Update DCAP Linux driver to v1.35

### DIFF
--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/bionic.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/bionic.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.6/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.33.bin"
-intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu18.04-server/sgx_linux_x64_driver_2.6.0_95eaa6f.bin"
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.7/linux/distro/ubuntu18.04-server/sgx_linux_x64_driver_1.35.bin"
+intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.10/distro/ubuntu18.04-server/sgx_linux_x64_driver_2.6.0_602374c.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf10"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/xenial.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/xenial.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.6/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.33.bin"
-intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu16.04-server/sgx_linux_x64_driver_2.6.0_95eaa6f.bin"
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.7/linux/distro/ubuntu16.04-server/sgx_linux_x64_driver_1.35.bin"
+intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.10/distro/ubuntu16.04-server/sgx_linux_x64_driver_2.6.0_602374c.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf9v5"


### PR DESCRIPTION
Due to incompatibilities between the new Azure Linux 5.4 release, and DCAP driver v1.33, an update to DCAP driver v1.35 is required. DCAP driver v1.35 is compatible with the current Azure Linux release on both 16.04 and 18.04.

Ran a successful end-to-end test here: https://oe-jenkins-tf.westeurope.cloudapp.azure.com/job/CI-CD_Infrastructure/job/OpenEnclave-E2E-Testing/242/

Closes #2850

Signed-off-by: Rob Sanchez <rosan@microsoft.com>