### PR TITLE
add cert verification error msg when extension is not matched

### DIFF
--- a/common/attest_plugin.c
+++ b/common/attest_plugin.c
@@ -463,7 +463,8 @@ oe_result_t oe_verify_attestation_certificate_with_evidence(
 
     // if there is no match
     if (oid_array_index == oid_array_count)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE_MSG(
+            OE_FAILURE, "No expected certificate extension matched", NULL);
 
     // find the extension
     OE_TRACE_VERBOSE("extract_x509_report_extension() succeeded");

--- a/common/sgx/tlsverifier.c
+++ b/common/sgx/tlsverifier.c
@@ -138,7 +138,8 @@ oe_result_t oe_verify_attestation_certificate(
     }
     else
     {
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE_MSG(
+            OE_FAILURE, "No expected certificate extension matched", NULL);
     }
 
     OE_TRACE_VERBOSE("extract_x509_report_extension() succeeded");

--- a/include/openenclave/attestation/verifier.h
+++ b/include/openenclave/attestation/verifier.h
@@ -186,6 +186,8 @@ typedef oe_result_t (*oe_verify_claims_callback_t)(
  * certificate before validating this evidence. An optional
  * claim_verify_callback could be passed in for a calling client to further
  * validate the claims of the enclave creating the certificate.
+ * OE_FAILURE is returned if the expected certificate extension OID is not
+ * found.
  * @param[in] cert_in_der a pointer to buffer holding certificate contents
  *  in DER format
  * @param[in] cert_in_der_len size of certificate buffer above

--- a/include/openenclave/enclave.h
+++ b/include/openenclave/enclave.h
@@ -658,6 +658,8 @@ typedef oe_result_t (
  * certificate before validating this evidence. An optional
  * enclave_identity_callback could be passed in for a calling client to further
  * validate the identity of the enclave creating the quote.
+ * OE_FAILURE is returned if the expected certificate extension OID is not
+ * found.
  * @param[in] cert_in_der a pointer to buffer holding certificate contents
  *  in DER format
  * @param[in] cert_in_der_len size of certificate buffer above

--- a/include/openenclave/host_verify.h
+++ b/include/openenclave/host_verify.h
@@ -65,6 +65,8 @@ typedef oe_result_t (
  * certificate before validating this evidence. An optional
  * enclave_identity_callback could be passed in for a calling client to further
  * validate the identity of the enclave creating the quote.
+ * OE_FAILURE is returned if the expected certificate extension OID is not
+ * found.
  * @param[in] cert_in_der a pointer to buffer holding certificate contents
  *  in DER format
  * @param[in] cert_in_der_len size of certificate buffer above


### PR DESCRIPTION
When oe_verify_attestation_certificate_with_evidence/oe_verify_attestation_certificate did not find an expected certificate extension OID, it returns a general OE_FAILURE.
Add error message for caller to determine such failure.

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>