### PR TITLE
Add check_submodule_not_empty

### DIFF
--- a/3rdparty/mbedtls/CMakeLists.txt
+++ b/3rdparty/mbedtls/CMakeLists.txt
@@ -1,10 +1,12 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
+check_submodule_not_empty(mbedtls)
+
 # Load the compiler info if we're cross compiling on Windows.
 if (USE_CLANGW)
   include(toolchain-clangw.cmake)
-endif()
+endif ()
 
 # We use configure_file since the config.h file has #cmakedefines in it, so
 # the C header changes if we're running in debug mode or not. This will copy
@@ -22,23 +24,19 @@ string(REGEX MATCH "Clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER_ID}")
 string(REGEX MATCH "GNU" CMAKE_COMPILER_IS_GNU "${CMAKE_C_COMPILER_ID}")
 
 set(MBEDTLS_COMPILE_OPTS
-  -W
-  -Wdeclaration-after-statement
-  -Wwrite-strings
-  -Wshadow
-  # Disable conversion warnings inherited from OE.
-  -Wno-sign-conversion
-  -Wno-conversion)
+    -W -Wdeclaration-after-statement -Wwrite-strings -Wshadow
+    # Disable conversion warnings inherited from OE.
+    -Wno-sign-conversion -Wno-conversion)
 
 if (CMAKE_COMPILER_IS_GNU)
-  list(APPEND MBEDTLS_COMPILE_OPTS
-    -Wlogical-op
-    -Wmissing-declarations
-    -Wmissing-prototypes)
-endif()
+  list(APPEND MBEDTLS_COMPILE_OPTS -Wlogical-op -Wmissing-declarations
+       -Wmissing-prototypes)
+endif ()
 
 if (CMAKE_COMPILER_IS_CLANG)
-  list(APPEND MBEDTLS_COMPILE_OPTS
+  list(
+    APPEND
+    MBEDTLS_COMPILE_OPTS
     -Wpointer-arith
     -Wimplicit-fallthrough
     -Wmissing-declarations
@@ -46,7 +44,7 @@ if (CMAKE_COMPILER_IS_CLANG)
     -Wdocumentation
     -Wno-documentation-deprecated-sync
     -Wunreachable-code)
-endif()
+endif ()
 
 if (USE_CLANGW)
   list(APPEND MBEDTLS_COMPILE_OPTS "-target x86_64-pc-linux")
@@ -54,12 +52,14 @@ if (USE_CLANGW)
   # Set up the linker.
   find_program(LLVM_AR "llvm-ar.exe")
   set(CMAKE_AR ${LLVM_AR})
-endif()
+endif ()
 
 # Sources for the three mbedtls libraries. We name the mbedcrypto library
 # as "mbedcrypto_static" because the exported target for all 3 mbedtls
 # libraries in OE is called "mbedcrypto."
-add_enclave_library(mbedcrypto_static STATIC
+add_enclave_library(
+  mbedcrypto_static
+  STATIC
   mbedtls/library/aes.c
   mbedtls/library/aesni.c
   mbedtls/library/arc4.c
@@ -126,7 +126,9 @@ add_enclave_library(mbedcrypto_static STATIC
   # circular library dependecies.
   mbedtls_hardware_poll.c)
 
-add_enclave_library(mbedx509 STATIC
+add_enclave_library(
+  mbedx509
+  STATIC
   mbedtls/library/certs.c
   mbedtls/library/pkcs11.c
   mbedtls/library/x509.c
@@ -137,7 +139,9 @@ add_enclave_library(mbedx509 STATIC
   mbedtls/library/x509write_crt.c
   mbedtls/library/x509write_csr.c)
 
-add_enclave_library(mbedtls STATIC
+add_enclave_library(
+  mbedtls
+  STATIC
   mbedtls/library/debug.c
   mbedtls/library/net_sockets.c
   mbedtls/library/ssl_cache.c
@@ -156,14 +160,16 @@ maybe_build_using_clangw(mbedtls)
 # Change the mbedcrypto_static target to the real mbedcrypto library name.
 set_target_properties(mbedcrypto_static PROPERTIES OUTPUT_NAME "mbedcrypto")
 if (LVI_MITIGATION MATCHES ControlFlow)
-  set_target_properties(mbedcrypto_static-lvi-cfg PROPERTIES OUTPUT_NAME "mbedcrypto-lvi-cfg")
-endif()
+  set_target_properties(mbedcrypto_static-lvi-cfg
+                        PROPERTIES OUTPUT_NAME "mbedcrypto-lvi-cfg")
+endif ()
 
 # Add the custom config file in the build interface only.
 # In the install interface, we will just replace the default
 # config file.
-enclave_compile_definitions(mbedcrypto_static
-  PUBLIC $<BUILD_INTERFACE:MBEDTLS_CONFIG_FILE=<config.h$<ANGLE-R>>)
+enclave_compile_definitions(
+  mbedcrypto_static PUBLIC
+  $<BUILD_INTERFACE:MBEDTLS_CONFIG_FILE=<config.h$<ANGLE-R>>)
 
 enclave_compile_options(mbedcrypto_static PRIVATE ${MBEDTLS_COMPILE_OPTS})
 enclave_compile_options(mbedx509 PRIVATE ${MBEDTLS_COMPILE_OPTS})
@@ -171,10 +177,12 @@ enclave_compile_options(mbedtls PRIVATE ${MBEDTLS_COMPILE_OPTS})
 
 # We include ${CMAKE_CURRENT_BINARY_DIR} because the generated config.h
 # from the configure_file is located there.
-enclave_include_directories(mbedcrypto_static
-  PUBLIC   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/include>
-           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty>)
+enclave_include_directories(
+  mbedcrypto_static
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty>)
 
 # Link all the libraries.
 enclave_link_libraries(mbedcrypto_static PUBLIC oelibc oe_includes)
@@ -182,13 +190,20 @@ enclave_link_libraries(mbedx509 PUBLIC mbedcrypto_static)
 enclave_link_libraries(mbedtls PUBLIC mbedx509)
 
 # Install the include files and the static libraries.
-install_enclaves(TARGETS mbedcrypto_static mbedx509 mbedtls
-  EXPORT openenclave-targets
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+install_enclaves(
+  TARGETS
+  mbedcrypto_static
+  mbedx509
+  mbedtls
+  EXPORT
+  openenclave-targets
+  ARCHIVE
+  DESTINATION
+  ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/include/mbedtls
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/mbedtls/)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/mbedtls/)
 
 # Create mbedcrypto export target.
 add_enclave_library(mbedcrypto INTERFACE)


### PR DESCRIPTION
Gives better error message if mbedtles submodule has not been checked out.
Consistent with other submodules.

Also run cmake-format on the file.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>