### PR TITLE
Refactor _load_elf_image into subfunctions

### DIFF
--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -763,12 +763,18 @@ oe_result_t oe_sgx_build_enclave(
         props = *properties;
 
         /* Update image to the properties passed in */
-        memcpy(oeimage.image_base + oeimage.oeinfo_rva, &props, sizeof(props));
+        memcpy(
+            oeimage.elf.image_base + oeimage.elf.oeinfo_rva,
+            &props,
+            sizeof(props));
     }
     else
     {
         /* Copy the properties from the image */
-        memcpy(&props, oeimage.image_base + oeimage.oeinfo_rva, sizeof(props));
+        memcpy(
+            &props,
+            oeimage.elf.image_base + oeimage.elf.oeinfo_rva,
+            sizeof(props));
     }
 
     /* Validate the enclave prop_override structure */
@@ -813,7 +819,6 @@ oe_result_t oe_sgx_build_enclave(
     /* Save the enclave base address, size, and text address */
     enclave->addr = enclave_addr;
     enclave->size = enclave_size;
-    enclave->text = enclave_addr + oeimage.text_rva;
 
     /* Patch image */
     OE_CHECK(oeimage.sgx_patch(&oeimage, context, enclave_size));
@@ -823,12 +828,12 @@ oe_result_t oe_sgx_build_enclave(
 
 #ifdef OE_WITH_EXPERIMENTAL_EEID
     OE_CHECK(_add_eeid_marker_page(
-        context, enclave, image_size, oeimage.entry_rva, &props, &vaddr));
+        context, enclave, image_size, oeimage.elf.entry_rva, &props, &vaddr));
 #endif
 
     /* Add data pages */
-    OE_CHECK(
-        _add_data_pages(context, enclave, &props, oeimage.entry_rva, &vaddr));
+    OE_CHECK(_add_data_pages(
+        context, enclave, &props, oeimage.elf.entry_rva, &vaddr));
 
 #ifdef OE_WITH_EXPERIMENTAL_EEID
     /* Add optional EEID pages */

--- a/host/sgx/enclave.h
+++ b/host/sgx/enclave.h
@@ -101,9 +101,6 @@ typedef struct _oe_enclave
     /* Base address of enclave within enclave address space (BASEADDR) */
     uint64_t addr;
 
-    /* Address of .text section (for gdb) */
-    uint64_t text;
-
     /* Size of enclave in bytes */
     uint64_t size;
 

--- a/host/sgx/loadelf.c
+++ b/host/sgx/loadelf.c
@@ -24,222 +24,263 @@
 #include "enclave.h"
 #include "sgxload.h"
 
-static oe_result_t _free_elf_image(oe_enclave_image_t* image)
+static void _unload_elf_image(oe_enclave_elf_image_t* image)
 {
-    if (image->u.elf.elf.data)
+    if (image)
     {
-        free(image->u.elf.elf.data);
-    }
+        if (image->elf.data)
+            free(image->elf.data);
 
-    if (image->image_base)
+        if (image->image_base)
+            oe_memalign_free(image->image_base);
+
+        if (image->segments)
+            oe_memalign_free(image->segments);
+
+        if (image->reloc_data)
+            oe_memalign_free(image->reloc_data);
+    }
+}
+
+static oe_result_t _unload_image(oe_enclave_image_t* image)
+{
+    if (image)
     {
-        oe_memalign_free(image->image_base);
+        _unload_elf_image(&image->elf);
+        memset(image, 0, sizeof(*image));
     }
-
-    if (image->u.elf.segments)
-    {
-        oe_memalign_free(image->u.elf.segments);
-    }
-
-    memset(image, 0, sizeof(*image));
-
     return OE_OK;
 }
 
