### PR TITLE
Refactor oeptrace library for easier upstreaming.

### DIFF
--- a/debugger/CMakeLists.txt
+++ b/debugger/CMakeLists.txt
@@ -2,7 +2,24 @@
 # Licensed under the MIT License.
 
 if (UNIX)
-  add_subdirectory(ptraceLib)
+  set(PTRACE_LIBRARY ${OE_LIBDIR}/openenclave/debugger/liboe_ptrace.so)
+
+  include(ExternalProject)
+
+  ExternalProject_Add(
+    ptraceLib
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ptraceLib
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/ptraceLib
+    CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    BUILD_ALWAYS on
+    TEST_BEFORE_INSTALL off
+    INSTALL_COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/ptraceLib/libsgxptrace.so
+                    ${PTRACE_LIBRARY}
+    BUILD_BYPRODUCTS ${PTRACE_LIBRARY})
+
+  install(PROGRAMS ${PTRACE_LIBRARY}
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/debugger)
+
   add_subdirectory(pythonExtension)
 
   # Copy oegdb to build/output/bin so that it can be used

--- a/debugger/ptraceLib/CMakeLists.txt
+++ b/debugger/ptraceLib/CMakeLists.txt
@@ -1,23 +1,35 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
+cmake_minimum_required(VERSION 3.1)
+
+# Set CMAKE_BUILD_TYPE if not specified
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Debug")
+endif ()
+
+if (NOT ";Debug;RelWithDebInfo;Release;" MATCHES ";${CMAKE_BUILD_TYPE};")
+  message(
+    FATAL_ERROR "CMAKE_BUILD_TYPE must be Debug, RelWithDebInfo or Release")
+endif ()
+
+project(sgxptrace)
+
 find_library(DL_LIB NAMES dl)
-add_library(openenclave::dl SHARED IMPORTED)
-set_target_properties(openenclave::dl PROPERTIES IMPORTED_LOCATION ${DL_LIB})
+add_library(dl SHARED IMPORTED)
+set_target_properties(dl PROPERTIES IMPORTED_LOCATION ${DL_LIB})
 
 find_package(Threads REQUIRED)
 
-add_library(oe_ptrace SHARED oe_ptrace.c inferior_status.c enclave_context.c)
+add_library(sgxptrace SHARED ptrace.c inferior_status.c enclave_context.c)
 
-target_link_libraries(oe_ptrace oe_includes openenclave::dl Threads::Threads)
+target_link_libraries(sgxptrace dl Threads::Threads)
 
