### PR TITLE
pass check type of GLOB_DAT in rel.dyn in elf64_load_relocations

### DIFF
--- a/host/sgx/elf.c
+++ b/host/sgx/elf.c
@@ -1909,7 +1909,11 @@ oe_result_t elf64_load_relocations(
     for (; p != end; p++)
     {
         uint64_t reloc_type = ELF64_R_TYPE(p->r_info);
-        if (reloc_type != R_X86_64_RELATIVE && reloc_type != R_X86_64_TPOFF64)
+        /* The enclave doesn't perform relocations on R_X86_64_GLOB_DAT, but
+         * we allow it for code that checks for the existence of weak symbols
+         * before using them. */
+        if (reloc_type != R_X86_64_RELATIVE && reloc_type != R_X86_64_TPOFF64 &&
+            reloc_type != R_X86_64_GLOB_DAT)
         {
             // Relocations are critical for correct code behavior.
             // Error out for unsupported relocations

--- a/include/openenclave/internal/elf.h
+++ b/include/openenclave/internal/elf.h
@@ -137,6 +137,7 @@ ELF_EXTERNC_BEGIN
 #define STT_HIPROC 15
 
 /* elf64_rel.r_info */
+#define R_X86_64_GLOB_DAT 6
 #define R_X86_64_RELATIVE 8
 
 /* Supported thread-local storage relocations */


### PR DESCRIPTION
Signed-off-by: Xiangping Ji <xiangping.ji@intel.com>
GLOB_DAT in rel.dyn check should pass in elf64_load_relocations in case where an extern func is declared as a weak symbol (__attribute__((weak))) and it's not actually defined.

regression test passed