-static oe_result_t _load_elf_image(const char* path, oe_enclave_image_t* image)
+/* Loads an ELF64 binary from disk into memory as image->elf.data
+ * and provides a pointer to it as an ELF64 header structure.
+ *
+ * The caller is responsible for calling free on image->elf.data.
+ */
+static oe_result_t _read_elf_header(
+    const char* path,
+    oe_enclave_elf_image_t* image,
+    elf64_ehdr_t** ehdr)
 {
     oe_result_t result = OE_UNEXPECTED;
-    size_t i;
-    const elf64_ehdr_t* eh;
-    size_t pt_load_segments_index;
-    bool has_build_id = false;
-    size_t segments_size = 0;
+    elf64_ehdr_t* eh = NULL;
 
-    assert(image && path);
-
-    memset(image, 0, sizeof(*image));
-
-    if (elf64_load(path, &image->u.elf.elf) != 0)
+    /* Load the ELF64 into memory */
+    if (elf64_load(path, &image->elf) != 0)
     {
         OE_RAISE(OE_INVALID_IMAGE);
     }
-
-    /* Save pointer to header for convenience */
-    eh = (elf64_ehdr_t*)image->u.elf.elf.data;
+    eh = (elf64_ehdr_t*)image->elf.data;
 
     /* Fail if not PIE or shared object */
     if (eh->e_type != ET_DYN)
         OE_RAISE_MSG(
-            OE_INVALID_IMAGE, "elf image is not a PIE or shared object", NULL);
+            OE_INVALID_IMAGE, "ELF image is not a PIE or shared object", NULL);
 
     /* Fail if not Intel X86 64-bit */
     if (eh->e_machine != EM_X86_64)
         OE_RAISE_MSG(
-            OE_INVALID_IMAGE, "elf image is not Intel X86 64-bit", NULL);
+            OE_INVALID_IMAGE, "ELF image is not Intel X86 64-bit", NULL);
 
-    /* Save entry point address */
+    /* Save entry point address needed to be set in the TCS for enclave app */
     image->entry_rva = eh->e_entry;
 
-    /* Scan through the section headers and extract the following values from
-     * these sections.
-     *   .text: text_rva
-     *   .oeinfo: oeinfo_rva, oeinfo_file_pos
-     *   .note.gnu.build-id: has_build_id
-     *   .tdata: tdata_rva, tdata_size, tdata_align
-     *   .tbss: tbss_size, tbss_align
-     */
+    *ehdr = eh;
+    result = OE_OK;
+
+done:
+    return result;
+}
+
+/* Scan through the section headers to populate the following properties in the
+ * image->elf struct:
+ *   .oeinfo: oeinfo_rva, oeinfo_file_pos
+ *   .tdata: tdata_rva, tdata_size, tdata_align
+ *   .tbss: tbss_size, tbss_align
+ *
+ * Also checks for the presence of the .note.gnu.build-id which is needed for
+ * the debugger contract.
+ */
+static oe_result_t _read_sections(
+    const elf64_ehdr_t* ehdr,
+    oe_enclave_elf_image_t* image)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    bool has_build_id = false;
+
+    for (size_t i = 0; i < ehdr->e_shnum; i++)
     {
-        for (i = 0; i < eh->e_shnum; i++)
+        const elf64_shdr_t* sh = elf64_get_section_header(&image->elf, i);
+
+        /* Invalid section header. The elf file is corrupted. */
+        if (sh == NULL)
+            OE_RAISE(OE_INVALID_IMAGE);
+
+        const char* name =
+            elf64_get_string_from_shstrtab(&image->elf, sh->sh_name);
+
+        if (name)
         {
-            const elf64_shdr_t* sh =
-                elf64_get_section_header(&image->u.elf.elf, i);
-
-            /* Invalid section header. The elf file is corrupted. */
-            if (sh == NULL)
-                OE_RAISE(OE_INVALID_IMAGE);
-
-            const char* name =
-                elf64_get_string_from_shstrtab(&image->u.elf.elf, sh->sh_name);
-
-            if (name)
+            if (strcmp(name, ".oeinfo") == 0)
             {
-                if (strcmp(name, ".text") == 0)
-                {
-                    image->text_rva = sh->sh_addr;
-                }
-                else if (strcmp(name, ".oeinfo") == 0)
-                {
-                    image->oeinfo_rva = sh->sh_addr;
-                    image->oeinfo_file_pos = sh->sh_offset;
-                    OE_TRACE_VERBOSE(
-                        "Found properties block offset %lx size %lx",
-                        sh->sh_offset,
-                        sh->sh_size);
-                }
+                image->oeinfo_rva = sh->sh_addr;
+                image->oeinfo_file_pos = sh->sh_offset;
+                OE_TRACE_VERBOSE(
+                    "Found properties block offset %lx size %lx",
+                    sh->sh_offset,
+                    sh->sh_size);
+            }
+            else if (strcmp(name, ".note.gnu.build-id") == 0)
+            {
+                has_build_id = true;
+            }
+            else if (strcmp(name, ".tdata") == 0)
+            {
+                // These items must match program header values.
+                image->tdata_rva = sh->sh_addr;
+                image->tdata_size = sh->sh_size;
+                image->tdata_align = sh->sh_addralign;
 
-                else if (strcmp(name, ".note.gnu.build-id") == 0)
-                {
-                    has_build_id = true;
-                }
-                else if (strcmp(name, ".tdata") == 0)
-                {
-                    // These items must match program header values.
-                    image->tdata_rva = sh->sh_addr;
-                    image->tdata_size = sh->sh_size;
-                    image->tdata_align = sh->sh_addralign;
-
-                    OE_TRACE_VERBOSE(
-                        "loadelf: tdata { rva=%lx, size=%lx, align=%ld }\n",
-                        sh->sh_addr,
-                        sh->sh_size,
-                        sh->sh_addralign);
-                }
-                else if (strcmp(name, ".tbss") == 0)
-                {
-                    image->tbss_size = sh->sh_size;
-                    image->tbss_align = sh->sh_addralign;
-                    OE_TRACE_VERBOSE(
-                        "loadelf: tbss { size=%ld, align=%ld }\n",
-                        sh->sh_size,
-                        sh->sh_addralign);
-                }
+                OE_TRACE_VERBOSE(
+                    "tdata { rva=%lx, size=%lx, align=%ld }",
+                    sh->sh_addr,
+                    sh->sh_size,
+                    sh->sh_addralign);
+            }
+            else if (strcmp(name, ".tbss") == 0)
+            {
+                image->tbss_size = sh->sh_size;
+                image->tbss_align = sh->sh_addralign;
+                OE_TRACE_VERBOSE(
+                    "tbss { size=%ld, align=%ld }",
+                    sh->sh_size,
+                    sh->sh_addralign);
             }
         }
-
-        /* Fail if required sections not found */
-        if ((0 == image->text_rva) || (0 == image->oeinfo_rva))
-        {
-            OE_RAISE(OE_INVALID_IMAGE);
-        }
-
-        /* It is now the default for linux shared libraries and executables to
-         * have the build-id note. GCC by default passes the --build-id option
-         * to linker, whereas clang does not. Build-id is also used as a key by
-         * debug symbol-servers. If no build-id is found emit a trace message.
-         * */
-        if (!has_build_id)
-        {
-            OE_TRACE_ERROR("loadelf: enclave image does not have build-id.\n");
-        }
     }
