### PR TITLE
Document and verify that claims in oe_verify_evidence() is optional

### DIFF
--- a/common/attest_plugin.c
+++ b/common/attest_plugin.c
@@ -295,8 +295,8 @@ oe_result_t oe_verify_evidence(
     size_t plugin_endorsements_size = 0;
 
     if (!evidence_buffer || !evidence_buffer_size ||
-        (!endorsements_buffer && endorsements_buffer_size) ||
-        (endorsements_buffer && !endorsements_buffer_size))
+        (!endorsements_buffer != !endorsements_buffer_size) ||
+        (!claims != !claims_length))
         OE_RAISE(OE_INVALID_PARAMETER);
 
     if (!format_id)

--- a/include/openenclave/attestation/verifier.h
+++ b/include/openenclave/attestation/verifier.h
@@ -149,8 +149,10 @@ oe_result_t oe_verifier_free_format_settings(uint8_t* settings);
  * @param[in] endorsements_buffer_size The size of endorsements_buffer in bytes.
  * @param[in] policies An optional list of policies to use.
  * @param[in] policies_size The size of the policy list.
- * @param[out] claims The list of claims (including base and custom).
- * @param[out] claims_length The length of the claims list.
+ * @param[out] claims If not NULL, an output pointer that will be assigned the
+ * address of the dynamically allocated list of claims (including base and
+ * custom).
+ * @param[out] claims_length If not NULL, the length of the claims list.
  * @retval OE_OK The function succeeded.
  * @retval OE_INVALID_PARAMETER At least one of the parameters is invalid.
  * @retval other appropriate error code.

--- a/include/openenclave/internal/sgx/plugin.h
+++ b/include/openenclave/internal/sgx/plugin.h
@@ -33,11 +33,11 @@ typedef enum _sgx_evidence_format_type_t
  * @param[in] format_id Pointer to the evidence format ID requested.
  * @param[in] report_body Pointer to a buffer with raw SGX quote / report.
  * @param[in] report_body_size Size of the report_body buffer.
- * @param[in] sgx_endorsements Pointer to the endorsements buffer.
- * @param[in] custom_claims_buffer The data in a flat buffer to be packaged as a
- * claim of ID OE_CLAIM_CUSTOM_CLAIMS_BUFFER when format_type has the right
- * value.
+ * @param[in] custom_claims_buffer If not NULL, it holds the data in a flat
+ * buffer to be packaged as a claim of ID OE_CLAIM_CUSTOM_CLAIMS_BUFFER when
+ * format_type has the right value.
  * @param[in] custom_claims_buffer_size The size of the custom_claims buffer.
+ * @param[in] sgx_endorsements Pointer to the endorsements buffer.
  * @param[out] claims_out Pointer to the address of a dynamically allocated
  * buffer holding the list of claims (including base and custom claims).
  * @param[out] claims_length_out The length of the claims_out list.

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -675,6 +675,44 @@ void verify_sgx_evidence(
         &endorsements_body,
         &endorsements_body_size);
 
+    // Try with no output claims.
+    OE_TEST_CODE(
+        oe_verify_evidence(
+            wrapped_with_header ? NULL : format_id,
+            evidence,
+            evidence_size,
+            endorsements,
+            endorsements_size,
+            NULL,
+            0,
+            NULL,
+            NULL),
+        OE_OK);
+    OE_TEST_CODE(
+        oe_verify_evidence(
+            wrapped_with_header ? NULL : format_id,
+            evidence,
+            evidence_size,
+            endorsements,
+            endorsements_size,
+            NULL,
+            0,
+            &claims,
+            NULL),
+        OE_INVALID_PARAMETER);
+    OE_TEST_CODE(
+        oe_verify_evidence(
+            wrapped_with_header ? NULL : format_id,
+            evidence,
+            evidence_size,
+            endorsements,
+            endorsements_size,
+            NULL,
+            0,
+            NULL,
+            &claims_size),
+        OE_INVALID_PARAMETER);
+
     // Try with no policies.
     OE_TEST_CODE(
         oe_verify_evidence(


### PR DESCRIPTION
Fix #3594 