### PR TITLE
Check evidence buffer size

### DIFF
--- a/common/attest_plugin.c
+++ b/common/attest_plugin.c
@@ -312,6 +312,15 @@ oe_result_t oe_verify_evidence(
                 evidence->version,
                 OE_ATTESTATION_HEADER_VERSION);
 
+        if (evidence_buffer_size !=
+            (evidence->data_size + sizeof(oe_attestation_header_t)))
+            OE_RAISE_MSG(
+                OE_INVALID_PARAMETER,
+                "Evidence size is invalid. "
+                "Header data size: %d bytes, evidence buffer size: %d",
+                evidence->data_size,
+                evidence_buffer_size);
+
         if (endorsements_buffer)
         {
             oe_attestation_header_t* endorsements =
@@ -324,6 +333,15 @@ oe_result_t oe_verify_evidence(
                     "Invalid attestation header version %d, expected %d",
                     endorsements->version,
                     OE_ATTESTATION_HEADER_VERSION);
+
+            if (endorsements_buffer_size !=
+                (endorsements->data_size + sizeof(oe_attestation_header_t)))
+                OE_RAISE_MSG(
+                    OE_INVALID_PARAMETER,
+                    "Endorsements buffer size is invalid. "
+                    "Header data size: %d bytes, endorsements buffer size: %d",
+                    endorsements->data_size,
+                    endorsements_buffer_size);
 
             if (memcmp(
                     &evidence->format_id,

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -227,6 +227,19 @@ static void _test_verify_evidence_fail()
             &claims_length),
         OE_INVALID_PARAMETER);
 
+    OE_TEST_CODE(
+        oe_verify_evidence(
+            NULL,
+            evidence,
+            evidence_size - 1,
+            endorsements,
+            endorsements_size,
+            NULL,
+            0,
+            &claims,
+            &claims_length),
+        OE_INVALID_PARAMETER);
+
     OE_TEST(
         oe_verify_evidence(
             NULL,
@@ -234,6 +247,18 @@ static void _test_verify_evidence_fail()
             evidence_size,
             endorsements,
             0,
+            NULL,
+            0,
+            &claims,
+            &claims_length) == OE_INVALID_PARAMETER);
+
+    OE_TEST(
+        oe_verify_evidence(
+            NULL,
+            evidence,
+            evidence_size,
+            endorsements,
+            endorsements_size - 1,
             NULL,
             0,
             &claims,


### PR DESCRIPTION
Ensure evidence/report buffer size is big enough to hold attestation/report header structure.

Fixes #3458
Fixes #3459