### PR TITLE
Install mallinfo.h

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -66,6 +66,10 @@ install(FILES openenclave/corelibc/bits/types.h
 install(FILES openenclave/advanced/allocator.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/advanced)
 
+# Install allocator info header.
+install(FILES openenclave/advanced/mallinfo.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/advanced)
+
 ##==============================================================================
 ##
 ## Install all system EDL files to be included by user EDL


### PR DESCRIPTION
Minor followup to #3484: Copy `mallinfo.h` to the installed `include` directory, so that it can be used by consumers of an OE installation.

Signed-off-by: Eddy Ashton <edashton@microsoft.com>