### PR TITLE
EXPERIMENTAL: WIP: Figure out elf information by parsing program headers.

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -61,6 +61,7 @@ if (OE_SGX)
     sgx/backtrace.c
     sgx/calls.c
     sgx/cpuid.c
+    sgx/elf.c
     sgx/enter.S
     sgx/entropy.c
     sgx/errno.c

--- a/enclave/core/sgx/elf.c
+++ b/enclave/core/sgx/elf.c
@@ -1,0 +1,101 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "elf.h"
+#include <openenclave/internal/elf.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
+
+static int _elf64_test_header(const elf64_ehdr_t* ehdr)
+{
+    if (!ehdr)
+        return -1;
+
+    if (ehdr->e_ident[EI_MAG0] != 0x7f)
+        return -1;
+
+    if (ehdr->e_ident[EI_MAG1] != 'E')
+        return -1;
+
+    if (ehdr->e_ident[EI_MAG2] != 'L')
+        return -1;
+
+    if (ehdr->e_ident[EI_MAG3] != 'F')
+        return -1;
+
+    if (ehdr->e_ident[EI_CLASS] != ELFCLASS64)
+        return -1;
+
+    if (ehdr->e_ident[EI_DATA] != ELFDATA2LSB)
+        return -1;
+
+    if (ehdr->e_machine != EM_X86_64)
+        return -1;
+
+    if (ehdr->e_ehsize != sizeof(elf64_ehdr_t))
+        return -1;
+
+    if (ehdr->e_phentsize != sizeof(elf64_phdr_t))
+        return -1;
+
+    if (ehdr->e_shentsize != sizeof(elf64_shdr_t))
+        return -1;
+
+    /* If there is no section header table, then the index should be 0. */
+    if (ehdr->e_shnum == 0 && ehdr->e_shstrndx != 0)
+        return -1;
+
+    /* If there is a section header table, then the index shouldn't overrun. */
+    if (ehdr->e_shnum > 0 && ehdr->e_shstrndx >= ehdr->e_shnum)
+        return -1;
+
+    return 0;
+}
+
+oe_result_t oe_get_elf_info(uint8_t* module_base, oe_elf_info_t* elf_info)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    elf64_ehdr_t* ehdr = (elf64_ehdr_t*)module_base;
+    elf64_rela_t* relocs = 0;
+    uint64_t num_relocs = 0;
+    uint64_t load_end_offset = 0;
+    elf64_phdr_t* phdrs = NULL;
+
+    memset(elf_info, 0, sizeof(*elf_info));
+    if (_elf64_test_header(ehdr) != 0)
+        OE_RAISE(OE_FAILURE);
+
+    // Iterate through the program headers and gather relevant information.
+    phdrs = (elf64_phdr_t*)(module_base + ehdr->e_phoff);
+
+    for (int32_t i = 0; i < ehdr->e_phnum; ++i)
+    {
+        elf64_phdr_t* phdr = &phdrs[i];
+        if (phdr->p_type == PT_TLS)
+        {
+            elf_info->tdata_align = elf_info->tbss_align = phdr->p_align;
+            elf_info->tdata_rva = phdr->p_vaddr;
+            elf_info->tdata_size = phdr->p_filesz;
+            elf_info->tbss_size = phdr->p_memsz - phdr->p_filesz;
+        }
+
+        {
+            uint64_t end = phdr->p_vaddr + phdr->p_memsz;
+            if (end > load_end_offset)
+                load_end_offset = end;
+        }
+    }
+
+    elf_info->reloc_rva =
+        oe_round_up_to_multiple(load_end_offset, OE_PAGE_SIZE);
+
+    relocs = (elf64_rela_t*)(module_base + elf_info->reloc_rva);
+
+    while (relocs[num_relocs].r_offset != 0)
+        ++num_relocs;
+    elf_info->num_relocs = num_relocs;
+
+    result = OE_OK;
+done:
+    return result;
+}

