### PR TITLE
Add written growth plan

### DIFF
--- a/docs/Community/governance/charter.md
+++ b/docs/Community/governance/charter.md
@@ -32,6 +32,8 @@ The primary responsibilities of this Committee are:
 - to define the governance structures of the Open Enclave SDK project as a whole
 - to assist in the resolution of disagreements between community organizations when necessary
 - to support the community through handling any code of conduct incidents and reports
+- to work with the mentor assigned by the Confidential Computing Consortium
+(CCC) in tracking a [growth plan](growth-plan.md)
 
 This Committee is not intended to make technical decisions, as those should
 generally be made by agreement among contributors PRs are reviewed and merged,

--- a/docs/Community/governance/growth-plan.md
+++ b/docs/Community/governance/growth-plan.md
@@ -1,0 +1,51 @@
+# Growth Plan
+
+## Introduction
+
+The Open Enclave SDK is an
+[Incubation stage](https://github.com/confidential-computing/governance/blob/master/project-progression-policy.md#incubation-stage)
+project of the Confidential Computing Consortium (CCC), with an approved
+[Technical Charter](/TECHNICAL_CHARTER.md).
+
+One requirement for Incubation stage projects is to develop, in
+conjunction with the mentor assigned by the CCC Technical Advisory
+Council, a growth plan for reaching the
+[Graduation stage](https://github.com/confidential-computing/governance/blob/master/project-progression-policy.md#graduation-stage)
+over time.
+
+## Graduation Stage Acceptance Criteria
+
+This section tracks the progress towards the Acceptance Criteria for the
+Graduation Stage, as defined by the CCC:
+
+- [ ] Have a defined [governing body](README.md) of at least 5 or more members
+(owners and core maintainers, or similar technical role), of which no
+more than 1/3 is affiliated with the same employer. In the case there
+are 5 governing members, 2 may be from the same employer.
+
+- [ ] Have a healthy number of [committers](../Committers.md#list-of-committers) from at least two organizations.
+A committer is defined as someone with the commit bit; i.e., someone who
+can accept contributions to some or all of the project.
+
+- [X] Adopt a [Code of Conduct](../../CODE_OF_CONDUCT.md).
+
+- [X] Explicitly define a project [governance and committer process](../Governance.md). This
+is preferably laid out in a GOVERNANCE.md file and references a
+CONTRIBUTING.md and OWNERS.md file showing the current and emeritus
+committers.
+
+- [ ] Have a public list of project adopters or users for at least the
+primary repo (e.g., ADOPTERS.md or logos on the project website).
+
+- [ ] Other metrics as defined by the applying Project during the application
+process in cooperation with the TAC.
+
+- [ ] Receive a supermajority vote from the TAC to move to Graduation stage.
+
+## Plan
+
+1. Invite contributors from other organizations to become maintainers as
+   they demonstrate good contributions via PRs and/or Issues filed and/or
+   code/design review feedback.
+
+2. Expand to other TEEs and other OS's by inviting contributions


### PR DESCRIPTION
Initial text of the "Plan" section was taken directly from the
https://lists.confidentialcomputing.io/g/main/files/TAC/Project%20Submissions/Accepted/OE%20CCC%20TAC%20Submission.docx
document that was presented to and approved by the CCC TAC October 31,
2019.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>