### PR TITLE
Add CONTRIBUTING file per Technical Charter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to Open Enclave
+
+**Did you find a bug?**
+
+* **Do not open up a GitHub issue if the bug is a security vulnerability in Open Enclave**, and instead refer to our [security policy](docs/Community/Contributing.md#reporting-security-issues).
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/openenclave/openenclave/issues).
+
+* If you're unable to find an open issue addressing the problem,
+[open a new one](https://github.com/openenclave/openenclave/issues/new).
+Be sure to include a title and clear description, as much relevant
+information as possible, and a code sample or an executable test case
+demonstrating the expected behavior that is not occurring.
+
+**Did you write a patch that fixes a bug?**
+
+Open a new GitHub pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution.
+Include the relevant issue number if applicable.
+
+* Before submitting, please read the
+[Contributing to Open Enclave](docs/Community/Contributing.md#general-guidelines)
+guidelines to know more about coding conventions and benchmarks.
+
+**Do you intend to add a new feature or change an existing one?**
+
+* See the
+[Contributing to Open Enclave](docs/Community/Contributing.md#design-discussion)
+guidelines regarding design discussion.
+
+**Additional References**
+
+* Explanation of the Open Enclave [governance structure](docs/Community/Governance.md#community-governance-structure)
+* Explanation of [Roles](docs/Community/Governance.md#committers-and-contributors)
+* List of [current Committers](docs/Community/Committers.md#list-of-committers)
+* List of [Community Governance Committee members](docs/Community/governance/README.md#members)


### PR DESCRIPTION
Per discussion in CGC meeting today.  This PR is intended to replace PR #3436 and only one or the other of these two PRs should be merged.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>