### PR TITLE
Print quote library load erorr

### DIFF
--- a/common/result.c
+++ b/common/result.c
@@ -138,6 +138,8 @@ const char* oe_result_str(oe_result_t result)
             return "OE_INVALID_SGX_SIGNING_KEY";
         case OE_INVALID_IMAGE:
             return "OE_INVALID_IMAGE";
+        case OE_QUOTE_LIBRARY_LOAD_ERROR:
+            return "OE_QUOTE_LIBRARY_LOAD_ERROR";
         case __OE_RESULT_MAX:
             break;
     }
@@ -210,6 +212,7 @@ bool oe_is_valid_result(uint32_t result)
         case OE_QUOTE_HASH_MISMATCH:
         case OE_INVALID_SGX_SIGNING_KEY:
         case OE_INVALID_IMAGE:
+        case OE_QUOTE_LIBRARY_LOAD_ERROR:
         {
             return true;
         }

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -395,8 +395,14 @@ oe_result_t oe_sgx_qe_get_target_info(
     else
     {
         _load_sgx_dcap_ql();
-        err = _sgx_qe_get_target_info((sgx_target_info_t*)target_info);
+        if (!_sgx_qe_get_target_info)
+            OE_RAISE_MSG(
+                OE_QUOTE_LIBRARY_LOAD_ERROR,
+                "Failed to access _sgx_qe_get_target_info from quote "
+                "library\n",
+                NULL);
 
+        err = _sgx_qe_get_target_info((sgx_target_info_t*)target_info);
         if (err != SGX_QL_SUCCESS)
             OE_RAISE_MSG(OE_PLATFORM_ERROR, "quote3_error_t=0x%x\n", err);
 
@@ -454,6 +460,13 @@ oe_result_t oe_sgx_qe_get_quote_size(
     else
     {
         _load_sgx_dcap_ql();
+
+        if (!_sgx_qe_get_quote_size)
+            OE_RAISE_MSG(
+                OE_QUOTE_LIBRARY_LOAD_ERROR,
+                "Failed to access _sgx_qe_get_quote_size from quote library\n",
+                NULL);
+
         err = _sgx_qe_get_quote_size(&local_quote_size);
 
         if (err != SGX_QL_SUCCESS)

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -366,6 +366,12 @@ typedef enum _oe_result
      */
     OE_INVALID_IMAGE,
 
+    /**
+     * Failed to load the quote library used for quote generation and
+     * attestation.
+     */
+    OE_QUOTE_LIBRARY_LOAD_ERROR,
+
     __OE_RESULT_MAX = OE_ENUM_MAX,
 } oe_result_t;
 /**< typedef enum _oe_result oe_result_t*/


### PR DESCRIPTION
Issue - Attestation tests hit SEGFAULT when DCAP quote library is not installed.

The fix is to check function pointers before calling them.