### PR TITLE
Update VS extension to OE 0.11

### DIFF
--- a/devex/vsextension/ItemTemplates/oehost/host.vstemplate
+++ b/devex/vsextension/ItemTemplates/oehost/host.vstemplate
@@ -17,7 +17,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.8.1-c3b6262c-3" />
+      <package id="open-enclave-cross" version="0.11.0-rc1-cbe4dedc-2" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.edl
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.edl
@@ -1,4 +1,7 @@
 enclave {
+    from "openenclave/edl/syscall.edl" import *;
+    from "platform.edl" import *;
+
     trusted {
         /* define ECALLs here. */
         public int ecall_DoWorkInEnclave();

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
@@ -169,12 +169,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\open-enclave-cross.0.8.1-c3b6262c-3\build\native\open-enclave-cross.targets" Condition="Exists('..\packages\open-enclave-cross.0.8.1-c3b6262c-3\build\native\open-enclave-cross.targets')" />
+    <Import Project="..\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2\build\native\open-enclave-cross.targets" Condition="Exists('..\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2\build\native\open-enclave-cross.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\open-enclave-cross.0.8.1-c3b6262c-3\build\native\open-enclave-cross.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\open-enclave-cross.0.8.1-c3b6262c-3\build\native\open-enclave-cross.targets'))" />
+    <Error Condition="!Exists('..\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2\build\native\open-enclave-cross.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2\build\native\open-enclave-cross.targets'))" />
   </Target>
 </Project>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
@@ -32,7 +32,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.8.1-c3b6262c-3" />
+      <package id="open-enclave-cross" version="0.11.0-rc1-cbe4dedc-2" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/packages.config
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="open-enclave-cross" version="0.8.1-c3b6262c-3" targetFramework="native" />
+  <package id="open-enclave-cross" version="0.11.0-rc1-cbe4dedc-2" targetFramework="native" />
 </packages>

--- a/devex/vsextension/ProjectTemplates/oeenclave-windows/MyEnclave.edl
+++ b/devex/vsextension/ProjectTemplates/oeenclave-windows/MyEnclave.edl
@@ -1,4 +1,7 @@
 enclave {
+    from "openenclave/edl/syscall.edl" import *;
+    from "platform.edl" import *;
+
     trusted {
         /* define ECALLs here. */
         public int ecall_DoWorkInEnclave();

--- a/devex/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
+++ b/devex/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
@@ -33,7 +33,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.8.1-c3b6262c-3" />
+      <package id="open-enclave-cross" version="0.11.0-rc1-cbe4dedc-2" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectWizard/ImportEnclaveCommand.cs
+++ b/devex/vsextension/ProjectWizard/ImportEnclaveCommand.cs
@@ -345,7 +345,7 @@ namespace OpenEnclaveSDK
                     // Add nuget package to project.
                     // See https://stackoverflow.com/questions/41803738/how-to-programmatically-install-a-nuget-package/41895490#41895490
                     // and more particularly https://docs.microsoft.com/en-us/nuget/visual-studio-extensibility/nuget-api-in-visual-studio
-                    var packageVersions = new Dictionary<string, string>() { { "open-enclave-cross", "0.8.1-c3b6262c-3" } };
+                    var packageVersions = new Dictionary<string, string>() { { "open-enclave-cross", "0.11.0-rc1-cbe4dedc-2" } };
                     var componentModel = (IComponentModel)(await this.ServiceProvider.GetServiceAsync(typeof(SComponentModel)));
                     var packageInstaller = componentModel.GetService<IVsPackageInstaller2>();
                     packageInstaller.InstallPackagesFromVSExtensionRepository(

--- a/devex/vsextension/ProjectWizard/VSExtension.csproj
+++ b/devex/vsextension/ProjectWizard/VSExtension.csproj
@@ -3,13 +3,15 @@
      Licensed under the MIT License.
   -->
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <UseCodebase>true</UseCodebase>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -28,7 +30,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenEnclaveSDK</RootNamespace>
     <AssemblyName>OpenEnclaveSDK</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
@@ -152,7 +154,7 @@
       <ResourceName>Menus.ctmenu</ResourceName>
       <SubType>Designer</SubType>
     </VSCTCompile>
-    <Content Include="Packages\open-enclave-cross.0.8.1-c3b6262c-3.nupkg">
+    <Content Include="Packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="VCTargets\OpenEnclave.Cpp.Common.props">
@@ -197,32 +199,41 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\EnvDTE.8.0.2\lib\net10\EnvDTE.dll</HintPath>
+      <HintPath>..\packages\EnvDTE.16.7.30328.74\lib\net45\EnvDTE.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="EnvDTE80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\EnvDTE80.8.0.3\lib\net10\EnvDTE80.dll</HintPath>
+      <HintPath>..\packages\EnvDTE80.16.7.30328.74\lib\net45\EnvDTE80.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="MessagePack, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b4a0369545f0a1be, processorArchitecture=MSIL">
+      <HintPath>..\packages\MessagePack.2.1.194\lib\netstandard2.0\MessagePack.dll</HintPath>
+    </Reference>
+    <Reference Include="MessagePack.Annotations, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b4a0369545f0a1be, processorArchitecture=MSIL">
+      <HintPath>..\packages\MessagePack.Annotations.2.1.194\lib\netstandard2.0\MessagePack.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.ComponentModelHost.14.0.25424\lib\net45\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.ComponentModelHost.16.6.255\lib\net472\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.15.0.26201\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.16.6.255\lib\net472\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.ImageCatalog, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.ImageCatalog.15.9.28307\lib\net45\Microsoft.VisualStudio.ImageCatalog.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.ImageCatalog, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.ImageCatalog.16.7.30328.74\lib\net472\Microsoft.VisualStudio.ImageCatalog.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Imaging, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Imaging.15.9.28307\lib\net45\Microsoft.VisualStudio.Imaging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.14.3.26930\lib\net20\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.16.7.30328.74\lib\net45\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6071\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.16.7.30328.74\lib\net45\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.14.0.14.3.25407\lib\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
@@ -243,70 +254,150 @@
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.14.0.15.0.25405\lib\net45\Microsoft.VisualStudio.Shell.Immutable.14.0.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6072\lib\net11\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.16.7.30328.74\lib\net45\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.10.0.10.0.30320\lib\net20\Microsoft.VisualStudio.Shell.Interop.10.0.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.10.0.16.7.30328.74\lib\net45\Microsoft.VisualStudio.Shell.Interop.10.0.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.11.0.11.0.61031\lib\net20\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.11.0.16.7.30328.74\lib\net45\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.12.0.12.0.30111\lib\net20\Microsoft.VisualStudio.Shell.Interop.12.0.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.12.0.16.7.30328.74\lib\net45\Microsoft.VisualStudio.Shell.Interop.12.0.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.14.3.26929\lib\net20\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.16.7.30328.74\lib\net45\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.8.0.8.0.50728\lib\net11\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.8.0.16.7.30328.74\lib\net45\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.9.0.9.0.30730\lib\net11\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.9.0.16.7.30328.74\lib\net45\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6071\lib\net11\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.16.7.30328.74\lib\net45\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50728\lib\net11\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.16.7.30328.74\lib\net45\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.8.209\lib\net46\Microsoft.VisualStudio.Threading.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=16.7.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Threading.16.7.56\lib\net472\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Utilities.15.9.28307\lib\net46\Microsoft.VisualStudio.Utilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.3.58\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.5.31\lib\netstandard2.0\Microsoft.VisualStudio.Validation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <SpecificVersion>False</SpecificVersion>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.7.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.VisualStudio, Version=4.9.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.VisualStudio.4.9.3\lib\net46\NuGet.VisualStudio.dll</HintPath>
+    <Reference Include="Nerdbank.Streams, Version=2.5.0.0, Culture=neutral, PublicKeyToken=cac503e1823ce71c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nerdbank.Streams.2.5.76\lib\netstandard2.0\Nerdbank.Streams.dll</HintPath>
+    </Reference>
+    <Reference Include="netstandard" />
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.VisualStudio, Version=5.7.0.7, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.VisualStudio.5.7.0\lib\net472\NuGet.VisualStudio.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\stdole.7.0.3303\lib\net10\stdole.dll</HintPath>
+      <HintPath>..\packages\stdole.16.7.30328.74\lib\net45\stdole.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="StreamJsonRpc, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\StreamJsonRpc.1.3.23\lib\net45\StreamJsonRpc.dll</HintPath>
+    <Reference Include="StreamJsonRpc, Version=2.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\StreamJsonRpc.2.5.46\lib\netstandard2.0\StreamJsonRpc.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.7.1\lib\net461\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Pipelines, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.4.7.2\lib\net461\System.IO.Pipelines.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.WebSockets, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.WebSockets.4.3.0\lib\net46\System.Net.WebSockets.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.AccessControl, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.7.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.11.1\lib\net461\System.Threading.Tasks.Dataflow.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
@@ -321,9 +412,16 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.209\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.209\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.7.9\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.7.9\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.CSharp.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.VisualBasic.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
@@ -366,7 +464,7 @@
       </Content>
     </ItemGroup>
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets. -->
   <Target Name="BeforeBuild">
     <CallTarget Targets="PlaceTemplates" RunEachTargetSeparately="true" />
@@ -378,20 +476,23 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.27\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.27\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.209\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.209\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
-    <Error Condition="!Exists('..\packages\NuGet.VisualStudio.4.9.3\build\NuGet.VisualStudio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGet.VisualStudio.4.9.3\build\NuGet.VisualStudio.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.7.9\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.7.9\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.27\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.27\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.209\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.209\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
-  <Import Project="..\packages\NuGet.VisualStudio.4.9.3\build\NuGet.VisualStudio.targets" Condition="Exists('..\packages\NuGet.VisualStudio.4.9.3\build\NuGet.VisualStudio.targets')" />
   <PropertyGroup>
-    <PreBuildEvent>curl --proto "=https" --tlsv1.2 -sSfL https://www.nuget.org/api/v2/package/open-enclave-cross/0.8.1-c3b6262c-3 --output $(ProjectDir)\packages\open-enclave-cross.0.8.1-c3b6262c-3.nupkg -z $(ProjectDir)\packages\open-enclave-cross.0.8.1-c3b6262c-3.nupkg</PreBuildEvent>
+    <PreBuildEvent>curl --proto "=https" --tlsv1.2 -sSfL https://www.nuget.org/api/v2/package/open-enclave-cross/0.11.0-rc1-cbe4dedc-2 --output $(ProjectDir)\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2.nupkg -z $(ProjectDir)\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2.nupkg</PreBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.7.9\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.7.9\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
+  <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets')" />
+  <Import Project="..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets" Condition="Exists('..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.targets')" />
 </Project>

--- a/devex/vsextension/ProjectWizard/WizardImplementation.cs
+++ b/devex/vsextension/ProjectWizard/WizardImplementation.cs
@@ -135,7 +135,7 @@ namespace OpenEnclaveSDK
                 // User picked a specific board for which we have binaries in the nuget package.
                 string solutionDirectory;
                 replacementsDictionary.TryGetValue("$solutiondirectory$", out solutionDirectory);
-                oeFolder = Path.Combine(solutionDirectory, "packages\\open-enclave-cross.0.8.1-c3b6262c-3\\lib\\native\\linux\\optee\\v3.6.0\\" + board);
+                oeFolder = Path.Combine(solutionDirectory, "packages\\open-enclave-cross.0.11.0-rc1-cbe4dedc-2\\lib\\native\\linux\\optee\\v3.6.0\\" + board);
             }
             else
             {

--- a/devex/vsextension/ProjectWizard/app.config
+++ b/devex/vsextension/ProjectWizard/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.8.0.0" newVersion="15.8.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-16.7.0.0" newVersion="16.7.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Shell.Immutable.11.0" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -32,16 +32,52 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.ImageCatalog" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-16.0.0.0" newVersion="16.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.ComponentModelHost" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-16.0.0.0" newVersion="16.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.6.5.0" newVersion="4.6.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-16.0.0.0" newVersion="16.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.1" newVersion="4.0.2.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/devex/vsextension/ProjectWizard/packages.config
+++ b/devex/vsextension/ProjectWizard/packages.config
@@ -1,40 +1,68 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EnvDTE" version="8.0.2" targetFramework="net461" />
-  <package id="EnvDTE80" version="8.0.3" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.ComponentModelHost" version="14.0.25424" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.ImageCatalog" version="15.9.28307" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Imaging" version="15.9.28307" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.3.26930" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6071" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.SDK.Analyzers" version="15.8.36" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.SDK.EmbedInteropTypes" version="15.0.27" targetFramework="net461" />
+  <package id="EnvDTE" version="16.7.30328.74" targetFramework="net461" />
+  <package id="EnvDTE80" version="16.7.30328.74" targetFramework="net461" />
+  <package id="MessagePack" version="2.1.194" targetFramework="net472" />
+  <package id="MessagePack.Annotations" version="2.1.194" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.0" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.VisualStudio.ComponentModelHost" version="16.6.255" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="16.6.255" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.ImageCatalog" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Imaging" version="15.9.28307" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.OLE.Interop" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.SDK.Analyzers" version="16.7.9" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.SDK.EmbedInteropTypes" version="15.0.34" targetFramework="net472" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.3.25407" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.26201" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.26201" targetFramework="net472" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="15.0.25415" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.11.0" version="15.0.25415" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.12.0" version="15.0.25415" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.14.0" version="15.0.25405" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6072" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30320" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61031" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.12.0" version="12.0.30111" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" version="14.3.26929" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50728" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30730" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6071" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50728" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Threading" version="15.8.209" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.8.209" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Utilities" version="15.9.28307" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Validation" version="15.3.58" targetFramework="net461" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.9.3032" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.VisualStudio.Shell.Interop" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.10.0" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.11.0" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.12.0" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="16.7.30328.74" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Threading" version="16.7.56" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="16.7.56" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.9.28307" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Validation" version="15.5.31" targetFramework="net461" />
+  <package id="Microsoft.VSSDK.BuildTools" version="16.7.3069" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.Win32.Registry" version="4.7.0" targetFramework="net472" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net461" />
-  <package id="NuGet.VisualStudio" version="4.9.3" targetFramework="net461" />
-  <package id="stdole" version="7.0.3303" targetFramework="net461" />
-  <package id="StreamJsonRpc" version="1.3.23" targetFramework="net461" />
+  <package id="Nerdbank.Streams" version="2.5.76" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="NuGet.VisualStudio" version="5.7.0" targetFramework="net472" />
+  <package id="stdole" version="16.7.30328.74" targetFramework="net461" />
+  <package id="StreamJsonRpc" version="2.5.46" targetFramework="net461" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Collections.Immutable" version="1.7.1" targetFramework="net472" />
+  <package id="System.ComponentModel.Composition" version="4.7.0" targetFramework="net472" />
+  <package id="System.IO" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.Pipelines" version="4.7.2" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
+  <package id="System.Net.WebSockets" version="4.3.0" targetFramework="net461" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Reflection.Emit" version="4.7.0" targetFramework="net472" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
+  <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net472" />
+  <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.11.1" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" requireReinstallation="true" />
   <package id="VSSDK.DTE" version="7.0.4" targetFramework="net461" />
   <package id="VSSDK.IDE" version="7.0.4" targetFramework="net461" />
   <package id="VSSDK.IDE.12" version="12.0.4" targetFramework="net461" />

--- a/devex/vsextension/ProjectWizard/source.extension.vsixmanifest
+++ b/devex/vsextension/ProjectWizard/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
   -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="OpenEnclaveVisualStudioExtension-1" Version="0.7.29" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="OpenEnclaveVisualStudioExtension-1" Version="0.11.30" Language="en-US" Publisher="Microsoft" />
         <DisplayName>Open Enclave - Preview</DisplayName>
         <Description xml:space="preserve">Support for developing and debugging Trusted Execution Environment enclaves that can run on both SGX and TrustZone, and using them from your own applications.</Description>
         <MoreInfo>https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/visualstudio_dev.md</MoreInfo>
@@ -19,7 +19,7 @@
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveWindowsProject.zip" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveLinuxProject.zip" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
-        <Asset Type="open-enclave-cross.0.8.1-c3b6262c-3.nupkg" d:Source="File" Path="Packages\open-enclave-cross.0.8.1-c3b6262c-3.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="open-enclave-cross.0.11.0-rc1-cbe4dedc-2.nupkg" d:Source="File" Path="Packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="ItemTemplates\Built\OEHostItem.zip" />
     </Assets>

--- a/devex/vsextension/VSExtension.sln
+++ b/devex/vsextension/VSExtension.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.271
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VS Extension", "ProjectWizard\VS Extension.csproj", "{7942F7C6-D426-4123-B825-CE7BD3CBAB33}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VS Extension", "ProjectWizard\VSExtension.csproj", "{7942F7C6-D426-4123-B825-CE7BD3CBAB33}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/devex/vsextension/msbuild/edl-t.targets
+++ b/devex/vsextension/msbuild/edl-t.targets
@@ -11,6 +11,6 @@
 
   <Target Name="_OEGenerateTrustedCode" BeforeTargets="ClCompile" Inputs="%(EdlItem.Identity)" Outputs="%(EdlItem.Identity)_t.h;%(EdlItem.Identity)_t.c;%(EdlItem.Identity)_args.h">
     <Message Text="Creating trusted proxy/bridge routines: %(EdlItem.Identity)" />
-    <Exec Command='"$(OEEdger8rPath)" --trusted "%(EdlItem.Identity)" --search-path "$(OEIncludePath)"'/>
+    <Exec Command='"$(OEEdger8rPath)" --trusted "%(EdlItem.Identity)" --search-path "$(OEIncludePath)" --search-path "$(OEPlatformEdlPath)"'/>
   </Target>  
 </Project>

--- a/devex/vsextension/msbuild/edl-u.targets
+++ b/devex/vsextension/msbuild/edl-u.targets
@@ -11,6 +11,6 @@
 
   <Target Name="_OEGenerateUntrustedCode" BeforeTargets="ClCompile" Inputs="%(EdlItem.Identity)" Outputs="%(EdlItem.Identity)_u.h;%(EdlItem.Identity)_u.c;%(EdlItem.Identity)_args.h">
     <Message Text="Creating untrusted proxy/bridge routines: %(EdlItem.Identity)" />
-    <Exec Command='"$(OEEdger8rPath)" --untrusted "%(EdlItem.Identity)" --search-path "$(OEIncludePath)"'/>
+    <Exec Command='"$(OEEdger8rPath)" --untrusted "%(EdlItem.Identity)" --search-path "$(OEIncludePath)" --search-path "$(OEPlatformEdlPath)"'/>
   </Target>  
 </Project>

--- a/devex/vsextension/msbuild/open-enclave-cross.targets
+++ b/devex/vsextension/msbuild/open-enclave-cross.targets
@@ -15,12 +15,11 @@
 
     <!-- Expose oeedger8r.exe -->
     <PropertyGroup>
-        <OEBinPath>$(MSBuildThisFileDirectory)..\..\tools\win\flc\</OEBinPath>
+        <OEBinPath>$(MSBuildThisFileDirectory)..\..\tools\win\default\</OEBinPath>
         <OEEdger8rPath>$(OEBinPath)oeedger8r.exe</OEEdger8rPath>
         <OELibPath>$(MSBuildThisFileDirectory)..\..\lib\native\</OELibPath>
         <OESignPath>$(OEBinPath)oesign.exe</OESignPath>
         <OEDebugRTPath>$(OEBinPath)oedebugrt.dll</OEDebugRTPath>
-        <SgxDcapQlPath>$(OEBinPath)sgx_dcap_ql.dll</SgxDcapQlPath>
     </PropertyGroup>
 
     <!--
@@ -89,7 +88,7 @@
                 <OEIsSgx>True</OEIsSgx>
                 <OEIsTz>False</OEIsTz>
                 <OEIsSim>False</OEIsSim>
-                <OEPlatformPathSegment>sgx\flc</OEPlatformPathSegment>
+                <OEPlatformPathSegment>sgx\default</OEPlatformPathSegment>
             </PropertyGroup>
         </When>
         <When Condition="('$(Configuration)' == 'Simulation') And ($(OEIsX86) == True Or $(OEIsX64) == True)">
@@ -97,7 +96,7 @@
                 <OEIsSgx>True</OEIsSgx>
                 <OEIsTz>False</OEIsTz>
                 <OEIsSim>True</OEIsSim>
-                <OEPlatformPathSegment>sgx\flc</OEPlatformPathSegment>
+                <OEPlatformPathSegment>sgx\default</OEPlatformPathSegment>
             </PropertyGroup>
         </When>
         <When Condition="('$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Release' Or '$(Configuration)' == 'TZ-OPTEE-Debug') And ($(OEIsARM) == True)">
@@ -139,6 +138,7 @@
         <When Condition="$(OEIsSgx) == True">
             <PropertyGroup>
                 <OEIncludePath>$(MSBuildThisFileDirectory)$(OEOSPathSegment)\$(OEPlatformPathSegment)\$(OEConfigurationPathSegment)\include</OEIncludePath>
+                <OEPlatformEdlPath>$(OEIncludePath)\openenclave\edl\sgx</OEPlatformEdlPath>
                 <OEHostLibPath>$(OELibPath)$(OEOSPathSegment)\$(OEPlatformPathSegment)\$(OEConfigurationPathSegment)\host\$(OECompilerPathSegment)</OEHostLibPath>
                 <OEEnclaveLibPath>$(OELibPath)$(OEOSPathSegment)\$(OEPlatformPathSegment)\$(OEConfigurationPathSegment)\enclave\clang-7</OEEnclaveLibPath>
             </PropertyGroup>
@@ -351,13 +351,13 @@
     <!-- Additional Dependencies for Hosts -->
     <ItemDefinitionGroup Condition="'$(OEType)' != 'Enclave' And $(OEIsLinux) == False And $(OEIsSgx) == True">
         <Link>
-            <AdditionalDependencies>oehost.lib;ws2_32.lib;bcrypt.lib;crypt32.lib;synchronization.lib;sgx_enclave_common.lib;sgx_dcap_ql.lib;%(AdditionalDependencies)</AdditionalDependencies>
+            <AdditionalDependencies>oehost.lib;shlwapi.lib;ws2_32.lib;bcrypt.lib;crypt32.lib;synchronization.lib;%(AdditionalDependencies)</AdditionalDependencies>
             <AdditionalLibraryDirectories>$(OEHostLibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
         </Link>
     </ItemDefinitionGroup>
     <ItemDefinitionGroup Condition="'$(OEType)' != 'Enclave' And $(OEIsLinux) == False And $(OEIsSgx) == False">
         <Link>
-            <AdditionalDependencies>oehost.lib;ws2_32.lib;bcrypt.lib;crypt32.lib;synchronization.lib;%(AdditionalDependencies)</AdditionalDependencies>
+            <AdditionalDependencies>oehost.lib;shlwapi.lib;ws2_32.lib;bcrypt.lib;crypt32.lib;synchronization.lib;%(AdditionalDependencies)</AdditionalDependencies>
             <AdditionalLibraryDirectories>$(OEHostLibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
         </Link>
     </ItemDefinitionGroup>
@@ -381,7 +381,7 @@
     <ItemDefinitionGroup Condition="'$(OEType)' != 'Enclave' And $(OEIsLinux) == False">
         <!-- *-SGX-* -->
         <PostBuildEvent Condition="$(OEIsSgx) == True">
-            <Command>copy "$(OEDebugRTPath)" "$(OutDir)" &amp;&amp; copy "$(SgxDcapQlPath)" "$(OutDir)"</Command>
+            <Command>copy "$(OEDebugRTPath)" "$(OutDir)"</Command>
         </PostBuildEvent>
     </ItemDefinitionGroup>
 


### PR DESCRIPTION
Changes:
* Add System EDLs (syscall.edl and platform.edl).  PR #2961 did this for samples but not for the VS extension
* Remove dependencies on sgx_enclave_common.lib and sgx_dcap_ql.lib.  (Anand, please let me know if this is incorrect.)
* Add dependency on shlwapi.lib since oehost.lib now depends on it for PathCombineW
* Update package dependencies to latest versions to pick up any bug fixes
* Update version numbers of OE and the extension

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>