### PR TITLE
Extend attested tls server for autoscaling deployments

### DIFF
--- a/samples/attested_tls/Makefile
+++ b/samples/attested_tls/Makefile
@@ -24,3 +24,7 @@ run:
 	./server/host/tls_server_host ./server/enc/tls_server_enc.signed -port:12341 &
 	sleep 2
 	./non_enc_client/tls_non_enc_client -server:localhost -port:12341
+
+run-server-in-loop:
+	echo "Launch long-running Attested TLS server"
+	./server/host/tls_server_host ./server/enc/tls_server_enc.signed -port:12341 -server-in-loop

--- a/samples/attested_tls/README.md
+++ b/samples/attested_tls/README.md
@@ -93,3 +93,10 @@ mkdir build && cd build
 cmake ..
 make run
 ```
+### Running attested TLS server in loop
+By default the server exits after completing a TLS session with a client. `-server-in-loop` run-time option changes this behavior to allow the TLS server to handle multiple client requests.
+```bash
+./server/host/tls_server_host ./server/enc/tls_server_enc.signed -port:12341 -server-in-loop
+or
+make run-server-in-loop
+```

--- a/samples/attested_tls/server/enc/server.cpp
+++ b/samples/attested_tls/server/enc/server.cpp
@@ -20,7 +20,7 @@
 
 extern "C"
 {
-    int setup_tls_server(char* server_port);
+    int setup_tls_server(char* server_port, bool keep_server_up);
 };
 
 #define MAX_ERROR_BUFF_SIZE 256
@@ -123,14 +123,18 @@ exit:
 int handle_communication_until_done(
     mbedtls_ssl_context* ssl,
     mbedtls_net_context* listen_fd,
-    mbedtls_net_context* client_fd)
+    mbedtls_net_context* client_fd,
+    bool keep_server_up)
 {
     int ret = 0;
     int len = 0;
 
 waiting_for_connection_request:
 
-    if (ret != 0)
+    if (ret != 0 &&
+        // ignore EOF errors, which can be caused due to Load Balancers
+        // or health checks
+        ret != MBEDTLS_ERR_SSL_CONN_EOF)
     {
         mbedtls_strerror(ret, error_buf, MAX_ERROR_BUFF_SIZE);
         printf("Last error was: %d - %s\n", ret, error_buf);
@@ -140,7 +144,8 @@ waiting_for_connection_request:
     mbedtls_net_free(client_fd);
     mbedtls_ssl_session_reset(ssl);
 
-    printf(TLS_SERVER "Waiting for a client connection request...\n");
+    if (ret != MBEDTLS_ERR_SSL_CONN_EOF)
+        printf(TLS_SERVER "Waiting for a client connection request...\n");
     if ((ret = mbedtls_net_accept(listen_fd, client_fd, NULL, 0, NULL)) != 0)
     {
         char errbuf[512];
@@ -151,20 +156,19 @@ waiting_for_connection_request:
             errbuf);
         goto done;
     }
-    printf(
-        TLS_SERVER
-        "mbedtls_net_accept returned successfully.(listen_fd = %d) (client_fd "
-        "= %d) \n",
-        listen_fd->fd,
-        client_fd->fd);
 
     // set up bio callbacks
     mbedtls_ssl_set_bio(
         ssl, client_fd, mbedtls_net_send, mbedtls_net_recv, NULL);
 
-    printf(TLS_SERVER "Performing the SSL/TLS handshake...\n");
     while ((ret = mbedtls_ssl_handshake(ssl)) != 0)
     {
+        // Load balancer health-check pings can cause EOF errors
+        // Ignore the error, and wait for client to send request
+        if (ret == MBEDTLS_ERR_SSL_CONN_EOF)
+        {
+            goto waiting_for_connection_request;
+        }
         if (ret != MBEDTLS_ERR_SSL_WANT_READ &&
             ret != MBEDTLS_ERR_SSL_WANT_WRITE)
         {
@@ -269,14 +273,15 @@ waiting_for_connection_request:
     }
 
     ret = 0;
-    // comment out the following line if you want the server in a loop
-    // goto waiting_for_connection_request;
+
+    if (keep_server_up)
+        goto waiting_for_connection_request;
 
 done:
     return ret;
 }
 
-int setup_tls_server(char* server_port)
+int setup_tls_server(char* server_port, bool keep_server_up)
 {
     int ret = 0;
     oe_result_t result = OE_FAILURE;
@@ -356,7 +361,8 @@ int setup_tls_server(char* server_port)
     }
 
     // handle communication
-    ret = handle_communication_until_done(&ssl, &listen_fd, &client_fd);
+    ret = handle_communication_until_done(
+        &ssl, &listen_fd, &client_fd, keep_server_up);
     if (ret != 0)
     {
         printf(TLS_SERVER "server communication error %d\n", ret);

--- a/samples/attested_tls/server/host/host.cpp
+++ b/samples/attested_tls/server/host/host.cpp
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include "tls_server_u.h"
 
+#define LOOP_OPTION "-server-in-loop"
+
 oe_enclave_t* create_enclave(const char* enclave_path)
 {
     oe_enclave_t* enclave = NULL;
@@ -43,15 +45,32 @@ int main(int argc, const char* argv[])
     oe_result_t result = OE_OK;
     int ret = 1;
     char* server_port = NULL;
+    bool keep_server_up = false;
 
     /* Check argument count */
     if (argc != 3)
     {
+        if (argc == 4)
+        {
+            if (strcmp(argv[3], LOOP_OPTION) != 0)
+            {
+                goto print_usage;
+            }
+            else
+            {
+                keep_server_up = true;
+                goto read_port;
+            }
+        }
     print_usage:
-        printf("Usage: %s TLS_SERVER_ENCLAVE_PATH -port:<port>\n", argv[0]);
+        printf(
+            "Usage: %s TLS_SERVER_ENCLAVE_PATH -port:<port> [%s]\n",
+            argv[0],
+            LOOP_OPTION);
         return 1;
     }
 
+read_port:
     // read port parameter
     {
         char* option = (char*)"-port:";
@@ -77,7 +96,7 @@ int main(int argc, const char* argv[])
     }
 
     printf("Host: calling setup_tls_server\n");
-    ret = setup_tls_server(enclave, &ret, server_port);
+    ret = setup_tls_server(enclave, &ret, server_port, keep_server_up);
     if (ret != 0)
     {
         printf("Host: setup_tls_server failed\n");

--- a/samples/attested_tls/server/tls_server.edl
+++ b/samples/attested_tls/server/tls_server.edl
@@ -6,6 +6,6 @@ enclave {
     from "platform.edl" import *;
 
     trusted {
-        public int setup_tls_server([in, string] char* port);
+        public int setup_tls_server([in, string] char* port, bool keep_server_up);
     };
 };


### PR DESCRIPTION
### Summary
The attested tls server if deployed as a ReplicaSet in kubernetes, treats load balancer pings as a failed TLS handshake and exits. The changes proposed here extend the tls server to be more suitable for such a deployment.