### PR TITLE
Fix calculation error of sgxenclave TLS size

### DIFF
--- a/enclave/core/sgx/init.c
+++ b/enclave/core/sgx/init.c
@@ -8,6 +8,7 @@
 #include <openenclave/corelibc/string.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/calls.h>
+#include <openenclave/internal/constants_x64.h>
 #include <openenclave/internal/eeid.h>
 #include <openenclave/internal/fault.h>
 #include <openenclave/internal/globals.h>
@@ -74,6 +75,7 @@ static oe_result_t _eeid_patch_memory()
         uint8_t* heap_end = (uint8_t*)__oe_get_heap_end();
         uint8_t* tcs_end =
             heap_end + (OE_SGX_TCS_CONTROL_PAGES + OE_SGX_TCS_GUARD_PAGES +
+                        OE_SGX_TCS_THREAD_DATA_PAGES + eeid->tls_page_count +
                         eeid->size_settings.num_stack_pages) *
                            OE_PAGE_SIZE * eeid->size_settings.num_tcs;
 

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -38,6 +38,7 @@ static char* get_fullpath(const char* path)
 #include <openenclave/bits/sgx/sgxtypes.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/calls.h>
+#include <openenclave/internal/constants_x64.h>
 #include <openenclave/internal/debugrt/host.h>
 #include <openenclave/internal/eeid.h>
 #include <openenclave/internal/load.h>
