### PR TITLE
Step 1 implementation for integrating SGX DCAP quote verification into OE

### DIFF
--- a/3rdparty/sgxsdk/include/sgx_dcap_quoteverify.h
+++ b/3rdparty/sgxsdk/include/sgx_dcap_quoteverify.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/**
+ * File: sgx_dcap_quoteverify.h
+ *
+ * Description: Definitions and prototypes for the DCAP Verification Library
+ *
+ */
+
+#ifndef _SGX_DCAP_QV_H_
+#define _SGX_DCAP_QV_H_
+
+#include "sgx_ql_quote.h"
+#include "sgx_qve_header.h"
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+    /**
+     * When the Quoting Verification Library is linked to a process, it needs to
+     *know the proper enclave loading policy. The library may be linked with a
+     *long lived process, such as a service, where it can load the enclaves and
+     *leave them loaded (persistent). This better ensures that the enclaves will
+     *be available upon quote requests and not subject to EPC limitations if
+     *loaded on demand. However, if the Quoting library is linked with an
+     *application process, there may be many applications with the Quoting
+     *library and a better utilization of EPC is to load and unloaded the
+     *quoting enclaves on demand (ephemeral).  The library will be shipped with
+     *a default policy of loading enclaves and leaving them loaded until the
+     *library is unloaded (PERSISTENT). If the policy is set to EPHEMERAL, then
+     *the QE and PCE will be loaded and unloaded on-demand.  If either enclave
+     *is already loaded when the policy is change to EPHEMERAL, the enclaves
+     *will be unloaded before returning.
+     *
+     * @param policy Sets the requested enclave loading policy to either
+     *SGX_QL_PERSISTENT, SGX_QL_EPHEMERAL or SGX_QL_DEFAULT.
+     *
+     * @return SGX_QL_SUCCESS Successfully set the enclave loading policy for
+     *the quoting library's enclaves.
+     * @return SGX_QL_UNSUPPORTED_LOADING_POLICY The selected policy is not
+     *support by the quoting library.
+     * @return SGX_QL_ERROR_UNEXPECTED Unexpected internal error.
+     *
+     **/
+    quote3_error_t sgx_qv_set_enclave_load_policy(
+        sgx_ql_request_policy_t policy);
+
+    /**
+     * Get supplemental data required size.
+     * @param p_data_size[OUT] - Pointer to hold the size of the buffer in bytes
+     *required to contain all of the supplemental data.
+     *
+     * @return Status code of the operation, one of:
+     *      - SGX_QL_SUCCESS
+     *      - SGX_QL_ERROR_INVALID_PARAMETER
+     *      - SGX_QL_ERROR_QVL_QVE_MISMATCH
+     *      - SGX_QL_ENCLAVE_LOAD_ERROR
+     **/
+    quote3_error_t sgx_qv_get_quote_supplemental_data_size(
+        uint32_t* p_data_size);
+
+    /**
+     * Perform quote verification.
+     *
+     * @param p_quote[IN] - Pointer to SGX Quote.
+     * @param quote_size[IN] - Size of the buffer pointed to by p_quote (in
+     *bytes).
+     * @param p_quote_collateral[IN] - This is a pointer to the Quote
+     *Certification Collateral provided by the caller.
+     * @param expiration_check_date[IN] - This is the date that the QvE will use
+     *to determine if any of the inputted collateral have expired.
+     * @param p_collateral_expiration_status[OUT] - Address of the outputted
+     *expiration status.  This input must not be NULL.
+     * @param p_quote_verification_result[OUT] - Address of the outputted quote
+     *verification result.
+     * @param p_qve_report_info[IN/OUT] - This parameter can be used in 2 ways.
+     *        If p_qve_report_info is NOT NULL, the API will use Intel QvE to
+     *perform quote verification, and QvE will generate a report using the
+     *target_info in sgx_ql_qe_report_info_t structure. if p_qve_report_info is
+     *NULL, the API will use QVL library to perform quote verification, not that
+     *the results can not be cryptographically authenticated in this mode.
+     * @param supplemental_data_size[IN] - Size of the buffer pointed to by
+     *p_quote (in bytes).
+     * @param p_supplemental_data[OUT] - The parameter is optional.  If it is
+     *NULL, supplemental_data_size must be 0.
+     *
+     * @return Status code of the operation, one of:
+     *      - SGX_QL_SUCCESS
+     *      - SGX_QL_ERROR_INVALID_PARAMETER
+     *      - SGX_QL_QUOTE_FORMAT_UNSUPPORTED
+     *      - SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED
+     *      - SGX_QL_UNABLE_TO_GENERATE_REPORT
+     *      - SGX_QL_ERROR_UNEXPECTED
+     **/
+    quote3_error_t sgx_qv_verify_quote(
+        const uint8_t* p_quote,
+        uint32_t quote_size,
+        const struct _sgx_ql_qve_collateral_t* p_quote_collateral,
+        const time_t expiration_check_date,
+        uint32_t* p_collateral_expiration_status,
+        sgx_ql_qv_result_t* p_quote_verification_result,
+        sgx_ql_qe_report_info_t* p_qve_report_info,
+        uint32_t supplemental_data_size,
+        uint8_t* p_supplemental_data);
+
+    /**
+     * Call quote provider library to get QvE identity.
+     *
+     * @param pp_qveid[OUT] - Pointer to the pointer of QvE identity
+     * @param p_qveid_size[OUT] -  Pointer to the size of QvE identity
+     * @param pp_qveid_issue_chain[OUT] - Pointer to the pointer QvE identity
+     *certificate chain
+     * @param p_qveid_issue_chain_size[OUT] - Pointer to the QvE identity
+     *certificate chain size
+     * @param pp_root_ca_crl[OUT] - Pointer to the pointer of Intel Root CA CRL
+     * @param p_root_ca_crl_size[OUT] - Pointer to the Intel Root CA CRL size
+     *
+     * @return Status code of the operation, one of:
+     *      - SGX_QL_SUCCESS
+     *      - SGX_QL_ERROR_INVALID_PARAMETER
+     *      - SGX_QL_NO_QVE_IDENTITY_DATA
+     *      - SGX_QL_ERROR_OUT_OF_MEMORY
+     *      - SGX_QL_NETWORK_ERROR
+     *      - SGX_QL_MESSAGE_ERROR
+     *      - SGX_QL_ERROR_UNEXPECTED
+     **/
+    quote3_error_t sgx_qv_get_qve_identity(
+        uint8_t** pp_qveid,
+        uint32_t* p_qveid_size,
+        uint8_t** pp_qveid_issue_chain,
+        uint32_t* p_qveid_issue_chain_size,
+        uint8_t** pp_root_ca_crl,
+        uint16_t* p_root_ca_crl_size);
+
+    /**
+     * Call quote provider library to free the p_qve_id, p_qveid_issuer_chain
+     *buffer and p_root_ca_crl allocated by sgx_qv_get_qve_identity
+     **/
+    quote3_error_t sgx_qv_free_qve_identity(
+        uint8_t* p_qveid,
+        uint8_t* p_qveid_issue_chain,
+        uint8_t* p_root_ca_crl);
+
+#ifndef _MSC_VER
+    typedef enum
+    {
+        SGX_QV_QVE_PATH,
+        SGX_QV_QPL_PATH
+    } sgx_qv_path_type_t;
+
+    quote3_error_t sgx_qv_set_path(
+        sgx_qv_path_type_t path_type,
+        const char* p_path);
+#endif
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !_SGX_DCAP_QV_H_*/