+
+    /* It is now the default for linux shared libraries and executables to
+     * have the build-id note. GCC by default passes the --build-id option
+     * to linker, whereas clang does not. Build-id is also used as a key by
+     * debug symbol-servers. If no build-id is found emit a trace message.
+     * */
+    if (!has_build_id)
+    {
+        OE_TRACE_ERROR("Enclave image does not have build-id.");
+    }
+
+    result = OE_OK;
+
+done:
+    return result;
+}
+
+/* Reads the number of loadable segments and allocates a zeroed, page-aligned
+ * image buffer for reading the segment contents into.
+ *
+ * The caller is responsible for calling memalign_free on image->image_base.
+ */
+static oe_result_t _initialize_image_segments(
+    const elf64_ehdr_t* ehdr,
+    oe_enclave_elf_image_t* image)
+{
+    oe_result_t result = OE_UNEXPECTED;
 
     /* Find out the image size and number of segments to be loaded */
-    {
-        uint64_t lo = 0xFFFFFFFFFFFFFFFF; /* lowest address of all segments */
-        uint64_t hi = 0;                  /* highest address of all segments */
+    uint64_t lo = 0xFFFFFFFFFFFFFFFF; /* lowest address of all segments */
+    uint64_t hi = 0;                  /* highest address of all segments */
 
-        for (i = 0; i < eh->e_phnum; i++)
+    for (size_t i = 0; i < ehdr->e_phnum; i++)
+    {
+        const elf64_phdr_t* ph = elf64_get_program_header(&image->elf, i);
+
+        /* Check for corrupted program header. */
+        if (ph == NULL)
+            OE_RAISE(OE_INVALID_IMAGE);
+
+        /* Check for proper sizes for the program segment. */
+        if (ph->p_filesz > ph->p_memsz)
+            OE_RAISE(OE_INVALID_IMAGE);
+
+        switch (ph->p_type)
         {
-            const elf64_phdr_t* ph =
-                elf64_get_program_header(&image->u.elf.elf, i);
+            case PT_LOAD:
+                if (lo > ph->p_vaddr)
+                    lo = ph->p_vaddr;
 
-            /* Check for corrupted program header. */
-            if (ph == NULL)
-                OE_RAISE(OE_INVALID_IMAGE);
+                if (hi < ph->p_vaddr + ph->p_memsz)
+                    hi = ph->p_vaddr + ph->p_memsz;
 
-            /* Check for proper sizes for the program segment. */
-            if (ph->p_filesz > ph->p_memsz)
-                OE_RAISE(OE_INVALID_IMAGE);
+                image->num_segments++;
+                break;
 
-            switch (ph->p_type)
-            {
-                case PT_LOAD:
-                    if (lo > ph->p_vaddr)
-                        lo = ph->p_vaddr;
-
-                    if (hi < ph->p_vaddr + ph->p_memsz)
-                        hi = ph->p_vaddr + ph->p_memsz;
-
-                    image->u.elf.num_segments++;
-                    break;
-
-                default:
-                    break;
-            }
+            default:
+                break;
         }
-
-        /* Fail if LO not found */
-        if (lo != 0)
-            OE_RAISE(OE_INVALID_IMAGE);
-
-        /* Fail if HI not found */
-        if (hi == 0)
-            OE_RAISE(OE_INVALID_IMAGE);
-
-        /* Fail if no segment found */
-        if (image->u.elf.num_segments == 0)
-            OE_RAISE(OE_INVALID_IMAGE);
-
-        /* Calculate the full size of the image (rounded up to the page size) */
-        image->image_size = oe_round_up_to_page_size(hi - lo);
     }
 
-    /* Allocate segments */
-    segments_size = image->u.elf.num_segments * sizeof(oe_elf_segment_t);
-    image->u.elf.segments =
-        (oe_elf_segment_t*)oe_memalign(OE_PAGE_SIZE, segments_size);
-    memset(image->u.elf.segments, 0, segments_size);
-    if (!image->u.elf.segments)
-    {
-        OE_RAISE(OE_OUT_OF_MEMORY);
-    }
+    /* Fail if LO not found */
+    if (lo != 0)
+        OE_RAISE(OE_INVALID_IMAGE);
 
-    /* Allocate image on a page boundary */
+    /* Fail if HI not found */
+    if (hi == 0)
+        OE_RAISE(OE_INVALID_IMAGE);
+
+    /* Fail if no segment found */
+    if (image->num_segments == 0)
+        OE_RAISE(OE_INVALID_IMAGE);
+
+    /* Calculate the full size of the image (rounded up to the page size) */
+    image->image_size = oe_round_up_to_page_size(hi - lo);
+
+    /* Allocate the in-memory image for program segments on a page boundary */
     image->image_base = (char*)oe_memalign(OE_PAGE_SIZE, image->image_size);
     if (!image->image_base)
     {
         OE_RAISE(OE_OUT_OF_MEMORY);
     }
 
-    /* Clear the image memory */
+    /* Zero initialize the in-memory image */
     memset(image->image_base, 0, image->image_size);
 
-    /* Add all loadable program segments to SEGMENTS array */
-    for (i = 0, pt_load_segments_index = 0; i < eh->e_phnum; i++)
+    result = OE_OK;
+
+done:
+    return result;
+}
+
+/* Populates the image buffer with the contents of all loadable segments.
+ * For each loaded segment, this function caches the segment properties
+ * needed during enclave load in image->segments.
+ *
+ * Also validates that the PT_TLS segment conforms to the enclave loader
+ * expectations for handling TLS.
+ *
+ * The caller is responsible for calling memalign_free on image->segments.
+ */
+static oe_result_t _stage_image_segments(
+    const elf64_ehdr_t* ehdr,
+    oe_enclave_elf_image_t* image)
+{
+    oe_result_t result = OE_UNEXPECTED;
+
+    /* Allocate array of cached segment structures for enclave load */
+    size_t segments_size = image->num_segments * sizeof(oe_elf_segment_t);
+    image->segments =
+        (oe_elf_segment_t*)oe_memalign(OE_PAGE_SIZE, segments_size);
+    memset(image->segments, 0, segments_size);
+    if (!image->segments)
     {
-        const elf64_phdr_t* ph = elf64_get_program_header(&image->u.elf.elf, i);
-        oe_elf_segment_t* seg = &image->u.elf.segments[pt_load_segments_index];
-        void* segdata;
+        OE_RAISE(OE_OUT_OF_MEMORY);
+    }
+
+    /* Read all loadable program segments into in-memory image and cache their
+     * properties in the segments array. */
+    for (size_t i = 0, pt_read_segments_index = 0; i < ehdr->e_phnum; i++)
+    {
+        const elf64_phdr_t* ph = elf64_get_program_header(&image->elf, i);
+        oe_elf_segment_t* segment = &image->segments[pt_read_segments_index];
 
         assert(ph);
         assert(ph->p_filesz <= ph->p_memsz);
@@ -248,34 +289,26 @@ static oe_result_t _load_elf_image(const char* path, oe_enclave_image_t* image)
         {
             case PT_LOAD:
             {
-                /* Cache the segment properties used during the image load */
-                seg->memsz = ph->p_memsz;
-                seg->vaddr = ph->p_vaddr;
+                /* Cache the segment properties for enclave page add */
+                segment->memsz = ph->p_memsz;
+                segment->vaddr = ph->p_vaddr;
+                segment->flags = ph->p_flags;
 
-                /* Map the segment permission flags to OE equivalents */
-                {
-                    if (ph->p_flags & PF_R)
-                        seg->flags |= OE_SEGMENT_FLAG_READ;
-
-                    if (ph->p_flags & PF_W)
-                        seg->flags |= OE_SEGMENT_FLAG_WRITE;
-
-                    if (ph->p_flags & PF_X)
-                        seg->flags |= OE_SEGMENT_FLAG_EXEC;
-                }
-
-                segdata = elf64_get_segment(&image->u.elf.elf, i);
-                if (!segdata)
+                void* segment_data = elf64_get_segment(&image->elf, i);
+                if (!segment_data)
                 {
                     OE_RAISE_MSG(
                         OE_INVALID_IMAGE,
-                        "loadelf: failed to get segment at index %lu\n",
+                        "Failed to get segment at index %lu",
                         i);
                 }
 
-                /* Copy the segment to the image */
-                memcpy(image->image_base + seg->vaddr, segdata, ph->p_filesz);
-                pt_load_segments_index++;
+                /* Copy the segment data to the image buffer */
+                memcpy(
+                    image->image_base + segment->vaddr,
+                    segment_data,
+                    ph->p_filesz);
+                pt_read_segments_index++;
                 break;
             }
             case PT_TLS:
@@ -305,25 +338,23 @@ static oe_result_t _load_elf_image(const char* path, oe_enclave_image_t* image)
                     }
                     else
                     {
-                        OE_TRACE_ERROR(
-                            "loadelf: .tdata rva mismatch. Section value = "
-                            "%lx, "
-                            "Program header value = 0x%lx\n",
+                        OE_RAISE_MSG(
+                            OE_INVALID_IMAGE,
+                            ".tdata rva mismatch. Section value = "
+                            "%lx, Program header value = 0x%lx",
                             image->tdata_rva,
                             ph->p_vaddr);
-                        OE_RAISE(OE_INVALID_IMAGE);
                     }
                 }
                 if (image->tdata_size != ph->p_filesz)
                 {
                     // Always assert on size mismatch.
-                    OE_TRACE_ERROR(
-                        "loadelf: .tdata_size mismatch. Section value = %lx, "
-                        "Program "
-                        "header value = 0x%lx\n",
+                    OE_RAISE_MSG(
+                        OE_INVALID_IMAGE,
+                        ".tdata_size mismatch. Section value = %lx, "
+                        "Program header value = 0x%lx",
                         image->tdata_size,
                         ph->p_filesz);
-                    OE_RAISE(OE_INVALID_IMAGE);
                 }
                 break;
             }
@@ -333,36 +364,26 @@ static oe_result_t _load_elf_image(const char* path, oe_enclave_image_t* image)
         }
     }
 
-    assert(pt_load_segments_index == image->u.elf.num_segments);
-
-    /* check that segments are valid */
-    for (i = 0; i < image->u.elf.num_segments - 1; i++)
+    /* Check that segments are valid */
+    for (size_t i = 0; i < image->num_segments - 1; i++)
     {
-        const oe_elf_segment_t* seg = &image->u.elf.segments[i];
-        const oe_elf_segment_t* seg_next = &image->u.elf.segments[i + 1];
-        if (seg->vaddr >= seg_next->vaddr)
+        const oe_elf_segment_t* current = &image->segments[i];
+        const oe_elf_segment_t* next = &image->segments[i + 1];
+        if (current->vaddr >= next->vaddr)
         {
             OE_RAISE_MSG(
-                OE_UNEXPECTED,
-                "loadelf: segment vaddrs found out of order\n",
-                NULL);
+                OE_UNEXPECTED, "Segment vaddrs found out of order", NULL);
         }
-        if ((seg->vaddr + seg->memsz) >
-            oe_round_down_to_page_size(seg_next->vaddr))
+        if ((current->vaddr + current->memsz) >
+            oe_round_down_to_page_size(next->vaddr))
         {
-            OE_RAISE(OE_OUT_OF_BOUNDS);
+            OE_RAISE_MSG(OE_INVALID_IMAGE, "Overlapping segments found", NULL);
         }
     }
 
