### PR TITLE
Reduce max threads to 8 for pluggable_allocator sample.

### DIFF
--- a/samples/pluggable_allocator/enclave/allocator_demo.conf
+++ b/samples/pluggable_allocator/enclave/allocator_demo.conf
@@ -12,6 +12,6 @@ Debug=1
 # each enclave thread in the sample.
 NumHeapPages=4096
 NumStackPages=16
-NumTCS=16
+NumTCS=8
 ProductID=1
 SecurityVersion=1

--- a/samples/pluggable_allocator/host/host.cpp
+++ b/samples/pluggable_allocator/host/host.cpp
@@ -15,7 +15,7 @@
 using namespace std;
 using namespace std::chrono;
 
-static uint32_t _max_threads = 16;
+static uint32_t _max_threads = 8;
 static uint64_t _num_allocations = 100000;
 static uint64_t _max_allocation_size = 16 * 1024;
 static uint32_t _flags = OE_ENCLAVE_FLAG_DEBUG;


### PR DESCRIPTION
This value allows the sample to pass on all known ACC VM configurations.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>