--- a/3rdparty/sgxsdk/include/sgx_ql_quote.h
+++ b/3rdparty/sgxsdk/include/sgx_ql_quote.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/**
+ * File: sgx_ql_quote.h
+ *
+ * Description: Generic SGX quote reference code definitions.
+ *
+ */
+
+/* User defined types */
+#ifndef _SGX_QL_QUOTE_H_
+#define _SGX_QL_QUOTE_H_
+#include <stddef.h>
+#include "sgx_ql_lib_common.h"
+#include "sgx_quote.h"
+#include "sgx_quote_3.h"
+
+#pragma pack(push, 1)
+/** Describes the algorithm parameters needed to generate the given algorithm's
+ * signature.  Used for quote generation APIs. */
+typedef struct _sgx_ql_att_key_id_param_t
+{
+    uint32_t algorithm_param_size; ///< Size of additional attestation key
+                                   ///< information.  0 is valid.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif
+    uint8_t algorithm_param[]; ///< Additional attestation algorithm
+                               ///< information.For example, SigRL for EPID.
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+} sgx_ql_att_key_id_param_t;
+
+/** The full data structure passed to the platform by the verifier. It will list
+ * all of the attestation algorithms and QE's supported by the verifier */
+typedef struct _sgx_ql_att_id_list_t
+{
+    sgx_ql_att_key_id_list_header_t
+        header; ///< Header for the attestation key ID list provided by the
+                ///< quote verifier.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif
+    sgx_att_key_id_ext_t
+        ext_id_list[]; ///< Place holder for the extended attestation ID list.
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+} sgx_ql_att_key_id_list_t;
+
+typedef struct _sgx_ql_qe_report_info_t
+{
+    sgx_quote_nonce_t nonce;
+    sgx_target_info_t app_enclave_target_info;
+    sgx_report_t qe_report;
+} sgx_ql_qe_report_info_t;
+
+#pragma pack(pop)
+
+#ifdef __cplusplus
+/** Describes the generic Quoting API used by all attestation keys/algorithms.
+   A particular quoting implementer will implement this interface. Application
+   can use this interface to remain agnostic to the attestation key used to
+   generate a quote. */
+class IQuote
+{
+  public:
+    virtual ~IQuote()
+    {
+    }
+
+    virtual quote3_error_t init_quote(
+        sgx_ql_att_key_id_t* p_att_key_id,
+        sgx_ql_cert_key_type_t certification_key_type,
+        sgx_target_info_t* p_target_info,
+        bool refresh_att_key,
+        size_t* p_pub_key_id_size,
+        uint8_t* p_pub_key_id) = 0;
+
+    virtual quote3_error_t get_quote_size(
+        sgx_ql_att_key_id_t* p_att_key_id,
+        sgx_ql_cert_key_type_t certification_key_type,
+        uint32_t* p_quote_size) = 0;
+
+    virtual quote3_error_t get_quote(
+        const sgx_report_t* p_app_report,
+        sgx_ql_att_key_id_t* p_att_key_id,
+        sgx_ql_qe_report_info_t* p_qe_report_info,
+        sgx_quote3_t* p_quote,
+        uint32_t quote_size) = 0;
+};
+#endif //#ifdef __cplusplus
+#endif //_SGX_QL_QUOTE_H_

--- a/3rdparty/sgxsdk/include/sgx_qve_header.h
+++ b/3rdparty/sgxsdk/include/sgx_qve_header.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _SGX_QVE_HEADER_H_
+#define _SGX_QVE_HEADER_H_
+
+#include "sgx_key.h"
+#include "time.h"
+
+#ifndef SGX_QL_QV_MK_ERROR
+#define SGX_QL_QV_MK_ERROR(x) (0x0000A000 | (x))
+#endif // SGX_QL_QV_MK_ERROR
+/** Contains the possible values of the quote verification result. */
+typedef enum _sgx_ql_qv_result_t
+{
+    SGX_QL_QV_RESULT_OK = 0x0000, ///< The Quote verification passed and is at
+                                  ///< the latest TCB level
+    SGX_QL_QV_RESULT_MIN = SGX_QL_QV_MK_ERROR(0x0001),
+    SGX_QL_QV_RESULT_CONFIG_NEEDED = SGX_QL_QV_MK_ERROR(
+        0x0001), ///< The Quote verification passed and the platform is patched
+                 ///< to the latest TCB level but additional configuration of
+                 ///< the SGX platform may be needed
+    SGX_QL_QV_RESULT_OUT_OF_DATE = SGX_QL_QV_MK_ERROR(
+        0x0002), ///< The Quote is good but TCB level of the platform is out of
+                 ///< date. The platform needs patching to be at the latest TCB
+                 ///< level
+    SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED = SGX_QL_QV_MK_ERROR(
+        0x0003), ///< The Quote is good but the TCB level of the platform is out
+                 ///< of date and additional configuration of the SGX Platform
+                 ///< at its current patching level may be needed. The platform
+                 ///< needs patching to be at the latest TCB level
+    SGX_QL_QV_RESULT_INVALID_SIGNATURE = SGX_QL_QV_MK_ERROR(
+        0x0004), ///< The signature over the application report is invalid
+    SGX_QL_QV_RESULT_REVOKED = SGX_QL_QV_MK_ERROR(
+        0x0005), ///< The attestation key or platform has been revoked
+    SGX_QL_QV_RESULT_UNSPECIFIED =
+        SGX_QL_QV_MK_ERROR(0x0006), ///< The Quote verification failed due to an
+                                    ///< error in one of the input
+    SGX_QL_QV_RESULT_SW_HARDENING_NEEDED =
+        SGX_QL_QV_MK_ERROR(0x0007), ///< The TCB level of the platform is up to
+                                    ///< date, but SGX SW Hardening is needed
+    SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED = SGX_QL_QV_MK_ERROR(
+        0x0008), ///< The TCB level of the platform is up to date, but
+                 ///< additional configuration of the platform at its current
+                 ///< patching level may be needed. Moreove, SGX SW Hardening is
+                 ///< also needed
+
+    SGX_QL_QV_RESULT_MAX = SGX_QL_QV_MK_ERROR(
+        0x00FF), ///< Indicate max result to allow better translation
+
+} sgx_ql_qv_result_t;
+
+typedef enum _pck_cert_flag_enum_t
+{
+    PCK_FLAG_FALSE = 0,
+    PCK_FLAG_TRUE,
+    PCK_FLAG_UNDEFINED
+} pck_cert_flag_enum_t;
+
+#define ROOT_KEY_ID_SIZE 48
+#define PLATFORM_INSTANCE_ID_SIZE 16
+
+/** Contains data that will allow an alternative quote verification policy. */
+typedef struct _sgx_ql_qv_supplemental_t
+{
+    uint32_t version;           ///< Supplemental data version
+    time_t earliest_issue_date; ///< Earliest issue date of all the collateral
+                                ///< (UTC)
+    time_t latest_issue_date; ///< Latest issue date of all the collateral (UTC)
+    time_t earliest_expiration_date; ///< Earliest expiration date of all the
+                                     ///< collateral (UTC)
+    time_t tcb_level_date_tag; ///< The SGX TCB of the platform that generated
+                               ///< the quote is not vulnerable to any Security
+                               ///< Advisory with an SGX TCB impact released on
+                               ///< or before this date. See Intel Security
+                               ///< Center Advisories
+    uint32_t pck_crl_num;      ///< CRL Num from PCK Cert CRL
+    uint32_t root_ca_crl_num;  ///< CRL Num from Root CA CRL
+    uint32_t tcb_eval_ref_num; ///< Lower number of the TCBInfo and QEIdentity
+    uint8_t root_key_id[ROOT_KEY_ID_SIZE]; ///< ID of the collateral's root
+                                           ///< signer (hash of Root CA's public
+                                           ///< key SHA-384)
+    sgx_key_128bit_t pck_ppid; ///< PPID from remote platform.  Can be used for
+                               ///< platform ownership checks
+    sgx_cpu_svn_t tcb_cpusvn;  ///< CPUSVN of the remote platform's PCK Cert
+    sgx_isv_svn_t
+        tcb_pce_isvsvn; ///< PCE_ISVNSVN of the remote platform's PCK Cert
+    uint16_t pce_id;    ///< PCE_ID of the remote platform
+    uint8_t sgx_type;   ///< Indicate the type of memory protection available on
+                        ///< the platform, it should be one of Standard (0) and
+                        ///< Scalable (1)
+
+    // Multi-Package PCK cert related flags, they are only relevant to PCK
+    // Certificates issued by PCK Platform CA
+    uint8_t
+        platform_instance_id[PLATFORM_INSTANCE_ID_SIZE]; ///< Value of Platform
+                                                         ///< Instance ID, 16
+                                                         ///< bytes
+    pck_cert_flag_enum_t
+        dynamic_platform; ///< Indicate whether a platform can be extended with
+                          ///< additional packages - via Package Add calls to
+                          ///< SGX Registration Backend
+    pck_cert_flag_enum_t
+        cached_keys; ///< Indicate whether platform root keys are cached by SGX
+                     ///< Registration Backend
+    pck_cert_flag_enum_t smt_enabled; ///< Indicate whether a plat form has SMT
+                                      ///< (simultaneous multithreading) enabled
+
+} sgx_ql_qv_supplemental_t;
+
+#endif //_QVE_HEADER_H_

--- a/3rdparty/sgxsdk/update.make
+++ b/3rdparty/sgxsdk/update.make
@@ -24,3 +24,6 @@ update-sgxsdk-headers:
 	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteGeneration/quote_wrapper/common/inc/sgx_quote_3.h )
 	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteGeneration/quote_wrapper/common/inc/sgx_ql_lib_common.h )
 	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteGeneration/pce_wrapper/inc/sgx_pce.h )
+	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteGeneration/quote_wrapper/common/inc/sgx_ql_quote.h )
+	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteVerification/QvE/Include/sgx_qve_header.h )
+	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteVerification/dcap_quoteverify/inc/sgx_dcap_quoteverify.h )

--- a/common/datetime.c
+++ b/common/datetime.c
@@ -265,3 +265,35 @@ void oe_datetime_log(const char* msg, const oe_datetime_t* date)
         OE_TRACE_VERBOSE("%s %s\n", msg, str);
     }
 }
