### PR TITLE
Disable unsafe OpenSSL APIs/Macros

### DIFF
--- a/3rdparty/openssl/CMakeLists.txt
+++ b/3rdparty/openssl/CMakeLists.txt
@@ -10,6 +10,7 @@ set(INTELSSL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/intel-sgx-ssl/openssl_source)
 set(OPENSSL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/openssl)
 set(OPENSSL_BUILD ${CMAKE_CURRENT_BINARY_DIR}/build)
 set(OPENSSL_BUILD_INCLUDES ${OPENSSL_BUILD}/include)
+set(OPENSSL_INSTALL_INCLUDES ${OE_INCDIR}/openenclave/openssl)
 # CMake-generated path.
 set(OPENSSL_GENERATED_BUILD
     ${CMAKE_CURRENT_BINARY_DIR}/openssl_generated-prefix/src/openssl_generated-build
@@ -17,6 +18,10 @@ set(OPENSSL_GENERATED_BUILD
 
 set(OPENSSL_C_COMPILER ${CMAKE_C_COMPILER})
 set(OPENSSL_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+
+set(OPENSSL_APPEND_UNSUPPORTED
+    "${CMAKE_CURRENT_SOURCE_DIR}/append-unsupported ${OPENSSL_INSTALL_INCLUDES}"
+)
 
 if (OE_SGX)
   set(ARCH "linux-x86_64")
@@ -77,6 +82,27 @@ ExternalProject_Add(
           ${OPENSSL_BUILD_INCLUDES}/crypto/dso_conf.h
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/opensslconf.h
           ${OPENSSL_BUILD_INCLUDES}/openssl/opensslconf.h
+  BUILD_COMMAND ""
+  INSTALL_COMMAND "")
+
+# The following commmand prepares the headers to be published. The headers
+# consist of those in the openssl/include/openssl folder, opensslconf.h,
+# and unsupported.h. The unsupported.h header file includes a list of APIs that are
+# disabled by OE for security concerns. A few headers are patched (using the
+# append-unsupported script) to include unsupported.h so that OE can enforce
+# compile-time errors when any of those unsafe APIs is used.
+ExternalProject_Add(
+  openssl_includes
+  SOURCE_DIR ${OPENSSL_DIR}
+  CONFIGURE_COMMAND
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${OPENSSL_DIR}/include/openssl
+          ${OPENSSL_INSTALL_INCLUDES}
+  COMMAND
+    ${CMAKE_COMMAND} -E copy ${OPENSSL_BUILD_INCLUDES}/openssl/opensslconf.h
+    ${OPENSSL_INSTALL_INCLUDES}/opensslconf.h
+  COMMAND ${OE_BASH} -c "${OPENSSL_APPEND_UNSUPPORTED}"
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/unsupported.h
+          ${OPENSSL_INSTALL_INCLUDES}/unsupported.h
   BUILD_COMMAND ""
   INSTALL_COMMAND "")
 
@@ -250,6 +276,7 @@ ExternalProject_Add(
   BUILD_BYPRODUCTS ${PATCHED_ASM_SRC}
   INSTALL_COMMAND "")
 
+add_dependencies(openssl_includes openssl_configure)
 add_dependencies(openssl_generated openssl_configure)
 add_dependencies(openssl_generated openssl_copied)
 
@@ -868,12 +895,12 @@ add_enclave_library(
   openssl/ssl/tls_srp.c)
 
 enclave_include_directories(
-  opensslcrypto PUBLIC $<BUILD_INTERFACE:${OPENSSL_BUILD_INCLUDES}>
+  opensslcrypto PRIVATE $<BUILD_INTERFACE:${OPENSSL_BUILD_INCLUDES}>
   $<BUILD_INTERFACE:${OPENSSL_DIR}> $<BUILD_INTERFACE:${OPENSSL_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty>)
 
 enclave_include_directories(
-  opensslssl PUBLIC $<BUILD_INTERFACE:${OPENSSL_BUILD_INCLUDES}>
+  opensslssl PRIVATE $<BUILD_INTERFACE:${OPENSSL_BUILD_INCLUDES}>
   $<BUILD_INTERFACE:${OPENSSL_DIR}> $<BUILD_INTERFACE:${OPENSSL_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty>)
 
@@ -1034,13 +1061,11 @@ install_enclaves(
   DESTINATION
   ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 install(
-  DIRECTORY ${OPENSSL_DIR}/include/openssl
+  DIRECTORY ${OPENSSL_INSTALL_INCLUDES}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty
   PATTERN "__DECC_INCLUDE_EPILOGUE.H" EXCLUDE
   PATTERN "__DECC_INCLUDE_PROLOGUE.H" EXCLUDE
   PATTERN "opensslconf.h.in" EXCLUDE)
-install(FILES ${OPENSSL_BUILD_INCLUDES}/openssl/opensslconf.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/openssl)
 
 # Create openssl export target.
 add_enclave_library(openssl INTERFACE)

--- a/3rdparty/openssl/README.md
+++ b/3rdparty/openssl/README.md
@@ -27,3 +27,10 @@ that work with Open Enclave. The structure of the directory is as follows.
   the version of Perl that comes with the git bash does not support the Pod::Usage module required by the OpenSSL
   configuration scripts. See https://groups.google.com/g/git-for-windows/c/AQf2YbaxH6U/m/mwRScOGRCwAJ
   for the reference on the perl issue with git bash on Windows.
+
+- unsupported.h
+  The header lists the OpenSSL APIs, which are unsupported by OE for security concerns.
+
+- append-unsupported
+  Script to append the `#include<openssl/unsupported.h>` to the OpenSSL headers that include the
+  corresponding APIs. The patched headers will be installed as part of OE release packages.

--- a/3rdparty/openssl/append-unsupported
+++ b/3rdparty/openssl/append-unsupported
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+##==============================================================================
+##
+## append-unsupported:
+##
+##     Append inclusion of the unsupported.h to corresponding header file under
+##     the given directory.
+##
+##==============================================================================
+
+## Check arguments.
+if [ "$#" != "1" ]; then
+    echo "Usage: $0 directory"
+    exit 1
+fi
+
+## Name arguments.
+directory=$1
+
+## If the directory does not exist:
+if [ ! -d "${directory}" ]; then
+    echo "$0: no such directory: ${directory}"
+    exit 1
+fi
+
+headers=`find ${directory} -name '*.h'`
+
+## Append the inclusion of unsupported.h */
+for i in ${headers}
+do
+    if [[ "${i}" != *"crypto.h" ]] && [[ "${i}" != *"ssl.h" ]] && [[ "${i}" != *"x509_vfy.h" ]]; then
+        continue
+    fi
+    echo "#include <openssl/unsupported.h>" >> ${i}
+    if [ "$?" != "0" ]; then
+        echo "$0: failed to append ${string}"
+        exit 1
+    fi
+done

--- a/3rdparty/openssl/unsupported.h
+++ b/3rdparty/openssl/unsupported.h
@@ -1,0 +1,158 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_OPENSSL_UNSUPPORTED_H
+#define _OE_OPENSSL_UNSUPPORTED_H
+
+#if !defined(OE_OPENSSL_SUPPRESS_UNSUPPORTED)
+
+#if defined(__cplusplus)
+#define OE_OPENSSL_EXTERN_C_BEGIN \
+    extern "C"                    \
+    {
+#define OE_OPENSSL_EXTERN_C_END }
+#else
+#define OE_OPENSSL_EXTERN_C_BEGIN
+#define OE_OPENSSL_EXTERN_C_END
+#endif
+
+#if defined(__GNUC__)
+#define OE_OPENSSL_UNSUPPORTED(MSG) __attribute__((deprecated(MSG)))
+#else
+#define OE_OPENSSL_UNSUPPORTED(MSG)
+#endif
+#define OE_OPENSSL_RAISE_ERROR(NAME) (OE_OPENSSL_UNSUPPORTED_ERROR, NAME)
+
+OE_OPENSSL_EXTERN_C_BEGIN
+
+#include <openssl/crypto.h>
+#include <openssl/ssl.h>
+#include <openssl/x509_vfy.h>
+
+// clang-format off
+#define OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION \
+    "The function may be unsafe inside an enclave as it causes the enclave to read " \
+    "files from an untrusted host. Please refer to the following link for security guidance.\n\n" \
+    "https://github.com/openenclave/openenclave/blob/master/docs/OpenSSLSupport.md#security-guidance-for-using-openssl-apismacros" \
+    "\n\nTo use the function anyway, add the -DOE_OPENSSL_SUPPRESS_UNSUPPORTED option when compiling the program."
+#define OE_UNSUPPORTED_ENCLAVE_OPENSSL_MACRO \
+    "The macro may be unsafe inside an enclave as it causes the enclave to read " \
+    "files from an untrusted host. Please refer to the following link for security guidance.\n\n" \
+    "https://github.com/openenclave/openenclave/blob/master/docs/OpenSSLSupport.md#security-guidance-for-using-openssl-apismacros" \
+    "\n\nTo use the macro anyway, add the -DOE_OPENSSL_SUPPRESS_UNSUPPORTED option when compiling the program."
+// clang-format on
+
+/*
+**==============================================================================
+**
+** <openssl/crypto.h>
+**
+**==============================================================================
+*/
+
+/*
+ * The following macro allows users to configure an OpenSSL application (via
+ * OPENSSL_init_crypto or OPENSSL_init_ssl) to lookup a configuration file from
+ * the host filesystem, which is not trusted in OE's threat model, and therefore
+ * are recommended not to use inside an enclave.
+ */
+
+#ifdef OPENSSL_INIT_LOAD_CONFIG
+#undef OPENSSL_INIT_LOAD_CONFIG
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_MACRO)
+static inline unsigned long OPENSSL_INIT_LOAD_CONFIG()
+{
+    return 0x00000040L;
+}
+#define OPENSSL_INIT_LOAD_CONFIG \
+    OE_OPENSSL_RAISE_ERROR(OPENSSL_INIT_LOAD_CONFIG)
+#endif
+
+/*
+**==============================================================================
+**
+** <openssl/ssl.h>
+**
+**==============================================================================
+*/
+
+/*
+ * The following APIs allow users to configure an OpenSSL application to look up
+ * certificates from the host filesystem, which is not trusted in OE's
+ * threat model, and therefore are recommended not to use inside an enclave.
+ */
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+int SSL_CTX_set_default_verify_paths(SSL_CTX* ctx);
+#define SSL_CTX_set_default_verify_paths \
+    OE_OPENSSL_RAISE_ERROR(SSL_CTX_set_default_verify_paths)
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+int SSL_CTX_set_default_verify_dir(SSL_CTX* ctx);
+#define SSL_CTX_set_default_verify_dir \
+    OE_OPENSSL_RAISE_ERROR(SSL_CTX_set_default_verify_dir)
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+int SSL_CTX_set_default_verify_file(SSL_CTX* ctx);
+#define SSL_CTX_set_default_verify_file \
+    OE_OPENSSL_RAISE_ERROR(SSL_CTX_set_default_verify_file)
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+int SSL_CTX_load_verify_locations(
+    SSL_CTX* ctx,
+    const char* CAfile,
+    const char* CApath);
+#define SSL_CTX_load_verify_locations \
+    OE_OPENSSL_RAISE_ERROR(SSL_CTX_load_verify_locations)
+
+/*
+**==============================================================================
+**
+** <openssl/x509_vfy.h>
+**
+**==============================================================================
+*/
+
+/*
+ * The following APIs allow users to configure an OpenSSL application to look up
+ * certificates from the host filesystem, which is not trusted in OE's
+ * threat model, and therefore are recommended not to use inside an enclave.
+ */
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+int X509_load_cert_file(X509_LOOKUP* ctx, const char* file, int type);
+#define X509_load_cert_file OE_OPENSSL_RAISE_ERROR(X509_load_cert_file)
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+int X509_load_crl_file(X509_LOOKUP* ctx, const char* file, int type);
+#define X509_load_crl_file OE_OPENSSL_RAISE_ERROR(X509_load_crl_file)
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+int X509_load_cert_crl_file(X509_LOOKUP* ctx, const char* file, int type);
+#define X509_load_cert_crl_file OE_OPENSSL_RAISE_ERROR(X509_load_cert_crl_file)
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+X509_LOOKUP_METHOD* X509_LOOKUP_hash_dir(void);
+#define X509_LOOKUP_hash_dir OE_OPENSSL_RAISE_ERROR(X509_LOOKUP_hash_dir)
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+X509_LOOKUP_METHOD* X509_LOOKUP_file(void);
+#define X509_LOOKUP_file OE_OPENSSL_RAISE_ERROR(X509_LOOKUP_file)
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+int X509_STORE_load_locations(
+    X509_STORE* ctx,
+    const char* file,
+    const char* dir);
+#define X509_STORE_load_locations \
+    OE_OPENSSL_RAISE_ERROR(X509_STORE_load_locations)
+
+OE_OPENSSL_UNSUPPORTED(OE_UNSUPPORTED_ENCLAVE_OPENSSL_FUNCTION)
+int X509_STORE_set_default_paths(X509_STORE* ctx);
+#define X509_STORE_set_default_paths \
+    OE_OPENSSL_RAISE_ERRO(X509_STORE_set_default_paths)
+
+OE_OPENSSL_EXTERN_C_END
+
+#endif /* !defined(OE_OPENSSL_SUPPRESS_UNSUPPORTED) */
+#endif /* _OE_OPENSSL_UNSUPPORTED_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,6 +144,7 @@ if (UNIX
 
     if (BUILD_OPENSSL)
       add_subdirectory(openssl)
+      add_subdirectory(openssl_unsupported)
     endif ()
   endif ()
 

--- a/tests/openssl/enc/CMakeLists.txt
+++ b/tests/openssl/enc/CMakeLists.txt
@@ -96,7 +96,7 @@ function (add_openssl_test_enc NAME BUILDTEST)
     ${CMAKE_CURRENT_BINARY_DIR}/openssl_t.c)
 
   enclave_include_directories(
-    openssl-${NAME}_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+    openssl-${NAME}_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${OPENSSL_DIR}
     ${OPENSSL_DIR}/include ${CMAKE_BINARY_DIR}/3rdparty/openssl/build/include)
 
   enclave_compile_options(

--- a/tests/openssl_unsupported/CMakeLists.txt
+++ b/tests/openssl_unsupported/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()

--- a/tests/openssl_unsupported/README.md
+++ b/tests/openssl_unsupported/README.md
@@ -1,0 +1,8 @@
+Unsupported OpenSSL APIs/macros tests
+==============================
+
+This directory includes the tests of OpenSSL APIs/macros that are disabled by OE for
+security concerns. Each test compiles an enclave that uses one of such APIs/macros
+and expects the compilation to fail. Specifically, the test checks if the
+build log contains a particular string that indicates the compilation fails
+expectedly.

--- a/tests/openssl_unsupported/enc/CMakeLists.txt
+++ b/tests/openssl_unsupported/enc/CMakeLists.txt
@@ -1,0 +1,74 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../openssl_unsupported.edl)
+
+add_custom_command(
+  OUTPUT openssl_unsupported_t.h openssl_unsupported_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+function (add_unsupported_test NAME)
+  set(DEFINE OE_${NAME})
+  string(TOUPPER ${DEFINE} DEFINE)
+  string(TOLOWER ${NAME} NAME)
+
+  add_enclave(TARGET openssl_unsupported_${NAME}_enc SOURCES enc.c
+              ${CMAKE_CURRENT_BINARY_DIR}/openssl_unsupported_t.c)
+
+  # Suppress Werror to verify that the compilation still fails as expected.
+  enclave_compile_options(openssl_unsupported_${NAME}_enc PRIVATE -Wno-error)
+
+  enclave_compile_definitions(openssl_unsupported_${NAME}_enc PRIVATE ${DEFINE})
+
+  enclave_include_directories(
+    openssl_unsupported_${NAME}_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+    ${OE_INCDIR}/openenclave)
+
+  enclave_link_libraries(openssl_unsupported_${NAME}_enc openssl oelibc
+                         oehostsock oehostfs oehostresolver)
+
+  # Exclude the enclave from build.
+  # From: https://stackoverflow.com/questions/30155619/expected-build-failure-tests-in-cmake
+  set_enclave_properties(openssl_unsupported_${NAME}_enc PROPERTIES
+                         EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+
+  add_test(
+    NAME openssl_unsupported_${NAME}
+    COMMAND ${CMAKE_COMMAND} --build . --target openssl_unsupported_${NAME}_enc
+            --config $<CONFIGURATION>
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+  # In addition to expecting the compilation to fail, checking whether the log includes
+  # the specific error message, which indicates the unsupported.h header is
+  # correctly included.
+  set_tests_properties(
+    openssl_unsupported_${NAME}
+    PROPERTIES
+      WILL_FAIL
+      TRUE
+      FAIL_REGULAR_EXPRESSION
+      "warning: .* is deprecated: The function|macro may be unsafe inside an enclave"
+  )
+
+endfunction (add_unsupported_test)
+
+set(UNSUPPORTED_LIST
+    OPENSSL_INIT_LOAD_CONFIG
+    SSL_CTX_set_default_verify_paths
+    SSL_CTX_set_default_verify_dir
+    SSL_CTX_set_default_verify_file
+    SSL_CTX_load_verify_locations
+    X509_load_cert_file
+    X509_load_crl_file
+    X509_load_cert_crl_file
+    X509_LOOKUP_hash_dir
+    X509_LOOKUP_file
+    X509_STORE_load_locations
+    X509_STORE_set_default_paths)
+
+foreach (name ${UNSUPPORTED_LIST})
+  add_unsupported_test(${name})
+endforeach (name)

--- a/tests/openssl_unsupported/enc/enc.c
+++ b/tests/openssl_unsupported/enc/enc.c
@@ -1,0 +1,73 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/print.h>
+#include <openssl/crypto.h>
+#include <openssl/ssl.h>
+#include <openssl/x509_vfy.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "openssl_unsupported_t.h"
+
+void test()
+{
+#ifdef OE_OPENSSL_INIT_LOAD_CONFIG
+    unsigned long val = OPENSSL_INIT_LOAD_CONFIG;
+    oe_host_printf("val: %lu\n", val);
+#endif
+
+#ifdef OE_SSL_CTX_SET_DEFAULT_VERIFY_PATHS
+    SSL_CTX_set_default_verify_paths(NULL);
+#endif
+
+#ifdef OE_SSL_CTX_SET_DEFAULT_VERIFY_DIR
+    SSL_CTX_set_default_verify_dir(NULL);
+#endif
+
+#ifdef OE_SSL_CTX_SET_DEFAULT_VERIFY_FILE
+    SSL_CTX_set_default_verify_file(NULL);
+#endif
+
+#ifdef OE_SSL_CTX_LOAD_VERIFY_LOCATIONS
+    SSL_CTX_load_verify_locations(NULL, NULL, NULL);
+#endif
+
+#ifdef OE_X509_LOAD_CERT_FILE
+    X509_load_cert_file(NULL, NULL, 0);
+#endif
+
+#ifdef OE_X509_LOAD_CRL_FILE
+    X509_load_crl_file(NULL, NULL, 0);
+#endif
+
+#ifdef OE_X509_LOAD_CERT_CRL_FILE
+    X509_load_cert_crl_file(NULL, NULL, 0);
+#endif
+
+#ifdef OE_X509_LOOKUP_HASH_DIR
+    X509_LOOKUP_hash_dir();
+#endif
+
+#ifdef OE_X509_LOOKUP_FILE
+    X509_LOOKUP_file();
+#endif
+
+#ifdef OE_X509_STORE_LOAD_LOCATIONS
+    X509_STORE_load_locations(NULL, NULL, NULL);
+#endif
+
+#ifdef OE_X509_STORE_SET_DEFAULT_PATHS
+    X509_STORE_set_default_paths(NULL);
+#endif
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/openssl_unsupported/host/CMakeLists.txt
+++ b/tests/openssl_unsupported/host/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../openssl_unsupported.edl)
+
+add_custom_command(
+  OUTPUT openssl_unsupported_u.h openssl_unsupported_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(openssl_unsupported_host host.c openssl_unsupported_u.c)
+
+target_include_directories(openssl_unsupported_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(openssl_unsupported_host oehost)

--- a/tests/openssl_unsupported/host/host.c
+++ b/tests/openssl_unsupported/host/host.c
@@ -1,0 +1,42 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <limits.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "openssl_unsupported_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    if ((result = oe_create_openssl_unsupported_enclave(
+             argv[1], OE_ENCLAVE_TYPE_AUTO, flags, NULL, 0, &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    result = test(enclave);
+
+    if (result != OE_OK)
+        oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (openssl_unsupported)\n");
+
+    return 0;
+}

--- a/tests/openssl_unsupported/openssl_unsupported.edl
+++ b/tests/openssl_unsupported/openssl_unsupported.edl
@@ -1,0 +1,16 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public void test();
+    };
+};


### PR DESCRIPTION
This PR disables a set of OpenSSL APIs/macros that are considered as unsafe based on OE's threat model. More specifically, those APIs allow users to configure an OpenSSL application to read certificates from the host filesystem, which is not trusted, and therefore are recommended not to use inside an enclave.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>