### PR TITLE
Correctly find sgx_dcap_ql.dll  for samples testing.

### DIFF
--- a/samples/check_quote_provider.cmake
+++ b/samples/check_quote_provider.cmake
@@ -3,6 +3,16 @@
 cmake_minimum_required(VERSION 3.13)
 project("Check Quote Provider")
 
+if (WIN32)
+  # cmake documentation says that CMAKE_FIND_LIBRARY_SUFFIXES is typically .lib
+  # and .dll.
+  # https://cmake.org/cmake/help/v3.12/variable/CMAKE_FIND_LIBRARY_SUFFIXES.html
+  # However, it is initialized to only .lib on Windows. Therefore, we explicitly
+  # set the suffix to .dll.
+  # See also: http://cmake.3232098.n2.nabble.com/find-library-doesn-t-find-dll-on-windows-td7597643.html
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+endif ()
+
 find_library(SGX_DCAP_QL NAMES sgx_dcap_ql REQUIRED)
 
 # Raise fatal error if sgx_dcap_ql library is not found.


### PR DESCRIPTION
On Windows CMAKE_FIND_LIBRARY_SUFFIXES is initialized to
.lib. Therefore find_library does not find sgx_dcap_ql.dll.
Explicitly change the suffixes to .dll in order to find
the dcap library. Once the library is found,  remote attestation
dependent samples will be tested.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>