+
+oe_result_t oe_datetime_to_time_t(const oe_datetime_t* datetime, time_t* value)
+{
+    oe_result_t result = OE_FAILURE;
+    time_t tmp = 0;
+    struct tm timeinfo = {0};
+
+    if (datetime == NULL || value == NULL)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    OE_CHECK(oe_datetime_is_valid(datetime));
+
+    // Update timeinfo based on input oe_date_time
+    timeinfo.tm_year = (int)datetime->year - 1900;
+    timeinfo.tm_mon = (int)datetime->month - 1;
+    timeinfo.tm_mday = (int)datetime->day;
+    timeinfo.tm_hour = (int)datetime->hours;
+    timeinfo.tm_min = (int)datetime->minutes;
+    timeinfo.tm_sec = (int)datetime->seconds;
+
+#ifdef _WIN32
+    tmp = _mkgmtime(&timeinfo);
+#else
+    tmp = timegm(&timeinfo);
+#endif
+
+    *value = tmp;
+
+    result = OE_OK;
+done:
+    return result;
+}

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -19,6 +19,7 @@ if (OE_SGX)
       ../common/sgx/verifier.c
       sgx/attester.c
       sgx/report.c
+      sgx/verifier.c
       sgx/collateralinfo.c
       sgx/start.S)
   if (WITH_EEID)

--- a/enclave/sgx/verifier.c
+++ b/enclave/sgx/verifier.c
@@ -1,0 +1,349 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "verifier.h"
+#include <openenclave/corelibc/stdio.h>
+#include <openenclave/enclave.h>
+#include <openenclave/internal/calls.h>
+#include <openenclave/internal/crypto/sha.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/safecrt.h>
+#include <openenclave/internal/safemath.h>
+#include <stdlib.h>
+#include <string.h>
+#include "platform_t.h"
+#include "report.h"
+
+// Hard code Intel signed QvE Identity below
+// You can get such info from latest QvE Identity JSON file
+// e.g., Get the QvE Identity JSON file from
+// https://api.trustedservices.intel.com/sgx/certification/v2/qve/identity
+//
+
+static const uint32_t g_qve_misc_select = 0x00000000;
+static const uint32_t g_qve_misc_select_mask = 0xFFFFFFFF;
+
+static const uint64_t g_qve_attribute_flags = 0x0000000000000001;
+static const uint64_t g_qve_attribute_xfrm = 0x0000000000000000;
+static const uint64_t g_qve_attribute_flags_mask = 0xFFFFFFFFFFFFFFFb;
+static const uint64_t g_qve_attribute_xfrm_mask = 0x0000000000000000;
+
+static const uint8_t g_qve_mrsigner[32] = {
+    0x8C, 0x4F, 0x57, 0x75, 0xD7, 0x96, 0x50, 0x3E, 0x96, 0x13, 0x7F,
+    0x77, 0xC6, 0x8A, 0x82, 0x9A, 0x00, 0x56, 0xAC, 0x8D, 0xED, 0x70,
+    0x14, 0x0B, 0x08, 0x1B, 0x09, 0x44, 0x90, 0xC5, 0x7B, 0xFF};
+
+static const uint16_t QVE_PRODID = 2;
+
+// Defense in depth, threshold must be greater or equal to least QvE ISV SVN
+const uint16_t LEAST_QVE_ISVSVN = 3;
+
+static void dump_info(
+    const char* title,
+    const uint8_t* data,
+    const uint8_t count)
+{
+    OE_TRACE_INFO("%s\n", title);
+    for (uint8_t i = 0; i < count; i++)
+    {
+        OE_TRACE_INFO("[%d] = %x\n", i, data[i]);
+    }
+}
+
+#if !defined(OE_USE_BUILTIN_EDL)
+/**
+ * Declare the prototype of the following function to avoid the
+ * missing-prototypes warning.
+ */
+
+oe_result_t _oe_verify_quote_ocall(
+    oe_result_t* _retval,
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    const void* p_quote,
+    uint32_t quote_size,
+    const time_t expiration_check_date,
+    uint32_t* p_collateral_expiration_status,
+    uint32_t* p_quote_verification_result,
+    void* p_qve_report_info,
+    uint32_t qve_report_size,
+    void* p_supplemental_data,
+    uint32_t supplemental_data_size,
+    uint32_t* p_supplemental_data_size_out,
+    uint32_t collateral_version,
+    const void* p_tcb_info,
+    uint32_t tcb_info_size,
+    const void* p_tcb_info_issuer_chain,
+    uint32_t tcb_info_issuer_chain_size,
+    const void* p_pck_crl,
+    uint32_t pck_crl_size,
+    const void* p_root_ca_crl,
+    uint32_t root_ca_crl_size,
+    const void* p_pck_crl_issuer_chain,
+    uint32_t pck_crl_issuer_chain_size,
+    const void* p_qe_identity,
+    uint32_t qe_identity_size,
+    const void* p_qe_identity_issuer_chain,
+    uint32_t qe_identity_issuer_chain_size);
+
+oe_result_t _oe_verify_quote_ocall(
+    oe_result_t* _retval,
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    const void* p_quote,
+    uint32_t quote_size,
+    const time_t expiration_check_date,
+    uint32_t* p_collateral_expiration_status,
+    uint32_t* p_quote_verification_result,
+    void* p_qve_report_info,
+    uint32_t qve_report_size,
+    void* p_supplemental_data,
+    uint32_t supplemental_data_size,
+    uint32_t* p_supplemental_data_size_out,
+    uint32_t collateral_version,
+    const void* p_tcb_info,
+    uint32_t tcb_info_size,
+    const void* p_tcb_info_issuer_chain,
+    uint32_t tcb_info_issuer_chain_size,
+    const void* p_pck_crl,
+    uint32_t pck_crl_size,
+    const void* p_root_ca_crl,
+    uint32_t root_ca_crl_size,
+    const void* p_pck_crl_issuer_chain,
+    uint32_t pck_crl_issuer_chain_size,
+    const void* p_qe_identity,
+    uint32_t qe_identity_size,
+    const void* p_qe_identity_issuer_chain,
+    uint32_t qe_identity_issuer_chain_size)
+{
+    OE_UNUSED(format_id);
+    OE_UNUSED(opt_params);
+    OE_UNUSED(opt_params_size);
+    OE_UNUSED(p_quote);
+    OE_UNUSED(quote_size);
+    OE_UNUSED(expiration_check_date);
+    OE_UNUSED(p_collateral_expiration_status);
+    OE_UNUSED(p_quote_verification_result);
+    OE_UNUSED(p_qve_report_info);
+    OE_UNUSED(qve_report_size);
+    OE_UNUSED(p_supplemental_data);
+    OE_UNUSED(supplemental_data_size);
+    OE_UNUSED(p_supplemental_data_size_out);
+    OE_UNUSED(collateral_version);
+    OE_UNUSED(p_tcb_info);
+    OE_UNUSED(tcb_info_size);
+    OE_UNUSED(p_tcb_info_issuer_chain);
+    OE_UNUSED(tcb_info_issuer_chain_size);
+    OE_UNUSED(p_pck_crl);
+    OE_UNUSED(pck_crl_size);
+    OE_UNUSED(p_root_ca_crl);
+    OE_UNUSED(root_ca_crl_size);
+    OE_UNUSED(p_pck_crl_issuer_chain);
+    OE_UNUSED(pck_crl_issuer_chain_size);
+    OE_UNUSED(p_qe_identity);
+    OE_UNUSED(qe_identity_size);
+    OE_UNUSED(p_qe_identity_issuer_chain);
+    OE_UNUSED(qe_identity_issuer_chain_size);
+
+    if (_retval)
+        *_retval = OE_UNSUPPORTED;
+
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_verify_quote_ocall, oe_verify_quote_ocall);
+#endif
+
+oe_result_t oe_verify_qve_report_and_identity(
+    const uint8_t* p_quote,
+    uint32_t quote_size,
+    const sgx_ql_qe_report_info_t* p_qve_report_info,
+    time_t expiration_check_date,
+    uint32_t collateral_expiration_status,
+    uint32_t quote_verification_result,
+    const uint8_t* p_supplemental_data,
+    uint32_t supplemental_data_size,
+    uint16_t qve_isvsvn_threshold)
+{
+    oe_result_t result = OE_UNEXPECTED;
+
+    oe_sha256_context_t sha_handle = {0};
+    OE_SHA256 report_data_hash = {0};
+    sgx_report_data_t report_data = {0};
+    const sgx_report_t* p_qve_report = &(p_qve_report_info->qe_report);
+
+    if (p_quote == NULL || p_qve_report_info == NULL ||
+        sizeof(*p_qve_report_info) != sizeof(sgx_ql_qe_report_info_t) ||
+        !oe_is_within_enclave(p_quote, quote_size) ||
+        !oe_is_within_enclave(
+            p_qve_report_info, sizeof(sgx_ql_qe_report_info_t)) ||
+        (p_supplemental_data == NULL && supplemental_data_size != 0) ||
+        (p_supplemental_data != NULL && supplemental_data_size == 0))
+        return OE_INVALID_PARAMETER;
+
+    if (p_supplemental_data && supplemental_data_size > 0)
+    {
+        if (!oe_is_within_enclave(p_supplemental_data, supplemental_data_size))
+        {
+            return OE_INVALID_PARAMETER;
+        }
+    }
+
+    // Defense in depth, threshold must be greater or equal to 3
+    if (qve_isvsvn_threshold < LEAST_QVE_ISVSVN)
+    {
+        OE_RAISE_MSG(
+            OE_QUOTE_ENCLAVE_IDENTITY_VERIFICATION_FAILED,
+            "Input QvE ISV SVN is not valid. Required SVN is larger or equal "
+            "to 0x%08X, actual SVN 0x%08X",
+            LEAST_QVE_ISVSVN,
+            qve_isvsvn_threshold);
+    }
+
+    // verify QvE report
+    OE_CHECK_MSG(
+        oe_verify_raw_sgx_report((uint8_t*)p_qve_report, sizeof(sgx_report_t)),
+        "SGX Verifier Plugin: Failed to verify QvE report. %s",
+        oe_result_str(result));
+
+    // verify QvE report data
+    // report_data = SHA256([nonce || quote || expiration_check_date ||
+    // expiration_status || verification_result || supplemental_data]) || 32 -
+    // 0x00
+    OE_CHECK(oe_sha256_init(&sha_handle));
+
+    // nonce
+    OE_CHECK(oe_sha256_update(
+        &sha_handle,
+        &(p_qve_report_info->nonce),
+        sizeof(p_qve_report_info->nonce)));
+
+    // quote
+    OE_CHECK(oe_sha256_update(&sha_handle, p_quote, quote_size));
+
+    // expiration_check_date
+    OE_CHECK(oe_sha256_update(
+        &sha_handle, &expiration_check_date, sizeof(expiration_check_date)));
+
+    // collateral_expiration_status
+    OE_CHECK(oe_sha256_update(
+        &sha_handle,
+        &collateral_expiration_status,
+        sizeof(collateral_expiration_status)));
+
+    // quote_verification_result
+    OE_CHECK(oe_sha256_update(
+        &sha_handle,
+        &quote_verification_result,
+        sizeof(quote_verification_result)));
+
+    // p_supplemental_data
+    if (p_supplemental_data)
+    {
+        OE_CHECK(oe_sha256_update(
+            &sha_handle, p_supplemental_data, supplemental_data_size));
+    }
+
+    // get the hashed report_data
+    OE_CHECK(oe_sha256_final(&sha_handle, &report_data_hash));
+
+    memcpy(&report_data, &report_data_hash, sizeof(report_data_hash));
+
+    if (memcmp(
+            &p_qve_report->body.report_data,
+            &report_data,
+            sizeof(report_data)) != 0)
+    {
+        OE_RAISE_MSG(
+            OE_QUOTE_ENCLAVE_IDENTITY_VERIFICATION_FAILED,
+            "QvE report data is not correct.",
+            NULL);
+    }
+
+    // Check MiscSelect in QvE report
+    if (((p_qve_report->body.miscselect) & g_qve_misc_select_mask) !=
+        g_qve_misc_select)
+    {
+        OE_RAISE_MSG(
+            OE_QUOTE_ENCLAVE_IDENTITY_VERIFICATION_FAILED,
+            "Expect QvE misc select = 0x%lx, msic slect mask = 0x%lx"
+            "QvE report misc select = 0x%lx",
+            g_qve_misc_select,
+            g_qve_misc_select_mask,
+            p_qve_report->body.miscselect);
+
+        OE_RAISE_MSG(
+            OE_QUOTE_ENCLAVE_IDENTITY_VERIFICATION_FAILED,
+            "QvE misc select is not correct",
+            NULL);
+    }
+
+    // Check Attribute in QvE report
+    if (((p_qve_report->body.attributes.flags) & g_qve_attribute_flags_mask) !=
+        g_qve_attribute_flags)
+    {
+        OE_RAISE_MSG(
+            OE_QUOTE_ENCLAVE_IDENTITY_VERIFICATION_FAILED,
+            "Expect QvE attribute flag = 0x%lx, attributes_flag_mask = "
+            "0x%lx"
+            "QvE report attributes.flag = 0x%lx",
+            g_qve_attribute_flags,
+            g_qve_attribute_flags_mask,
+            p_qve_report->body.attributes.flags);
+    }
+
+    if (((p_qve_report->body.attributes.xfrm) & g_qve_attribute_xfrm_mask) !=
+        g_qve_attribute_xfrm)
+    {
+        OE_RAISE_MSG(
+            OE_QUOTE_ENCLAVE_IDENTITY_VERIFICATION_FAILED,
+            "Expect QvE attribute xfrm = 0x%lx, attributes_xfrm_mask = "
+            "0x%lx"
+            "QvE report attributes.xfrm = 0x%lx",
+            g_qve_attribute_xfrm,
+            g_qve_attribute_xfrm_mask,
+            p_qve_report->body.attributes.xfrm);
+    }
+
+    // Check Mrsigner in QvE report
+    if (memcmp(
+            &(p_qve_report->body.mrsigner),
+            g_qve_mrsigner,
+            sizeof(g_qve_mrsigner)) != 0)
+    {
+        dump_info(
+            "Expected QvE mrsigner:", g_qve_mrsigner, sizeof(g_qve_mrsigner));
+        dump_info(
+            "Actual QvE mrsigner, qe_report_body->mrsigner:",
+            p_qve_report->body.mrsigner,
+            sizeof(p_qve_report->body.mrsigner));
+        OE_RAISE(OE_QUOTE_ENCLAVE_IDENTITY_VERIFICATION_FAILED);
+    }
+
+    // Check Prod ID in QvE report
+    if (p_qve_report->body.isvprodid != QVE_PRODID)
+    {
+        OE_RAISE_MSG(
+            OE_QUOTE_ENCLAVE_IDENTITY_VERIFICATION_FAILED,
+            "QvE isvprodid mismatch. Expected 0x%04X, actual 0x%04X",
+            QVE_PRODID,
+            p_qve_report->body.isvprodid);
+    }
+
+    // Check QvE ISV SVN in QvE report
+    if (p_qve_report->body.isvsvn < qve_isvsvn_threshold)
+    {
+        OE_RAISE_MSG(
+            OE_QUOTE_ENCLAVE_IDENTITY_VERIFICATION_FAILED,
+            "QvE isvsvn is out-of-date. Required SVN is larger or equal to "
+            "0x%08X, actual SVN 0x%08X",
+            qve_isvsvn_threshold,
+            p_qve_report->body.isvsvn);
+    }
+
+    result = OE_OK;
+
+done:
+    return result;
+}

