### PR TITLE
Explicitly init OpenSSL to prevent the unsafe configuration

### DIFF
--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -20,6 +20,7 @@ if (OE_SGX)
       sgx/attester.c
       sgx/report.c
       sgx/collateralinfo.c
+      sgx/openssl_init.c
       sgx/start.S)
   if (WITH_EEID)
     list(APPEND PLATFORM_SRC ../common/sgx/eeid_verifier.c ../common/sgx/eeid.c

--- a/enclave/sgx/openssl_init.c
+++ b/enclave/sgx/openssl_init.c
@@ -1,0 +1,47 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/bits/types.h>
+
+/* Refer to openssl/crypto.h for the original definitions */
+#define OE_OPENSSL_INIT_NO_LOAD_CONFIG 0x00000080L
+
+/* Forward declarion */
+typedef struct oe_openssl_init_settings OE_OPENSSL_INIT_SETTINGS;
+int OE_OPENSSL_init_crypto(
+    uint64_t opts,
+    const OE_OPENSSL_INIT_SETTINGS* settings);
+
+/*
+ * Weak implementation that prevents link-time errors when an enclave
+ * does not link against OpenSSL libraries.
+ */
+int OE_OPENSSL_init_crypto(
+    uint64_t opts,
+    const OE_OPENSSL_INIT_SETTINGS* settings)
+{
+    OE_UNUSED(opts);
+    OE_UNUSED(settings);
+    return 0;
+}
+OE_WEAK_ALIAS(OE_OPENSSL_init_crypto, OPENSSL_init_crypto);
+
+/*
+ * Define the function as a constructor that ensures it is invoked before
+ * any OpenSSL APIs. Note that the constructor is only included by the linker
+ * when an enclave links against OpenSSL libraries (i.e., the
+ * OPENSSL_init_crypto symbol is included in the binary); i.e., when the enclave
+ * does not link against OpenSSL libraries, the constructor is discarded by the
+ * linker.
+ */
+__attribute__((constructor)) void oe_openssl_init()
+{
+    /*
+     * Invoke the API with the OPENSSL_INIT_NO_LOAD_CONFIG option effectively
+     * nullifies the OPENSSL_INIT_LOAD_CONFIG option. This prevents users to
+     * explicitly configure an OpenSSL application to load openssl.cnf from
+     * the host filesystem, which is considered as untrusted under the threat
+     * model of TEE.
+     */
+    OPENSSL_init_crypto(OE_OPENSSL_INIT_NO_LOAD_CONFIG, NULL);
+}


### PR DESCRIPTION
This PR adds a constructor to the `oeenclave` that explicitly invokes the OpenSSL `OPENSSL_init_crypto` API with the `OE_OPENSSL_INIT_NO_LOAD_CONFIG` option when an enclave links against OpenSSL libraries. Doing so effectively prevents users to initialize an OpenSSL program with the `OE_OPENSSL_INIT_LOAD_CONFIG`, which would load the `openssl.cnf` from untrusted host filesystem (with hard-coded path determined at compile-time). Such behavior is not recommended by OE based on the threat model and the lack of secure FS support.

Note that this PR does not break the user experiences of using OpenSSL APIs as `OPENSSL_init_crypto` is allowed to be invoked multiple times.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>