### PR TITLE
Determine the certificate size for different reports dynamically

### DIFF
--- a/enclave/tls_cert.c
+++ b/enclave/tls_cert.c
@@ -48,6 +48,7 @@ static oe_result_t generate_x509_self_signed_certificate(
     size_t bytes_written = 0;
     uint8_t* cert_buf = NULL;
     oe_cert_config_t config = {0};
+    size_t oe_cert_size = 0;
 
     config.private_key_buf = private_key_buf;
     config.private_key_buf_size = private_key_buf_size;
@@ -64,13 +65,16 @@ static oe_result_t generate_x509_self_signed_certificate(
     config.ext_oid = (char*)oid;
     config.ext_oid_size = oid_size;
 
-    // allocate memory for cert output buffer
-    cert_buf = (uint8_t*)oe_malloc(OE_MAX_CERT_SIZE);
+    // allocate memory for cert output buffer and leave room for paddings
+    oe_cert_size =
+        remote_report_buf_size + public_key_buf_size + OE_MIN_CERT_SIZE;
+    cert_buf = (uint8_t*)oe_malloc(oe_cert_size);
     if (cert_buf == NULL)
         goto done;
 
     result = oe_gen_custom_x509_cert(
-        &config, cert_buf, OE_MAX_CERT_SIZE, &bytes_written);
+        &config, cert_buf, oe_cert_size, &bytes_written);
+
     OE_CHECK_MSG(
         result,
         "oe_gen_custom_x509_cert failed with %s",

--- a/include/openenclave/internal/crypto/cert.h
+++ b/include/openenclave/internal/crypto/cert.h
@@ -377,7 +377,9 @@ typedef struct _oe_cert_config
     size_t ext_oid_size;
 } oe_cert_config_t;
 
-#define OE_MAX_CERT_SIZE 8192
+/* includes all the headers from version number to subject unique identifier of
+ * a X509 certificate */
+#define OE_MIN_CERT_SIZE 2048
 
 oe_result_t oe_gen_custom_x509_cert(
     oe_cert_config_t* cert_config,


### PR DESCRIPTION
Replace `OE_MAX_CERT_SIZE` with a combination of `OE_MIN_CERT_SIZE` and other inputs: `oid_size`, `public_key_buf_size` and `remote_report_buf_size`. A multiplier of one and a quarter is included to create room for paddings.

The fixed value of `OE_MIN_CERT_SIZE` (=256 bytes) is larger than the summation of sizes of the subject name (~64 bytes), issuer name (~64 bytes), first valid date (~16 bytes) and last valid date (~16 bytes) of a certificate.

In the `attestation_cert_api` `ctest`, 5KB of data are written into a 6KB-sized buffer in both test cases.

Fix #3378.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>