--- a/enclave/sgx/verifier.h
+++ b/enclave/sgx/verifier.h
@@ -1,0 +1,30 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_ENCLAVE_VERIFIER_H
+#define _OE_ENCLAVE_VERIFIER_H
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/report.h>
+
+#ifndef sgx_ql_qe_report_info_t
+typedef struct _sgx_ql_qe_report_info_t
+{
+    sgx_nonce_t nonce;
+    sgx_target_info_t app_enclave_target_info;
+    sgx_report_t qe_report;
+} sgx_ql_qe_report_info_t;
+#endif
+
+oe_result_t oe_verify_qve_report_and_identity(
+    const uint8_t* p_quote,
+    uint32_t quote_size,
+    const sgx_ql_qe_report_info_t* p_qve_report_info,
+    time_t expiration_check_date,
+    uint32_t collateral_expiration_status,
+    uint32_t quote_verification_result,
+    const uint8_t* p_supplemental_data,
+    uint32_t supplemental_data_size,
+    uint16_t qve_isvsvn_threshold);
+
+#endif /* OE_ENCLAVE_VERIFIER_H */

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -206,7 +206,9 @@ if (OE_SGX)
     ../common/sgx/verifier.c
     sgx/hostverify_report.c
     sgx/report_common.c
-    sgx/sgxquoteprovider.c)
+    sgx/sgxquoteprovider.c
+    sgx/quote.c
+    sgx/sgxquote.c)
 
   if (WITH_EEID)
     list(APPEND PLATFORM_HOST_ONLY_SRC ../common/sgx/eeid_verifier.c
@@ -242,7 +244,11 @@ if (OE_SGX)
 
   # OS specific as well.
   if (UNIX)
-    list(APPEND PLATFORM_HOST_ONLY_SRC sgx/linux/sgxquoteproviderloader.c)
+    list(
+      APPEND
+      PLATFORM_HOST_ONLY_SRC
+      sgx/linux/sgxquoteproviderloader.c
+      sgx/linux/sgxquoteexloader.c)
 
     list(
       APPEND
@@ -255,7 +261,11 @@ if (OE_SGX)
       sgx/linux/sgxquoteexloader.c
       sgx/linux/xstate.c)
   else ()
-    list(APPEND PLATFORM_HOST_ONLY_SRC sgx/windows/sgxquoteproviderloader.c)
+    list(
+      APPEND
+      PLATFORM_HOST_ONLY_SRC
+      sgx/windows/sgxquoteproviderloader.c
+      sgx/windows/sgxquoteexloader.c)
 
     list(
       APPEND
@@ -345,6 +355,9 @@ target_link_libraries(oehost PUBLIC oe_includes)
 if (OE_SGX)
   target_include_directories(
     oehost PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include)
+  target_include_directories(
+    oehostverify PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include)
+
 endif ()
 
 if (WIN32)

--- a/host/sgx/ocalls/ocalls.c
+++ b/host/sgx/ocalls/ocalls.c
@@ -279,3 +279,68 @@ oe_result_t oe_get_supported_attester_format_ids_ocall(
 
     return result;
 }
+
+oe_result_t oe_verify_quote_ocall(
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    const void* p_quote,
+    uint32_t quote_size,
+    const time_t expiration_check_date,
+    uint32_t* p_collateral_expiration_status,
+    uint32_t* p_quote_verification_result,
+    void* p_qve_report_info,
+    uint32_t qve_report_size,
+    void* p_supplemental_data,
+    uint32_t supplemental_data_size,
+    uint32_t* p_supplemental_data_size_out,
+    uint32_t collateral_version,
+    const void* p_tcb_info,
+    uint32_t tcb_info_size,
+    const void* p_tcb_info_issuer_chain,
+    uint32_t tcb_info_issuer_chain_size,
+    const void* p_pck_crl,
+    uint32_t pck_crl_size,
+    const void* p_root_ca_crl,
+    uint32_t root_ca_crl_size,
+    const void* p_pck_crl_issuer_chain,
+    uint32_t pck_crl_issuer_chain_size,
+    const void* p_qe_identity,
+    uint32_t qe_identity_size,
+    const void* p_qe_identity_issuer_chain,
+    uint32_t qe_identity_issuer_chain_size)
+{
+    oe_result_t result;
+
+    result = sgx_verify_quote(
+        format_id,
+        opt_params,
+        opt_params_size,
+        p_quote,
+        quote_size,
+        expiration_check_date,
+        p_collateral_expiration_status,
+        p_quote_verification_result,
+        p_qve_report_info,
+        qve_report_size,
+        p_supplemental_data,
+        supplemental_data_size,
+        p_supplemental_data_size_out,
+        collateral_version,
+        p_tcb_info,
+        tcb_info_size,
+        p_tcb_info_issuer_chain,
+        tcb_info_issuer_chain_size,
+        p_pck_crl,
+        pck_crl_size,
+        p_root_ca_crl,
+        root_ca_crl_size,
+        p_pck_crl_issuer_chain,
+        pck_crl_issuer_chain_size,
+        p_qe_identity,
+        qe_identity_size,
+        p_qe_identity_issuer_chain,
+        qe_identity_issuer_chain_size);
+
+    return result;
+}

--- a/host/sgx/quote.c
+++ b/host/sgx/quote.c
@@ -129,3 +129,121 @@ oe_result_t sgx_get_supported_attester_format_ids(
 done:
     return result;
 }
+
+oe_result_t sgx_get_supplemental_data_size(
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    uint32_t* supplemental_data_size)
+{
+    oe_result_t result = OE_UNEXPECTED;
+
+    if (!supplemental_data_size)
+        OE_RAISE(OE_INVALID_PARAMETER);
+    else
+        *supplemental_data_size = 0;
+
+    result = oe_sgx_get_supplemental_data_size(
+        format_id, opt_params, opt_params_size, supplemental_data_size);
+
+done:
+    return result;
+}
+
+oe_result_t sgx_verify_quote(
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    const uint8_t* p_quote,
+    uint32_t quote_size,
+    time_t expiration_check_date,
+    uint32_t* p_collateral_expiration_status,
+    uint32_t* p_quote_verification_result,
+    void* p_qve_report_info,
+    uint32_t qve_report_info_size,
+    void* p_supplemental_data,
+    uint32_t supplemental_data_size,
+    uint32_t* p_supplemental_data_size_out,
+    uint32_t collateral_version,
+    const void* p_tcb_info,
+    uint32_t tcb_info_size,
+    const void* p_tcb_info_issuer_chain,
+    uint32_t tcb_info_issuer_chain_size,
+    const void* p_pck_crl,
+    uint32_t pck_crl_size,
+    const void* p_root_ca_crl,
+    uint32_t root_ca_crl_size,
+    const void* p_pck_crl_issuer_chain,
+    uint32_t pck_crl_issuer_chain_size,
+    const void* p_qe_identity,
+    uint32_t qe_identity_size,
+    const void* p_qe_identity_issuer_chain,
+    uint32_t qe_identity_issuer_chain_size)
+{
+    oe_result_t result = OE_UNEXPECTED;
+
+    /* Reject null parameters */
+    if (!p_quote || !p_collateral_expiration_status ||
+        !p_quote_verification_result ||
+        (!p_supplemental_data && supplemental_data_size > 0))
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    /* Try to get supplemental data size if needed */
+    if (p_supplemental_data)
+    {
+        uint32_t size;
+
+        // Don't use OE_CHECK here as this function will try to
+        // detect QVL first, if QVL is not installed, we should not
+        // throw error
+        result = sgx_get_supplemental_data_size(
+            format_id, opt_params, opt_params_size, &size);
+        if (result != OE_OK)
+            goto done;
+
+        if (supplemental_data_size < size)
+        {
+            supplemental_data_size = size;
+            OE_CHECK_NO_TRACE(OE_BUFFER_TOO_SMALL);
+        }
+
+        /* Return correct size of the supplemental data size */
+        supplemental_data_size = size;
+        *p_supplemental_data_size_out = size;
+
+        memset(p_supplemental_data, 0, supplemental_data_size);
+    }
+
+    /* Verify the quote by DCAP QVL/QvE */
+    result = oe_sgx_verify_quote(
+        format_id,
+        opt_params,
+        opt_params_size,
+        p_quote,
+        quote_size,
+        expiration_check_date,
+        p_collateral_expiration_status,
+        p_quote_verification_result,
+        p_qve_report_info,
+        qve_report_info_size,
+        p_supplemental_data,
+        supplemental_data_size,
+        collateral_version,
+        p_tcb_info,
+        tcb_info_size,
+        p_tcb_info_issuer_chain,
+        tcb_info_issuer_chain_size,
+        p_pck_crl,
+        pck_crl_size,
+        p_root_ca_crl,
+        root_ca_crl_size,
+        p_pck_crl_issuer_chain,
+        pck_crl_issuer_chain_size,
+        p_qe_identity,
+        qe_identity_size,
+        p_qe_identity_issuer_chain,
+        qe_identity_issuer_chain_size);
+done:
+
+    return result;
+}

--- a/host/sgx/quote.h
+++ b/host/sgx/quote.h
@@ -71,6 +71,56 @@ oe_result_t oe_verify_report_internal(
     size_t report_size,
     oe_report_t* parsed_report);
 
+/*
+**==============================================================================
+**
+** sgx_get_supplemental_data_size()
+**
+**==============================================================================
+*/
+oe_result_t sgx_get_supplemental_data_size(
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    uint32_t* supplemental_data_size);
+
+/*
+**==============================================================================
+**
+** sgx_verify_quote()
+**
+**==============================================================================
+*/
+oe_result_t sgx_verify_quote(
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    const uint8_t* p_quote,
+    uint32_t quote_size,
+    time_t expiration_check_date,
+    uint32_t* p_collateral_expiration_status,
+    uint32_t* p_quote_verification_result,
+    void* p_qve_report_info,
+    uint32_t qve_report_info_size,
+    void* p_supplemental_data,
+    uint32_t supplemental_data_size,
+    uint32_t* p_supplemental_data_size_out,
+    uint32_t collateral_version,
+    const void* p_tcb_info,
+    uint32_t tcb_info_size,
+    const void* p_tcb_info_issuer_chain,
+    uint32_t tcb_info_issuer_chain_size,
+    const void* p_pck_crl,
+    uint32_t pck_crl_size,
+    const void* p_root_ca_crl,
+    uint32_t root_ca_crl_size,
+    const void* p_pck_crl_issuer_chain,
+    uint32_t pck_crl_issuer_chain_size,
+    const void* p_qe_identity,
+    uint32_t qe_identity_size,
+    const void* p_qe_identity_issuer_chain,
+    uint32_t qe_identity_issuer_chain_size);
+
 OE_EXTERNC_END
 
 #endif /* _OE_HOST_QUOTE_H */

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -9,12 +9,14 @@
 #include <openenclave/internal/sgx/plugin.h>
 #include <openenclave/internal/tests.h>
 #include <openenclave/internal/trace.h>
+#include <sgx_dcap_quoteverify.h>
 #include <sgx_ql_lib_common.h>
 #include <sgx_quote_3.h>
 #include <sgx_uae_quote_ex.h>
 #include <stdlib.h>
 #include <string.h>
 #include "../../common/oe_host_stdlib.h"
+#include "../../common/sgx/endorsements.h"
 #include "../hostthread.h"
 #include "sgxquote_ex.h"
 
@@ -63,58 +65,93 @@ static quote3_error_t (*_sgx_qe_get_quote)(
     uint32_t quote_size,
     uint8_t* p_quote);
 
+static quote3_error_t (*_sgx_qv_get_quote_supplemental_data_size)(
+    uint32_t* p_data_size);
+
+static quote3_error_t (*_sgx_qv_verify_quote)(
+    const uint8_t* p_quote,
+    uint32_t quote_size,
+    const struct _sgx_ql_qve_collateral_t* p_quote_collateral,
+    const time_t expiration_check_date,
+    uint32_t* p_collateral_expiration_status,
+    sgx_ql_qv_result_t* p_quote_verification_result,
+    sgx_ql_qe_report_info_t* p_qve_report_info,
+    uint32_t supplemental_data_size,
+    uint8_t* p_supplemental_data);
+
 #ifdef _WIN32
 
 #include <windows.h>
 
-#define LIBRARY_NAME "sgx_dcap_ql.dll"
+#define SGX_DCAP_QL_NAME "sgx_dcap_ql.dll"
+#define SGX_DCAP_QVL_NAME "sgx_dcap_quoteverify.dll"
+
 // Use LOAD_LIBRARY_SEARCH_SYSTEM32 flag since sgx_enclave_common.dll is part of
 // the Intel driver components and should only be loaded from there.
-#define LOAD_SGX_DCAP_QL() \
-    (void*)LoadLibraryEx(LIBRARY_NAME, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+#define LOAD_SGX_DCAP_LIB(libname) \
+    (void*)LoadLibraryEx((LPCSTR)libname, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
-#define LOOKUP_FUNCTION(fcn) (void*)GetProcAddress((HANDLE)_module, fcn)
+#define LOOKUP_FUNCTION(module, fcn) (void*)GetProcAddress((HANDLE)module, fcn)
 
-#define UNLOAD_SGX_DCAP_QL() FreeLibrary((HANDLE)_module)
+#define UNLOAD_SGX_DCAP_LIB(module) FreeLibrary((HANDLE)module)
 
 #define SGX_DCAP_IN_PROCESS_QUOTING() \
     (GetEnvironmentVariableA("SGX_AESM_ADDR", NULL, 0) == 0)
+
+#define TRY_TO_USE_SGX_DCAP_QVL() \
+    (GetEnvironmentVariableA("USE_SGX_QVL", NULL, 0) != 0)
 
 #else
 
 #include <dlfcn.h>
 
-#define LIBRARY_NAME "libsgx_dcap_ql.so"
+#define SGX_DCAP_QL_NAME "libsgx_dcap_ql.so"
+#define SGX_DCAP_QVL_NAME "libsgx_dcap_quoteverify.so"
 
 // Use best practices
 // - RTLD_NOW  Bind all undefined symbols before dlopen returns.
 // - RTLD_GLOBAL Make symbols from this shared library visible to
 //   subsequently loaded libraries.
-#define LOAD_SGX_DCAP_QL() dlopen(LIBRARY_NAME, RTLD_NOW | RTLD_GLOBAL)
+#define LOAD_SGX_DCAP_LIB(libname) dlopen(libname, RTLD_NOW | RTLD_GLOBAL)
 
-#define LOOKUP_FUNCTION(fcn) (void*)dlsym(_module, fcn)
+#define LOOKUP_FUNCTION(module, fcn) (void*)dlsym(module, fcn)
 
-#define UNLOAD_SGX_DCAP_QL() dlclose(_module)
+#define UNLOAD_SGX_DCAP_LIB(module) dlclose(module)
 
 #define SGX_DCAP_IN_PROCESS_QUOTING() (getenv("SGX_AESM_ADDR") == NULL)
 
+#define TRY_TO_USE_SGX_DCAP_QVL() (getenv("USE_SGX_QVL") != NULL)
+
 #endif
 
-static void* _module;
+static void* _ql_module;
+static void* _qvl_module;
 
 static void _unload_sgx_dcap_ql(void)
 {
-    if (_module)
+    if (_ql_module)
     {
-        UNLOAD_SGX_DCAP_QL();
-        _module = NULL;
+        UNLOAD_SGX_DCAP_LIB(_ql_module);
+        _ql_module = NULL;
     }
 }
 
-static oe_result_t _lookup_function(const char* name, void** function_ptr)
+static void _unload_sgx_dcap_qvl(void)
+{
+    if (_qvl_module)
+    {
+        UNLOAD_SGX_DCAP_LIB(_qvl_module);
+        _qvl_module = NULL;
+    }
+}
+
+static oe_result_t _lookup_function(
+    const void* module,
+    const char* name,
+    void** function_ptr)
 {
     oe_result_t result = OE_FAILURE;
-    *function_ptr = LOOKUP_FUNCTION(name);
+    *function_ptr = LOOKUP_FUNCTION((void*)(module), name);
     if (!*function_ptr)
     {
         OE_TRACE_ERROR("%s function not found.\n", name);
@@ -128,25 +165,29 @@ done:
 static void _load_sgx_dcap_ql_impl(void)
 {
     oe_result_t result = OE_FAILURE;
-    OE_TRACE_INFO("Loading %s\n", LIBRARY_NAME);
-    _module = LOAD_SGX_DCAP_QL();
+    OE_TRACE_INFO("Loading %s\n", SGX_DCAP_QL_NAME);
+    _ql_module = LOAD_SGX_DCAP_LIB(SGX_DCAP_QL_NAME);
 
-    if (_module)
+    if (_ql_module)
     {
         OE_CHECK(_lookup_function(
-            "sgx_qe_get_target_info", (void**)&_sgx_qe_get_target_info));
+            _ql_module,
+            "sgx_qe_get_target_info",
+            (void**)&_sgx_qe_get_target_info));
         OE_CHECK(_lookup_function(
-            "sgx_qe_get_quote_size", (void**)&_sgx_qe_get_quote_size));
-        OE_CHECK(
-            _lookup_function("sgx_qe_get_quote", (void**)&_sgx_qe_get_quote));
+            _ql_module,
+            "sgx_qe_get_quote_size",
+            (void**)&_sgx_qe_get_quote_size));
+        OE_CHECK(_lookup_function(
+            _ql_module, "sgx_qe_get_quote", (void**)&_sgx_qe_get_quote));
 
         atexit(_unload_sgx_dcap_ql);
         result = OE_OK;
-        OE_TRACE_INFO("Loaded %s\n", LIBRARY_NAME);
+        OE_TRACE_INFO("Loaded %s\n", SGX_DCAP_QL_NAME);
     }
     else
     {
-        OE_TRACE_WARNING("Failed to load %s\n", LIBRARY_NAME);
+        OE_TRACE_WARNING("Failed to load %s\n", SGX_DCAP_QL_NAME);
         goto done;
     }
 
@@ -161,7 +202,47 @@ static bool _load_sgx_dcap_ql(void)
 {
     static oe_once_type _once;
     oe_once(&_once, _load_sgx_dcap_ql_impl);
-    return (_module != NULL);
+    return (_ql_module != NULL);
+}
+
+static void _load_sgx_dcap_qvl_impl(void)
+{
+    oe_result_t result = OE_FAILURE;
+    OE_TRACE_INFO("Loading %s\n", SGX_DCAP_QVL_NAME);
+    _qvl_module = LOAD_SGX_DCAP_LIB(SGX_DCAP_QVL_NAME);
+
+    if (_qvl_module)
+    {
+        OE_CHECK(_lookup_function(
+            _qvl_module,
+            "sgx_qv_get_quote_supplemental_data_size",
+            (void**)&_sgx_qv_get_quote_supplemental_data_size));
+        OE_CHECK(_lookup_function(
+            _qvl_module, "sgx_qv_verify_quote", (void**)&_sgx_qv_verify_quote));
+
+        atexit(_unload_sgx_dcap_qvl);
+        result = OE_OK;
+        OE_TRACE_INFO("Loaded %s\n", SGX_DCAP_QVL_NAME);
+    }
+    else
+    {
+        OE_TRACE_WARNING("Failed to load %s\n", SGX_DCAP_QVL_NAME);
+        goto done;
+    }
+
+done:
+    if (result != OE_OK)
+    {
+        OE_TRACE_WARNING(
+            "Alternative quote verification library will be needed.");
+    }
+}
+
+static bool _load_sgx_dcap_qvl(void)
+{
+    static oe_once_type _once;
+    oe_once(&_once, _load_sgx_dcap_qvl_impl);
+    return (_qvl_module != NULL);
 }
 
 static void _load_quote_ex_library_once(void)
@@ -402,6 +483,7 @@ oe_result_t oe_sgx_qe_get_target_info(
 
         result = OE_OK;
     }
+
 done:
     return result;
 }
@@ -547,14 +629,20 @@ oe_result_t oe_sgx_qe_get_quote(
             OE_RAISE(OE_INVALID_PARAMETER);
 
         local_quote_size = (uint32_t)quote_size;
-        _load_sgx_dcap_ql();
 
-        err = _sgx_qe_get_quote((sgx_report_t*)report, local_quote_size, quote);
-        if (err != SGX_QL_SUCCESS)
-            OE_RAISE_MSG(OE_PLATFORM_ERROR, "quote3_error_t=0x%x\n", err);
-        OE_TRACE_INFO("quote_size=%d", local_quote_size);
+        if (_load_sgx_dcap_ql())
+        {
+            err = _sgx_qe_get_quote(
+                (sgx_report_t*)report, local_quote_size, quote);
+            if (err != SGX_QL_SUCCESS)
+                OE_RAISE_MSG(OE_PLATFORM_ERROR, "quote3_error_t=0x%x\n", err);
+            OE_TRACE_INFO("quote_size=%d", local_quote_size);
 
-        result = OE_OK;
+            result = OE_OK;
+        }
+        else
+            // Failed to load DCAP QL library
+            result = OE_PLATFORM_ERROR;
     }
 done:
     return result;
@@ -625,6 +713,235 @@ oe_result_t oe_sgx_get_supported_attester_format_ids(
         OE_TRACE_INFO("DCAP only supports ECDSA_P256\n");
         result = OE_OK;
     }
+done:
+    return result;
+}
+
+oe_result_t oe_sgx_get_supplemental_data_size(
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    uint32_t* supplemental_data_size)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    quote3_error_t err = SGX_QL_ERROR_UNEXPECTED;
+    uint32_t local_data_size = 0;
+
+    // Add format_id for forward compatibility
+    // Only support ECDSA-p256 now
+    if (memcmp(format_id, &_ecdsa_p256_uuid, sizeof(_ecdsa_p256_uuid)) != 0)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    if (!supplemental_data_size || (!opt_params && opt_params_size > 0))
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    if (TRY_TO_USE_SGX_DCAP_QVL() && _load_sgx_dcap_qvl())
+    {
+        err = _sgx_qv_get_quote_supplemental_data_size(&local_data_size);
+        if (err != SGX_QL_SUCCESS)
+            OE_RAISE_MSG(
+                OE_PLATFORM_ERROR,
+                "Get SGX QVL/QvE supplemental data size quote3_error_t=0x%x\n",
+                err);
+
+        *supplemental_data_size = local_data_size;
+        result = OE_OK;
+    }
+    else
+        // Failed to load DCAP QVL library
+        result = OE_PLATFORM_ERROR;
+
+done:
+    return result;
+}
+
+static oe_result_t sgx_qvl_error_to_oe(quote3_error_t err)
+{
+    switch (err)
+    {
+        case SGX_QL_SUCCESS:
+        case SGX_QL_TCB_SW_HARDENING_NEEDED:
+        case SGX_QL_SGX_TCB_INFO_EXPIRED:
+            return OE_OK;
+
+        case SGX_QL_ERROR_INVALID_PARAMETER:
+            return OE_INVALID_PARAMETER;
+
+        case SGX_QL_PCK_CERT_UNSUPPORTED_FORMAT:
+        case SGX_QL_PCK_CERT_CHAIN_ERROR:
+        case SGX_QL_TCBINFO_UNSUPPORTED_FORMAT:
+        case SGX_QL_TCBINFO_CHAIN_ERROR:
+        case SGX_QL_TCBINFO_MISMATCH:
+        case SGX_QL_QEIDENTITY_UNSUPPORTED_FORMAT:
+        case SGX_QL_QEIDENTITY_CHAIN_ERROR:
+        case SGX_QL_TCB_OUT_OF_DATE:
+        case SGX_QL_SGX_ENCLAVE_IDENTITY_OUT_OF_DATE:
+        case SGX_QL_SGX_ENCLAVE_REPORT_ISVSVN_OUT_OF_DATE:
+        case SGX_QL_QE_IDENTITY_OUT_OF_DATE:
+        case SGX_QL_SGX_PCK_CERT_CHAIN_EXPIRED:
+        case SGX_QL_SGX_SIGNING_CERT_CHAIN_EXPIRED:
+        case SGX_QL_SGX_ENCLAVE_IDENTITY_EXPIRED:
+            return OE_INVALID_ENDORSEMENT;
+
+        case SGX_QL_QUOTE_FORMAT_UNSUPPORTED:
+        case SGX_QL_QE_REPORT_INVALID_SIGNATURE:
+        case SGX_QL_QE_REPORT_UNSUPPORTED_FORMAT:
+        case SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED:
+            return OE_QUOTE_VERIFICATION_ERROR;
+
+        case SGX_QL_SGX_CRL_EXPIRED:
+            return OE_VERIFY_CRL_EXPIRED;
+
+        case SGX_QL_PCK_REVOKED:
+        case SGX_QL_TCB_REVOKED:
+            return OE_VERIFY_REVOKED;
+
+        case SGX_QL_TCB_CONFIGURATION_NEEDED:
+        case SGX_QL_TCB_OUT_OF_DATE_CONFIGURATION_NEEDED:
+        case SGX_QL_TCB_CONFIGURATION_AND_SW_HARDENING_NEEDED:
+            return OE_TCB_LEVEL_INVALID;
+
+        default:
+            return OE_UNEXPECTED;
+    }
+}
+
+oe_result_t oe_sgx_verify_quote(
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    const uint8_t* p_quote,
+    uint32_t quote_size,
+    time_t expiration_check_date,
+    uint32_t* p_collateral_expiration_status,
+    uint32_t* p_quote_verification_result,
+    void* p_qve_report_info,
+    uint32_t qve_report_info_size,
+    void* p_supplemental_data,
+    uint32_t supplemental_data_size,
+    uint32_t collateral_version,
+    const void* p_tcb_info,
+    uint32_t tcb_info_size,
+    const void* p_tcb_info_issuer_chain,
+    uint32_t tcb_info_issuer_chain_size,
+    const void* p_pck_crl,
+    uint32_t pck_crl_size,
+    const void* p_root_ca_crl,
+    uint32_t root_ca_crl_size,
+    const void* p_pck_crl_issuer_chain,
+    uint32_t pck_crl_issuer_chain_size,
+    const void* p_qe_identity,
+    uint32_t qe_identity_size,
+    const void* p_qe_identity_issuer_chain,
+    uint32_t qe_identity_issuer_chain_size)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    quote3_error_t err = SGX_QL_ERROR_UNEXPECTED;
+
+    // Add format_id for forward compatibility
+    // Only support ECDSA-p256 now
+    if (memcmp(format_id, &_ecdsa_p256_uuid, sizeof(_ecdsa_p256_uuid)) != 0)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    if (!p_quote || quote_size > OE_MAX_UINT32 ||
+        !p_collateral_expiration_status || !p_quote_verification_result ||
+        (!p_supplemental_data && supplemental_data_size > 0) ||
+        (!opt_params && opt_params_size > 0))
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    if ((p_qve_report_info &&
+         qve_report_info_size != sizeof(sgx_ql_qe_report_info_t)) ||
+        (!p_qve_report_info && qve_report_info_size > 0))
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    if (quote_size > OE_MAX_UINT32)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    if (TRY_TO_USE_SGX_DCAP_QVL() && _load_sgx_dcap_qvl())
+    {
+        sgx_ql_qve_collateral_t* p_sgx_endorsements = NULL;
+
+        // If user provide OE endorsements buffer, try to use it
+        if (p_tcb_info && tcb_info_size > 0 && p_tcb_info_issuer_chain &&
+            tcb_info_size > 0 && p_pck_crl && pck_crl_size > 0 &&
+            p_root_ca_crl && root_ca_crl_size > 0 && p_pck_crl_issuer_chain &&
+            pck_crl_issuer_chain_size > 0 && p_qe_identity &&
+            qe_identity_size > 0 && p_qe_identity_issuer_chain &&
+            qe_identity_issuer_chain_size > 0)
+        {
+            p_sgx_endorsements = (sgx_ql_qve_collateral_t*)oe_malloc(
+                sizeof(sgx_ql_qve_collateral_t));
+            if (p_sgx_endorsements == NULL)
+            {
+                OE_RAISE_MSG(
+                    OE_OUT_OF_MEMORY,
+                    "Out of memory while creating SGX QVL endorsements.",
+                    NULL);
+            }
+            memset(p_sgx_endorsements, 0, sizeof(sgx_ql_qve_collateral_t));
+
+            p_sgx_endorsements->version = collateral_version;
+            p_sgx_endorsements->tcb_info = (char*)p_tcb_info;
+            p_sgx_endorsements->tcb_info_size = tcb_info_size;
+            p_sgx_endorsements->tcb_info_issuer_chain =
+                (char*)p_tcb_info_issuer_chain;
+            p_sgx_endorsements->tcb_info_issuer_chain_size =
+                tcb_info_issuer_chain_size;
+            p_sgx_endorsements->pck_crl = (char*)p_pck_crl;
+            p_sgx_endorsements->pck_crl_size = pck_crl_size;
+            p_sgx_endorsements->root_ca_crl = (char*)p_root_ca_crl;
+            p_sgx_endorsements->root_ca_crl_size = root_ca_crl_size;
+            p_sgx_endorsements->pck_crl_issuer_chain =
+                (char*)p_pck_crl_issuer_chain;
+            p_sgx_endorsements->pck_crl_issuer_chain_size =
+                pck_crl_issuer_chain_size;
+            p_sgx_endorsements->qe_identity = (char*)p_qe_identity;
+            p_sgx_endorsements->qe_identity_size = qe_identity_size;
+            p_sgx_endorsements->qe_identity_issuer_chain =
+                (char*)p_qe_identity_issuer_chain;
+            p_sgx_endorsements->qe_identity_issuer_chain_size =
+                qe_identity_issuer_chain_size;
+
+            OE_TRACE_INFO("SGX endorsements from OE SDK are used for quote "
+                          "verification\n");
+        }
+
+        err = _sgx_qv_verify_quote(
+            p_quote,
+            (uint32_t)quote_size,
+            p_sgx_endorsements,
+            expiration_check_date,
+            (uint32_t*)p_collateral_expiration_status,
+            (sgx_ql_qv_result_t*)p_quote_verification_result,
+            (sgx_ql_qe_report_info_t*)p_qve_report_info,
+            (uint32_t)supplemental_data_size,
+            p_supplemental_data);
+
+        oe_free(p_sgx_endorsements);
+
+        // To align with current quote verification logic, only accept TCB
+        // status
+        // - UpToDate
+        // - SW Hardening needed
+        result = sgx_qvl_error_to_oe(err);
+
+        if (result != OE_OK)
+        {
+            OE_RAISE_MSG(
+                OE_PLATFORM_ERROR,
+                "SGX ECDSA QVL-based quote verificaton error "
+                "quote3_error_t=0x%x\n",
+                err);
+        }
+
+        OE_TRACE_INFO("verfication status=%d", *p_quote_verification_result);
+    }
+    else
+    {
+        // SGX_DCAP_QVL env doesn't set or QVL doesn't exist
+        result = OE_PLATFORM_ERROR;
+    }
+
 done:
     return result;
 }