-    image->u.elf.elf.magic = ELF_MAGIC;
     result = OE_OK;
 
 done:
-
-    if (result != OE_OK)
-    {
-        _free_elf_image(image);
-    }
     return result;
 }
 
@@ -385,22 +406,52 @@ OE_INLINE void _dump_relocations(const void* data, size_t size)
     }
 }
 
+/* Loads an ELF binary into memory and parses it for addition into the enclave
+ * The caller is expected to have zeroed the output image memory buffer and is
+ * responsible for calling _unload_elf_image on the resulting buffer when done.
+ */
+static oe_result_t _load_elf_image(
+    const char* path,
+    oe_enclave_elf_image_t* image)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    elf64_ehdr_t* ehdr = NULL;
+
+    assert(image && path);
+
+    OE_CHECK(_read_elf_header(path, image, &ehdr));
+
+    OE_CHECK(_read_sections(ehdr, image));
+
+    OE_CHECK(_initialize_image_segments(ehdr, image));
+
+    OE_CHECK(_stage_image_segments(ehdr, image));
+
+    /* Load the relocations into memory (zero-padded to next page size) */
+    if (elf64_load_relocations(
+            &image->elf, &image->reloc_data, &image->reloc_size) != 0)
+        OE_RAISE(OE_INVALID_IMAGE);
+
+    if (oe_get_current_logging_level() >= OE_LOG_LEVEL_VERBOSE)
+        _dump_relocations(image->reloc_data, image->reloc_size);
+
+    image->elf.magic = ELF_MAGIC;
+    result = OE_OK;
+
+done:
+    if (result != OE_OK)
+    {
+        _unload_elf_image(image);
+    }
+    return result;
+}
+
 static oe_result_t _calculate_size(
     const oe_enclave_image_t* image,
     size_t* image_size)
 {
-    *image_size = image->image_size + image->reloc_size;
+    *image_size = image->elf.image_size + image->elf.reloc_size;
     return OE_OK;
-}
-
-static oe_result_t _unload(oe_enclave_image_t* image)
-{
-    if (image->u.elf.reloc_data)
-    {
-        oe_memalign_free(image->u.elf.reloc_data);
-    }
-
-    return _free_elf_image(image);
 }
 
 // ------------------------------------------------------------------
