### PR TITLE
PR TO EXPERIMANTAL DEV BRANCH: Thread-local support for multiple modules.

### DIFF
--- a/enclave/core/sgx/reloc.c
+++ b/enclave/core/sgx/reloc.c
@@ -62,6 +62,17 @@ static uint64_t _apply_relocations(
                 {
                     *dest = (uint64_t)(baseaddr + p->r_addend);
                 }
+                break;
+            }
+            case R_X86_64_TPOFF64:
+            {
+                /* TODO: Thread local relocation RHS does not depend on base
+                 * address and is a precomputed constant value. Therefore the
+                 * loader itself can apply the relocation before measurement.
+                 * NOTE: OE SDK performs this relocation differently.
+                 * See loadelf.c */
+                *dest = (uint64_t)p->r_addend;
+                break;
             }
         }
     }

--- a/host/sgx/loadelf.c
+++ b/host/sgx/loadelf.c
@@ -25,6 +25,7 @@
 #include "../memalign.h"
 #include "../strings.h"
 #include "enclave.h"
+#include "openenclave/bits/result.h"
 #include "sgxload.h"
 
 /* Forward declarations */
@@ -963,9 +964,12 @@ static void _update_module_offset(
 
 static oe_result_t _link_elf_images(
     oe_enclave_elf_image_t* image,
-    uint64_t* module_base)
+    uint64_t* module_base,
+    int64_t* previous_module_tls_start_offset)
 {
     oe_result_t result = OE_UNEXPECTED;
+    int64_t module_tls_start_offset = oe_get_module_tls_start_offset(
+        &image->link_info, *previous_module_tls_start_offset);
 
     OE_TRACE_INFO("Performing program linking\n");
     image->link_info.base_rva = *module_base;
@@ -1044,14 +1048,43 @@ static oe_result_t _link_elf_images(
                         "symbol %s not found in needed images\n", name);
                 break;
             }
+            case R_X86_64_TPOFF64:
+            {
+                // Performing thread-local relocations requires knowledge of
+                // the module's tls start offset. Since the relocations from
+                // different modules are aggregated into a single array of
+                // relocations, it is not possible for the enclave to figure out
+                // which module each relocation came from. As a result, enclave
+                // cannot perform thread local relocations.
+                // To address this, the loader performs part of the calculation
+                // that requires the module's tls start offset. It uses the
+                // r_addend field to save this result. The enclave does the rest
+                // of thread local relocation, interpreting r_addend differently
+                // from how MUSL would interpret it.
+                //
+                // module_tls_start_offset contains negative value that is added
+                // to FS register to obtain the starting address of this
+                // module's thread local data. Adding p->r_added gives this
+                // thread local variable's FS relative offset. Store this value
+                // back into r_addend.
+                p->r_offset += *module_base;
+                p->r_addend =
+                    (elf64_sxword_t)module_tls_start_offset - p->r_addend;
+                break;
+            }
         }
     }
 
     /* Repeat for the rest of the images */
     *module_base += image->image_size;
+    /* The tls end for the next module is the the tls start of this module */
+    *previous_module_tls_start_offset = module_tls_start_offset;
     for (size_t i = 0; i < image->num_needed_images; i++)
     {
-        OE_CHECK(_link_elf_images(&image->needed_images[i], module_base));
+        OE_CHECK(_link_elf_images(
+            &image->needed_images[i],
+            module_base,
+            previous_module_tls_start_offset));
     }
 
     result = OE_OK;
