### PR TITLE
Replace temporary_buffer_size with NULL in _get_attester_plugins()

### DIFF
--- a/enclave/sgx/attester.c
+++ b/enclave/sgx/attester.c
@@ -372,10 +372,7 @@ static oe_result_t _get_attester_plugins(
 
         // Get the format IDs
         result = oe_get_supported_attester_format_ids_ocall(
-            (uint32_t*)&retval,
-            temporary_buffer,
-            temporary_buffer_size,
-            &temporary_buffer_size);
+            (uint32_t*)&retval, temporary_buffer, temporary_buffer_size, NULL);
         OE_CHECK(result);
         OE_CHECK(retval);
     }


### PR DESCRIPTION
Replace `&temporary_buffer_size` in line 378 in `enclave/sgx/attester.c` with `NULL`.

The value of `temporary_buffer_size` is already validated near line 360 where `oe_get_supported_attester_format_ids_ocall` is first called, which eventually calls `oe_sgx_get_supported_attester_format_ids` in `host/sgx/sgxquote.c` and does check against supplied buffer size.

Fix #3500 .

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>