### PR TITLE
Add gmtime.c to enclave/core

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -161,6 +161,7 @@ add_enclave_library(
   backtrace.c
   ctype.c
   debugmalloc.c
+  gmtime.c
   hexdump.c
   hostcalls.c
   intstr.c


### PR DESCRIPTION
I needed `gmtime_r`, but `gmtime.c` was missing. I'm not sure whether it was intentionally excluded, but I think it should be included.