### PR TITLE
EXPERIMENT: Figure out enclave_base_address without help from loader.

### DIFF
--- a/enclave/core/sgx/globals.c
+++ b/enclave/core/sgx/globals.c
@@ -125,7 +125,8 @@ OE_EXPORT extern volatile const oe_sgx_enclave_properties_t
  *
  **/
 
-OE_EXPORT volatile uint64_t _enclave_rva;
+OE_EXPORT volatile void* _enclave_rva = &_enclave_rva;
+volatile void* _enclave_base;
 OE_EXPORT volatile uint64_t _reloc_rva;
 OE_EXPORT volatile uint64_t _reloc_size;
 
@@ -140,10 +141,14 @@ oe_eeid_t* oe_eeid = NULL;
 **
 **==============================================================================
 */
+void __oe_set_enclave_base_pre_relocation(void)
+{
+    _enclave_base = (uint8_t*)&_enclave_rva - (uint64_t)_enclave_rva;
+}
 
 const void* __oe_get_enclave_base()
 {
-    return (uint8_t*)&_enclave_rva - _enclave_rva;
+    return (void*)_enclave_base;
 }
 
 size_t __oe_get_enclave_size()

--- a/enclave/core/sgx/reloc.c
+++ b/enclave/core/sgx/reloc.c
@@ -20,6 +20,7 @@
 
 bool oe_apply_relocations(void)
 {
+    __oe_set_enclave_base_pre_relocation();
     const elf64_rela_t* relocs = (const elf64_rela_t*)__oe_get_reloc_base();
     size_t nrelocs = __oe_get_reloc_size() / sizeof(elf64_rela_t);
     const uint8_t* baseaddr = (const uint8_t*)__oe_get_enclave_base();

--- a/host/sgx/loadelf.c
+++ b/host/sgx/loadelf.c
@@ -659,10 +659,10 @@ static oe_result_t _patch(
     oeprops->image_info.oeinfo_rva = image->oeinfo_rva;
     oeprops->image_info.oeinfo_size = sizeof(oe_sgx_enclave_properties_t);
 
-    /* Set _enclave_rva to its own rva offset*/
+    /* Assert that _enclave_rva has its own rva in image.*/
     OE_CHECK(_get_dynamic_symbol_rva(image, "_enclave_rva", &enclave_rva));
-    OE_CHECK(
-        _set_uint64_t_dynamic_symbol_value(image, "_enclave_rva", enclave_rva));
+    if (*(uint64_t*)(image->image_base + enclave_rva) != enclave_rva)
+        OE_RAISE(OE_FAILURE);
 
     /* reloc right after image */
     oeprops->image_info.reloc_rva = image->image_size;

--- a/include/openenclave/internal/globals.h
+++ b/include/openenclave/internal/globals.h
@@ -11,6 +11,7 @@
 OE_EXTERNC_BEGIN
 
 /* Enclave */
+void __oe_set_enclave_base_pre_relocation(void);
 const void* __oe_get_enclave_base(void);
 size_t __oe_get_enclave_size(void);
 const void* __oe_get_enclave_elf_header(void);


### PR DESCRIPTION
Initialize _enclave_rva to its own address:
   OE_EXPORT volatile void* _enclave_rva = &_enclave_rva;

Due to this an X64_RELATIVE relocation entry will be created for _enclave_rva.
Additionally, in the image and in the enclave before relocation,
_enclave_rva will have its own RVA value. This is asserted by the loader.

Thus, before relocation,
   (uint8_t*) &_enclave_rva - (uint64_t) _enclave_rva
will give the enclave's base address which is stored in another variable for use.
After relocation, the above expression will evaluate to zero.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>