### PR TITLE
Rename Callsite to oe_callsite_t

### DIFF
--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -349,7 +349,7 @@ static void _handle_ecall(
     oe_result_t result = OE_OK;
 
     /* Insert ECALL context onto front of oe_sgx_td_t.ecalls list */
-    Callsite callsite = {{0}};
+    oe_callsite_t callsite = {{0}};
     uint64_t arg_out = 0;
 
     td_push_callsite(td, &callsite);
@@ -473,7 +473,7 @@ OE_INLINE void _handle_oret(
     uint16_t result,
     uint64_t arg)
 {
-    Callsite* callsite = td->callsites;
+    oe_callsite_t* callsite = td->callsites;
 
     if (!callsite)
         return;
@@ -631,7 +631,7 @@ oe_result_t oe_ocall(uint16_t func, uint64_t arg_in, uint64_t* arg_out)
 {
     oe_result_t result = OE_UNEXPECTED;
     oe_sgx_td_t* td = oe_sgx_get_td();
-    Callsite* callsite = td->callsites;
+    oe_callsite_t* callsite = td->callsites;
 
     /* If the enclave is in crashing/crashed status, new OCALL should fail
     immediately. */

--- a/enclave/core/sgx/td.c
+++ b/enclave/core/sgx/td.c
@@ -37,7 +37,7 @@ OE_STATIC_ASSERT(
 // Static asserts for consistency with
 // debugger/pythonExtension/gdb_sgx_plugin.py
 OE_STATIC_ASSERT(td_callsites == 0xf0);
-OE_STATIC_ASSERT(OE_OFFSETOF(Callsite, ocall_context) == 0x40);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_callsite_t, ocall_context) == 0x40);
 OE_STATIC_ASSERT(sizeof(oe_ocall_context_t) == (2 * sizeof(uintptr_t)));
 
 // Offset of the td page from the tcs page in bytes. This varies depending on
@@ -69,13 +69,13 @@ oe_thread_data_t* oe_get_thread_data()
 **
 ** td_push_callsite()
 **
-**     Insert the Callsite structure for the current ECALL at the
+**     Insert the oe_callsite_t structure for the current ECALL at the
 **     front of the oe_sgx_td_t.callsites list.
 **
 **==============================================================================
 */
 
-void td_push_callsite(oe_sgx_td_t* td, Callsite* callsite)
+void td_push_callsite(oe_sgx_td_t* td, oe_callsite_t* callsite)
 {
     callsite->next = td->callsites;
     td->callsites = callsite;

--- a/enclave/core/sgx/td.h
+++ b/enclave/core/sgx/td.h
@@ -13,7 +13,7 @@
 /*
 **==============================================================================
 **
-** Callsite
+** oe_callsite_t
 **
 **     This structure stores callsite information saved when initiating an
 **     OCALL (__oe_ocall). It stores:
@@ -41,9 +41,9 @@
 **==============================================================================
 */
 
-typedef struct _callsite Callsite;
+typedef struct _oe_callsite oe_callsite_t;
 
-struct _callsite
+struct _oe_callsite
 {
     /* Enclave callsite stored here when exiting to make an OCALL */
     oe_jmpbuf_t jmpbuf;
@@ -52,7 +52,7 @@ struct _callsite
     oe_ocall_context_t* ocall_context;
 
     /* Pointer to next ECALL context */
-    Callsite* next;
+    oe_callsite_t* next;
 };
 
 /* Some basic td function do not have the opportunity to keep consistency of
@@ -69,7 +69,7 @@ struct _callsite
 **==============================================================================
 */
 
-void td_push_callsite(oe_sgx_td_t* td, Callsite* ec);
+void td_push_callsite(oe_sgx_td_t* td, oe_callsite_t* ec);
 
 oe_sgx_td_t* td_from_tcs(void* tcs);
 

--- a/enclave/core/sgx/td_basic.c
+++ b/enclave/core/sgx/td_basic.c
@@ -20,7 +20,7 @@
 **
 ** td_pop_callsite()
 **
-**     Remove the Callsite structure that is at the head of the
+**     Remove the oe_callsite_t structure that is at the head of the
 **     oe_sgx_td_t.callsites list.
 **
 **==============================================================================

--- a/include/openenclave/internal/sgx/td.h
+++ b/include/openenclave/internal/sgx/td.h
@@ -76,14 +76,14 @@ oe_thread_data_t* oe_get_thread_data(void);
 
 /**
  * thread_specific_data is the last field in oe_sgx_td_t. It takes up any
- * remainaing space after the declarations of the previous fields. Its size is
+ * remaining space after the declarations of the previous fields. Its size is
  * equal to sizeof(oe_sgx_td_t) - OE_OFFSETOF(oe_sgx_td_t, thread_specific_data)
  * Due to the inability to use OE_OFFSETOF on a struct while defining its
  * members, this value is computed and hard-coded.
  */
 #define OE_THREAD_SPECIFIC_DATA_SIZE (3744)
 
-typedef struct _callsite Callsite;
+typedef struct _oe_callsite oe_callsite_t;
 
 /* Thread specific TLS atexit call parameters */
 typedef struct _oe_tls_atexit
@@ -129,8 +129,8 @@ typedef struct _td
     uint16_t padding[2];
     uint64_t oret_arg;
 
-    /* List of Callsite structures (most recent call is first) */
-    Callsite* callsites;
+    /* List of oe_callsite_t structures (most recent call is first) */
+    oe_callsite_t* callsites;
 
     /* Simulation mode is active if non-zero */
     uint64_t simulate;


### PR DESCRIPTION
Clean up the internal variable name to match OE developer guidelines.

Signed-off-by: Simon Leet <simon.leet@microsoft.com>