@@ -446,13 +497,13 @@ static uint64_t _make_secinfo_flags(uint32_t flags)
 {
     uint64_t r = 0;
 
-    if (flags & OE_SEGMENT_FLAG_READ)
+    if (flags & PF_R)
         r |= SGX_SECINFO_R;
 
-    if (flags & OE_SEGMENT_FLAG_WRITE)
+    if (flags & PF_W)
         r |= SGX_SECINFO_W;
 
-    if (flags & OE_SEGMENT_FLAG_EXEC)
+    if (flags & PF_X)
         r |= SGX_SECINFO_X;
 
     return r;
@@ -517,7 +568,7 @@ static oe_result_t _add_segment_pages(
     if (flags == 0)
     {
         OE_RAISE_MSG(
-            OE_UNEXPECTED, "Segment with no page protections found.\n", NULL);
+            OE_UNEXPECTED, "Segment with no page protections found.", NULL);
     }
 
     flags |= SGX_SECINFO_REG;
@@ -539,15 +590,13 @@ done:
     return result;
 }
 
-/* Add image to enclave */
-static oe_result_t _add_pages(
-    oe_enclave_image_t* image,
+static oe_result_t _add_elf_image_pages(
+    oe_enclave_elf_image_t* image,
     oe_sgx_load_context_t* context,
     oe_enclave_t* enclave,
     uint64_t* vaddr)
 {
     oe_result_t result = OE_UNEXPECTED;
-    size_t i;
 
     assert(context);
     assert(enclave);
@@ -557,24 +606,17 @@ static oe_result_t _add_pages(
     assert(enclave->size > image->image_size);
 
     /* Add the program segments first */
-    for (i = 0; i < image->u.elf.num_segments; i++)
+    for (size_t i = 0; i < image->num_segments; i++)
     {
         OE_CHECK(_add_segment_pages(
-            context,
-            enclave->addr,
-            &image->u.elf.segments[i],
-            image->image_base));
+            context, enclave->addr, &image->segments[i], image->image_base));
     }
 
     *vaddr = image->image_size;
 
     /* Add the relocation pages (contain relocation entries) */
     OE_CHECK(_add_relocation_pages(
-        context,
-        enclave->addr,
-        image->u.elf.reloc_data,
-        image->reloc_size,
-        vaddr));
+        context, enclave->addr, image->reloc_data, image->reloc_size, vaddr));
 
     result = OE_OK;
 
