### PR TITLE
Run attestation sample only if DCAP libraries exist

### DIFF
--- a/samples/test-samples.cmake
+++ b/samples/test-samples.cmake
@@ -62,12 +62,12 @@ else ()
   # they can run even if they weren't built against SGX, because in
   # that cause they directly interface with the AESM service.
   if (BUILD_ENCLAVES)
-    list(APPEND SAMPLES_LIST data-sealing attestation)
+    list(APPEND SAMPLES_LIST data-sealing)
 
     # These tests can only run with SGX-FLC, meaning they were built
     # against SGX.
     if (HAS_QUOTE_PROVIDER)
-      list(APPEND SAMPLES_LIST attested_tls)
+      list(APPEND SAMPLES_LIST attested_tls attestation)
     endif ()
   endif ()
 endif ()


### PR DESCRIPTION
Move `attestation` sample to line 70 so that, like `attested_tls` sample, it will be included in `ctest` only if DCAP libraries exist.

Fix #3595 .

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>