-target_compile_options(oe_ptrace PRIVATE -Wall -Werror -Wno-attributes
+target_compile_options(sgxptrace PRIVATE -Wall -Werror -Wno-attributes
                                          -Wmissing-prototypes -m64)
 
-target_compile_definitions(oe_ptrace PRIVATE -DOE_BUILD_UNTRUSTED -D_GNU_SOURCE)
+# RTLD_NEXT requires _GNU_SOURCE to be defined.
+target_compile_definitions(sgxptrace PRIVATE -D_GNU_SOURCE)
 
-set_property(TARGET oe_ptrace PROPERTY LIBRARY_OUTPUT_DIRECTORY
-                                       ${OE_LIBDIR}/openenclave/debugger)
-
-install(TARGETS oe_ptrace
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/debugger)
+set_property(TARGET sgxptrace PROPERTY TARGET_OUTPUT_DIRECTORY
+                                       ${PROJECT_BINARY_DIR})

--- a/debugger/ptraceLib/contract.h
+++ b/debugger/ptraceLib/contract.h
@@ -1,0 +1,19 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _CONTRACT_H
+#define _CONTRACT_H
+
+#define ENCLAVE_PAGE_SIZE 4096
+
+// OSSA must be allocated immediately after the TCS page.
+#define OSSA_FROM_TCS PAGE_SIZE
+
+// Enclave must have at least 1 SSA by default
+#define DEFAULT_SSA_FRAME_SIZE 1
+
+// GS register must point to a structure that has an uint64_t ssa_frame_size
+// member at the following offset.
+#define GS_SSA_FRAME_SIZE_OFFSET 0x38
+
+#endif // _CONTRACT_H

--- a/debugger/ptraceLib/enclave_context.c
+++ b/debugger/ptraceLib/enclave_context.c
@@ -12,6 +12,8 @@
 #include <sys/user.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include "contract.h"
+#include "sgxtypes.h"
 
 typedef struct _ssa_info
 {
@@ -22,7 +24,7 @@ typedef struct _ssa_info
 /*
 **==============================================================================
 **
-** oe_read_process_memory()
+** sgx_read_process_memory()
 **
 **     This function is used to read process memory.
 **
@@ -41,7 +43,7 @@ typedef struct _ssa_info
 **==============================================================================
 */
 
-int oe_read_process_memory(
+int sgx_read_process_memory(
     pid_t proc,
     void* base_addr,
     void* buffer,
@@ -92,7 +94,7 @@ cleanup:
 /*
 **==============================================================================
 **
-** oe_write_process_memory()
+** sgx_write_process_memory()
 **
 **     This function is used to write process memory.
 **
@@ -111,7 +113,7 @@ cleanup:
 **==============================================================================
 */
 
-int oe_write_process_memory(
+int sgx_write_process_memory(
     pid_t proc,
     void* base_addr,
     void* buffer,
@@ -165,30 +167,29 @@ static int _get_enclave_ssa_frame_size(
     uint64_t* ssa_frame_size)
 {
     int ret;
-    oe_thread_data_t oe_thread_data;
+    uint64_t td_ssa_frame_size = 0;
     size_t read_byte_length = 0;
 
-    oe_sgx_td_t* td = (oe_sgx_td_t*)td_t_addr;
-    ret = oe_read_process_memory(
+    ret = sgx_read_process_memory(
         pid,
-        (void*)td,
-        (void*)&oe_thread_data,
-        sizeof(oe_thread_data_t),
+        (char*)td_t_addr + GS_SSA_FRAME_SIZE_OFFSET,
+        (void*)&td_ssa_frame_size,
+        sizeof(td_ssa_frame_size),
         &read_byte_length);
     if (ret != 0)
     {
         return ret;
     }
 
-    if (read_byte_length != sizeof(oe_thread_data_t))
+    if (read_byte_length != sizeof(td_ssa_frame_size))
     {
         return -1;
     }
 
-    *ssa_frame_size = oe_thread_data.__ssa_frame_size;
+    *ssa_frame_size = td_ssa_frame_size;
     if (*ssa_frame_size == 0)
     {
-        *ssa_frame_size = OE_DEFAULT_SSA_FRAME_SIZE;
+        *ssa_frame_size = DEFAULT_SSA_FRAME_SIZE;
     }
 
     return 0;
@@ -207,18 +208,14 @@ static int _get_enclave_thread_current_ssa_info(
     void* td_t_addr;
 
     // Read TCS header.
-    ret = oe_read_process_memory(
-        pid,
-        tcs_addr,
-        (void*)&tcs,
-        OE_SGX_TCS_HEADER_BYTE_SIZE,
-        &read_byte_length);
+    ret = sgx_read_process_memory(
+        pid, tcs_addr, (void*)&tcs, TCS_HEADER_BYTE_SIZE, &read_byte_length);
     if (ret != 0)
     {
         return ret;
     }
 
-    if (read_byte_length != OE_SGX_TCS_HEADER_BYTE_SIZE)
+    if (read_byte_length != TCS_HEADER_BYTE_SIZE)
     {
         return -1;
     }
@@ -231,7 +228,7 @@ static int _get_enclave_thread_current_ssa_info(
     // This can be used to compute the enclave base address:
     //    encave-base-address + tcs.ossa = tcs_addr + page-size
     //    enclave-base-address = tcs_addr + page-size - tcs.ossa
-    enclave_base_address = (uint8_t*)tcs_addr + OE_PAGE_SIZE - tcs.ossa;
+    enclave_base_address = (uint8_t*)tcs_addr + ENCLAVE_PAGE_SIZE - tcs.ossa;
 
     // GS register will point to td_t. GS register value can be computed by
     // adding tcs.gsbase to enclave base address.
@@ -249,8 +246,8 @@ static int _get_enclave_thread_current_ssa_info(
 
     // Get current SSA base addr and size.
     ssa_info->base_address =
-        (void*)(((uint8_t*)tcs_addr) + OE_SSA_FROM_TCS_BYTE_OFFSET + (tcs.cssa - 1) * ssa_frame_size * OE_PAGE_SIZE);
-    ssa_info->frame_byte_size = ssa_frame_size * OE_PAGE_SIZE;
+        (void*)(((uint8_t*)tcs_addr) + OSSA_FROM_TCS + (tcs.cssa - 1) * ssa_frame_size * ENCLAVE_PAGE_SIZE);
+    ssa_info->frame_byte_size = ssa_frame_size * ENCLAVE_PAGE_SIZE;
     return 0;
 }
 
@@ -315,7 +312,7 @@ static inline void _user_regs_to_ssa_gpr(
 /*
 **==============================================================================
 **
-** oe_get_enclave_thread_gpr()
+** sgx_get_enclave_thread_gpr()
 **
 **     This function is used get the GPR registers of the enclave thread.
 **
@@ -331,7 +328,7 @@ static inline void _user_regs_to_ssa_gpr(
 **==============================================================================
 */
 
-int oe_get_enclave_thread_gpr(
+int sgx_get_enclave_thread_gpr(
     pid_t pid,
     void* tcs_addr,
     struct user_regs_struct* regs)
@@ -351,10 +348,10 @@ int oe_get_enclave_thread_gpr(
 
     // Get gpr base address. Gpr is at the end of an SSA frame.
     gpr_addr =
-        (void*)(((uint8_t*)ssa_info.base_address) + ssa_info.frame_byte_size - OE_SGX_GPR_BYTE_SIZE);
+        (void*)(((uint8_t*)ssa_info.base_address) + ssa_info.frame_byte_size - SGX_GPR_BYTE_SIZE);
 
     // Read gpr from ssa.
-    ret = oe_read_process_memory(
+    ret = sgx_read_process_memory(
         pid,
         gpr_addr,
         (void*)&ssa_gpr,
@@ -379,7 +376,7 @@ int oe_get_enclave_thread_gpr(
 /*
 **==============================================================================
 **
-** oe_set_enclave_thread_gpr()
+** sgx_set_enclave_thread_gpr()
 **
 **     This function is used get the GPR registers of the enclave thread.
 **
@@ -395,7 +392,7 @@ int oe_get_enclave_thread_gpr(
 **==============================================================================
 */
 
-int oe_set_enclave_thread_gpr(
+int sgx_set_enclave_thread_gpr(
     pid_t pid,
     void* tcs_addr,
     struct user_regs_struct* regs)
@@ -416,10 +413,10 @@ int oe_set_enclave_thread_gpr(
 
     // Get gpr base address. Gpr is at the end of an SSA frame.
     gpr_addr =
-        (void*)(((uint8_t*)ssa_info.base_address) + ssa_info.frame_byte_size - OE_SGX_GPR_BYTE_SIZE);
+        (void*)(((uint8_t*)ssa_info.base_address) + ssa_info.frame_byte_size - SGX_GPR_BYTE_SIZE);
 
     // Read gpr from ssa.
-    ret = oe_read_process_memory(
+    ret = sgx_read_process_memory(
         pid,
         gpr_addr,
         (void*)&ssa_gpr,
@@ -439,7 +436,7 @@ int oe_set_enclave_thread_gpr(
     _user_regs_to_ssa_gpr(regs, &ssa_gpr);
 
     // Write gpr value to ssa.
-    ret = oe_write_process_memory(
+    ret = sgx_write_process_memory(
         pid,
         gpr_addr,
         (void*)&ssa_gpr,
@@ -461,7 +458,7 @@ int oe_set_enclave_thread_gpr(
 /*
 **==============================================================================
 **
-** oe_get_enclave_thread_fpr()
+** sgx_get_enclave_thread_fpr()
 **
 **     This function is used get the FPR registers of the enclave thread.
 **
@@ -477,7 +474,7 @@ int oe_set_enclave_thread_gpr(
 **==============================================================================
 */
 
-int oe_get_enclave_thread_fpr(
+int sgx_get_enclave_thread_fpr(
     pid_t pid,
     void* tcs_addr,
     struct user_fpregs_struct* regs)
@@ -494,7 +491,7 @@ int oe_get_enclave_thread_fpr(
     }
 
     // Read fpr values from ssa.
-    ret = oe_read_process_memory(
+    ret = sgx_read_process_memory(
         pid,
         ssa_info.base_address,
         (void*)regs,
@@ -516,7 +513,7 @@ int oe_get_enclave_thread_fpr(
 /*
 **==============================================================================
 **
-** oe_set_enclave_thread_fpr()
+** sgx_set_enclave_thread_fpr()
 **
 **     This function is used get the FPR registers of the enclave thread.
 **
@@ -532,7 +529,7 @@ int oe_get_enclave_thread_fpr(
 **==============================================================================
 */
 
-int oe_set_enclave_thread_fpr(
+int sgx_set_enclave_thread_fpr(
     pid_t pid,
     void* tcs_addr,
     struct user_fpregs_struct* regs)
@@ -549,7 +546,7 @@ int oe_set_enclave_thread_fpr(
     }
 
     // Write fpr values to ssa.
-    ret = oe_write_process_memory(
+    ret = sgx_write_process_memory(
         pid,
         ssa_info.base_address,
         (void*)regs,
@@ -571,7 +568,7 @@ int oe_set_enclave_thread_fpr(
 /*
 **==============================================================================
 **
-** oe_get_enclave_thread_xstate()
+** sgx_get_enclave_thread_xstate()
 **
 **     This function is used get the XState of the enclave thread.
 **
@@ -588,7 +585,7 @@ int oe_set_enclave_thread_fpr(
 **==============================================================================
 */
 
-int oe_get_enclave_thread_xstate(
+int sgx_get_enclave_thread_xstate(
     pid_t pid,
     void* tcs_addr,
     void* xstate,
@@ -612,7 +609,7 @@ int oe_get_enclave_thread_xstate(
     }
 
     // Read xstate from ssa.
-    ret = oe_read_process_memory(
+    ret = sgx_read_process_memory(
         pid,
         ssa_info.base_address,
         (void*)xstate,
@@ -634,7 +631,7 @@ int oe_get_enclave_thread_xstate(
 /*
 **==============================================================================
 **
-** oe_set_enclave_thread_xstate()
+** sgx_set_enclave_thread_xstate()
 **
 **     This function is used set the XState of the enclave thread.
 **
@@ -651,7 +648,7 @@ int oe_get_enclave_thread_xstate(
 **==============================================================================
 */
 
-int oe_set_enclave_thread_xstate(
+int sgx_set_enclave_thread_xstate(
     pid_t pid,
     void* tcs_addr,
     void* xstate,
@@ -675,7 +672,7 @@ int oe_set_enclave_thread_xstate(
     }
 
     // Write xstate values to ssa.
-    ret = oe_write_process_memory(
+    ret = sgx_write_process_memory(
         pid,
         ssa_info.base_address,
         (void*)xstate,
@@ -697,7 +694,7 @@ int oe_set_enclave_thread_xstate(
 /*
 **==============================================================================
 **
-** oe_is_aep()
+** sgx_is_aep()
 **
 **     This function is used to check if the input thread is on a OE AEP.
 **
@@ -712,7 +709,7 @@ int oe_set_enclave_thread_xstate(
 **==============================================================================
 */
 
-bool oe_is_aep(pid_t pid, struct user_regs_struct* regs)
+bool sgx_is_aep(pid_t pid, struct user_regs_struct* regs)
 {
     uint32_t op_code;
 
@@ -722,7 +719,7 @@ bool oe_is_aep(pid_t pid, struct user_regs_struct* regs)
         return false;
     }
 
-    if (oe_read_process_memory(
+    if (sgx_read_process_memory(
             pid, (void*)regs->rip, (char*)&op_code, sizeof(op_code), NULL) != 0)
     {
         return false;

--- a/debugger/ptraceLib/enclave_context.h
+++ b/debugger/ptraceLib/enclave_context.h
@@ -1,61 +1,60 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#ifndef _OE_ENCLAVE_CONTEXT_H
-#define _OE_ENCLAVE_CONTEXT_H
+#ifndef _ENCLAVE_CONTEXT_H
+#define _ENCLAVE_CONTEXT_H
 
-#include <openenclave/bits/sgx/sgxtypes.h>
-#include <openenclave/internal/constants_x64.h>
-#include <openenclave/internal/sgx/td.h>
 #include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <sys/user.h>
 
-int oe_read_process_memory(
+int sgx_read_process_memory(
     pid_t proc,
     void* base_addr,
     void* buffer,
     size_t buffer_size,
     size_t* read_size);
 
-int oe_write_process_memory(
+int sgx_write_process_memory(
     pid_t proc,
     void* base_addr,
     void* buffer,
     size_t buffer_size,
     size_t* write_size);
 
-bool oe_is_aep(pid_t pid, struct user_regs_struct* regs);
+bool sgx_is_aep(pid_t pid, struct user_regs_struct* regs);
 
-int oe_get_enclave_thread_gpr(
+int sgx_get_enclave_thread_gpr(
     pid_t pid,
     void* tcs_addr,
     struct user_regs_struct* regs);
 
-int oe_set_enclave_thread_gpr(
+int sgx_set_enclave_thread_gpr(
     pid_t pid,
     void* tcs_addr,
     struct user_regs_struct* regs);
 
-int oe_get_enclave_thread_fpr(
+int sgx_get_enclave_thread_fpr(
     pid_t pid,
     void* tcs_addr,
     struct user_fpregs_struct* regs);
 
-int oe_set_enclave_thread_fpr(
+int sgx_set_enclave_thread_fpr(
     pid_t pid,
     void* tcs_addr,
     struct user_fpregs_struct* regs);
 
-int oe_get_enclave_thread_xstate(
+int sgx_get_enclave_thread_xstate(
     pid_t pid,
     void* tcs_addr,
     void* xstate,
     uint64_t xstate_size);
 
-int oe_set_enclave_thread_xstate(
+int sgx_set_enclave_thread_xstate(
     pid_t pid,
     void* tcs_addr,
     void* xstate,
     uint64_t xstate_size);
 
-#endif /* _OE_ENCLAVE_CONTEXT_H */
+#endif /* _ENCLAVE_CONTEXT_H */

--- a/debugger/ptraceLib/inferior_status.c
+++ b/debugger/ptraceLib/inferior_status.c
@@ -8,23 +8,23 @@
 #include <sys/user.h>
 #include <sys/wait.h>
 
-typedef struct _oe_inferior_info
+typedef struct _sgx_inferior_info
 {
-    struct _oe_inferior_info* next;
+    struct _sgx_inferior_info* next;
     pid_t pid;
     int64_t flags;
-} oe_inferior_info_t;
+} sgx_inferior_info_t;
 
-static oe_inferior_info_t* g_inferior_info_head = NULL;
+static sgx_inferior_info_t* g_inferior_info_head = NULL;
 static pthread_mutex_t inferior_info_lock;
 
-int oe_track_inferior(pid_t pid)
+int sgx_track_inferior(pid_t pid)
 {
     int ret = -1;
     pthread_mutex_lock(&inferior_info_lock);
 
     // Check if the inferior is already in the track list.
-    oe_inferior_info_t* inferior_info = g_inferior_info_head;
+    sgx_inferior_info_t* inferior_info = g_inferior_info_head;
     while (inferior_info != NULL)
     {
         if (inferior_info->pid == pid)
@@ -36,12 +36,12 @@ int oe_track_inferior(pid_t pid)
     }
 
     // Allocate a new node.
-    inferior_info = (oe_inferior_info_t*)malloc(sizeof(oe_inferior_info_t));
+    inferior_info = (sgx_inferior_info_t*)malloc(sizeof(sgx_inferior_info_t));
     if (inferior_info == NULL)
     {
         goto cleanup;
     }
-    memset(inferior_info, 0, sizeof(oe_inferior_info_t));
+    memset(inferior_info, 0, sizeof(sgx_inferior_info_t));
     inferior_info->pid = pid;
 
     // Insert new node at the beginning of the track list.
@@ -54,13 +54,13 @@ cleanup:
     return ret;
 }
 
-int oe_untrack_inferior(pid_t pid)
+int sgx_untrack_inferior(pid_t pid)
 {
     int ret = -1;
     pthread_mutex_lock(&inferior_info_lock);
 
-    oe_inferior_info_t* prev_inferior_info = NULL;
-    oe_inferior_info_t* cur_inferior_info = g_inferior_info_head;
+    sgx_inferior_info_t* prev_inferior_info = NULL;
+    sgx_inferior_info_t* cur_inferior_info = g_inferior_info_head;
 
     while (cur_inferior_info != NULL)
     {
@@ -93,7 +93,7 @@ cleanup:
 /*
 **==============================================================================
 **
-** oe_get_inferior_flags()
+** sgx_get_inferior_flags()
 **
 **     This function is used to get the flags of a tracked inferior.
 **
@@ -108,12 +108,12 @@ cleanup:
 **==============================================================================
 */
 
-int oe_get_inferior_flags(pid_t pid, int64_t* flags)
+int sgx_get_inferior_flags(pid_t pid, int64_t* flags)
 {
     int ret = -1;
     pthread_mutex_lock(&inferior_info_lock);
 
-    oe_inferior_info_t* inferior_info = g_inferior_info_head;
+    sgx_inferior_info_t* inferior_info = g_inferior_info_head;
     while (inferior_info != NULL)
     {
         if (inferior_info->pid == pid)
@@ -134,7 +134,7 @@ cleanup:
 /*
 **==============================================================================
 **
-** oe_set_inferior_flags()
+** sgx_set_inferior_flags()
 **
 **     This function is used to set the flags of a tracked inferior.
 **
@@ -149,12 +149,12 @@ cleanup:
 **==============================================================================
 */
 
-int oe_set_inferior_flags(pid_t pid, int64_t flags)
+int sgx_set_inferior_flags(pid_t pid, int64_t flags)
 {
     int ret = -1;
     pthread_mutex_lock(&inferior_info_lock);
 
-    oe_inferior_info_t* inferior_info = g_inferior_info_head;
+    sgx_inferior_info_t* inferior_info = g_inferior_info_head;
     while (inferior_info != NULL)
     {
         if (inferior_info->pid == pid)

--- a/debugger/ptraceLib/inferior_status.h
+++ b/debugger/ptraceLib/inferior_status.h
@@ -1,23 +1,23 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#ifndef _OE_INFERIOR_STATUS_H_
-#define _OE_INFERIOR_STATUS_H_
+#ifndef _INFERIOR_STATUS_H_
+#define _INFERIOR_STATUS_H_
 
-#include <openenclave/bits/types.h>
 #include <pthread.h>
+#include <stdint.h>
 
-typedef enum _oe_inferior_flags
+typedef enum _sgx_inferior_flags
 {
-    OE_INFERIOR_SINGLE_STEP = 0X1
-} oe_inferior_flags_t;
+    SGX_INFERIOR_SINGLE_STEP = 0X1
+} sgx_inferior_flags_t;
 
-int oe_track_inferior(pid_t pid);
+int sgx_track_inferior(pid_t pid);
 
-int oe_untrack_inferior(pid_t pid);
+int sgx_untrack_inferior(pid_t pid);
 
-int oe_get_inferior_flags(pid_t pid, int64_t* flags);
+int sgx_get_inferior_flags(pid_t pid, int64_t* flags);
 
-int oe_set_inferior_flags(pid_t pid, int64_t flags);
+int sgx_set_inferior_flags(pid_t pid, int64_t flags);
 
 #endif

--- a/debugger/ptraceLib/ptrace.c
+++ b/debugger/ptraceLib/ptrace.c
@@ -5,6 +5,7 @@
 #include <elf.h>
 #include <pthread.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ptrace.h>
@@ -15,29 +16,31 @@
 #include "enclave_context.h"
 #include "inferior_status.h"
 
+#define COUNTOF(arr) (sizeof(arr) / sizeof((arr)[0]))
+
 // Function pointer definitions.
-typedef int64_t (*oe_ptrace_func_t)(
+typedef int64_t (*sgx_ptrace_func_t)(
     enum __ptrace_request request,
     pid_t pid,
     void* addr,
     void* data);
 
-typedef pid_t (*oe_waitpid_func_t)(pid_t pid, int* status, int options);
+typedef pid_t (*sgx_waitpid_func_t)(pid_t pid, int* status, int options);
 
 // Original syscall functions.
-static oe_ptrace_func_t g_system_ptrace = NULL;
-static oe_waitpid_func_t g_system_waitpid = NULL;
+static sgx_ptrace_func_t g_system_ptrace = NULL;
+static sgx_waitpid_func_t g_system_waitpid = NULL;
 
 // Initializer.
 __attribute__((constructor)) void init(void);
 __attribute__((constructor)) void init()
 {
     // Get the ptrace and waitpid syscall function address.
-    g_system_ptrace = (oe_ptrace_func_t)dlsym(RTLD_NEXT, "ptrace");
-    g_system_waitpid = (oe_waitpid_func_t)dlsym(RTLD_NEXT, "waitpid");
+    g_system_ptrace = (sgx_ptrace_func_t)dlsym(RTLD_NEXT, "ptrace");
+    g_system_waitpid = (sgx_waitpid_func_t)dlsym(RTLD_NEXT, "waitpid");
 }
 
-static int64_t oe_get_gpr_handler(pid_t pid, void* addr, void* data)
+static int64_t sgx_get_gpr_handler(pid_t pid, void* addr, void* data)
 {
     if (!data)
     {
@@ -52,10 +55,10 @@ static int64_t oe_get_gpr_handler(pid_t pid, void* addr, void* data)
 
     // Get the gpr values from enclave thread if the pc is an AEP.
     struct user_regs_struct* regs = (struct user_regs_struct*)data;
-    if (oe_is_aep(pid, regs))
+    if (sgx_is_aep(pid, regs))
     {
         // rbx has the TCS of enclave thread.
-        if (oe_get_enclave_thread_gpr(pid, (void*)regs->rbx, regs) != 0)
+        if (sgx_get_enclave_thread_gpr(pid, (void*)regs->rbx, regs) != 0)
         {
             return -1;
         }
@@ -64,7 +67,7 @@ static int64_t oe_get_gpr_handler(pid_t pid, void* addr, void* data)
     return 0;
 }
 
-static int64_t oe_set_gpr_handler(pid_t pid, void* addr, void* data)
+static int64_t sgx_set_gpr_handler(pid_t pid, void* addr, void* data)
 {
     if (!data)
     {
@@ -79,11 +82,11 @@ static int64_t oe_set_gpr_handler(pid_t pid, void* addr, void* data)
     }
 
     // Set the enclave thread gpr if the pc is an AEP.
-    if (oe_is_aep(pid, &aep_regs))
+    if (sgx_is_aep(pid, &aep_regs))
     {
         // rbx has the TCS of enclave thread.
         struct user_regs_struct* regs = (struct user_regs_struct*)data;
-        if (oe_set_enclave_thread_gpr(pid, (void*)aep_regs.rbx, regs) != 0)
+        if (sgx_set_enclave_thread_gpr(pid, (void*)aep_regs.rbx, regs) != 0)
         {
             return -1;
         }
@@ -96,7 +99,7 @@ static int64_t oe_set_gpr_handler(pid_t pid, void* addr, void* data)
     return g_system_ptrace(PTRACE_SETREGS, pid, addr, data);
 }
 
-static int64_t oe_get_fpr_handler(pid_t pid, void* addr, void* data)
+static int64_t sgx_get_fpr_handler(pid_t pid, void* addr, void* data)
 {
     if (!data)
     {
@@ -111,10 +114,10 @@ static int64_t oe_get_fpr_handler(pid_t pid, void* addr, void* data)
     }
 
     // Get the fpr values from enclave thread if the pc is an AEP.
-    if (oe_is_aep(pid, &regs))
+    if (sgx_is_aep(pid, &regs))
     {
         // rbx has the TCS of enclave thread.
-        if (oe_get_enclave_thread_fpr(
+        if (sgx_get_enclave_thread_fpr(
                 pid, (void*)regs.rbx, (struct user_fpregs_struct*)data) != 0)
         {
             return -1;
@@ -128,7 +131,7 @@ static int64_t oe_get_fpr_handler(pid_t pid, void* addr, void* data)
     return g_system_ptrace(PTRACE_GETFPREGS, pid, addr, data);
 }
 
-static int64_t oe_set_fpr_handler(pid_t pid, void* addr, void* data)
+static int64_t sgx_set_fpr_handler(pid_t pid, void* addr, void* data)
 {
     if (!data)
     {
@@ -143,10 +146,10 @@ static int64_t oe_set_fpr_handler(pid_t pid, void* addr, void* data)
     }
 
     // Set the fpr values to enclave thread if the pc is an AEP.
-    if (oe_is_aep(pid, &regs))
+    if (sgx_is_aep(pid, &regs))
     {
         // rbx has the TCS of enclave thread.
-        if (oe_set_enclave_thread_fpr(
+        if (sgx_set_enclave_thread_fpr(
                 pid, (void*)regs.rbx, (struct user_fpregs_struct*)data) != 0)
         {
             return -1;
@@ -160,7 +163,7 @@ static int64_t oe_set_fpr_handler(pid_t pid, void* addr, void* data)
     return g_system_ptrace(PTRACE_GETFPREGS, pid, addr, data);
 }
 
-static int64_t oe_get_reg_set_handler(pid_t pid, void* addr, void* data)
+static int64_t sgx_get_reg_set_handler(pid_t pid, void* addr, void* data)
 {
     if (!data)
     {
@@ -175,7 +178,7 @@ static int64_t oe_get_reg_set_handler(pid_t pid, void* addr, void* data)
     }
 
     // Get the XState values from enclave thread if the pc is an AEP.
-    if (oe_is_aep(pid, &regs))
+    if (sgx_is_aep(pid, &regs))
     {
         uint64_t type = (uint64_t)addr;
         if (NT_X86_XSTATE != type)
@@ -186,7 +189,7 @@ static int64_t oe_get_reg_set_handler(pid_t pid, void* addr, void* data)
         // rbx has the TCS of enclave thread.
         struct iovec* iov = (struct iovec*)data;
         if (iov->iov_base && iov->iov_len &&
-            (oe_get_enclave_thread_xstate(
+            (sgx_get_enclave_thread_xstate(
                  pid, (void*)regs.rbx, (void*)iov->iov_base, iov->iov_len) ==
              0))
         {
@@ -201,7 +204,7 @@ static int64_t oe_get_reg_set_handler(pid_t pid, void* addr, void* data)
     return g_system_ptrace(PTRACE_GETREGSET, pid, addr, data);
 }
 
-static int64_t oe_set_reg_set_handler(pid_t pid, void* addr, void* data)
+static int64_t sgx_set_reg_set_handler(pid_t pid, void* addr, void* data)
 {
     if (!data)
     {
@@ -216,7 +219,7 @@ static int64_t oe_set_reg_set_handler(pid_t pid, void* addr, void* data)
     }
 
     // Set the XState values to enclave thread if the pc is an AEP.
-    if (oe_is_aep(pid, &regs))
+    if (sgx_is_aep(pid, &regs))
     {
         uint64_t type = (uint64_t)addr;
         if (NT_X86_XSTATE != type)
@@ -227,7 +230,7 @@ static int64_t oe_set_reg_set_handler(pid_t pid, void* addr, void* data)
         // rbx has the TCS of enclave thread.
         struct iovec* iov = (struct iovec*)data;
         if (iov->iov_base && iov->iov_len &&
-            (oe_set_enclave_thread_xstate(
+            (sgx_set_enclave_thread_xstate(
                  pid, (void*)regs.rbx, (void*)iov->iov_base, iov->iov_len) ==
              0))
         {
@@ -242,42 +245,42 @@ static int64_t oe_set_reg_set_handler(pid_t pid, void* addr, void* data)
     return g_system_ptrace(PTRACE_SETREGSET, pid, addr, data);
 }
 
-static int64_t oe_single_step_handler(pid_t pid, void* addr, void* data)
+static int64_t sgx_single_step_handler(pid_t pid, void* addr, void* data)
 {
-    oe_track_inferior(pid);
-    oe_set_inferior_flags(pid, OE_INFERIOR_SINGLE_STEP);
+    sgx_track_inferior(pid);
+    sgx_set_inferior_flags(pid, SGX_INFERIOR_SINGLE_STEP);
 
     return g_system_ptrace(PTRACE_SINGLESTEP, pid, addr, data);
 }
 
 // Customized ptrace request handler table.
-typedef int64_t (*oe_ptrace_request_handler)(pid_t, void*, void*);
-typedef enum __ptrace_request oe_ptrace_request_type;
+typedef int64_t (*sgx_ptrace_request_handler)(pid_t, void*, void*);
+typedef enum __ptrace_request sgx_ptrace_request_type;
 
 struct
 {
-    oe_ptrace_request_type request_type;
-    oe_ptrace_request_handler request_handler;
+    sgx_ptrace_request_type request_type;
+    sgx_ptrace_request_handler request_handler;
 } g_request_handlers[] = {
     // GRP requests.
-    {PTRACE_GETREGS, oe_get_gpr_handler},
-    {PTRACE_SETREGS, oe_set_gpr_handler},
+    {PTRACE_GETREGS, sgx_get_gpr_handler},
+    {PTRACE_SETREGS, sgx_set_gpr_handler},
 
     // Floating pointer registers requests.
-    {PTRACE_GETFPREGS, oe_get_fpr_handler},
-    {PTRACE_SETFPREGS, oe_set_fpr_handler},
+    {PTRACE_GETFPREGS, sgx_get_fpr_handler},
+    {PTRACE_SETFPREGS, sgx_set_fpr_handler},
 
     // Extended floating pointer registers requests.
-    {PTRACE_GETFPXREGS, oe_get_fpr_handler},
-    {PTRACE_SETFPXREGS, oe_set_fpr_handler},
+    {PTRACE_GETFPXREGS, sgx_get_fpr_handler},
+    {PTRACE_SETFPXREGS, sgx_set_fpr_handler},
 
     // Register set request, can be used to get extended processor
     // states(XState).
-    {PTRACE_GETREGSET, oe_get_reg_set_handler},
-    {PTRACE_SETREGSET, oe_set_reg_set_handler},
+    {PTRACE_GETREGSET, sgx_get_reg_set_handler},
+    {PTRACE_SETREGSET, sgx_set_reg_set_handler},
 
     // Single step request.
-    {PTRACE_SINGLESTEP, oe_single_step_handler},
+    {PTRACE_SINGLESTEP, sgx_single_step_handler},
 };
 
 /*
@@ -291,7 +294,7 @@ struct
 **==============================================================================
 */
 
-int64_t ptrace(oe_ptrace_request_type __request, ...)
+int64_t ptrace(sgx_ptrace_request_type __request, ...)
 {
     pid_t pid;
     void* addr;
@@ -306,7 +309,7 @@ int64_t ptrace(oe_ptrace_request_type __request, ...)
 
     // If the request should be handled by the customized handler, calls
     // customer handler.
-    for (uint32_t i = 0; i < OE_COUNTOF(g_request_handlers); i++)
+    for (uint32_t i = 0; i < COUNTOF(g_request_handlers); i++)
     {
         if (__request == g_request_handlers[i].request_type)
         {
@@ -341,7 +344,7 @@ pid_t waitpid(pid_t pid, int* status, int options)
     // Remove the inferior info if it is terminated.
     if (WIFEXITED(*status) || WIFSIGNALED(*status))
     {
-        oe_untrack_inferior(ret_pid);
+        sgx_untrack_inferior(ret_pid);
     }
 
     // Handle the traps.
@@ -351,27 +354,28 @@ pid_t waitpid(pid_t pid, int* status, int options)
         int64_t flags;
 
         // Cleanup the single step flag.
-        ret = oe_get_inferior_flags(ret_pid, &flags);
-        if ((ret == 0) && (flags & OE_INFERIOR_SINGLE_STEP))
+        ret = sgx_get_inferior_flags(ret_pid, &flags);
+        if ((ret == 0) && (flags & SGX_INFERIOR_SINGLE_STEP))
         {
-            oe_set_inferior_flags(ret_pid, (flags & ~OE_INFERIOR_SINGLE_STEP));
+            sgx_set_inferior_flags(
+                ret_pid, (flags & ~SGX_INFERIOR_SINGLE_STEP));
         }
 
         // Fix the register if it is a breakpoint inside enclave.
         struct user_regs_struct regs;
         ret = g_system_ptrace(PTRACE_GETREGS, ret_pid, 0, &regs);
-        if (ret == 0 && oe_is_aep(ret_pid, &regs))
+        if (ret == 0 && sgx_is_aep(ret_pid, &regs))
         {
             void* tcs = (void*)regs.rbx;
-            if (oe_get_enclave_thread_gpr(ret_pid, (void*)tcs, &regs) == 0)
+            if (sgx_get_enclave_thread_gpr(ret_pid, (void*)tcs, &regs) == 0)
             {
                 uint8_t bp = 0;
-                ret = oe_read_process_memory(
+                ret = sgx_read_process_memory(
                     ret_pid, (void*)regs.rip, (void*)&bp, 1, NULL);
                 if ((ret == 0) && (bp == 0xcc))
                 {
                     regs.rip++;
-                    oe_set_enclave_thread_gpr(ret_pid, (void*)tcs, &regs);
+                    sgx_set_enclave_thread_gpr(ret_pid, (void*)tcs, &regs);
                 }
             }
         }

--- a/debugger/ptraceLib/sgxtypes.h
+++ b/debugger/ptraceLib/sgxtypes.h
@@ -1,0 +1,97 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _SGX_TYPES_H
+#define _SGX_TYPES_H
+
+#include <stdint.h>
+
+#define ENCLU_ERESUME 3
+#define TCS_HEADER_BYTE_SIZE 72
+#define SGX_GPR_BYTE_SIZE 0xb8
+#define ENCLU_INSTRUCTION 0xd7010f
+
+typedef struct _sgx_tcs
+{
+    /* (0) enclave execution state (0=available, 1=unavailable) */
+    uint64_t state;
+
+    /* (8) thread's execution flags */
+    uint64_t flags;
+
+    /* (16) offset to the base of the State Save Area (SSA) stack */
+    uint64_t ossa;
+
+    /* (24) Current slot of an SSA frame */
+    uint32_t cssa;
+
+    /* (28) Number of available slots for SSA frames */
+    uint32_t nssa;
+
+    /* (32) entry point where control is transferred upon EENTER */
+    uint64_t oentry;
+
+    /* (40) Value of asynchronous exit pointer saved at EENTER time */
+    uint64_t aep;
+
+    /* (48) Added to enclave base address to get the FS segment address */
+    uint64_t fsbase;
+
+    /* (56) Added to enclave base address to get the GS segment address */
+    uint64_t gsbase;
+
+    /* (64) Size to become the new FS limit in 32-bit mode */
+    uint32_t fslimit;
+
+    /* (68) Size to become the new GS limit in 32-bit mode */
+    uint32_t gslimit;
+
+    /* (72) reserved */
+    union {
+        uint8_t reserved[4024];
+
+        /* (72) Enclave's entry point (defaults to _start) */
+        void (*entry)(void);
+    } u;
+} sgx_tcs_t;
+
+typedef union {
+    struct
+    {
+        uint32_t vector : 8;
+        uint32_t exit_type : 3;
+        uint32_t mbz : 20;
+        uint32_t valid : 1;
+    } as_fields;
+    uint32_t as_uint32;
+} sgx_exit_info;
+
+typedef struct sgx_ssa_gpr_t
+{
+    uint64_t rax;
+    uint64_t rcx;
+    uint64_t rdx;
+    uint64_t rbx;
+    uint64_t rsp;
+    uint64_t rbp;
+    uint64_t rsi;
+    uint64_t rdi;
+    uint64_t r8;
+    uint64_t r9;
+    uint64_t r10;
+    uint64_t r11;
+    uint64_t r12;
+    uint64_t r13;
+    uint64_t r14;
+    uint64_t r15;
+    uint64_t rflags;
+    uint64_t rip;
+    uint64_t ursp;
+    uint64_t urbp;
+    sgx_exit_info exit_info;
+    uint32_t reserved;
+    uint64_t fs_base;
+    uint64_t gs_base;
+} sgx_ssa_gpr_t;
+
+#endif // _SGX_TYPES_H


### PR DESCRIPTION
The following changes would make it easier to upstream oeptrace library

- Avoid use of OE headers. Use standard headers instead.
- Build ptrace library as an external project.
  This eliminates any dependency on OE build system.
- The above two changes make ptraceLib folder standalone.
- Captures the SGX types used by ptrace in sgxtypes.h
- Defines the minimal binary contract between the ptrace library and an SGX enclave
  in contract.h

Makes progress on #3064

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>