@@ -1171,7 +1204,6 @@ static oe_result_t _patch_elf_image(
     oe_result_t result = OE_UNEXPECTED;
     oe_sgx_enclave_properties_t* oeprops;
     uint64_t enclave_rva = 0;
-    uint64_t aligned_size = 0;
     uint64_t module_base = 0;
 
     oeprops =
@@ -1206,43 +1238,31 @@ static oe_result_t _patch_elf_image(
     oeprops->image_info.heap_rva =
         oeprops->image_info.reloc_rva + oeprops->image_info.reloc_size;
 
-    /* TODO: Remove these as special globals once thread init for multiple
-     * modules is added */
-    if (image->link_info.tdata_size)
-    {
-        _set_uint64_t_dynamic_symbol_value(
-            image, "_tdata_rva", image->link_info.tdata_rva);
-        _set_uint64_t_dynamic_symbol_value(
-            image, "_tdata_size", image->link_info.tdata_size);
-        _set_uint64_t_dynamic_symbol_value(
-            image, "_tdata_align", image->link_info.tdata_align);
-
-        aligned_size += oe_round_up_to_multiple(
-            image->link_info.tdata_size, image->link_info.tdata_align);
-    }
-    if (image->link_info.tbss_size)
-    {
-        _set_uint64_t_dynamic_symbol_value(
-            image, "_tbss_size", image->link_info.tbss_size);
-        _set_uint64_t_dynamic_symbol_value(
-            image, "_tbss_align", image->link_info.tbss_align);
-
-        aligned_size += oe_round_up_to_multiple(
-            image->link_info.tbss_size, image->link_info.tbss_align);
-    }
-
-    aligned_size = oe_round_up_to_multiple(aligned_size, OE_PAGE_SIZE);
-    _set_uint64_t_dynamic_symbol_value(
-        image,
-        "_td_from_tcs_offset",
-        aligned_size + OE_SGX_NUM_CONTROL_PAGES * OE_PAGE_SIZE);
-    context->num_tls_pages = aligned_size / OE_PAGE_SIZE;
-
     /* Clear the hash when taking the measure */
     memset(oeprops->sigstruct, 0, sizeof(oeprops->sigstruct));
 
     /* Dynamically link the enclave and its needed modules */
-    OE_CHECK(_link_elf_images(image, &module_base));
+    {
+        int64_t tls_start_offset = 0;
+        OE_CHECK(_link_elf_images(image, &module_base, &tls_start_offset));
+
+        // Assert that tls_start_offset is a negative value.
+        if (tls_start_offset > 0)
+        {
+            OE_TRACE_ERROR("tls starting offset is non negative.");
+            OE_RAISE(OE_FAILURE);
+        }
+
+        // Compute the offset of td from total thread local size.
+        uint64_t total_tls_size = (uint64_t)-tls_start_offset;
+        uint64_t aligned_total_tls_size =
+            oe_round_up_to_multiple(total_tls_size, OE_PAGE_SIZE);
+        _set_uint64_t_dynamic_symbol_value(
+            image,
+            "_td_from_tcs_offset",
+            aligned_total_tls_size + OE_SGX_NUM_CONTROL_PAGES * OE_PAGE_SIZE);
+        context->num_tls_pages = aligned_total_tls_size / OE_PAGE_SIZE;
+    }
 
     /* Patch the link info for all loaded modules as a global array
      *

--- a/include/openenclave/internal/link.h
+++ b/include/openenclave/internal/link.h
@@ -6,6 +6,8 @@
 
 #include <openenclave/bits/defs.h>
 #include <openenclave/bits/types.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/utils.h>
 
 OE_EXTERNC_BEGIN
 
@@ -36,6 +38,44 @@ typedef struct _oe_module_link_info
     uint64_t fini_array_size;
 
 } oe_module_link_info_t;
+
+/* thread-local management functions shared by host and enclave */
+OE_INLINE size_t oe_module_has_tls(const oe_module_link_info_t* link_info)
+{
+    return (link_info->tdata_size || link_info->tbss_size);
+}
+
+OE_INLINE int64_t oe_get_module_tls_start_offset(
+    const oe_module_link_info_t* link_info,
+    int64_t previous_module_tls_start_offset)
+{
+    // Previous module's start is the current module's end.
+    int64_t tls_end = previous_module_tls_start_offset;
+
+    if (oe_module_has_tls(link_info))
+    {
+        // Choose the maximum of the two alignments. This is consistent with
+        // PT_TLS program header that has a single alignment value (the
+        // maximum).
+        uint64_t alignment = link_info->tdata_align;
+        if (link_info->tbss_align > alignment)
+            alignment = link_info->tbss_align;
+
+        // Round down the end to multiple of alignment. We round down because
+        // current module's tls will lie *before* the previous module's tls.
+        // Rounding down makes sure that current module's tls will not overlap
+        // previous module's tls due to alignment/rounding.
+        tls_end = (tls_end / (int64_t)alignment) * (int64_t)alignment;
+
+        size_t tls_size =
+            oe_round_up_to_multiple(link_info->tdata_size, alignment) +
+            oe_round_up_to_multiple(link_info->tbss_size, alignment);
+
+        return tls_end - (int64_t)tls_size;
+    }
+
+    return tls_end;
+}
 
 OE_EXTERNC_END
 

--- a/tests/ldd/enc/dep_1a/CMakeLists.txt
+++ b/tests/ldd/enc/dep_1a/CMakeLists.txt
@@ -25,15 +25,11 @@ target_compile_options(
     # This allows aggressively eliminating unused code.
     -ffunction-sections
     -fdata-sections
-    # "The default without -fpic is 'initial-exec'; with -fpic the
-    # default is 'global-dynamic'."
-    # https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
-    #
-    # Enclaves are linked using -pie and therefore global-dynamic is
-    # too conservative. Of the two efficient static thread-local
-    # storage models, inital-exec and local-exec, we choose the most
-    # optimal one.
-    -ftls-model=local-exec
+    # The secondary modules are compiled with -ftls-model=initial-exec flag.
+    # This informs the compiler that the modules will be loaded along with the main module,
+    # rather than being dynamically loaded via dlopen. In this case, the compiler
+    # will generate R_X86_64_TPOFF relocations for thread-local variables.
+    -ftls-model=initial-exec
     # Disable builtin functions for enclaves, but only in our build.
     #
     # We do this to work-around compiler bugs (see #1429) due to our
@@ -52,7 +48,10 @@ target_link_libraries(
     -nostdlib
     -nodefaultlibs
     -nostartfiles
-    -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,-pie,--build-id
+    -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,--build-id
+    # Secondary modules are linked as position independent libraries (-pic) instead
+    # of position independent executables (-pie).
+    -Wl,-pic
     -Wl,-z,noexecstack
     -Wl,-z,now
     -Wl,-gc-sections)

--- a/tests/ldd/enc/dep_1a/dep_2a/CMakeLists.txt
+++ b/tests/ldd/enc/dep_1a/dep_2a/CMakeLists.txt
@@ -22,15 +22,11 @@ target_compile_options(
     # This allows aggressively eliminating unused code.
     -ffunction-sections
     -fdata-sections
-    # "The default without -fpic is 'initial-exec'; with -fpic the
-    # default is 'global-dynamic'."
-    # https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
-    #
-    # Enclaves are linked using -pie and therefore global-dynamic is
-    # too conservative. Of the two efficient static thread-local
-    # storage models, inital-exec and local-exec, we choose the most
-    # optimal one.
-    -ftls-model=local-exec
+    # The secondary modules are compiled with -ftls-model=initial-exec flag.
+    # This informs the compiler that the modules will be loaded along with the main module,
+    # rather than being dynamically loaded via dlopen. In this case, the compiler
+    # will generate R_X86_64_TPOFF relocations for thread-local variables.
+    -ftls-model=initial-exec
     # Disable builtin functions for enclaves, but only in our build.
     #
     # We do this to work-around compiler bugs (see #1429) due to our
@@ -48,7 +44,10 @@ target_link_libraries(
     -nostdlib
     -nodefaultlibs
     -nostartfiles
-    -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,-pie,--build-id
+    -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,--build-id
+    # Secondary modules are linked as position independent libraries (-pic) instead
+    # of position independent executables (-pie).
+    -Wl,-pic
     -Wl,-z,noexecstack
     -Wl,-z,now
     -Wl,-gc-sections)

--- a/tests/ldd/enc/dep_1b/CMakeLists.txt
+++ b/tests/ldd/enc/dep_1b/CMakeLists.txt
@@ -12,18 +12,30 @@ set_target_properties(ldd_enc_dep_1b PROPERTIES LIBRARY_OUTPUT_DIRECTORY
 target_include_directories(ldd_enc_dep_1b PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_compile_options(
   ldd_enc_dep_1b
-  PUBLIC -fPIC -nostdinc -fstack-protector-strong
-         # Preserve frame-pointer in Release mode to enable oe_backtrace.
-         -fno-omit-frame-pointer)
+  PUBLIC
+    -fPIC
+    -nostdinc
+    -fstack-protector-strong
+    # The secondary modules are compiled with -ftls-model=initial-exec flag.
+    # This informs the compiler that the modules will be loaded along with the main module,
+    # rather than being dynamically loaded via dlopen. In this case, the compiler
+    # will generate R_X86_64_TPOFF relocations for thread-local variables.
+    -ftls-model=initial-exec
+    # Preserve frame-pointer in Release mode to enable oe_backtrace.
+    -fno-omit-frame-pointer)
 
 target_link_libraries(
   ldd_enc_dep_1b
-  PRIVATE -nostdlib
-          -nodefaultlibs
-          -nostartfiles
-          # Removed -Bsymbolic to trigger generation of relocations.
-          # Removed -pie to create a shared library and instead used pic.
-          -Wl,--no-undefined,-Bstatic,--export-dynamic,-pic,--build-id
-          -Wl,-z,noexecstack
-          -Wl,-z,now
-          -Wl,-gc-sections)
+  PRIVATE
+    -nostdlib
+    -nodefaultlibs
+    -nostartfiles
+    # Removed -Bsymbolic to trigger generation of relocations.
+    # Removed -pie to create a shared library and instead used pic.
+    -Wl,--no-undefined,-Bstatic,--export-dynamic,--build-id
+    # Secondary modules are linked as position independent libraries (-pic) instead
+    # of position independent executables (-pie).
+    -Wl,-pic
+    -Wl,-z,noexecstack
+    -Wl,-z,now
+    -Wl,-gc-sections)

--- a/tests/ldd/enc/dep_common.c.in
+++ b/tests/ldd/enc/dep_common.c.in
@@ -3,9 +3,11 @@
 
 #include <openenclave/bits/types.h>
 
+__thread int tls_var_@LDD_TEST_DEP_SUFFIX@ = @LDD_TEST_DEP_MAGIC@;
+
 int multiply_local_const_@LDD_TEST_DEP_SUFFIX@(int a)
 {
-    const int magic = @LDD_TEST_DEP_MAGIC@;
+    const int magic = tls_var_@LDD_TEST_DEP_SUFFIX@;
     return a * magic;
 }
 


### PR DESCRIPTION
The main module uses -ftls-model=local-exec flag.
This is the most optimal. The compiler/linker hard-codes the offsets from FS
since it knows that the main module is the first one to be loaded.

The secondary modules are compiles with -ftls-model=initial-exec flag.
This informs the compiler that the modules will be loaded along with the main module,
rather than being dynamically loaded via dlopen. In this case, the compiler
will generate R_X86_64_TPOFF relocations for thread-local variables.
Each thread-local variable has a corresponding offset variable. In order to
access a thread-local variable, the value of the corresponding offset variable is
first read and then added to FS. Since thread-locals have negative offsets, this
implies that the offset variables have negative values.

The loader places the thread local sections (tdata + tbss) of the modules one after
the other, starting with the main module. The linker initializes the offset variables
to offsets within the module's tls section. The loader converts these offsets to values
to values relative to the start of the aggregated tls section. Care is taken to account
for possible different alignments of the different tls sections.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>