### PR TITLE
Remove oe_time/time from corelibc

### DIFF
--- a/common/datetime.c
+++ b/common/datetime.c
@@ -238,7 +238,7 @@ oe_result_t oe_datetime_now(oe_datetime_t* value)
 #ifndef OE_BUILD_ENCLAVE
     time(&now);
 #else
-    now = oe_get_time() / 1000;
+    now = (time_t)(oe_get_time() / 1000);
 #endif
     gmtime_r(&now, &timeinfo);
 

--- a/common/datetime.c
+++ b/common/datetime.c
@@ -4,6 +4,7 @@
 #include <openenclave/bits/defs.h>
 #include <openenclave/internal/datetime.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/time.h>
 #include <time.h>
 
 #define UNIX_EPOCH_YEAR (1970)
@@ -234,7 +235,11 @@ oe_result_t oe_datetime_now(oe_datetime_t* value)
     if (value == NULL)
         OE_RAISE(OE_INVALID_PARAMETER);
 
+#ifndef OE_BUILD_ENCLAVE
     time(&now);
+#else
+    now = oe_get_time() / 1000;
+#endif
     gmtime_r(&now, &timeinfo);
 
     value->year = (uint32_t)timeinfo.tm_year + 1900;

--- a/include/openenclave/corelibc/time.h
+++ b/include/openenclave/corelibc/time.h
@@ -23,8 +23,6 @@ struct oe_tm
     int tm_isdst;
 };
 
-time_t oe_time(time_t* tloc);
-
 struct oe_tm* oe_gmtime(const time_t* timep);
 
 struct oe_tm* oe_gmtime_r(const time_t* timep, struct oe_tm* result);
@@ -49,12 +47,6 @@ struct timespec
     time_t tv_sec;
     long tv_nsec;
 };
-
-OE_INLINE
-time_t time(time_t* tloc)
-{
-    return oe_time(tloc);
-}
 
 OE_INLINE
 struct tm* gmtime(const time_t* timep)


### PR DESCRIPTION
Removes `oe_time` and `time` from corelibc. Proposed fix for #3516.

This changes `oe_datetime_now` to use `oe_get_time` instead of `time` in the enclave, so that it works in corelibc-only projects. However, it still calls `gmtime_r`, which may or may not end up being included in corelibc, see #3517.