### PR TITLE
Update CPUID exception handler to support more CPUID leaves.

### DIFF
--- a/common/sgx/cpuid.c
+++ b/common/sgx/cpuid.c
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/bits/types.h>
+#include <openenclave/internal/cpuid.h>
+
+/* The list of cpuid leaves that are emulated.
+ * Currently 0, 1, 4, 7, 0x80000000 and 0x80000001 leaves are
+ * emulated.
+ */
+const uint32_t supported_cpuid_leaves[OE_CPUID_LEAF_COUNT] =
+    {0, 1, 4, 7, 0x80000000, 0x80000001};

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -56,6 +56,7 @@ if (OE_SGX)
     ${MUSL_SRC_DIR}/string/x86_64/memset.s
     ../../common/sgx/endorsements.c
     ../../common/sgx/rand.S
+    ../../common/sgx/cpuid.c
     sgx/arena.c
     sgx/asmdefs.c
     sgx/backtrace.c

--- a/enclave/core/sgx/cpuid.c
+++ b/enclave/core/sgx/cpuid.c
@@ -79,18 +79,18 @@ int oe_emulate_cpuid(uint64_t* rax, uint64_t* rbx, uint64_t* rcx, uint64_t* rdx)
     uint32_t cpuid_leaf = (*rax) & 0xFFFFFFFF;
     uint32_t cpuid_sub_leaf = (*rcx) & 0xFFFFFFFF;
 
