### PR TITLE
README files for SIGs

### DIFF
--- a/docs/Community/sig-api/README.md
+++ b/docs/Community/sig-api/README.md
@@ -1,22 +1,29 @@
-SIG API
-========
+API Special Interest Group
+==========================
 
-SIG-API is responsible for reviewing and approving changes to the project's core APIs.
+SIG-API is responsible for reviewing and approving changes to the project's
+public APIs, and for maintaining [guidelines](../../ApiGuidelines.md)
+around creating such APIs.
 
 Meetings
 --------
 
-TBD
+Currently combined with [SIG-Architecture](../sig-architecture/README.md).
 
-SIG leads
+SIG Chair
 ---------
 
-TBD
+Dave Thaler ([dthaler](https://github.com/dthaler))
 
-Meeting Chair
+SIG Approvers
 -------------
 
-TBD
+(none)
+
+SIG Reviewers
+-------------
+
+(none)
 
 Charter
 -------

--- a/docs/Community/sig-architecture/README.md
+++ b/docs/Community/sig-architecture/README.md
@@ -1,5 +1,5 @@
-SIG Architecture
-================
+Architecture Special Interest Group
+===================================
 
 SIG-Architecture is responsible for reviewing high level designs which inform project goals and technical norms.
 
@@ -10,15 +10,26 @@ Meetings
 
 Regular SIG-Architecture meeting: TBD
 
-SIG leads
+SIG Chair
 ---------
 
-TBD
+Simon Leet (CodeMonkeyLeet)
 
-Meeting Chair
+SIG Approvers
 -------------
 
-TBD
+Simon Leet (CodeMonkeyLeet)
+
+SIG Reviewers
+-------------
+
+* [SIG-API](../sig-api/README.md) Chair
+* [SIG-Attestation](../sig-attestation/README.md) Chair
+* [SIG-Testing](../sig-testing/README.md) Chair
+* [SIG-Tools](../sig-tools/README.md) Chair
+* [SIG-Release](../sig-release/README.md) Chair
+* [SIG-SGX](../sig-sgx/README.md) Chair
+* [SIG-OPTEE](../sig-optee/README.md) Chair
 
 Charter
 -------

--- a/docs/Community/sig-attestation/README.md
+++ b/docs/Community/sig-attestation/README.md
@@ -14,15 +14,26 @@ Meetings
 
 Regular meetings: TBD
 
-SIG leads
+SIG Chair
 ---------
 
-TBD
+Yen Lee ([yentsanglee](https://github.com/yentsanglee))
 
-Meeting Chair
+SIG Approvers
 -------------
 
-TBD
+* Shruti Ratnam ([shruti25ratnam](https://github.com/shruti25ratnam))
+* Jiri Appl ([jiria](https://github.com/jiria))
+* Sergio Wong ([jazzybluesea](https://github.com/jazzybluesea))
+* Akash Gupta ([gupta-ak](https://github.com/gupta-ak))
+* Brian Telfer ([Britel](https://github.com/Britel))
+* Cheng-mean Liu ([soccerGB](https://github.com/soccerGB))
+* Shanwei Cen ([shnwc](https://github.com/shnwc))
+
+SIG Reviewers
+-------------
+
+(none)
 
 Charter
 -------

--- a/docs/Community/sig-optee/README.md
+++ b/docs/Community/sig-optee/README.md
@@ -1,0 +1,32 @@
+OP-TEE Special Interest Group
+=============================
+
+SIG-OPTEE is responsible for ...
+
+Meetings
+--------
+
+Regular meetings: none presently
+
+SIG Chair
+---------
+
+Brian Telfer ([Britel](https://github.com/Britel))
+
+SIG Approvers
+-------------
+
+* Brian Telfer ([Britel](https://github.com/Britel))
+* Hernan Gatta ([HernanGatta](https://github.com/HernanGatta))
+* Paul Allen ([paulcallen](https://github.com/paulcallen))
+* Dave Thaler ([dthaler](https://github.com/dthaler))
+
+SIG Reviewers
+-------------
+
+(none)
+
+Charter
+-------
+
+TBD

--- a/docs/Community/sig-release/README.md
+++ b/docs/Community/sig-release/README.md
@@ -1,0 +1,32 @@
+Release Special Interest Group
+==============================
+
+SIG Release is responsible for the generation of periodic numerical binary
+releases of the Open Enclave SDK project. This includes the processes
+necessary for tracking feature delivery and coordinating various teams'
+execution towards planned milestones.
+
+Meetings
+--------
+
+TBD
+
+SIG Chair
+---------
+
+Radhika Jandhyala ([radhikaj](https://github.com/radhikaj))
+
+SIG Approvers
+-------------
+
+(none)
+
+SIG Reviewers
+-------------
+
+(none)
+
+Charter
+-------
+
+See [charter](charter.md)

--- a/docs/Community/sig-sgx/README.md
+++ b/docs/Community/sig-sgx/README.md
@@ -1,0 +1,37 @@
+SGX Special Interest Group
+=============================
+
+SIG-SGX is responsible for ...
+
+Meetings
+--------
+
+TBD
+
+SIG Chair
+---------
+
+TBD
+
+SIG Approvers
+-------------
+
+* Anand Krishnamoorthi ([anakrish](https://github.com/anakrish))
+* Simon Leet ([CodeMonkeyLeet](https://github.com/CodeMonkeyLeet))
+* Akash Gupta ([gupta-ak](https://github.com/gupta-ak))
+* Jordan Hand ([jhand2](https://github.com/jhand2))
+* Xuejun Yang ([jxyang](https://github.com/jxyang))
+* Mike Brasher ([mikbras](https://github.com/mikbras))
+* Radhika Jandhyala ([radhikaj](https://github.com/radhikaj))
+* Cheng-mean Liu ([soccerGB](https://github.com/soccerGB))
+* Bruce Campbell ([yakman2020](https://github.com/yakman2020))
+
+SIG Reviewers
+-------------
+
+(none)
+
+Charter
+-------
+
+TBD

--- a/docs/Community/sig-testing/README.md
+++ b/docs/Community/sig-testing/README.md
@@ -21,15 +21,22 @@ Regular SIG-Testing meeting: Weekly on [Tuesdays at 17:30 PT (Pacific Time)](htt
 
 [Meeting Agenda and Notes](https://hackmd.io/@aeva/oesdk-sig-testing)
 
-SIG leads
+SIG Chair
 ---------
 
-TBD
+Anand Krishnamoorthi ([anakrish](https://github.com/anakrish))
 
-Meeting Chair
+SIG Approvers
 -------------
 
-TBD
+* Anand Krishnamoorthi ([anakrish](https://github.com/anakrish))
+* Brett McLaren ([BRMcLaren](https://github.com/BRMcLaren))
+* John Kordich ([johnkord](https://github.com/johnkord))
+
+SIG Reviewers
+-------------
+
+(none)
 
 Charter
 -------

--- a/docs/Community/sig-tools/README.md
+++ b/docs/Community/sig-tools/README.md
@@ -1,0 +1,32 @@
+Tools Special Interest Group
+=============================
+
+SIG-Tools is responsible for ...
+
+Meetings
+--------
+
+Regular meetings: none presently
+
+SIG Chair
+---------
+
+Anand Krishnamoorthi ([anakrish](https://github.com/anakrish))
+
+SIG Approvers
+-------------
+
+* Anand Krishnamoorthi ([anakrish](https://github.com/anakrish))
+* Andy Schwartzmeyer ([andschwa](https://github.com/andschwa))
+* Dave Thaler ([dthaler](https://github.com/dthaler))
+* John Kordich ([johnkord](https://github.com/johnkord))
+
+SIG Reviewers
+-------------
+
+(none)
+
+Charter
+-------
+
+TBD

--- a/docs/Community/sig-website/README.md
+++ b/docs/Community/sig-website/README.md
@@ -1,0 +1,30 @@
+Website Special Interest Group
+=============================
+
+SIG-Website is responsible for ...
+
+Meetings
+--------
+
+TBD
+
+SIG Chair
+---------
+
+Radhika Jandhyala ([radhikaj](https://github.com/radhikaj))
+
+SIG Approvers
+-------------
+
+* Radhika Jandhyala ([radhikaj](https://github.com/radhikaj))
+* Aeva van der Veen ([AevaOnline](https://github.com/AevaOnline))
+
+SIG Reviewers
+-------------
+
+(none)
+
+Charter
+-------
+
+TBD


### PR DESCRIPTION
A few SIGs already had README files and others did not.  This PR makes all SIGs have consistent README files.

PR #3412 updated the OWNERS files with chairs, but did not make corresponding changes to the README files which still said "TBD". This PR addresses that inconsistency.

Names simply match those already in the OWNERS files in the same directories. Any changes to names should be in a separate PR, since those are up to SIG chairs.

Any other content changes to the README files would be up to the relevant SIGs.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>