### PR TITLE
Fallback to FXRSTOR in oe_enter if XSAVE is unsupported

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -85,7 +85,8 @@ if (OE_SGX)
     sgx/td_basic.c
     sgx/thread.c
     sgx/threadlocal.c
-    sgx/tracee.c)
+    sgx/tracee.c
+    sgx/xstate.c)
 
   # Functions in td_basic.c will change the status of td and may trigger
   # stack check fail, thus it is necessary to turn off stack check.

--- a/enclave/core/sgx/asmcommon.inc
+++ b/enclave/core/sgx/asmcommon.inc
@@ -28,13 +28,22 @@
     push %rax
     push %rdx
 
+    // Check if XSAVE/XRSTOR is supported
+    lea     oe_is_xsave_supported(%rip), %rax
+    movl    (%rax), %eax
+    cmpl    $0, %eax
+    jz      1f
+
     // Set the XSAVE_MASK
     mov $0xFFFFFFFF, %eax
     mov $0xFFFFFFFF, %edx
 
     // Restore initial enclave XSAVE state
     xrstor64 OE_XSAVE_INITIAL_STATE(%rip)
-
+    jmp     2f
+1:
+    fxrstor64 OE_XSAVE_INITIAL_STATE(%rip)
+2:
     // Restore the registers
     pop %rdx
     pop %rax
@@ -70,7 +79,9 @@
     xor %r14, %r14
     xor %r15, %r15
 
-    // zero out flags
+    // Zero out the RFLAGS
+    // This only clears the DF and state flag bits since
+    // the system flags and reserved bits are not writable here
     push %r15
     popfq
 .endm

--- a/enclave/core/sgx/asmcommon.inc
+++ b/enclave/core/sgx/asmcommon.inc
@@ -28,9 +28,10 @@
     push %rax
     push %rdx
 
-    // Check if XSAVE/XRSTOR is supported
-    lea     oe_is_xsave_supported(%rip), %rax
-    movl    (%rax), %eax
+    // Check if extended states are supported by the OS.
+    // If not, fallback to FXRSTOR to clear legacy SSE states only.
+    // Otherwise, clear both legacy SSE states and extended states with XRSTOR.
+    movl    oe_is_xsave_supported(%rip), %eax
     cmpl    $0, %eax
     jz      1f
 
@@ -42,6 +43,7 @@
     xrstor64 OE_XSAVE_INITIAL_STATE(%rip)
     jmp     2f
 1:
+    // Restore initial enclave legacy SSE state
     fxrstor64 OE_XSAVE_INITIAL_STATE(%rip)
 2:
     // Restore the registers

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -40,6 +40,7 @@
 #include "report.h"
 #include "switchlesscalls.h"
 #include "td.h"
+#include "xstate.h"
 
 oe_result_t __oe_enclave_status = OE_OK;
 uint8_t __oe_initialized = 0;
@@ -170,6 +171,10 @@ static oe_result_t _handle_init_enclave(uint64_t arg_in)
 
             /* Initialize the CPUID table before calling global constructors. */
             OE_CHECK(oe_initialize_cpuid());
+
+            /* Initialize the xstate settings
+             * Depends on TD and sgx_create_report, so can't happen earlier */
+            OE_CHECK(oe_set_is_xsave_supported());
 
             /* Call global constructors. Now they can safely use simulated
              * instructions like CPUID. */

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -134,12 +134,6 @@ oe_enter:
     mov %rsp, %rbp
 
 .call_function:
-    // Initialize the RFLAGS prior to calling enclave functions
-    // This only clears the DF and state flag bits since
-    // the system flags and reserved bits are not writable here
-    push $0
-    popfq
-
     // Get the host stack pointer.
     mov td_host_rsp(%r11), %r8
     mov td_host_rbp(%r11), %r9
@@ -179,7 +173,8 @@ oe_enter:
     mov %r11, OM_ENC_TD
 
     // Clear the XSTATE so that enclave has clean legacy SSE and extended states
-    oe_cleanup_xstates
+    xor %r11, %r11
+    oe_cleanup_registers
 
     // Call __oe_handle_main(ARG1=RDI, ARG2=RSI, CSSA=RDX, TCS=RCX, OUTPUTARG1=R8, OUTPUTARG2=R9)
     mov %rax, %rdx

--- a/enclave/core/sgx/xstate.c
+++ b/enclave/core/sgx/xstate.c
@@ -1,0 +1,25 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/bits/sgx/sgxtypes.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/sgx/td.h>
+#include "report.h"
+
+int oe_is_xsave_supported = 0;
+
+oe_result_t oe_set_is_xsave_supported()
+{
+    oe_result_t result = OE_UNEXPECTED;
+    oe_sgx_td_t* td = oe_sgx_get_td();
+    if (!td->simulate)
+    {
+        sgx_report_t report;
+        OE_CHECK_NO_TRACE(sgx_create_report(NULL, 0, NULL, 0, &report));
+        oe_is_xsave_supported =
+            (report.body.attributes.xfrm != SGX_XFRM_LEGACY) ? 1 : 0;
+    }
+    result = OE_OK;
+done:
+    return result;
+}

--- a/enclave/core/sgx/xstate.h
+++ b/enclave/core/sgx/xstate.h
@@ -1,0 +1,6 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+extern int oe_is_xsave_supported;
+
+oe_result_t oe_set_is_xsave_supported();


### PR DESCRIPTION
- Check if XSAVE/XRSTOR is supported during enclave init and cache the state globally.
- Update `oe_enter` to use XRSTOR only if it is enabled by the OS, otherwise, fallback to FXRSTOR.
  - On first EENTER, this always uses FXRSTOR because the enclave hasn't checked feature support from the EREPORT yet.
  - This is acceptable as the first invocation is always the enclave init method, which doesn't use extended feature states.
  - Simulation mode only uses FXRSTOR as the use of EREPORT is not supported.
- Update `oe_enter` to always clear general purpose registers as well.
  - `oe_enter` now calls `oe_cleanup_registers` instead of just `oe_cleanup_xstates`, which also clears the RFLAGS that were previously handled separately at the beginning of `oe_enter`.

Fixes #3360

Signed-off-by: Simon Leet <simon.leet@microsoft.com>