--- a/enclave/core/sgx/elf.h
+++ b/enclave/core/sgx/elf.h
@@ -1,0 +1,28 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_ENCLAVE_ELF_H
+#define _OE_ENCLAVE_ELF_H
+
+#include <openenclave/bits/defs.h>
+#include <openenclave/bits/result.h>
+#include <openenclave/bits/types.h>
+
+OE_EXTERNC_BEGIN
+
+typedef struct _elf_info
+{
+    uint64_t tdata_rva;
+    uint64_t tdata_size;
+    uint64_t tdata_align;
+    uint64_t tbss_size;
+    uint64_t tbss_align;
+    uint64_t reloc_rva;
+    uint64_t num_relocs;
+} oe_elf_info_t;
+
+oe_result_t oe_get_elf_info(uint8_t* module_base, oe_elf_info_t* elf_info);
+
+OE_EXTERNC_END
+
+#endif // _OE_ENCLAVE_ELF_H

--- a/enclave/core/sgx/reloc.c
+++ b/enclave/core/sgx/reloc.c
@@ -4,7 +4,17 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/elf.h>
 #include <openenclave/internal/globals.h>
+#include "elf.h"
 #include "init.h"
+
+// Declare just for assertion. Temporary code.
+extern uint64_t _reloc_rva, _reloc_size, _tdata_rva, _tdata_size, _tdata_align,
+    _tbss_size, _tbss_align;
+
+// Before reloations, _enclave_base will contain its own RVA, and
+// subtracting its address from its value will give the actual enclave base
+// address.
+uint8_t* _enclave_base = (uint8_t*)&_enclave_base;
 
 /*
 **==============================================================================
@@ -23,8 +33,25 @@ bool oe_apply_relocations(void)
     const elf64_rela_t* relocs = (const elf64_rela_t*)__oe_get_reloc_base();
     size_t nrelocs = __oe_get_reloc_size() / sizeof(elf64_rela_t);
     const uint8_t* baseaddr = (const uint8_t*)__oe_get_enclave_base();
+    oe_elf_info_t elf_info = {0};
+    size_t i = 0;
 
-    for (size_t i = 0; i < nrelocs; i++)
+    // Before relocation, compute the enclave base address.
+    _enclave_base = (uint8_t*)&_enclave_base - (uint64_t)_enclave_base;
+    if (baseaddr != _enclave_base)
+        return false;
+
+    if (oe_get_elf_info((uint8_t*)baseaddr, &elf_info) != OE_OK)
+        return false;
+
+    if (elf_info.reloc_rva != _reloc_rva || elf_info.tdata_rva != _tdata_rva ||
+        elf_info.tdata_size != _tdata_size ||
+        elf_info.tbss_size != _tbss_size ||
+        (elf_info.tdata_align != _tdata_align &&
+         elf_info.tbss_align != _tbss_align))
+        return false;
+
+    for (i = 0; i < nrelocs; i++)
     {
         const elf64_rela_t* p = &relocs[i];
 
@@ -34,6 +61,8 @@ bool oe_apply_relocations(void)
 
         /* Compute address of reference to be relocated */
         uint64_t* dest = (uint64_t*)(baseaddr + p->r_offset);
+        if ((void*)dest == &_enclave_base)
+            continue;
 
         uint64_t reloc_type = ELF64_R_TYPE(p->r_info);
 
@@ -43,6 +72,12 @@ bool oe_apply_relocations(void)
             *dest = (uint64_t)(baseaddr + p->r_addend);
         }
     }
+
+    if (baseaddr != _enclave_base)
+        return false;
+
+    if (i != elf_info.num_relocs)
+        return false;
 
     return true;
 }


### PR DESCRIPTION
Program headers are loaded as part of enclave image.
The enclave can iterate thorugh the program headers
- And find the header with PT_TLS to figure out
 tdata_rva, tdata_size, tdata_align, tbss_size and tbss_align.
 Note: Even though tdata_align and tbss_align can be different,
 their maximum is chosen and put in the program header.
 The maximum value is enough to align both .tdata and .tbss.

 The p_filesz gives tdata_size where as p_memsz - p_filesz gives
 the tbss size.

- Find out the ending offset of the loaded sections.
  This value rounded to OE_PAGE_SIZE gives the reloc_rva.
  Iterating through the contents of the relocations until
  an entry with zero r_offset, gives the number of actual
  relocations.

The enclave base address is computed by defining a variable

uint8_t* _base_address = (uint8_t*)&_base_address.

For such a variable, before relocations, its value will be equal
to its rva. Subtracting its value (rva) from its address gives
enclave base.

Assertions are added to make sure that the loader populated
values of correspoing symbols match the values we computed above.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>