--- a/host/sgx/sgxquote.h
+++ b/host/sgx/sgxquote.h
@@ -34,4 +34,39 @@ oe_result_t oe_sgx_get_supported_attester_format_ids(
     void* format_ids,
     size_t* format_ids_size);
 
+oe_result_t oe_sgx_get_supplemental_data_size(
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    uint32_t* supplemental_data_size);
+
+oe_result_t oe_sgx_verify_quote(
+    const oe_uuid_t* format_id,
+    const void* opt_params,
+    size_t opt_params_size,
+    const uint8_t* p_quote,
+    uint32_t quote_size,
+    time_t expiration_check_date,
+    uint32_t* p_collateral_expiration_status,
+    uint32_t* p_quote_verification_result,
+    void* p_qve_report_info,
+    uint32_t qve_report_info_size,
+    void* p_supplemental_data,
+    uint32_t supplemental_data_size,
+    uint32_t collateral_version,
+    const void* p_tcb_info,
+    uint32_t tcb_info_size,
+    const void* p_tcb_info_issuer_chain,
+    uint32_t tcb_info_issuer_chain_size,
+    const void* p_pck_crl,
+    uint32_t pck_crl_size,
+    const void* p_root_ca_crl,
+    uint32_t root_ca_crl_size,
+    const void* p_pck_crl_issuer_chain,
+    uint32_t pck_crl_issuer_chain_size,
+    const void* p_qe_identity,
+    uint32_t qe_identity_size,
+    const void* p_qe_identity_issuer_chain,
+    uint32_t qe_identity_issuer_chain_size);
+
 #endif // _OE_SGXQUOTE_H

