### PR TITLE
Add proper EEID endorsements and move SGX endorsements there.

### DIFF
--- a/common/sgx/eeid_verifier.c
+++ b/common/sgx/eeid_verifier.c
@@ -15,6 +15,7 @@
 
 #include <openenclave/attestation/sgx/eeid_plugin.h>
 #include <openenclave/attestation/sgx/eeid_verifier.h>
+#include <openenclave/attestation/sgx/evidence.h>
 #include <openenclave/bits/attestation.h>
 #include <openenclave/bits/eeid.h>
 #include <openenclave/bits/evidence.h>
@@ -29,6 +30,8 @@
 #include "../attest_plugin.h"
 #include "../common.h"
 #include "quote.h"
+
+static const oe_uuid_t _sgx_uuid = {OE_FORMAT_UUID_LEGACY_REPORT_REMOTE};
 
 static oe_result_t _eeid_verifier_on_register(
     oe_attestation_role_t* context,
@@ -47,54 +50,10 @@ static oe_result_t _eeid_verifier_on_unregister(oe_attestation_role_t* context)
     return OE_OK;
 }
 
-typedef struct _header
-{
-    uint32_t version;
-    oe_uuid_t format_id;
-    uint64_t data_size;
-    uint8_t data[];
-} header_t;
-
-static oe_result_t _add_claim(
-    oe_claim_t* claim,
-    void* name,
-    size_t name_size,
-    void* value,
-    size_t value_size)
-{
-    oe_result_t result = OE_UNEXPECTED;
-
-    if (*((uint8_t*)name + name_size - 1) != '\0')
-        return OE_CONSTRAINT_FAILED;
-
-    claim->name = (char*)oe_malloc(name_size);
-    if (claim->name == NULL)
-        return OE_OUT_OF_MEMORY;
-    OE_CHECK(oe_memcpy_s(claim->name, name_size, name, name_size));
-
-    claim->value = (uint8_t*)oe_malloc(value_size);
-    if (claim->value == NULL)
-    {
-        oe_free(claim->name);
-        claim->name = NULL;
-        return OE_OUT_OF_MEMORY;
-    }
-    OE_CHECK(oe_memcpy_s(claim->value, value_size, value, value_size));
-    claim->value_size = value_size;
-
-    result = OE_OK;
-done:
-    return result;
-}
-
 static oe_result_t _add_claims(
     oe_verifier_t* context,
-    const uint8_t* r_enclave_hash,
-    const uint8_t* r_signer_id,
-    uint16_t r_product_id,
-    uint32_t r_security_version,
-    uint64_t r_attributes,
-    uint32_t r_id_version,
+    const oe_claim_t* sgx_claims,
+    size_t sgx_claims_length,
     const uint8_t* r_enclave_base_hash,
     uint8_t* eeid_data,
     size_t eeid_data_size,
@@ -104,7 +63,7 @@ static oe_result_t _add_claims(
     oe_result_t result = OE_UNEXPECTED;
     size_t claims_index = 0;
     oe_claim_t* claims = NULL;
-    size_t num_claims = OE_REQUIRED_CLAIMS_COUNT + 1;
+    size_t num_claims = sgx_claims_length + 2;
 
     if (!claims_out || !claims_size_out)
         OE_RAISE(OE_INVALID_PARAMETER);
@@ -116,56 +75,28 @@ static oe_result_t _add_claims(
     if (claims == NULL)
         return OE_OUT_OF_MEMORY;
 
-    OE_CHECK(_add_claim(
-        &claims[claims_index++],
-        OE_CLAIM_ID_VERSION,
-        sizeof(OE_CLAIM_ID_VERSION),
-        &r_id_version,
-        sizeof(r_id_version)));
+    for (size_t i = 0; i < sgx_claims_length; i++)
+    {
+        const oe_claim_t* sgx_claim = &sgx_claims[i];
+        if (strcmp(sgx_claim->name, OE_CLAIM_FORMAT_UUID) != 0)
+        {
+            OE_CHECK(oe_sgx_add_claim(
+                &claims[claims_index++],
+                sgx_claim->name,
+                strlen(sgx_claim->name) + 1,
+                sgx_claim->value,
+                sgx_claim->value_size));
+        }
+    }
 
-    OE_CHECK(_add_claim(
-        &claims[claims_index++],
-        OE_CLAIM_SECURITY_VERSION,
-        sizeof(OE_CLAIM_SECURITY_VERSION),
-        &r_security_version,
-        sizeof(r_security_version)));
-
-    OE_CHECK(_add_claim(
-        &claims[claims_index++],
-        OE_CLAIM_ATTRIBUTES,
-        sizeof(OE_CLAIM_ATTRIBUTES),
-        &r_attributes,
-        sizeof(r_attributes)));
-
-    OE_CHECK(_add_claim(
-        &claims[claims_index++],
-        OE_CLAIM_UNIQUE_ID,
-        sizeof(OE_CLAIM_UNIQUE_ID),
-        (void*)r_enclave_hash,
-        OE_UNIQUE_ID_SIZE));
-
-    OE_CHECK(_add_claim(
-        &claims[claims_index++],
-        OE_CLAIM_SIGNER_ID,
-        sizeof(OE_CLAIM_SIGNER_ID),
-        (void*)r_signer_id,
-        OE_SIGNER_ID_SIZE));
-
-    OE_CHECK(_add_claim(
-        &claims[claims_index++],
-        OE_CLAIM_PRODUCT_ID,
-        sizeof(OE_CLAIM_PRODUCT_ID),
-        &r_product_id,
-        OE_PRODUCT_ID_SIZE));
-
-    OE_CHECK(_add_claim(
+    OE_CHECK(oe_sgx_add_claim(
         &claims[claims_index++],
         OE_CLAIM_FORMAT_UUID,
         sizeof(OE_CLAIM_FORMAT_UUID),
         &context->base.format_id,
         sizeof(oe_uuid_t)));
 
-    OE_CHECK(_add_claim(
+    OE_CHECK(oe_sgx_add_claim(
         &claims[claims_index++],
         OE_CLAIM_EEID_BASE_ID,
         sizeof(OE_CLAIM_EEID_BASE_ID),
@@ -174,7 +105,7 @@ static oe_result_t _add_claims(
 
     if (eeid_data && eeid_data_size)
     {
-        OE_CHECK(_add_claim(
+        OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_EEID_DATA,
             sizeof(OE_CLAIM_EEID_DATA),
@@ -190,65 +121,93 @@ done:
     return result;
 }
 
-static oe_result_t _verify_sgx_report(
-    const oe_verifier_t* context,
+oe_result_t _verify_evidence(
+    oe_verifier_t* context,
+    const uint8_t* evidence_buffer,
+    size_t evidence_buffer_size,
+    const uint8_t* endorsements_buffer,
+    size_t endorsements_buffer_size,
     const oe_policy_t* policies,
     size_t policies_size,
-    const uint8_t* sgx_evidence_buffer,
-    size_t sgx_evidence_buffer_size,
-    const uint8_t* sgx_endorsements_buffer,
-    size_t sgx_endorsements_buffer_size,
-    oe_claim_t** sgx_claims,
-    size_t* sgx_claims_length,
-    oe_report_t* parsed_report)
+    oe_claim_t** claims,
+    size_t* claims_length);
+
+static oe_result_t _get_relevant_base_claims(
+    const oe_claim_t* claims,
+    size_t claims_length,
+    oe_eeid_relevant_base_claims_t* relevant_claims)
 {
     oe_result_t result = OE_UNEXPECTED;
-    const uint8_t* report_buffer = sgx_evidence_buffer;
-    oe_datetime_t* time = NULL;
-    oe_report_header_t* header = (oe_report_header_t*)report_buffer;
-    oe_sgx_endorsements_t sgx_endorsements;
-    size_t sgx_claims_size = 0;
 
-    for (size_t i = 0; i < policies_size; i++)
+    for (size_t i = 0; i < claims_length; i++)
     {
-        if (policies[i].type == OE_POLICY_ENDORSEMENTS_TIME)
+        const oe_claim_t* claim = &claims[i];
+
+        if (strcmp(claim->name, OE_CLAIM_UNIQUE_ID) == 0)
         {
-            if (policies[i].policy_size != sizeof(*time))
-                return OE_INVALID_PARAMETER;
-            time = (oe_datetime_t*)policies[i].policy;
+            relevant_claims->enclave_hash = claim->value;
+            relevant_claims->enclave_hash_size = claim->value_size;
+        }
+        else if (strcmp(claim->name, OE_CLAIM_SIGNER_ID) == 0)
+        {
+            relevant_claims->signer_id = claim->value;
+            relevant_claims->signer_id_size = claim->value_size;
+        }
+        else if (strcmp(claim->name, OE_CLAIM_PRODUCT_ID) == 0)
+        {
+            if (claim->value_size != OE_PRODUCT_ID_SIZE)
+                OE_RAISE(QE_QUOTE_ENCLAVE_IDENTITY_PRODUCTID_MISMATCH);
+            relevant_claims->product_id =
+                (uint16_t)(claim->value[1] << 8 | claim->value[0]);
+        }
+        else if (strcmp(claim->name, OE_CLAIM_SECURITY_VERSION) == 0)
+        {
+            if (claim->value_size != sizeof(uint32_t))
+                OE_RAISE(OE_INVALID_ISVSVN);
+            relevant_claims->security_version = *(uint32_t*)(claim->value);
+        }
+        else if (strcmp(claim->name, OE_CLAIM_ATTRIBUTES) == 0)
+        {
+            if (claim->value_size != sizeof(uint64_t))
+                OE_RAISE(OE_INVALID_PARAMETER);
+            relevant_claims->attributes = *(uint64_t*)(claim->value);
+        }
+        else if (strcmp(claim->name, OE_CLAIM_ID_VERSION) == 0)
+        {
+            if (claim->value_size != sizeof(uint32_t))
+                OE_RAISE(OE_INVALID_PARAMETER);
+            relevant_claims->id_version = *(uint32_t*)(claim->value);
         }
     }
 
-    OE_CHECK(oe_parse_sgx_endorsements(
-        (oe_endorsements_t*)sgx_endorsements_buffer,
-        sgx_endorsements_buffer_size,
-        &sgx_endorsements));
-    OE_CHECK(oe_verify_quote_with_sgx_endorsements(
-        header->report, header->report_size, &sgx_endorsements, time));
+    result = OE_OK;
 
-    sgx_claims_size = sgx_evidence_buffer_size -
-                      (header->report_size + sizeof(oe_report_header_t));
-    *sgx_claims = NULL;
+done:
 
-    OE_CHECK(oe_parse_report(
-        sgx_evidence_buffer,
-        sgx_evidence_buffer_size - sgx_claims_size,
-        parsed_report));
+    return result;
+}
 
-    /* Extract SGX claims */
-    oe_sgx_extract_claims(
-        SGX_FORMAT_TYPE_REMOTE,
-        &context->base.format_id,
-        header->report,
-        header->report_size,
-        header->report + header->report_size,
-        sgx_claims_size,
-        &sgx_endorsements,
-        sgx_claims,
-        sgx_claims_length);
+static oe_result_t _align_buffer(
+    const uint8_t* buffer,
+    size_t buffer_size,
+    uint8_t** aligned_buffer)
+{
+    oe_result_t result = OE_UNEXPECTED;
+
+    if (buffer_size == 0)
+    {
+        *aligned_buffer = NULL;
+        return OE_OK;
+    }
+
+    if ((*aligned_buffer = oe_memalign(2 * sizeof(void*), buffer_size)) == 0)
+        OE_RAISE(OE_OUT_OF_MEMORY);
+    OE_CHECK(oe_memcpy_s(*aligned_buffer, buffer_size, buffer, buffer_size));
 
     result = OE_OK;
+
 done:
+
     return result;
 }
 
@@ -270,147 +229,120 @@ static oe_result_t _eeid_verify_evidence(
             *eeid_buffer = NULL;
     size_t sgx_evidence_buffer_size = 0, sgx_endorsements_buffer_size = 0,
            eeid_buffer_size = 0;
-    oe_eeid_t *attester_eeid = NULL, *verifier_eeid = NULL;
+    oe_eeid_t* attester_eeid = NULL;
+    uint8_t* verifier_eeid_data = NULL;
+    size_t verifier_eeid_data_size = 0;
     oe_eeid_evidence_t* evidence = NULL;
+    oe_eeid_endorsements_t* endorsements = NULL;
+    oe_claim_t* sgx_claims = NULL;
+    size_t sgx_claims_length = 0;
+    oe_eeid_relevant_base_claims_t relevant_claims;
+    const uint8_t* enclave_base_hash = NULL;
+    oe_verifier_t sgx_context; /* Only needed for format id */
 
     if ((!endorsements_buffer && endorsements_buffer_size) ||
         (endorsements_buffer && !endorsements_buffer_size))
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    evidence = oe_malloc(evidence_buffer_size);
+    if ((evidence = oe_malloc(evidence_buffer_size)) == NULL)
+        OE_RAISE(OE_OUT_OF_MEMORY);
     OE_CHECK(
         oe_eeid_evidence_ntoh(evidence_buffer, evidence_buffer_size, evidence));
 
-    sgx_evidence_buffer_size = evidence->sgx_evidence_size;
-    sgx_endorsements_buffer_size = evidence->sgx_endorsements_size;
+    sgx_evidence_buffer_size = evidence->base_evidence_size;
+
     eeid_buffer_size = evidence->eeid_size;
-    eeid_buffer = evidence->data + evidence->sgx_evidence_size +
-                  evidence->sgx_endorsements_size;
+    eeid_buffer = evidence->data + evidence->base_evidence_size;
 
     // Make sure buffers are aligned so they can be cast to structs. Note that
     // the SGX evidendence and endorsements buffers contain structs that have
     // not been corrected for endianness.
-    if (sgx_evidence_buffer_size != 0)
-    {
-        if ((sgx_evidence_buffer =
-                 oe_memalign(2 * sizeof(void*), sgx_evidence_buffer_size)) == 0)
-            OE_RAISE(OE_OUT_OF_MEMORY);
-        OE_CHECK(oe_memcpy_s(
-            sgx_evidence_buffer,
-            sgx_evidence_buffer_size,
-            evidence->data,
-            sgx_evidence_buffer_size));
-    }
+    OE_CHECK(_align_buffer(
+        evidence->data, sgx_evidence_buffer_size, &sgx_evidence_buffer));
 
-    if (sgx_endorsements_buffer_size != 0)
+    if (endorsements_buffer)
     {
-        if ((sgx_endorsements_buffer = oe_memalign(
-                 2 * sizeof(void*), sgx_endorsements_buffer_size)) == 0)
+        if ((endorsements = oe_malloc(endorsements_buffer_size)) == NULL)
             OE_RAISE(OE_OUT_OF_MEMORY);
-        OE_CHECK(oe_memcpy_s(
-            sgx_endorsements_buffer,
+        OE_CHECK(oe_eeid_endorsements_ntoh(
+            endorsements_buffer, endorsements_buffer_size, endorsements));
+
+        sgx_endorsements_buffer_size = endorsements->sgx_endorsements_size;
+        OE_CHECK(_align_buffer(
+            endorsements->data,
             sgx_endorsements_buffer_size,
-            evidence->data + evidence->sgx_evidence_size,
-            sgx_endorsements_buffer_size));
+            &sgx_endorsements_buffer));
+
+        /* EEID data passed to the verifier */
+        verifier_eeid_data_size = endorsements->eeid_endorsements_size;
+        OE_CHECK(_align_buffer(
+            endorsements->data + endorsements->sgx_endorsements_size,
+            verifier_eeid_data_size,
+            &verifier_eeid_data));
     }
 
     if (eeid_buffer_size != 0)
     {
-        attester_eeid = oe_memalign(2 * sizeof(void*), eeid_buffer_size);
-        if (!attester_eeid)
+        if ((attester_eeid =
+                 oe_memalign(2 * sizeof(void*), eeid_buffer_size)) == NULL)
             OE_RAISE(OE_OUT_OF_MEMORY);
         OE_CHECK(oe_eeid_ntoh(eeid_buffer, eeid_buffer_size, attester_eeid));
-
         if (attester_eeid->version != OE_EEID_VERSION)
             OE_RAISE(OE_INVALID_PARAMETER);
     }
 
-    {
-        /* Verify SGX report */
-        oe_report_t parsed_report;
-        oe_claim_t* sgx_claims = NULL;
-        size_t sgx_claims_length = 0;
-        OE_CHECK(_verify_sgx_report(
+    /* Verify SGX report */
+    sgx_context.base.format_id = _sgx_uuid;
+    OE_CHECK(oe_sgx_verify_evidence(
+        &sgx_context,
+        sgx_evidence_buffer,
+        sgx_evidence_buffer_size,
+        sgx_endorsements_buffer,
+        sgx_endorsements_buffer_size,
+        policies,
+        policies_size,
+        &sgx_claims,
+        &sgx_claims_length));
+
+    OE_CHECK(_get_relevant_base_claims(
+        sgx_claims, sgx_claims_length, &relevant_claims));
+
+    /* Check that the enclave-reported EEID data matches the verifier's
+     * expectation. */
+    if (verifier_eeid_data &&
+        (attester_eeid->data_size != verifier_eeid_data_size ||
+         memcmp(
+             attester_eeid->data,
+             verifier_eeid_data,
+             verifier_eeid_data_size) != 0))
+        OE_RAISE(OE_VERIFY_FAILED);
+
+    /* Verify EEID */
+    OE_CHECK(verify_eeid(&relevant_claims, &enclave_base_hash, attester_eeid));
+
+    /* Produce claims */
+    if (claims && claims_size)
+        _add_claims(
             context,
-            policies,
-            policies_size,
-            sgx_evidence_buffer,
-            sgx_evidence_buffer_size,
-            sgx_endorsements_buffer,
-            sgx_endorsements_buffer_size,
-            &sgx_claims,
-            &sgx_claims_length,
-            &parsed_report));
-
-        const uint8_t* r_enclave_hash = parsed_report.identity.unique_id;
-        const uint8_t* r_signer_id = parsed_report.identity.signer_id;
-        uint16_t r_product_id = *((uint16_t*)parsed_report.identity.product_id);
-        uint32_t r_security_version = parsed_report.identity.security_version;
-        uint64_t r_attributes = parsed_report.identity.attributes;
-        uint32_t r_id_version = parsed_report.identity.id_version;
-
-        oe_free_claims(sgx_claims, sgx_claims_length);
-
-        /* EEID passed to the verifier */
-        if (endorsements_buffer)
-        {
-            verifier_eeid =
-                oe_memalign(2 * sizeof(void*), endorsements_buffer_size);
-            if (!verifier_eeid)
-                OE_RAISE(OE_OUT_OF_MEMORY);
-            OE_CHECK(oe_eeid_ntoh(
-                endorsements_buffer, endorsements_buffer_size, verifier_eeid));
-        }
-
-        /* Check that the enclave-reported EEID data matches the verifier's
-         * expectation. */
-        if (verifier_eeid &&
-            (attester_eeid->data_size != verifier_eeid->data_size ||
-             attester_eeid->signature_size != verifier_eeid->signature_size ||
-             memcmp(
-                 attester_eeid->data,
-                 verifier_eeid->data,
-                 verifier_eeid->data_size + verifier_eeid->signature_size) !=
-                 0))
-            OE_RAISE(OE_VERIFY_FAILED);
-
-        /* Verify EEID */
-        const uint8_t* r_enclave_base_hash;
-        OE_CHECK(verify_eeid(
-            r_enclave_hash,
-            r_signer_id,
-            r_product_id,
-            r_security_version,
-            r_attributes,
-            &r_enclave_base_hash,
-            attester_eeid));
-
-        /* Produce claims */
-        if (claims && claims_size)
-            _add_claims(
-                context,
-                r_enclave_hash,
-                r_signer_id,
-                r_product_id,
-                r_security_version,
-                r_attributes,
-                r_id_version,
-                r_enclave_base_hash,
-                attester_eeid->data,
-                attester_eeid->data_size,
-                claims,
-                claims_size);
-    }
+            sgx_claims,
+            sgx_claims_length,
+            enclave_base_hash,
+            attester_eeid->data,
+            attester_eeid->data_size,
+            claims,
+            claims_size);
 
     result = OE_OK;
 
 done:
 
+    oe_sgx_free_claims_list(&sgx_context, sgx_claims, sgx_claims_length);
     oe_memalign_free(sgx_evidence_buffer);
     oe_memalign_free(sgx_endorsements_buffer);
     oe_memalign_free(attester_eeid);
-    oe_memalign_free(verifier_eeid);
+    oe_memalign_free(verifier_eeid_data);
     oe_free(evidence);
+    oe_free(endorsements);
 
     return result;
 }
@@ -423,7 +355,7 @@ static oe_verifier_t _eeid_verifier = {
             .on_unregister = &_eeid_verifier_on_unregister,
         },
     .verify_evidence = &_eeid_verify_evidence,
-    .free_claims = &sgx_attestation_plugin_free_claims_list};
+    .free_claims = &oe_sgx_free_claims_list};
 
 oe_result_t oe_sgx_eeid_verifier_initialize(void)
 {

--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -69,7 +69,7 @@ static void _free_claim(oe_claim_t* claim)
     oe_free(claim->value);
 }
 
-oe_result_t sgx_attestation_plugin_free_claims_list(
+oe_result_t oe_sgx_free_claims_list(
     oe_verifier_t* context,
     oe_claim_t* claims,
     size_t claims_length)
@@ -185,7 +185,7 @@ done:
     return result;
 }
 
-static oe_result_t _add_claim(
+oe_result_t oe_sgx_add_claim(
     oe_claim_t* claim,
     const void* name,
     size_t name_size, // Must cover the '\0' at end of string
@@ -247,7 +247,7 @@ static oe_result_t _fill_with_known_claims(
         OE_RAISE(OE_INVALID_PARAMETER);
 
     // ID version.
-    OE_CHECK(_add_claim(
+    OE_CHECK(oe_sgx_add_claim(
         &claims[claims_index++],
         OE_CLAIM_ID_VERSION,
         sizeof(OE_CLAIM_ID_VERSION),
@@ -255,7 +255,7 @@ static oe_result_t _fill_with_known_claims(
         sizeof(id->id_version)));
 
     // Security version.
-    OE_CHECK(_add_claim(
+    OE_CHECK(oe_sgx_add_claim(
         &claims[claims_index++],
         OE_CLAIM_SECURITY_VERSION,
         sizeof(OE_CLAIM_SECURITY_VERSION),
@@ -263,7 +263,7 @@ static oe_result_t _fill_with_known_claims(
         sizeof(id->security_version)));
 
     // Attributes.
-    OE_CHECK(_add_claim(
+    OE_CHECK(oe_sgx_add_claim(
         &claims[claims_index++],
         OE_CLAIM_ATTRIBUTES,
         sizeof(OE_CLAIM_ATTRIBUTES),
@@ -271,7 +271,7 @@ static oe_result_t _fill_with_known_claims(
         sizeof(id->attributes)));
 
     // Unique ID
-    OE_CHECK(_add_claim(
+    OE_CHECK(oe_sgx_add_claim(
         &claims[claims_index++],
         OE_CLAIM_UNIQUE_ID,
         sizeof(OE_CLAIM_UNIQUE_ID),
@@ -279,7 +279,7 @@ static oe_result_t _fill_with_known_claims(
         sizeof(id->unique_id)));
 
     // Signer ID
-    OE_CHECK(_add_claim(
+    OE_CHECK(oe_sgx_add_claim(
         &claims[claims_index++],
         OE_CLAIM_SIGNER_ID,
         sizeof(OE_CLAIM_SIGNER_ID),
@@ -287,7 +287,7 @@ static oe_result_t _fill_with_known_claims(
         sizeof(id->signer_id)));
 
     // Product ID
-    OE_CHECK(_add_claim(
+    OE_CHECK(oe_sgx_add_claim(
         &claims[claims_index++],
         OE_CLAIM_PRODUCT_ID,
         sizeof(OE_CLAIM_PRODUCT_ID),
@@ -295,7 +295,7 @@ static oe_result_t _fill_with_known_claims(
         sizeof(id->product_id)));
 
     // Plugin UUID
-    OE_CHECK(_add_claim(
+    OE_CHECK(oe_sgx_add_claim(
         &claims[claims_index++],
         OE_CLAIM_FORMAT_UUID,
         sizeof(OE_CLAIM_FORMAT_UUID),
@@ -313,7 +313,7 @@ static oe_result_t _fill_with_known_claims(
             &valid_until));
 
         // Validity from.
-        OE_CHECK(_add_claim(
+        OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_VALIDITY_FROM,
             sizeof(OE_CLAIM_VALIDITY_FROM),
@@ -321,7 +321,7 @@ static oe_result_t _fill_with_known_claims(
             sizeof(valid_from)));
 
         // Validity to.
-        OE_CHECK(_add_claim(
+        OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_VALIDITY_UNTIL,
             sizeof(OE_CLAIM_VALIDITY_UNTIL),
@@ -329,7 +329,7 @@ static oe_result_t _fill_with_known_claims(
             sizeof(valid_until)));
 
         // TCB info
-        OE_CHECK(_add_claim(
+        OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_SGX_TCB_INFO,
             sizeof(OE_CLAIM_SGX_TCB_INFO),
@@ -337,7 +337,7 @@ static oe_result_t _fill_with_known_claims(
             sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_TCB_INFO].size));
 
         // TCB issuer chain
-        OE_CHECK(_add_claim(
+        OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_SGX_TCB_ISSUER_CHAIN,
             sizeof(OE_CLAIM_SGX_TCB_ISSUER_CHAIN),
@@ -347,7 +347,7 @@ static oe_result_t _fill_with_known_claims(
                 .size));
 
         // PCK CRL
-        OE_CHECK(_add_claim(
+        OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_SGX_PCK_CRL,
             sizeof(OE_CLAIM_SGX_PCK_CRL),
@@ -356,7 +356,7 @@ static oe_result_t _fill_with_known_claims(
                 .size));
 
         // Root CA CRL
-        OE_CHECK(_add_claim(
+        OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_SGX_ROOT_CA_CRL,
             sizeof(OE_CLAIM_SGX_ROOT_CA_CRL),
@@ -366,7 +366,7 @@ static oe_result_t _fill_with_known_claims(
                 .size));
 
         // CRL Issuer Chain
-        OE_CHECK(_add_claim(
+        OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_SGX_CRL_ISSUER_CHAIN,
             sizeof(OE_CLAIM_SGX_CRL_ISSUER_CHAIN),
@@ -378,7 +378,7 @@ static oe_result_t _fill_with_known_claims(
                 .size));
 
         // QE ID info
-        OE_CHECK(_add_claim(
+        OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_SGX_QE_ID_INFO,
             sizeof(OE_CLAIM_SGX_QE_ID_INFO),
@@ -386,7 +386,7 @@ static oe_result_t _fill_with_known_claims(
             sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_QE_ID_INFO].size));
 
         // QE ID issuer chain
-        OE_CHECK(_add_claim(
+        OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_SGX_QE_ID_ISSUER_CHAIN,
             sizeof(OE_CLAIM_SGX_QE_ID_ISSUER_CHAIN),
@@ -516,7 +516,7 @@ oe_result_t oe_sgx_extract_claims(
         {
             // Add custom claims buffer
             char* name = OE_CLAIM_CUSTOM_CLAIMS_BUFFER;
-            OE_CHECK(_add_claim(
+            OE_CHECK(oe_sgx_add_claim(
                 claims + claims_added,
                 name,
                 oe_strlen(name) + 1,
@@ -527,7 +527,7 @@ oe_result_t oe_sgx_extract_claims(
         {
             // Add SGX report data claim
             char* name = OE_CLAIM_SGX_REPORT_DATA;
-            OE_CHECK(_add_claim(
+            OE_CHECK(oe_sgx_add_claim(
                 claims + claims_added,
                 name,
                 oe_strlen(name) + 1,
@@ -543,11 +543,11 @@ oe_result_t oe_sgx_extract_claims(
 
 done:
     if (claims)
-        sgx_attestation_plugin_free_claims_list(NULL, claims, claims_length);
+        oe_sgx_free_claims_list(NULL, claims, claims_length);
     return result;
 }
 
-static oe_result_t _verify_evidence(
+oe_result_t oe_sgx_verify_evidence(
     oe_verifier_t* context,
     const uint8_t* evidence_buffer,
     size_t evidence_buffer_size,
@@ -882,9 +882,9 @@ static oe_result_t _get_verifier_plugins(
         plugin->base.on_register = &_on_register;
         plugin->base.on_unregister = &_on_unregister;
         plugin->get_format_settings = &_get_format_settings;
-        plugin->verify_evidence = &_verify_evidence;
+        plugin->verify_evidence = &oe_sgx_verify_evidence;
         plugin->verify_report = &_verify_report;
-        plugin->free_claims = &sgx_attestation_plugin_free_claims_list;
+        plugin->free_claims = &oe_sgx_free_claims_list;
     }
     *verifiers_length = uuid_count;
     result = OE_OK;

--- a/include/openenclave/bits/eeid.h
+++ b/include/openenclave/bits/eeid.h
@@ -62,6 +62,21 @@ typedef struct _oe_eeid
 } oe_eeid_t;
 OE_PACK_END
 
+OE_PACK_BEGIN
+/**
+ * Structure to keep EEID endorsements.
+ */
+typedef struct
+{
+    /** Size of the underlying SGX endorsements. */
+    size_t sgx_endorsements_size;
+    /** Size of EEID endorsements (EEID data). */
+    size_t eeid_endorsements_size;
+    /** Buffer holding the data (same order as the sizes). */
+    uint8_t data[];
+} oe_eeid_endorsements_t;
+OE_PACK_END
+
 OE_EXTERNC_END
 
 #endif /* OE_WITH_EXPERIMENTAL_EEID */

--- a/include/openenclave/internal/eeid.h
+++ b/include/openenclave/internal/eeid.h
@@ -28,6 +28,19 @@ static const uint8_t OE_DEBUG_PUBLIC_KEY[] = {
     0xce, 0x73, 0xe4, 0x33, 0x63, 0x83, 0x77, 0xf1, 0x79, 0xab, 0x44,
     0x56, 0xb2, 0xfe, 0x23, 0x71, 0x93, 0x19, 0x3a, 0x8d, 0xa};
 
+/** Struct to track EEID-relevant claims of the underlying base image. */
+typedef struct
+{
+    uint8_t* enclave_hash;
+    size_t enclave_hash_size;
+    uint8_t* signer_id;
+    size_t signer_id_size;
+    uint16_t product_id;
+    uint32_t security_version;
+    uint64_t attributes;
+    uint32_t id_version;
+} oe_eeid_relevant_base_claims_t;
+
 /**
  * Determine whether properties are those of a base image to be used with EEID
  *
@@ -50,7 +63,8 @@ int is_eeid_base_image(const oe_sgx_enclave_properties_t* properties);
  *
  * @param[in] buf_size The size of **buf**.
  *
- * @returns Returns OE_OK on success.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
  *
  */
 oe_result_t oe_serialize_eeid(
@@ -69,7 +83,8 @@ oe_result_t oe_serialize_eeid(
  *
  * @param[out] eeid The oe_eeid_t to deserialize to (must be non-NULL).
  *
- * @returns Returns OE_OK on success.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
  *
  */
 oe_result_t oe_deserialize_eeid(
@@ -97,7 +112,8 @@ typedef struct
  * @param[in] with_eeid_pages Flag indicating whether EEID pages should be
  * included (base image verification requires this to be disabled).
  *
- * @returns Returns OE_OK on success.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
  *
  */
 struct _OE_SHA256;
@@ -112,35 +128,19 @@ oe_result_t oe_remeasure_memory_pages(
  * This function verifies the consistency of enclave hashes of base and extended
  * images, as well as the base image signature.
  *
- * @param[in] reported_enclave_hash Enclave hash of the extended image (as
- * reported in the oe_report_t).
- *
- * @param[in] reported_enclave_signer Enclave signer of the extended image (as
- * reported in the oe_report_t).
- *
- * @param[in] reported_product_id Product ID of the extended image (as reported
- * in the oe_report_t).
- *
- * @param[in] reported_security_version Security version of the extended image
- * (as reported in the oe_report_t).
- *
- * @param[in] reported_attributes Attributes of the extended image (as reported
- * in the oe_report_t).
+ * @param[in] relevant_claims EEID-relevant base image claims.
  *
  * @param[in] eeid The oe_eeid_t holding all relevant information about the base
  * image.
  *
  * @param[out] base_enclave_hash The hash of the base image
  *
- * @returns Returns OE_OK on success.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
  *
  */
 oe_result_t verify_eeid(
-    const uint8_t* reported_enclave_hash,
-    const uint8_t* reported_enclave_signer,
-    uint16_t reported_product_id,
-    uint32_t reported_security_version,
-    uint64_t reported_attributes,
+    const oe_eeid_relevant_base_claims_t* relevant_claims,
     const uint8_t** base_enclave_hash,
     const oe_eeid_t* eeid);
 
@@ -151,7 +151,8 @@ oe_result_t verify_eeid(
  *
  * @param[out] eeid The oe_eeid_t
  *
- * @returns Returns OE_OK on success.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
  *
  */
 oe_result_t oe_create_eeid_sgx(size_t data_size, oe_eeid_t** eeid);
@@ -161,7 +162,7 @@ oe_result_t oe_create_eeid_sgx(size_t data_size, oe_eeid_t** eeid);
  *
  * @param[in] eeid The oe_eeid_t
  *
- * @returns Returns OE_OK on success.
+ * @returns the size (in bytes) of the given EEID structure.
  *
  */
 size_t oe_eeid_byte_size(const oe_eeid_t* eeid);
@@ -175,7 +176,8 @@ size_t oe_eeid_byte_size(const oe_eeid_t* eeid);
  *
  * @param[in] buffer_size Size of **buffer**.
  *
- * @returns Returns OE_OK on success.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
  *
  */
 oe_result_t oe_eeid_hton(
@@ -192,7 +194,8 @@ oe_result_t oe_eeid_hton(
  *
  * @param[in] eeid The oe_eeid_t to convert to.
  *
- * @returns Returns OE_OK on success.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
  *
  */
 oe_result_t oe_eeid_ntoh(
@@ -202,10 +205,9 @@ oe_result_t oe_eeid_ntoh(
 
 typedef struct
 {
-    size_t sgx_evidence_size;     /* Size of base-image evidence */
-    size_t sgx_endorsements_size; /* Size of base-image endorsements */
-    size_t eeid_size;             /* Size of EEID */
-    uint8_t data[];               /* Data (same order as the sizes) */
+    size_t base_evidence_size; /* Size of base-image evidence */
+    size_t eeid_size;          /* Size of EEID */
+    uint8_t data[];            /* Data (same order as the sizes) */
 } oe_eeid_evidence_t;
 
 /**
@@ -217,7 +219,8 @@ typedef struct
  *
  * @param[in] buffer_size Size of **buffer**.
  *
- * @returns Returns OE_OK on success.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
  *
  */
 oe_result_t oe_eeid_evidence_hton(
@@ -234,13 +237,50 @@ oe_result_t oe_eeid_evidence_hton(
  *
  * @param[in] evidence The oe_eeid_evidence_t to convert to.
  *
- * @returns Returns OE_OK on success.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
  *
  */
 oe_result_t oe_eeid_evidence_ntoh(
     const uint8_t* buffer,
     size_t buffer_size,
     oe_eeid_evidence_t* evidence);
+
+/**
+ * Convert an oe_eeid_endorsements_t into a buffer using network byte-order.
+ *
+ * @param[in] endorsements The oe_eeid_endorsements_t to convert.
+ *
+ * @param[in] buffer The buffer to write to.
+ *
+ * @param[in] buffer_size Size of **buffer**.
+ *
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
+ *
+ */
+oe_result_t oe_eeid_endorsements_hton(
+    const oe_eeid_endorsements_t* endorsements,
+    uint8_t* buffer,
+    size_t buffer_size);
+
+/**
+ * Read an oe_eeid_endorsements_t from a buffer using host byte-order.
+ *
+ * @param[in] buffer The buffer to read from.
+ *
+ * @param[in] buffer_size Size of **buffer**.
+ *
+ * @param[in] endorsements The oe_eeid_endorsements_t to convert to.
+ *
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
+ *
+ */
+oe_result_t oe_eeid_endorsements_ntoh(
+    const uint8_t* buffer,
+    size_t buffer_size,
+    oe_eeid_endorsements_t* endorsements);
 
 #endif /* OE_WITH_EXPERIMENTAL_EEID */
 

--- a/include/openenclave/internal/sgx/plugin.h
+++ b/include/openenclave/internal/sgx/plugin.h
@@ -80,19 +80,68 @@ oe_result_t oe_sgx_hash_custom_claims_buffer(
     OE_SHA256* hash_out);
 
 /**
- * sgx_attestation_plugin_free_claims_list
+ * oe_sgx_free_claims_list
  *
  * Free a claims list produced by the SGX verifier plugin.
  *
  * @param[in] context Plugin context (may be NULL).
  * @param[in] claims List of claims.
  * @param[in] claims_length The length of claims.
- * @retval OE_OK on success, otherwise an appropriate error code.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
  */
-oe_result_t sgx_attestation_plugin_free_claims_list(
+oe_result_t oe_sgx_free_claims_list(
     oe_verifier_t* context,
     oe_claim_t* claims,
     size_t claims_length);
+
+/**
+ * oe_sgx_add_claim
+ *
+ * Add a claim to the list of SGX claims.
+ *
+ * @param[in] claim The claim struct to populate.
+ * @param[in] name The name of the claim.
+ * @param[in] name_size The length of the claim name.
+ * @param[in] value The value of the claim.
+ * @param[in] value_size The length of the claim's value.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
+ */
+oe_result_t oe_sgx_add_claim(
+    oe_claim_t* claim,
+    const void* name,
+    size_t name_size,
+    const void* value,
+    size_t value_size);
+
+/**
+ * oe_sgx_verify_evidence
+ *
+ * Verify SGX evidence.
+ *
+ * @param[in] context Plugin context.
+ * @param[in] evidence_buffer The evidence buffer.
+ * @param[in] evidence_buffer_size The size of the evidence buffer.
+ * @param[in] endorsements_buffer The endorsements buffer.
+ * @param[in] endorsements_buffer_size The size of the endorsements buffer.
+ * @param[in] policies The policies.
+ * @param[in] policies_size The number of policies.
+ * @param[out] claims The claims.
+ * @param[out] claims_length The number of claims.
+ * @retval OE_OK The operation was successful.
+ * @retval other An appropriate error code.
+ */
+oe_result_t oe_sgx_verify_evidence(
+    oe_verifier_t* context,
+    const uint8_t* evidence_buffer,
+    size_t evidence_buffer_size,
+    const uint8_t* endorsements_buffer,
+    size_t endorsements_buffer_size,
+    const oe_policy_t* policies,
+    size_t policies_size,
+    oe_claim_t** claims,
+    size_t* claims_length);
 
 OE_EXTERNC_END
 

--- a/tests/eeid_plugin/enc/enc.c
+++ b/tests/eeid_plugin/enc/enc.c
@@ -52,7 +52,7 @@ static void _test_and_unregister_verifier()
     OE_TEST_CODE(oe_sgx_eeid_verifier_shutdown(), OE_OK);
 }
 
-static void _test_evidence_success(const oe_uuid_t* format_id)
+static void _test_evidence_success()
 {
     printf("====== running _test_evidence_success\n");
 
@@ -64,7 +64,7 @@ static void _test_evidence_success(const oe_uuid_t* format_id)
     size_t claims_length = 0;
 
     oe_result_t r = oe_get_evidence(
-        format_id,
+        &_eeid_uuid,
         OE_EVIDENCE_FLAGS_EMBED_FORMAT_ID,
         claims,
         claims_length,
@@ -74,49 +74,48 @@ static void _test_evidence_success(const oe_uuid_t* format_id)
         &evidence_size,
         &endorsements,
         &endorsements_size);
-
-#ifndef _OE_ENCLAVE_H
-    OE_UNUSED(_check_claims);
-    OE_TEST_CODE(r, OE_UNSUPPORTED);
-#else
     OE_TEST_CODE(r, OE_OK);
 
     // Verify evidence without endorsements.
-    OE_TEST(
-        oe_verify_evidence(
-            NULL,
-            evidence,
-            evidence_size,
-            NULL,
-            0,
-            NULL,
-            0,
-            &claims,
-            &claims_length) == OE_OK);
+    r = oe_verify_evidence(
+        NULL,
+        evidence,
+        evidence_size,
+        NULL,
+        0,
+        NULL,
+        0,
+        &claims,
+        &claims_length);
+    OE_TEST_CODE(r, OE_OK);
 
     OE_TEST(oe_free_claims(claims, claims_length) == OE_OK);
+    claims = NULL;
+    claims_length = 0;
 
     // Verify with endorsements.
-    OE_TEST(
-        oe_verify_evidence(
-            NULL,
-            evidence,
-            evidence_size,
-            endorsements,
-            endorsements_size,
-            NULL,
-            0,
-            &claims,
-            &claims_length) == OE_OK);
-
-    OE_TEST(
-        host_ocall_verify(
-            evidence, evidence_size, endorsements, endorsements_size) == OE_OK);
+    r = oe_verify_evidence(
+        NULL,
+        evidence,
+        evidence_size,
+        endorsements,
+        endorsements_size,
+        NULL,
+        0,
+        &claims,
+        &claims_length);
+    OE_TEST_CODE(r, OE_OK);
 
     OE_TEST(oe_free_claims(claims, claims_length) == OE_OK);
+    claims = NULL;
+    claims_length = 0;
+
+    r = host_ocall_verify(
+        evidence, evidence_size, endorsements, endorsements_size);
+    OE_TEST_CODE(r, OE_OK);
+
     OE_TEST(oe_free_endorsements(endorsements) == OE_OK);
     OE_TEST(oe_free_evidence(evidence) == OE_OK);
-#endif
 }
 
 static void _test_get_evidence_fail()
@@ -227,7 +226,7 @@ void run_tests()
     _test_and_register_verifier();
 
     // Test get evidence + verify evidence with the proper claims.
-    _test_evidence_success(&_eeid_uuid);
+    _test_evidence_success();
 
     // Test failures.
     _test_get_evidence_fail();

--- a/tests/eeid_plugin/host/host.c
+++ b/tests/eeid_plugin/host/host.c
@@ -5,11 +5,13 @@
 
 #include <openenclave/attestation/sgx/eeid_verifier.h>
 #include <openenclave/host.h>
+#include <openenclave/internal/eeid.h>
 #include <openenclave/internal/plugin.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 
+#include "../../../common/attest_plugin.h"
 #include "../../../common/sgx/endorsements.h"
 #include "../../../host/sgx/quote.h"
 #include "../test_helpers.h"
@@ -41,6 +43,7 @@ void host_ocall_verify(
             &claims_length),
         OE_OK);
 
+    oe_free_claims(claims, claims_length);
     claims = NULL;
     claims_length = 0;
 
@@ -57,6 +60,8 @@ void host_ocall_verify(
             &claims,
             &claims_length),
         OE_OK);
+
+    oe_free_claims(claims, claims_length);
 }
 
 void host_remote_verify(oe_enclave_t* enclave)
@@ -157,6 +162,33 @@ void free_stuff(enclave_stuff_t* stuff)
     free(stuff->endorsements);
 }
 
+oe_result_t make_half_endorsements(
+    const oe_uuid_t* format_id,
+    const oe_eeid_t* eeid,
+    uint8_t** header_out,
+    size_t* header_out_size)
+{
+    size_t endorsements_size = sizeof(oe_eeid_endorsements_t) + eeid->data_size;
+    size_t header_size = sizeof(oe_attestation_header_t) + endorsements_size;
+    oe_attestation_header_t* header = malloc(header_size);
+    if (!header)
+        return OE_OUT_OF_MEMORY;
+    header->version = OE_ATTESTATION_HEADER_VERSION;
+    header->data_size = endorsements_size;
+    memcpy(&header->format_id, format_id, sizeof(oe_uuid_t));
+    oe_eeid_endorsements_t* endorsements = malloc(endorsements_size);
+    if (!endorsements)
+        return OE_OUT_OF_MEMORY;
+    endorsements->sgx_endorsements_size = 0;
+    endorsements->eeid_endorsements_size = eeid->data_size;
+    memcpy(endorsements->data, eeid->data, eeid->data_size);
+    oe_eeid_endorsements_hton(endorsements, header->data, header->data_size);
+    free(endorsements);
+    *header_out = (uint8_t*)header;
+    *header_out_size = header_size;
+    return OE_OK;
+}
+
 void start_enclave(const char* filename, uint32_t flags, enclave_stuff_t* stuff)
 {
     oe_result_t result = OE_UNEXPECTED;
@@ -183,6 +215,7 @@ void start_enclave(const char* filename, uint32_t flags, enclave_stuff_t* stuff)
     stuff->claims = NULL;
     stuff->claims_length = 0;
 
+    /* Get evidence */
     OE_TEST_CODE(
         get_eeid_evidence(
             stuff->enclave,
@@ -196,6 +229,7 @@ void start_enclave(const char* filename, uint32_t flags, enclave_stuff_t* stuff)
         OE_OK);
     OE_TEST(result == OE_OK);
 
+    /* Verify evidence without endorsements */
     OE_TEST(
         oe_verify_evidence(
             NULL,
@@ -208,6 +242,7 @@ void start_enclave(const char* filename, uint32_t flags, enclave_stuff_t* stuff)
             &stuff->claims,
             &stuff->claims_length) == OE_OK);
 
+    /* Verify evidence with endorsements */
     OE_TEST(
         oe_verify_evidence(
             NULL,
@@ -220,6 +255,30 @@ void start_enclave(const char* filename, uint32_t flags, enclave_stuff_t* stuff)
             &stuff->claims,
             &stuff->claims_length) == OE_OK);
 
+    /* Verify evidence with EEID endorsements (copy of EEID data), but without
+     * SGX endorsements */
+    uint8_t* half_endorsements;
+    size_t half_endorsements_size;
+    OE_TEST(
+        make_half_endorsements(
+            &((oe_attestation_header_t*)stuff->evidence)->format_id,
+            stuff->eeid,
+            &half_endorsements,
+            &half_endorsements_size) == OE_OK);
+    OE_TEST(
+        oe_verify_evidence(
+            NULL,
+            stuff->evidence,
+            stuff->evidence_out_size,
+            half_endorsements,
+            half_endorsements_size,
+            0,
+            0,
+            &stuff->claims,
+            &stuff->claims_length) == OE_OK);
+    free(half_endorsements);
+
+    /* Extract some claims */
     stuff->enclave_hash = NULL;
     for (size_t i = 0; i < stuff->claims_length; i++)
         if (strcmp(stuff->claims[i].name, OE_CLAIM_UNIQUE_ID) == 0)

--- a/tests/eeid_plugin/test_helpers.c
+++ b/tests/eeid_plugin/test_helpers.c
@@ -22,9 +22,9 @@ oe_result_t make_test_eeid(oe_eeid_t** eeid, size_t data_size)
     (*eeid)->version = 1;
     (*eeid)->data_size = data_size;
     for (size_t i = 0; i < data_size; i++)
-        (*eeid)->data[i] = 'a' + (i % 26);
+        (*eeid)->data[i] = (uint8_t)('a' + (i % 26));
     (*eeid)->data[data_size - 1] = 0;
-    (*eeid)->size_settings.num_heap_pages = 110 + (data_size / OE_PAGE_SIZE);
+    (*eeid)->size_settings.num_heap_pages = 120 + (data_size / OE_PAGE_SIZE);
     (*eeid)->size_settings.num_stack_pages = 50;
     (*eeid)->size_settings.num_tcs = 2;
     (*eeid)->tls_page_count = 1;


### PR DESCRIPTION
The EEID attester plugin incorrectly kept the underlying SGX endorsements in its evidence. This PR moves them into the right place and adds a test that illustrates how to use the EEID endorsements with and without the SGX endorsements.