### PR TITLE
Fix for loop bugs in attesttls sample.

### DIFF
--- a/samples/attested_tls/client/enc/identity_verifier.cpp
+++ b/samples/attested_tls/client/enc/identity_verifier.cpp
@@ -55,13 +55,13 @@ oe_result_t enclave_claims_verifier_callback(
         goto exit;
     }
     printf(TLS_CLIENT "\nverify unique_id:\n");
-    for (int i = 0; i < claim->value_size; i++)
+    for (size_t i = 0; i < claim->value_size; i++)
     {
         printf("0x%0x ", (uint8_t)claim->value[i]);
         if (SERVER_ENCLAVE_MRENCLAVE[i] != (uint8_t)claim->value[i])
         {
             printf(
-                TLS_CLIENT "\nunique_id[%d] expected: 0x%0x  found: 0x%0x ",
+                TLS_CLIENT "\nunique_id[%lu] expected: 0x%0x  found: 0x%0x ",
                 i,
                 SERVER_ENCLAVE_MRENCLAVE[i],
                 (uint8_t)claim->value[i]);
@@ -87,7 +87,7 @@ oe_result_t enclave_claims_verifier_callback(
         goto exit;
     }
     printf(TLS_CLIENT "\nverify signer_id:\n");
-    for (int i = 0; i < claim->value_size; i++)
+    for (size_t i = 0; i < claim->value_size; i++)
         printf("0x%0x ", (uint8_t)claim->value[i]);
 
     if (!verify_signer_id(
@@ -117,7 +117,7 @@ oe_result_t enclave_claims_verifier_callback(
         goto exit;
     }
     printf(TLS_CLIENT "\nproduct_id:\n");
-    for (int i = 0; i < claim->value_size; i++)
+    for (size_t i = 0; i < claim->value_size; i++)
         printf("0x%0x ", (uint8_t)claim->value[i]);
     printf("\n\n");
 

--- a/samples/attested_tls/common/utility.cpp
+++ b/samples/attested_tls/common/utility.cpp
@@ -164,7 +164,7 @@ bool verify_signer_id(
     if (memcmp(signer, signer_id_buf, signer_id_buf_size) != 0)
     {
         printf("mrsigner is not equal!\n");
-        for (int i = 0; i < (int)signer_id_buf_size; i++)
+        for (size_t i = 0; i < signer_id_buf_size; i++)
         {
             printf(
                 "0x%x - 0x%x\n", (uint8_t)signer[i], (uint8_t)signer_id_buf[i]);

--- a/samples/attested_tls/non_enc_client/verify_callback.cpp
+++ b/samples/attested_tls/non_enc_client/verify_callback.cpp
@@ -65,7 +65,7 @@ bool verify_signer_id(
     if (memcmp(calculated_signer, expected_signer, expected_signer_size) != 0)
     {
         printf("signer_id is not equal\n");
-        for (int i = 0; i < expected_signer_size; i++)
+        for (size_t i = 0; i < expected_signer_size; i++)
         {
             printf(
                 "0x%x - 0x%x\n",
@@ -129,13 +129,13 @@ oe_result_t enclave_claims_verifier(
         goto done;
     }
     printf(TLS_CLIENT "\nverify unique_id:\n");
-    for (int i = 0; i < claim->value_size; i++)
+    for (size_t i = 0; i < claim->value_size; i++)
     {
         printf("0x%0x ", (uint8_t)claim->value[i]);
         if (SERVER_ENCLAVE_MRENCLAVE[i] != (uint8_t)claim->value[i])
         {
             printf(
-                TLS_CLIENT "unique_id[%d] expected: 0x%0x  found: 0x%0x ",
+                TLS_CLIENT "unique_id[%lu] expected: 0x%0x  found: 0x%0x ",
                 i,
                 SERVER_ENCLAVE_MRENCLAVE[i],
                 (uint8_t)claim->value[i]);
@@ -161,7 +161,7 @@ oe_result_t enclave_claims_verifier(
         goto done;
     }
     printf(TLS_CLIENT "\nproduct_id :\n");
-    for (int i = 0; i < claim->value_size; i++)
+    for (size_t i = 0; i < claim->value_size; i++)
         printf("0x%0x ", (uint8_t)claim->value[i]);
     printf("\n");
 
@@ -181,7 +181,7 @@ oe_result_t enclave_claims_verifier(
         goto done;
     }
     printf(TLS_CLIENT "\nverify signer_id:\n");
-    for (int i = 0; i < claim->value_size; i++)
+    for (size_t i = 0; i < claim->value_size; i++)
         printf("0x%0x ", (uint8_t)claim->value[i]);
 
     // In this sample, only signer_id validation is shown

--- a/samples/attested_tls/server/enc/identity_verifier.cpp
+++ b/samples/attested_tls/server/enc/identity_verifier.cpp
@@ -52,7 +52,7 @@ oe_result_t enclave_claims_verifier_callback(
         goto exit;
     }
     printf(TLS_CLIENT "\nunique_id:\n");
-    for (int i = 0; i < claim->value_size; i++)
+    for (size_t i = 0; i < claim->value_size; i++)
         printf("0x%0x ", (uint8_t)claim->value[i]);
     printf("\n");
 
@@ -72,7 +72,7 @@ oe_result_t enclave_claims_verifier_callback(
         goto exit;
     }
     printf(TLS_SERVER "\nverify signer_id:\n");
-    for (int i = 0; i < claim->value_size; i++)
+    for (size_t i = 0; i < claim->value_size; i++)
         printf("0x%0x ", (uint8_t)claim->value[i]);
 
     if (!verify_signer_id(
@@ -102,7 +102,7 @@ oe_result_t enclave_claims_verifier_callback(
         goto exit;
     }
     printf(TLS_SERVER "\nproduct_id:\n");
-    for (int i = 0; i < claim->value_size; i++)
+    for (size_t i = 0; i < claim->value_size; i++)
         printf("0x%0x ", (uint8_t)claim->value[i]);
     printf("\n\n");
 


### PR DESCRIPTION
PR#3453 introduced bugs in for loop in attesttls sample:
```
server\enc\identity_verifier.cpp:55:23: error: comparison of integers of different signs: 'int' and 'const size_t' (aka 'const unsigned long') [-Werror,-Wsign-compare]
    for (int i = 0; i < claim->value_size; i++)
```
This PR fixed those bugs.



Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>