-    if (cpuid_leaf < OE_CPUID_LEAF_COUNT &&
-        oe_is_emulated_cpuid_leaf(cpuid_leaf))
-    {
-        // For leaf 4 of cpuid, only subleaf of 0 is emulated
-        if ((cpuid_leaf == 4) && (cpuid_sub_leaf != 0))
-            return -1;
+    // emulate the cpuid leaves and find the corresponding index
+    uint32_t index = oe_get_emulated_cpuid_leaf_index(cpuid_leaf);
+    if (index == OE_UINT32_MAX)
+        return -1;
 
-        *rax = _cpuid_table[cpuid_leaf][OE_CPUID_RAX];
-        *rbx = _cpuid_table[cpuid_leaf][OE_CPUID_RBX];
-        *rcx = _cpuid_table[cpuid_leaf][OE_CPUID_RCX];
-        *rdx = _cpuid_table[cpuid_leaf][OE_CPUID_RDX];
-        return 0;
-    }
-    return -1;
+    // For leaf 4 of cpuid, only subleaf of 0 is emulated
+    if ((cpuid_leaf == 4) && (cpuid_sub_leaf != 0))
+        return -1;
+
+    *rax = _cpuid_table[index][OE_CPUID_RAX];
+    *rbx = _cpuid_table[index][OE_CPUID_RBX];
+    *rcx = _cpuid_table[index][OE_CPUID_RCX];
+    *rdx = _cpuid_table[index][OE_CPUID_RDX];
+    return 0;
 }

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -216,6 +216,7 @@ if (OE_SGX)
   list(
     APPEND
     PLATFORM_SDK_ONLY_SRC
+    ../common/sgx/cpuid.c
     sgx/calls.c
     sgx/create.c
     sgx/elf.c

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -392,7 +392,7 @@ oe_result_t oe_sgx_get_cpuid_table_ocall(
     for (unsigned int i = 0; i < OE_CPUID_LEAF_COUNT; i++)
     {
         oe_get_cpuid(
-            i,
+            supported_cpuid_leaves[i],
             subleaf,
             &leaf[OE_CPUID_RAX],
             &leaf[OE_CPUID_RBX],

--- a/include/openenclave/internal/cpuid.h
+++ b/include/openenclave/internal/cpuid.h
@@ -5,10 +5,10 @@
 #define _OE_CPUID_H
 
 #include <openenclave/bits/defs.h>
+#include <openenclave/bits/types.h>
 
 #define OE_CPUID_OPCODE 0xA20F
-#define OE_CPUID_LEAF_COUNT 8
-#define OE_CPUID_EXTENDED_CPUID_LEAF 0x80000000
+#define OE_CPUID_LEAF_COUNT 6 /* 0,1,4,7,0x80000000,0x80000001 */
 
 #define OE_CPUID_RAX 0
 #define OE_CPUID_RBX 1
@@ -20,17 +20,31 @@
 #define OE_CPUID_RDRAND_FEATURE 0x40000000u /* Leaf 1, subleaf 0, ECX */
 #define OE_CPUID_RDSEED_FEATURE 0x00040000u /* Leaf 7, subleaf 0, EBX */
 
+extern const uint32_t supported_cpuid_leaves[OE_CPUID_LEAF_COUNT];
+
 /**
- * The list of cpuid leafs that are emulated.
- * Currently 0, 1, 4, 7 leafs are emulated, consistent with Intel SDK.
- * Note: leaf 1 is used by mbedtls to determine aesni support.
- * The higher 8 bits of ebx for leaf 1 is the current processor id (initial APIC
+ * Get the leaf index for the emulated cpuid leaf
+ */
+OE_INLINE uint32_t oe_get_emulated_cpuid_leaf_index(uint32_t leaf)
+{
+    uint32_t i = 0;
+    while (i < OE_CPUID_LEAF_COUNT && leaf != supported_cpuid_leaves[i])
+        i++;
+    return i < OE_CPUID_LEAF_COUNT ? i : OE_UINT32_MAX;
+}
+
+/**
+ * Check if a cpuid leaf is emulated.
+ * Currently 0, 1, 4, 7, 0x80000000 and 0x80000001 leaves are
+ * emulated. Note: leaf 1 is used by mbedtls to determine aesni support. The
+ * higher 8 bits of ebx for leaf 1 is the current processor id (initial APIC
  * id). Since CPUID emulation returns cached values, this higher 8 bits of ebx
  * should not be relied upon for leaf 1.
  */
 OE_INLINE bool oe_is_emulated_cpuid_leaf(uint32_t leaf)
 {
-    return (leaf == 0) || (leaf == 1) || (leaf == 4) || (leaf == 7);
+    return (oe_get_emulated_cpuid_leaf_index(leaf) != OE_UINT32_MAX) ? true
+                                                                     : false;
 }
 
 #endif /* _OE_CPUID_H */

--- a/tests/VectorException/VectorException.edl
+++ b/tests/VectorException/VectorException.edl
@@ -21,6 +21,6 @@ enclave {
         public int enc_test_ocall_in_handler();
         public void enc_test_cpuid_in_global_constructors();
         public int enc_test_sigill_handling(
-            [out] uint32_t cpuid_table[8][4]);
+            [out] uint32_t cpuid_table[OE_CPUID_LEAF_COUNT][OE_CPUID_REG_COUNT]);
     };
 };

--- a/tests/VectorException/enc/sigill_handling.c
+++ b/tests/VectorException/enc/sigill_handling.c
@@ -6,6 +6,8 @@
 #include <openenclave/internal/print.h>
 #include "VectorException_t.h"
 
+#define OE_CPUID_TRACE_ENUM_LEAF 0x14
+
 // Wrapper over the CPUID instruction.
 void get_cpuid(
     unsigned int leaf,
@@ -164,12 +166,13 @@ int enc_test_sigill_handling(
     }
 
     // Test unsupported CPUID leaves
-    if (!test_unsupported_cpuid_leaf(OE_CPUID_LEAF_COUNT))
+    // Assume 0x14 is an unsupported CPUID leaf and oe_is_emulated_cpuid_leaf()
+    // returns false in this case
+    if (oe_is_emulated_cpuid_leaf(OE_CPUID_TRACE_ENUM_LEAF) != false)
     {
         return -1;
     }
-
-    if (!test_unsupported_cpuid_leaf(OE_CPUID_EXTENDED_CPUID_LEAF))
+    if (!test_unsupported_cpuid_leaf(OE_CPUID_TRACE_ENUM_LEAF))
     {
         return -1;
     }
@@ -177,10 +180,10 @@ int enc_test_sigill_handling(
     // Return enclave-cached CPUID leaves to host for further validation
     for (uint32_t i = 0; i < OE_CPUID_LEAF_COUNT; i++)
     {
-        if (oe_is_emulated_cpuid_leaf(i))
+        if (oe_is_emulated_cpuid_leaf(supported_cpuid_leaves[i]))
         {
             get_cpuid(
-                i,
+                supported_cpuid_leaves[i],
                 0,
                 &(cpuid_table[i][OE_CPUID_RAX]),
                 &(cpuid_table[i][OE_CPUID_RBX]),

--- a/tests/VectorException/host/host.c
+++ b/tests/VectorException/host/host.c
@@ -13,6 +13,7 @@
 #define SKIP_RETURN_CODE 2
 
 static bool _was_ocall_called = false;
+
 void host_set_was_ocall_called()
 {
     _was_ocall_called = true;
@@ -92,7 +93,8 @@ void test_sigill_handling(oe_enclave_t* enclave)
     // Check all values.
     for (uint32_t i = 0; i < OE_CPUID_LEAF_COUNT; i++)
     {
-        if (!oe_is_emulated_cpuid_leaf(i))
+        uint32_t leaf = supported_cpuid_leaves[i];
+        if (!oe_is_emulated_cpuid_leaf(leaf))
         {
             continue;
         }
@@ -100,7 +102,7 @@ void test_sigill_handling(oe_enclave_t* enclave)
         uint32_t cpuid_info[OE_CPUID_REG_COUNT];
         memset(cpuid_info, 0, sizeof(cpuid_info));
         oe_get_cpuid(
-            i,
+            leaf,
             0,
             &cpuid_info[OE_CPUID_RAX],
             &cpuid_info[OE_CPUID_RBX],


### PR DESCRIPTION
Current default CPUID exception handler handles CPUID leaf 0, 1, 4, 7, which meets the requirement for OpenSSL, mbedTLS and others.  IPP crypto requires to access some of the extended CPUID leaves besides the supported leaves, such as 0x80000000, 0x80000001, 0x80000008. 
This patch adds three more CPUID leaves support in the default handler to make things easy for IPP crypto support (or other libraries that request CPUID extended leaves).

Signed-off-by: Zhang Lili <lili.z.zhang@intel.com>