@@ -163,6 +164,7 @@ static oe_result_t _add_control_pages(
     uint64_t enclave_addr,
     uint64_t enclave_size,
     uint64_t entry,
+    size_t tls_page_count,
     uint64_t* vaddr,
     oe_enclave_t* enclave)
 {
@@ -227,8 +229,7 @@ static oe_result_t _add_control_pages(
          * segment.
          */
         tcs->fsbase =
-            *vaddr +
-            (context->num_tls_pages + OE_SGX_NUM_CONTROL_PAGES) * OE_PAGE_SIZE;
+            *vaddr + (tls_page_count + OE_SGX_TCS_CONTROL_PAGES) * OE_PAGE_SIZE;
 
         /* The existing Windows SGX enclave debugger finds the start of the
          * thread data by assuming that it is located at the start of the GS
@@ -268,8 +269,9 @@ static oe_result_t _add_control_pages(
     (*vaddr) += OE_PAGE_SIZE;
 
     /* Add blank pages (for either FS segment or GS segment) */
-    OE_CHECK(_add_filled_pages(
-        context, enclave_addr, vaddr, context->num_tls_pages, 0, true));
+    if (tls_page_count)
+        OE_CHECK(_add_filled_pages(
+            context, enclave_addr, vaddr, tls_page_count, 0, true));
 
     /* Add one page for thread-specific data (TSD) slots */
     OE_CHECK(_add_filled_pages(context, enclave_addr, vaddr, 1, 0, true));
@@ -285,6 +287,7 @@ done:
 
 static oe_result_t _calculate_enclave_size(
     size_t image_size,
+    size_t tls_page_count,
     const oe_sgx_enclave_properties_t* props,
     size_t* loaded_enclave_pages_size,
     size_t* enclave_size)
@@ -293,6 +296,7 @@ static oe_result_t _calculate_enclave_size(
     oe_result_t result = OE_UNEXPECTED;
     size_t heap_size;
     size_t stack_size;
+    size_t tls_size;
     size_t control_size;
     const oe_enclave_size_settings_t* size_settings;
 
@@ -310,13 +314,17 @@ static oe_result_t _calculate_enclave_size(
                  + (size_settings->num_stack_pages * OE_PAGE_SIZE) +
                  OE_PAGE_SIZE; // guard page
 
-    /* Compute the control size in bytes (6 pages total) */
-    control_size = 6 * OE_PAGE_SIZE;
+    /* Compute size of the TLS */
+    tls_size = tls_page_count * OE_PAGE_SIZE;
+
+    /* Compute the control size in bytes (5 pages total) */
+    control_size = (OE_SGX_TCS_CONTROL_PAGES + OE_SGX_TCS_THREAD_DATA_PAGES) *
+                   OE_PAGE_SIZE;
 
     /* Compute end of the enclave */
     *loaded_enclave_pages_size =
         image_size + heap_size +
-        (size_settings->num_tcs * (stack_size + control_size));
+        (size_settings->num_tcs * (stack_size + tls_size + control_size));
 
     if (enclave_size)
     {
@@ -338,6 +346,7 @@ static oe_result_t _add_data_pages(
     oe_enclave_t* enclave,
     const oe_sgx_enclave_properties_t* props,
     uint64_t entry,
+    size_t tls_page_count,
     uint64_t* vaddr)
 
 {
@@ -364,7 +373,13 @@ static oe_result_t _add_data_pages(
 
         /* Add the "control" pages */
         OE_CHECK(_add_control_pages(
-            context, enclave->addr, enclave->size, entry, vaddr, enclave));
+            context,
+            enclave->addr,
+            enclave->size,
+            entry,
+            tls_page_count,
+            vaddr,
+            enclave));
     }
 
     result = OE_OK;
@@ -585,6 +600,7 @@ static oe_result_t _add_eeid_marker_page(
     oe_sgx_load_context_t* context,
     oe_enclave_t* enclave,
     size_t image_size,
+    size_t tls_page_count,
     uint64_t entry_point,
     oe_sgx_enclave_properties_t* props,
     uint64_t* vaddr)
@@ -604,6 +620,7 @@ static oe_result_t _add_eeid_marker_page(
         oe_sha256_save(hctx, eeid->hash_state.H, eeid->hash_state.N);
         eeid->entry_point = entry_point;
         eeid->vaddr = *vaddr;
+        eeid->tls_page_count = tls_page_count;
         eeid->signature_size = sizeof(sgx_sigstruct_t);
         memcpy(
             eeid->data + eeid->data_size,
@@ -618,7 +635,8 @@ static oe_result_t _add_eeid_marker_page(
          * commit size of the base image and dynamically configured data
          * pages (stacks + heap) excluding the EEID data size.
          */
-        _calculate_enclave_size(image_size, props, &marker->offset, NULL);
+        _calculate_enclave_size(
+            image_size, tls_page_count, props, &marker->offset, NULL);
 
         uint64_t addr = enclave->addr + *vaddr;
         uint64_t src = (uint64_t)page;
@@ -721,6 +739,7 @@ oe_result_t oe_sgx_build_enclave(
     oe_enclave_image_t oeimage;
     void* ecall_data = NULL;
     size_t image_size;
+    size_t tls_page_count;
     uint64_t vaddr = 0;
     oe_sgx_enclave_properties_t props;
 
@@ -802,9 +821,16 @@ oe_result_t oe_sgx_build_enclave(
     /* Calculate the size of image */
     OE_CHECK(oeimage.calculate_size(&oeimage, &image_size));
 
+    /* Calculate the number of pages needed for thread-local data */
+    OE_CHECK(oeimage.get_tls_page_count(&oeimage, &tls_page_count));
+
     /* Calculate the size of this enclave in memory */
     OE_CHECK(_calculate_enclave_size(
-        image_size, &props, &loaded_enclave_pages_size, &enclave_size));
+        image_size,
+        tls_page_count,
+        &props,
+        &loaded_enclave_pages_size,
+        &enclave_size));
 
     /* Perform the ECREATE operation */
     OE_CHECK(oe_sgx_create_enclave(
@@ -822,12 +848,23 @@ oe_result_t oe_sgx_build_enclave(
 
 #ifdef OE_WITH_EXPERIMENTAL_EEID
     OE_CHECK(_add_eeid_marker_page(
-        context, enclave, image_size, oeimage.elf.entry_rva, &props, &vaddr));
+        context,
+        enclave,
+        image_size,
+        tls_page_count,
+        oeimage.elf.entry_rva,
+        &props,
+        &vaddr));
 #endif
 
     /* Add data pages */
     OE_CHECK(_add_data_pages(
-        context, enclave, &props, oeimage.elf.entry_rva, &vaddr));
+        context,
+        enclave,
+        &props,
+        oeimage.elf.entry_rva,
+        tls_page_count,
+        &vaddr));
 
 #ifdef OE_WITH_EXPERIMENTAL_EEID
     /* Add optional EEID pages */

--- a/host/sgx/sgxload.h
+++ b/host/sgx/sgxload.h
@@ -8,8 +8,6 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/sgxcreate.h>
 
-#define OE_SGX_NUM_CONTROL_PAGES 4
-
 OE_EXTERNC_BEGIN
 
 OE_INLINE bool oe_sgx_is_simulation_load_context(

--- a/include/openenclave/bits/eeid.h
+++ b/include/openenclave/bits/eeid.h
@@ -51,6 +51,9 @@ typedef struct _oe_eeid
     /** Entry point of the image. */
     uint64_t entry_point;
 
+    /* Number of pages needed for thread-local data */
+    uint64_t tls_page_count;
+
     /** Size of actual EEID data. */
     uint64_t data_size;
 

--- a/include/openenclave/internal/constants_x64.h
+++ b/include/openenclave/internal/constants_x64.h
@@ -26,6 +26,15 @@
 #define OE_SGX_TCS_HEADER_BYTE_SIZE 0x48
 
 //
+// SGX control pages, excluding thread data and local storage:
+// 1 TCS page + 2 SSA pages + 1 guard page
+//
+
+#define OE_SGX_TCS_CONTROL_PAGES 4
+
+#define OE_SGX_TCS_THREAD_DATA_PAGES 1
+
+//
 // oe_context_t Structure size and offset definitions.
 //
 

--- a/include/openenclave/internal/eeid.h
+++ b/include/openenclave/internal/eeid.h
@@ -19,7 +19,6 @@
  * will have, so we chose a reasonably large size here (64GB). */
 #define OE_EEID_SGX_ELRANGE 0x1000000000
 
-#define OE_SGX_TCS_CONTROL_PAGES 6
 #define OE_SGX_TCS_GUARD_PAGES 2
 
 /** This is the public key corresponding to the private key OE_DEBUG_SIGN_KEY in

--- a/include/openenclave/internal/load.h
+++ b/include/openenclave/internal/load.h
@@ -92,6 +92,10 @@ struct _oe_enclave_image
     oe_result_t (
         *calculate_size)(const oe_enclave_image_t* image, size_t* image_size);
 
+    oe_result_t (*get_tls_page_count)(
+        const oe_enclave_image_t* image,
+        size_t* tls_page_count);
+
     oe_result_t (*add_pages)(
         oe_enclave_image_t* image,
         oe_sgx_load_context_t* context,

--- a/include/openenclave/internal/sgxcreate.h
+++ b/include/openenclave/internal/sgxcreate.h
@@ -61,9 +61,6 @@ struct _oe_sgx_load_context
     /* Hash context used to measure enclave as it is loaded */
     oe_sha256_context_t hash_context;
 
-    /* Number of pages needed for thread-local data */
-    size_t num_tls_pages;
-
 #ifdef OE_WITH_EXPERIMENTAL_EEID
     /* EEID data needed during enclave creation */
     oe_eeid_t* eeid;

--- a/tests/eeid_plugin/test_helpers.c
+++ b/tests/eeid_plugin/test_helpers.c
@@ -27,6 +27,7 @@ oe_result_t make_test_eeid(oe_eeid_t** eeid, size_t data_size)
     (*eeid)->size_settings.num_heap_pages = 110 + (data_size / OE_PAGE_SIZE);
     (*eeid)->size_settings.num_stack_pages = 50;
     (*eeid)->size_settings.num_tcs = 2;
+    (*eeid)->tls_page_count = 1;
 
     result = OE_OK;
 


### PR DESCRIPTION
When the _calculate_enclave_size function calculates enclave_size, the tls size is calculated based on the default 1 page size, rather than the actual .tdata and .tbss size. This may cause the oe_sgx_enclave_load_data function to fail when the enclave is loaded, because the number of added pages exceeds the enclave_size size.

For example: modify samplew/helloworld code
helloworld.conf:

```
Debug=1
NumHeapPages=2360
NumStackPages=1024
NumTCS=1
ProductID=1
SecurityVersion=1
```

Declare tls data in enclave
enc.c:
```
#define TLS_SIZE (3848 + 1)
static __thread char tls[TLS_SIZE]
```

When loading enclave, calling oe_sgx_enclave_load_data failed. Error message:
enclave_load_data failed (addr=0x3c000000, prot=0x3 err=0xd) (oe_result_t=OE_PLATFORM_ERROR)

If TLS_SIZE = 3848, loading the enclave will succeed, and the TLS size is exactly 1 page size.

So the _calculate_enclave_size function should calculate enclave_size according to the actual TLS data size.

Signed-off-by: volcano <volcano_dr@163.com>