### PR TITLE
Add guideline against reusing function names with different prototypes

### DIFF
--- a/docs/Community/DevelopmentGuide.md
+++ b/docs/Community/DevelopmentGuide.md
@@ -5,7 +5,7 @@ Coding Conventions
 ------------------
 
 * **DO** use fixed length types defined in `include/openenclave/types.h` instead
-  of language keywords determined by the compiler (e.g. `int64_t, uint8_t`, not
+  of language keywords determined by the compiler (e.g., `int64_t, uint8_t`, not
   `long, unsigned char`).
 
 * **DO** use `const` and `static` and visibility modifiers to scope exposure of
@@ -22,16 +22,22 @@ Coding Conventions
 * **DON'T** use global variables where possible.
 
 * **DON'T** use abbreviations unless they are already well-known terms known by
-  users (e.g., "app", "info"), or are already required for use by developers (e.g,
+  users (e.g., "app", "info"), or are already required for use by developers (e.g.,
   "min", "max", "args").  Examples of bad use would be `num_widgets` instead of
   `widget_count`, and `opt_widgets` instead of `option_widgets` or `optional_widgets`.
+
+* **DON'T** use the same C function name with two different prototypes across
+  the SDK (e.g., for host vs. enclave) where possible.  A notable exception
+  is for edger8r-generated APIs that generate a host-side API that includes
+  an enclave argument in addition to the arguments for the enclave-side API,
+  but all other arguments are still identical.
 
 Style Guide
 -----------
 
 ### Automated Formatting with `clang-format`
 
-For all C/C++ files (`*.c`, `*.cpp` and `*.h`), we use `clang-format` (exactly
+For all C/C++ files (`*.c`, `*.cpp` and `*.h`), we use `clang-format` (specifically
 version 3.6) to apply our code formatting rules. After modifying C/C++ files and
 before merging, be sure to run:
 
@@ -39,12 +45,12 @@ before merging, be sure to run:
 $ ./scripts/format-code
 ```
 
-This allows us apply formatting choices such as the use of [Allman style](
+This allows us to apply formatting choices such as the use of [Allman style](
 http://en.wikipedia.org/wiki/Indent_style#Allman_style) braces and the 80
 character column width consistently.
 
 Please stage the formatting changes with your commit, instead of making an extra
-"Format Code" commit. Your editor can likely be setup to automatically run
+"Format Code" commit. Your editor can likely be set up to automatically run
 `clang-format` across the file or region you're editing. See:
 
 - [clang-format.el](https://github.com/llvm-mirror/clang/blob/master/tools/clang-format/clang-format.el) for Emacs
@@ -84,15 +90,15 @@ Naming conventions we use that are not automated include:
 1. Use `lower_snake_case` for variable, member/field, and function names.
 2. Use `UPPER_SNAKE_CASE` for macro names and constants.
 3. Prefer `lower_snake_case` file names for headers and sources.
-4. Prefer full words for names over contractions (i.e. `memory_context`, not
+4. Prefer full words for names over contractions (i.e., `memory_context`, not
    `mem_ctx`).
 5. Prefix names with `_` to indicate internal and private fields or methods
-   (e.g. `_internal_field, _internal_method()`).
+   (e.g., `_internal_field, _internal_method()`).
 6. The single underscore (`_` ) is reserved for local definitions (static,
    file-scope definitions).
-   e.g. static oe_result_t _parse_sgx_report_body(..).
-7. Prefix `struct` definitions with `_`, and always create a `typedef` with the
-   suffix `_t`:
+   e.g., static oe_result_t _parse_sgx_report_body(..).
+7. Prefix `struct` definitions with `_` (this is an exception to point 6), and always create a `typedef` with the
+   suffix `_t`.  For example:
 ```c
 typedef struct _oe_private_key
 {
@@ -100,10 +106,10 @@ typedef struct _oe_private_key
     mbedtls_pk_context pk;
 } oe_private_key_t;
 ```
-8. Prefix Open Enclave specific names in the global namespace with `oe_` (e.g.
+8. Prefix Open Enclave specific names in the global namespace with `oe_` (e.g.,
    `oe_result_t, oe_call_enclave`).
 
-Above all, if a file happens to differ in style from these guidelines (e.g.
+Above all, if a file happens to differ in style from these guidelines (e.g.,
 private members are named `m_member` rather than `_member`), the existing style
 in that file takes precedence.
 


### PR DESCRIPTION
Issue #3486 is an example where this happened but there was no
guideline against doing so.

Also clean up some editorial nits.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>