--- a/include/openenclave/edl/sgx/attestation.edl
+++ b/include/openenclave/edl/sgx/attestation.edl
@@ -93,5 +93,35 @@ enclave
             [out, size=qe_identity_issuer_chain_size] void* qe_identity_issuer_chain,
             size_t qe_identity_issuer_chain_size,
             [out] size_t* qe_identity_issuer_chain_size_out);
+
+        oe_result_t oe_verify_quote_ocall(
+            [in] const oe_uuid_t* format_id,
+            [in, size=opt_params_size] const void* opt_params,
+            size_t opt_params_size,
+            [in, size=quote_size] const void* p_quote,
+            uint32_t quote_size,
+            const time_t expiration_check_date,
+            [out] uint32_t* p_collateral_expiration_status,
+            [out] uint32_t* p_quote_verification_result,
+            [in, out, size=qve_report_info_size] void* p_qve_report_info,
+            uint32_t qve_report_info_size,
+            [out, size=supplemental_data_size] void* p_supplemental_data,
+            uint32_t supplemental_data_size,
+            [out] uint32_t* p_supplemental_data_size_out,
+            uint32_t collateral_version,
+            [in, size=tcb_info_size] const void* p_tcb_info,
+            uint32_t tcb_info_size,
+            [in, size=tcb_info_issuer_chain_size] const void* p_tcb_info_issuer_chain,
+            uint32_t tcb_info_issuer_chain_size,
+            [in, size=pck_crl_size] const void* p_pck_crl,
+            uint32_t pck_crl_size,
+            [in, size=root_ca_crl_size] const void* p_root_ca_crl,
+            uint32_t root_ca_crl_size,
+            [in, size=pck_crl_issuer_chain_size] const void* p_pck_crl_issuer_chain,
+            uint32_t pck_crl_issuer_chain_size,
+            [in, size=qe_identity_size] const void* p_qe_identity,
+            uint32_t qe_identity_size,
+            [in, size=qe_identity_issuer_chain_size] const void* p_qe_identity_issuer_chain,
+            uint32_t qe_identity_issuer_chain_size);
     };
 };