@@ -582,8 +624,18 @@ done:
     return result;
 }
 
-static oe_result_t _get_dynamic_symbol_rva(
+/* Add image to enclave */
+static oe_result_t _add_pages(
     oe_enclave_image_t* image,
+    oe_sgx_load_context_t* context,
+    oe_enclave_t* enclave,
+    uint64_t* vaddr)
+{
+    return _add_elf_image_pages(&image->elf, context, enclave, vaddr);
+}
+
+static oe_result_t _get_dynamic_symbol_rva(
+    oe_enclave_elf_image_t* image,
     const char* name,
     uint64_t* rva)
 {
@@ -593,7 +645,7 @@ static oe_result_t _get_dynamic_symbol_rva(
     if (!image || !name || !rva)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    if (elf64_find_dynamic_symbol_by_name(&image->u.elf.elf, name, &sym) != 0)
+    if (elf64_find_dynamic_symbol_by_name(&image->elf, name, &sym) != 0)
         goto done;
 
     *rva = sym.st_value;
@@ -603,7 +655,7 @@ done:
 }
 
 static oe_result_t _set_uint64_t_dynamic_symbol_value(
-    oe_enclave_image_t* image,
+    oe_enclave_elf_image_t* image,
     const char* name,
     uint64_t value)
 {
@@ -611,7 +663,7 @@ static oe_result_t _set_uint64_t_dynamic_symbol_value(
     elf64_sym_t sym = {0};
     uint64_t* symbol_address = NULL;
 
-    if (elf64_find_dynamic_symbol_by_name(&image->u.elf.elf, name, &sym) != 0)
+    if (elf64_find_dynamic_symbol_by_name(&image->elf, name, &sym) != 0)
         goto done;
 
     symbol_address = (uint64_t*)(image->image_base + sym.st_value);
@@ -622,14 +674,13 @@ done:
     return result;
 }
 
-static oe_result_t _patch(
-    oe_enclave_image_t* image,
+static oe_result_t _patch_elf_image(
+    oe_enclave_elf_image_t* image,
     oe_sgx_load_context_t* context,
     size_t enclave_size)
 {
     oe_result_t result = OE_UNEXPECTED;
     oe_sgx_enclave_properties_t* oeprops;
-    size_t i;
     uint64_t enclave_rva = 0;
     uint64_t aligned_size = 0;
 
@@ -641,9 +692,9 @@ static oe_result_t _patch(
     assert((enclave_size & (OE_PAGE_SIZE - 1)) == 0);
 
     /* Clear certain ELF header fields */
-    for (i = 0; i < image->u.elf.num_segments; i++)
+    for (size_t i = 0; i < image->num_segments; i++)
     {
-        const oe_elf_segment_t* seg = &image->u.elf.segments[i];
+        const oe_elf_segment_t* seg = &image->segments[i];
         elf64_ehdr_t* ehdr = (elf64_ehdr_t*)(image->image_base + seg->vaddr);
 
         if (elf64_test_header(ehdr) == 0)
@@ -713,6 +764,14 @@ done:
     return result;
 }
 
+static oe_result_t _patch(
+    oe_enclave_image_t* image,
+    oe_sgx_load_context_t* context,
+    size_t enclave_size)
+{
+    return _patch_elf_image(&image->elf, context, enclave_size);
+}
+
 static oe_result_t _sgx_load_enclave_properties(
     const oe_enclave_image_t* image,
     const char* section_name,
@@ -725,7 +784,7 @@ static oe_result_t _sgx_load_enclave_properties(
     OE_CHECK(oe_memcpy_s(
         properties,
         sizeof(*properties),
-        image->image_base + image->oeinfo_rva,
+        image->elf.image_base + image->elf.oeinfo_rva,
         sizeof(*properties)));
 
     result = OE_OK;
@@ -744,13 +803,13 @@ static oe_result_t _sgx_update_enclave_properties(
 
     /* Copy to both the image and ELF file*/
     OE_CHECK(oe_memcpy_s(
-        (uint8_t*)image->u.elf.elf.data + image->oeinfo_file_pos,
+        (uint8_t*)image->elf.elf.data + image->elf.oeinfo_file_pos,
         sizeof(*properties),
         properties,
         sizeof(*properties)));
 
     OE_CHECK(oe_memcpy_s(
-        image->image_base + image->oeinfo_rva,
+        image->elf.image_base + image->elf.oeinfo_rva,
         sizeof(*properties),
         properties,
         sizeof(*properties)));
@@ -770,16 +829,20 @@ oe_result_t oe_load_elf_enclave_image(
     memset(image, 0, sizeof(oe_enclave_image_t));
 
     /* Load the program segments into memory */
-    OE_CHECK(_load_elf_image(path, image));
+    OE_CHECK(_load_elf_image(path, &image->elf));
 
-    /* Load the relocations into memory (zero-padded to next page size) */
-    if (elf64_load_relocations(
-            &image->u.elf.elf, &image->u.elf.reloc_data, &image->reloc_size) !=
-        0)
-        OE_RAISE(OE_INVALID_IMAGE);
+    /* Verify that primary enclave image properties are found */
+    if (!image->elf.entry_rva)
+        OE_RAISE_MSG(
+            OE_UNSUPPORTED_ENCLAVE_IMAGE,
+            "Enclave image is missing entry point.",
+            NULL);
 
-    if (oe_get_current_logging_level() >= OE_LOG_LEVEL_VERBOSE)
-        _dump_relocations(image->u.elf.reloc_data, image->reloc_size);
+    if (!image->elf.oeinfo_rva || !image->elf.oeinfo_file_pos)
+        OE_RAISE_MSG(
+            OE_UNSUPPORTED_ENCLAVE_IMAGE,
+            "Enclave image is missing .oeinfo section.",
+            NULL);
 
     image->type = OE_IMAGE_TYPE_ELF;
     image->calculate_size = _calculate_size;
@@ -787,14 +850,14 @@ oe_result_t oe_load_elf_enclave_image(
     image->sgx_patch = _patch;
     image->sgx_load_enclave_properties = _sgx_load_enclave_properties;
     image->sgx_update_enclave_properties = _sgx_update_enclave_properties;
-    image->unload = _unload;
+    image->unload = _unload_image;
 
     result = OE_OK;
 
 done:
 
     if (OE_OK != result)
-        _unload(image);
+        _unload_image(image);
 
     return result;
 }

--- a/tests/props/host/host.c
+++ b/tests/props/host/host.c
@@ -116,7 +116,7 @@ static oe_result_t _sgx_load_enclave_properties(
 
 done:
 
-    if (oeimage.u.elf.elf.magic == ELF_MAGIC)
+    if (oeimage.elf.elf.magic == ELF_MAGIC)
         oe_unload_enclave_image(&oeimage);
 
     return result;

--- a/tools/oesign/oeinfo.c
+++ b/tools/oesign/oeinfo.c
@@ -34,7 +34,7 @@ oe_result_t oe_read_oeinfo_sgx(
 
 done:
 
-    if (oeimage.u.elf.elf.magic == ELF_MAGIC)
+    if (oeimage.elf.elf.magic == ELF_MAGIC)
         oeimage.unload(&oeimage);
 
     return result;
@@ -92,8 +92,8 @@ oe_result_t oe_write_oeinfo_sgx(
             goto done;
         }
 
-        if (fwrite(oeimage.u.elf.elf.data, 1, oeimage.u.elf.elf.size, os) !=
-            oeimage.u.elf.elf.size)
+        if (fwrite(oeimage.elf.elf.data, 1, oeimage.elf.elf.size, os) !=
+            oeimage.elf.elf.size)
         {
             oe_err("Failed to write: %s", p);
             goto done;


### PR DESCRIPTION
This PR captures cleanup and refactor of the existing SGX ELF load implementation into components so that they can be more cleanly modified for adding upcoming ELF loading features.

- Remove unused `oe_enclave_image_t.text_rva` and `oe_enclave_t.text` properties
- Remove unused PE data structures and unions
- Move ELF specific properties from `oe_enclave_image_t` to `oe_enclave_elf_image_t`
  - With the removal of an alternative enclave image type, the split between
    common and ELF-specific properties no longer makes sense.
- Break up implementation of `_load_elf_image` into discrete subfunctions for clarity.
  - The subfunctions deal specifically with the `oe_enclave_elf_image_t` instead
    of the generic `oe_enclave_image_t` type now.
- Move the loading of relocations into `_load_elf_image` so that all operations for
  handling a given ELF image are encapsulated in a single function.
- Move freeing of `oe_enclave_elf_image_t.elf.reloc_data` into `_free_elf_image`
  - Rename `_free_elf_image` to `_unload_elf_image` for symmetry with `_load_elf_image`.
  - Rename `_unload` wrapper for `oe_enclave_image_t*` type to `_unload_image`.
- Update `_patch` to serve as a wrapper for new `_patch_elf_image` that takes the
  `oe_enclave_elf_image_t` type directly.
  - Update internal dependency functions `_get_symbol_rva` and
    `_set_uint64_t_symbol_value` to also take `oe_enclave_elf_image_t` directly.
- Remove unused `OE_MAX_SEGMENTS` and redundant `OE_SEGMENT_FLAG` definitions.
  - Update `_make_secinfo_flags` to map ELF RF flags directly to `SGX_SECINFO` flags.

Signed-off-by: Simon Leet <simon.leet@microsoft.com>