### PR TITLE
Getting Started Guide for those consuming the OE SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,11 @@ systems.
 Getting Started Using OE SDK
 ---------------
 
-See the API documentation on [openenclave.io](https://openenclave.io/sdk/)
-
-Binary packages can be [downloaded from GitHub](https://github.com/openenclave/openenclave/releases)
+You'll find comprehensive documentation in the
+[Getting Started Guide](docs/GettingStartedDocs).
 
 Contributing to OE SDK
 ---------------
-
-You'll find comprehensive documentation in the
-[Contributor's Getting Started Guide](docs/GettingStartedDocs).
 
 The [community documentation](docs/Community/) hosts lots of information on
 where to go to get engaged with the community, whether you want to contribute

--- a/docs/GettingStartedDocs/install_host_verify_Ubuntu_16.04.md
+++ b/docs/GettingStartedDocs/install_host_verify_Ubuntu_16.04.md
@@ -34,6 +34,8 @@ sudo apt -y install ninja-build
 
 If you wish to make use of the Open Enclave Host-Verify CMake package, please install CMake and [follow the instructions here](/cmake/sdk_cmake_targets_readme.md).
 
+Open Enclave SDK binary packages can also be [downloaded from GitHub](https://github.com/openenclave/openenclave/releases).
+
 ### 3. Verify the Open Enclave Host-Verify SDK install
 
 See [Using the Open Enclave Host-Verify SDK](Linux_using_host_verify.md) for verifying and using the installed SDK.

--- a/docs/GettingStartedDocs/install_host_verify_Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_host_verify_Ubuntu_18.04.md
@@ -34,6 +34,8 @@ sudo apt -y install ninja-build
 
 If you wish to make use of the Open Enclave Host-Verify CMake package, please install CMake and [follow the instructions here](/cmake/sdk_cmake_targets_readme.md).
 
+Open Enclave SDK binary packages can also be [downloaded from GitHub](https://github.com/openenclave/openenclave/releases).
+
 ### 3. Verify the Open Enclave Host-Verify SDK install
 
 See [Using the Open Enclave Host-Verify SDK](Linux_using_host_verify.md) for verifying and using the installed SDK.

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_16.04.md
@@ -24,7 +24,7 @@ wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add 
 ```
 
 ### 2. Install the Intel SGX DCAP Driver
-<<<<<<< HEAD
+
 Some versions of Ubuntu come with the SGX driver already installed. You can check
 by running with the following:
 
@@ -64,6 +64,8 @@ sudo apt -y install ninja-build
 ```
 
 If you wish to make use of the Open Enclave CMake package, please install CMake and [follow the instructions here](/cmake/sdk_cmake_targets_readme.md).
+
+Open Enclave SDK binary packages can also be [downloaded from GitHub](https://github.com/openenclave/openenclave/releases).
 
 ### 4. Verify the Open Enclave SDK install
 

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
@@ -61,6 +61,8 @@ sudo apt -y install ninja-build
 
 If you wish to make use of the Open Enclave CMake package, please install CMake and [follow the instructions here](/cmake/sdk_cmake_targets_readme.md).
 
+Open Enclave SDK binary packages can also be [downloaded from GitHub](https://github.com/openenclave/openenclave/releases).
+
 ### 4. Verify the Open Enclave SDK install
 
 See [Using the Open Enclave SDK](Linux_using_oe_sdk.md) for verifying and using the installed SDK.


### PR DESCRIPTION
Previously the main README file implied the Getting Started Guide was
only for those contributing to the OE SDK itself, not those that just
want to consume it.  This is not the case, as the guide (also) already
covered using it and running the samples, and contains information that
anyone consuming it needs to know (e.g., installing prereqs) and was
not documented anywhere else.

In theory we could split/duplicate the Getting Started Guide and have
separate guides for those consuming vs contributing to the OE SDK, but
this PR just makes the minimal changes needed to unblock those who
want to consume the SDK.  SIG-Documentation can discuss whether to
later split and have two guides or not, but that is outside the scope of
this PR.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>