--- a/include/openenclave/internal/datetime.h
+++ b/include/openenclave/internal/datetime.h
@@ -58,6 +58,11 @@ oe_result_t oe_datetime_now(oe_datetime_t* value);
  */
 void oe_datetime_log(const char* msg, const oe_datetime_t* date);
 
+/**
+ * Convert oe datetime to time_t.
+ */
+oe_result_t oe_datetime_to_time_t(const oe_datetime_t* datetime, time_t* value);
+
 OE_EXTERNC_END
 
 #endif /* _OE_INTERNAL_DATETIME_H */

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -24,6 +24,19 @@
 
 #define SKIP_RETURN_CODE 2
 
+#ifdef _WIN32
+
+#include <windows.h>
+
+#define TRY_TO_USE_SGX_DCAP_QVL() \
+    (GetEnvironmentVariableA("USE_SGX_QVL", NULL, 0) != 0)
+
+#else
+
+#define TRY_TO_USE_SGX_DCAP_QVL() (getenv("USE_SGX_QVL") != NULL)
+
+#endif
+
 extern void TestVerifyTCBInfo(
     oe_enclave_t* enclave,
     const char* test_file_name);
@@ -302,19 +315,24 @@ int main(int argc, const char* argv[])
         TestVerifyTCBInfo_Negative(
             enclave, negative_files_v2, OE_COUNTOF(negative_files_v2));
         {
-            // Get current time and pass it to enclave.
-            std::time_t t = std::time(0);
-            std::tm tm;
-            gmtime_r(&t, &tm);
+            // _sgx_minimim_crl_tcb_issue_date cannot be used in DCAP QVL
+            // Disable below test when using QVL
+            if (!TRY_TO_USE_SGX_DCAP_QVL())
+            {
+                // Get current time and pass it to enclave.
+                std::time_t t = std::time(0);
+                std::tm tm;
+                gmtime_r(&t, &tm);
 
-            // convert std::tm to oe_datetime_t
-            oe_datetime_t now = {(uint32_t)tm.tm_year + 1900,
-                                 (uint32_t)tm.tm_mon + 1,
-                                 (uint32_t)tm.tm_mday,
-                                 (uint32_t)tm.tm_hour,
-                                 (uint32_t)tm.tm_min,
-                                 (uint32_t)tm.tm_sec};
-            test_minimum_issue_date(enclave, now);
+                // convert std::tm to oe_datetime_t
+                oe_datetime_t now = {(uint32_t)tm.tm_year + 1900,
+                                     (uint32_t)tm.tm_mon + 1,
+                                     (uint32_t)tm.tm_mday,
+                                     (uint32_t)tm.tm_hour,
+                                     (uint32_t)tm.tm_min,
+                                     (uint32_t)tm.tm_sec};
+                test_minimum_issue_date(enclave, now);
+            }
         }
     }
     else


### PR DESCRIPTION
Implementation of  PR [3414](https://github.com/openenclave/openenclave/pull/3414) step 1.

- Use existing quote verification logic by default
- Only when user installed DCAP QVL/QvE, and set env var "USE_SGX_QVL", quote verification logic would use QVL/QvE