### PR TITLE
Refactor and cleanup SYSCALLs infrastructure

### DIFF
--- a/include/openenclave/internal/syscall/declarations.h
+++ b/include/openenclave/internal/syscall/declarations.h
@@ -1,0 +1,187 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_SYSCALL_DECLARATIONS_H
+#define _OE_SYSCALL_DECLARATIONS_H
+
+#include <bits/syscall.h>
+#include <openenclave/bits/defs.h>
+#include <openenclave/bits/result.h>
+
+// For OE_SYS_ defines.
+// They are just used for asserting that they are equal to the corresponding
+// SYS_ ones.
+#if __x86_64__ || _M_X64
+#include <openenclave/internal/syscall/sys/bits/syscall_x86_64.h>
+#elif defined(__aarch64__)
+#include <openenclave/internal/syscall/sys/bits/syscall_aarch64.h>
+#else
+#error Unsupported architecture
+#endif
+
+OE_EXTERNC_BEGIN
+
+#define OE_SYSCALL_NAME(index) oe##index##_impl
+
+#define OE_SYSCALL_DISPATCH(index, ...) \
+    case OE_##index:                    \
+        return OE_SYSCALL_NAME(_##index)(__VA_ARGS__)
+
+#define OE_SYSCALL_ARGS0 void
+#define OE_SYSCALL_ARGS1 long arg1
+#define OE_SYSCALL_ARGS2 OE_SYSCALL_ARGS1, long arg2
+#define OE_SYSCALL_ARGS3 OE_SYSCALL_ARGS2, long arg3
+#define OE_SYSCALL_ARGS4 OE_SYSCALL_ARGS3, long arg4
+#define OE_SYSCALL_ARGS5 OE_SYSCALL_ARGS4, long arg5
+#define OE_SYSCALL_ARGS6 OE_SYSCALL_ARGS5, long arg6
+#define OE_SYSCALL_ARGS7 OE_SYSCALL_ARGS6, long arg7
+
+#define OE_DECLARE_SYSCALL0(index)         \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS0)
+#define OE_DECLARE_SYSCALL1(index)         \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS1)
+#define OE_DECLARE_SYSCALL2(index)         \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS2)
+#define OE_DECLARE_SYSCALL3(index)         \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS3)
+#define OE_DECLARE_SYSCALL4(index)         \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS4)
+#define OE_DECLARE_SYSCALL5(index)         \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS5)
+#define OE_DECLARE_SYSCALL6(index)         \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS6)
+#define OE_DECLARE_SYSCALL7(index)         \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS7)
+
+#define OE_DEFINE_SYSCALL0 OE_DECLARE_SYSCALL0
+#define OE_DEFINE_SYSCALL1 OE_DECLARE_SYSCALL1
+#define OE_DEFINE_SYSCALL2 OE_DECLARE_SYSCALL2
+#define OE_DEFINE_SYSCALL3 OE_DECLARE_SYSCALL3
+#define OE_DEFINE_SYSCALL4 OE_DECLARE_SYSCALL4
+#define OE_DEFINE_SYSCALL5 OE_DECLARE_SYSCALL5
+#define OE_DEFINE_SYSCALL6 OE_DECLARE_SYSCALL6
+#define OE_DEFINE_SYSCALL7 OE_DECLARE_SYSCALL7
+
+/** List of syscalls that are supported within enclaves.
+ ** In alphabetical order.
+ ** Certain syscalls are available only in some platforms.
+ **/
+
+OE_DECLARE_SYSCALL3(SYS_accept);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL2(SYS_access);
+#endif
+OE_DECLARE_SYSCALL3(SYS_bind);
+OE_DECLARE_SYSCALL1(SYS_chdir);
+OE_DECLARE_SYSCALL1(SYS_close);
+OE_DECLARE_SYSCALL3(SYS_connect);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL2(SYS_creat);
+#endif
+OE_DECLARE_SYSCALL1(SYS_dup);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL2(SYS_dup2);
+#endif
+OE_DECLARE_SYSCALL3(SYS_dup3);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL1(SYS_epoll_create);
+#endif
+OE_DECLARE_SYSCALL1(SYS_epoll_create1);
+OE_DECLARE_SYSCALL4(SYS_epoll_ctl);
+OE_DECLARE_SYSCALL5(SYS_epoll_pwait);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL4(SYS_epoll_wait);
+#endif
+OE_DECLARE_SYSCALL1(SYS_exit);
+OE_DECLARE_SYSCALL0(SYS_exit_group);
+OE_DECLARE_SYSCALL4(SYS_faccessat);
+OE_DECLARE_SYSCALL3(SYS_fcntl);
+OE_DECLARE_SYSCALL1(SYS_fdatasync);
+OE_DECLARE_SYSCALL2(SYS_flock);
+OE_DECLARE_SYSCALL2(SYS_fstat);
+OE_DECLARE_SYSCALL1(SYS_fsync);
+OE_DECLARE_SYSCALL2(SYS_getcwd);
+OE_DECLARE_SYSCALL3(SYS_getdents64);
+OE_DECLARE_SYSCALL0(SYS_getegid);
+OE_DECLARE_SYSCALL0(SYS_geteuid);
+OE_DECLARE_SYSCALL0(SYS_getgid);
+OE_DECLARE_SYSCALL2(SYS_getgroups);
+OE_DECLARE_SYSCALL3(SYS_getpeername);
+OE_DECLARE_SYSCALL1(SYS_getpgid);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL0(SYS_getpgrp);
+#endif
+OE_DECLARE_SYSCALL0(SYS_getpid);
+OE_DECLARE_SYSCALL0(SYS_getppid);
+OE_DECLARE_SYSCALL3(SYS_getsockname);
+OE_DECLARE_SYSCALL5(SYS_getsockopt);
+OE_DECLARE_SYSCALL0(SYS_getuid);
+OE_DECLARE_SYSCALL6(SYS_ioctl);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL2(SYS_link);
+#endif
+OE_DECLARE_SYSCALL5(SYS_linkat);
+OE_DECLARE_SYSCALL2(SYS_listen);
+OE_DECLARE_SYSCALL3(SYS_lseek);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL2(SYS_mkdir);
+#endif
+OE_DECLARE_SYSCALL3(SYS_mkdirat);
+OE_DECLARE_SYSCALL5(SYS_mount);
+OE_DECLARE_SYSCALL2(SYS_nanosleep);
+OE_DECLARE_SYSCALL4(SYS_newfstatat);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL3(SYS_open);
+#endif
+OE_DECLARE_SYSCALL4(SYS_openat);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL3(SYS_poll);
+#endif
+OE_DECLARE_SYSCALL4(SYS_ppoll);
+OE_DECLARE_SYSCALL4(SYS_pread64);
+OE_DECLARE_SYSCALL5(SYS_pselect6);
+OE_DECLARE_SYSCALL4(SYS_pwrite64);
+OE_DECLARE_SYSCALL3(SYS_read);
+OE_DECLARE_SYSCALL3(SYS_readv);
+OE_DECLARE_SYSCALL6(SYS_recvfrom);
+OE_DECLARE_SYSCALL3(SYS_recvmsg);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL2(SYS_rename);
+#endif
+OE_DECLARE_SYSCALL5(SYS_renameat);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL1(SYS_rmdir);
+#endif
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL5(SYS_select);
+#endif
+OE_DECLARE_SYSCALL6(SYS_sendto);
+OE_DECLARE_SYSCALL3(SYS_sendmsg);
+OE_DECLARE_SYSCALL5(SYS_setsockopt);
+OE_DECLARE_SYSCALL2(SYS_shutdown);
+OE_DECLARE_SYSCALL3(SYS_socket);
+OE_DECLARE_SYSCALL4(SYS_socketpair);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL2(SYS_stat);
+#endif
+OE_DECLARE_SYSCALL2(SYS_truncate);
+OE_DECLARE_SYSCALL3(SYS_write);
+OE_DECLARE_SYSCALL3(SYS_writev);
+OE_DECLARE_SYSCALL1(SYS_uname);
+#if __x86_64__ || _M_X64
+OE_DECLARE_SYSCALL1(SYS_unlink);
+#endif
+OE_DECLARE_SYSCALL3(SYS_unlinkat);
+OE_DECLARE_SYSCALL2(SYS_umount2);
+
+OE_EXTERNC_END
+
+#endif /* _OE_SYSCALL_DECLARATIONS_H */

--- a/include/openenclave/internal/syscall/hook.h
+++ b/include/openenclave/internal/syscall/hook.h
@@ -1,8 +1,8 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-#ifndef _OE_INTERNAL_SYSCALL_H
-#define _OE_INTERNAL_SYSCALL_H
+#ifndef _OE_SYSCALL_HOOK_H
+#define _OE_SYSCALL_HOOK_H
 
 #include <openenclave/bits/defs.h>
 #include <openenclave/bits/result.h>
@@ -37,4 +37,4 @@ void oe_register_syscall_hook(oe_syscall_hook_t hook);
 
 OE_EXTERNC_END
 
-#endif /* _OE_INTERNAL_SYSCALL_H */
+#endif /* _OE_SYSCALL_HOOK_H */

--- a/include/openenclave/internal/syscall/sys/syscall.h
+++ b/include/openenclave/internal/syscall/sys/syscall.h
@@ -19,6 +19,8 @@ OE_EXTERNC_BEGIN
 
 long oe_syscall(long number, ...);
 
+#include <openenclave/internal/syscall/declarations.h>
+
 OE_EXTERNC_END
 
 #endif /* _OE_SYSCALL_SYS_SYSCALL_H */

--- a/libc/syscalls.c
+++ b/libc/syscalls.c
@@ -8,7 +8,7 @@
 #include <openenclave/corelibc/errno.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/calls.h>
-#include <openenclave/internal/syscall.h>
+#include <openenclave/internal/syscall/hook.h>
 #include <openenclave/internal/syscall/sys/stat.h>
 #include <openenclave/internal/syscall/sys/syscall.h>
 #include <openenclave/internal/thread.h>

--- a/syscall/CMakeLists.txt
+++ b/syscall/CMakeLists.txt
@@ -58,6 +58,10 @@ enclave_enable_code_coverage(oesyscall)
 
 add_enclave_dependencies(oesyscall syscall_trusted_edl)
 
+# Depend on oelibc in order to include bits/syscall.h which contains MUSL definitions of syscall enums.
+# Syscall infrastructure will assert that MUSL enums (e.g SYS_open) match the corresponding OE enums (e.g OE_SYS_open).
+enclave_link_libraries(oesyscall PRIVATE oelibc_includes)
+
 enclave_include_directories(
   oesyscall PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
   ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)

--- a/syscall/syscall.c
+++ b/syscall/syscall.c
@@ -12,6 +12,7 @@
 #include <openenclave/internal/syscall/device.h>
 #include <openenclave/internal/syscall/dirent.h>
 #include <openenclave/internal/syscall/fcntl.h>
+#include <openenclave/internal/syscall/hook.h>
 #include <openenclave/internal/syscall/raise.h>
 #include <openenclave/internal/syscall/sys/ioctl.h>
 #include <openenclave/internal/syscall/sys/mount.h>
@@ -33,8 +34,938 @@ typedef int (*ioctl_proc)(
     long arg3,
     long arg4);
 
+OE_DEFINE_SYSCALL3(SYS_accept)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    struct oe_sockaddr* addr = (struct oe_sockaddr*)arg2;
+    oe_socklen_t* addrlen = (oe_socklen_t*)arg3;
+    return oe_accept(sockfd, addr, addrlen);
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL2(SYS_access)
+{
+    oe_errno = 0;
+    const char* pathname = (const char*)arg1;
+    int mode = (int)arg2;
+
+    return oe_access(pathname, mode);
+}
+#endif
+
+OE_DEFINE_SYSCALL3(SYS_bind)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    struct oe_sockaddr* addr = (struct oe_sockaddr*)arg2;
+    oe_socklen_t addrlen = (oe_socklen_t)arg3;
+    return oe_bind(sockfd, addr, addrlen);
+}
+
+OE_DEFINE_SYSCALL1(SYS_chdir)
+{
+    oe_errno = 0;
+    char* path = (char*)arg1;
+
+    return oe_chdir(path);
+}
+
+OE_DEFINE_SYSCALL1(SYS_close)
+{
+    oe_errno = 0;
+    int fd = (int)arg1;
+
+    return oe_close(fd);
+}
+
+OE_DEFINE_SYSCALL3(SYS_connect)
+{
+    oe_errno = 0;
+    int sd = (int)arg1;
+    const struct oe_sockaddr* addr = (const struct oe_sockaddr*)arg2;
+    oe_socklen_t addrlen = (oe_socklen_t)arg3;
+    return oe_connect(sd, addr, addrlen);
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL2(SYS_creat)
+{
+    oe_errno = 0;
+    long ret = -1;
+    const char* pathname = (const char*)arg1;
+    oe_mode_t mode = (oe_mode_t)arg2;
+    int flags = (OE_O_CREAT | OE_O_WRONLY | OE_O_TRUNC);
+
+    ret = oe_open(pathname, flags, mode);
+
+    if (oe_errno == OE_ENOENT)
+    {
+        /* If the file was not found, give the caller (libc) a chance
+         * to handle this syscall.
+         */
+        oe_errno = OE_ENOSYS;
+    }
+
+    return ret;
+}
+#endif
+
+OE_DEFINE_SYSCALL1(SYS_dup)
+{
+    oe_errno = 0;
+    int fd = (int)arg1;
+
+    return oe_dup(fd);
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL2(SYS_dup2)
+{
+    oe_errno = 0;
+    int oldfd = (int)arg1;
+    int newfd = (int)arg2;
+
+    return oe_dup2(oldfd, newfd);
+}
+#endif
+
+OE_DEFINE_SYSCALL3(SYS_dup3)
+{
+    oe_errno = 0;
+    long ret = -1;
+    int oldfd = (int)arg1;
+    int newfd = (int)arg2;
+    int flags = (int)arg3;
+
+    if (flags != 0)
+    {
+        oe_errno = OE_EINVAL;
+        goto done;
+    }
+
+    ret = oe_dup2(oldfd, newfd);
+done:
+    return ret;
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL1(SYS_epoll_create)
+{
+    oe_errno = 0;
+    int size = (int)arg1;
+    return oe_epoll_create(size);
+}
+#endif
+
+OE_DEFINE_SYSCALL1(SYS_epoll_create1)
+{
+    oe_errno = 0;
+    int flags = (int)arg1;
+    return oe_epoll_create1(flags);
+}
+
+OE_DEFINE_SYSCALL4(SYS_epoll_ctl)
+{
+    oe_errno = 0;
+    int epfd = (int)arg1;
+    int op = (int)arg2;
+    int fd = (int)arg3;
+    struct oe_epoll_event* event = (struct oe_epoll_event*)arg4;
+    return oe_epoll_ctl(epfd, op, fd, event);
+}
+
+OE_DEFINE_SYSCALL5(SYS_epoll_pwait)
+{
+    oe_errno = 0;
+    int epfd = (int)arg1;
+    struct oe_epoll_event* events = (struct oe_epoll_event*)arg2;
+    int maxevents = (int)arg3;
+    int timeout = (int)arg4;
+    const oe_sigset_t* sigmask = (const oe_sigset_t*)arg5;
+    return oe_epoll_pwait(epfd, events, maxevents, timeout, sigmask);
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL4(SYS_epoll_wait)
+{
+    oe_errno = 0;
+    int epfd = (int)arg1;
+    struct oe_epoll_event* events = (struct oe_epoll_event*)arg2;
+    int maxevents = (int)arg3;
+    int timeout = (int)arg4;
+    return oe_epoll_wait(epfd, events, maxevents, timeout);
+}
+#endif
+
+OE_DEFINE_SYSCALL1(SYS_exit)
+{
+    oe_errno = 0;
+    int status = (int)arg1;
+    oe_exit(status);
+
+    // Control does not reach here.
+    asm volatile("ud2");
+    return -1;
+}
+
+OE_DEFINE_SYSCALL0(SYS_exit_group)
+{
+    oe_errno = 0;
+    return 0;
+}
+
+OE_DEFINE_SYSCALL4(SYS_faccessat)
+{
+    oe_errno = 0;
+    long ret = -1;
+    int dirfd = (int)arg1;
+    const char* pathname = (const char*)arg2;
+    int mode = (int)arg3;
+    int flags = (int)arg4;
+
+    if (dirfd != OE_AT_FDCWD)
+    {
+        oe_errno = OE_EBADF;
+        goto done;
+    }
+
+    if (flags != 0)
+    {
+        oe_errno = OE_EINVAL;
+        goto done;
+    }
+
+    ret = oe_access(pathname, mode);
+done:
+    return ret;
+}
+
+OE_DEFINE_SYSCALL3(SYS_fcntl)
+{
+    oe_errno = 0;
+    int fd = (int)arg1;
+    int cmd = (int)arg2;
+    uint64_t arg = (uint64_t)arg3;
+    return oe_fcntl(fd, cmd, arg);
+}
+
+OE_DEFINE_SYSCALL1(SYS_fdatasync)
+{
+    oe_errno = 0;
+    const int fd = (int)arg1;
+
+    return oe_fdatasync(fd);
+}
+
+OE_DEFINE_SYSCALL2(SYS_flock)
+{
+    oe_errno = 0;
+    int fd = (int)arg1;
+    int operation = (int)arg2;
+
+    return oe_flock(fd, operation);
+}
+
+OE_DEFINE_SYSCALL2(SYS_fstat)
+{
+    oe_errno = 0;
+    const int fd = (int)arg1;
+    struct oe_stat_t* const buf = (struct oe_stat_t*)arg2;
+    return oe_fstat(fd, buf);
+}
+
+OE_DEFINE_SYSCALL1(SYS_fsync)
+{
+    oe_errno = 0;
+    const int fd = (int)arg1;
+
+    return oe_fsync(fd);
+}
+
+OE_DEFINE_SYSCALL2(SYS_getcwd)
+{
+    oe_errno = 0;
+    long ret = -1;
+    char* buf = (char*)arg1;
+    size_t size = (size_t)arg2;
+
+    if (!oe_getcwd(buf, size))
+    {
+        ret = -1;
+    }
+    else
+    {
+        ret = (long)size;
+    }
+
+    return ret;
+}
+
+OE_DEFINE_SYSCALL3(SYS_getdents64)
+{
+    oe_errno = 0;
+    unsigned int fd = (unsigned int)arg1;
+    struct oe_dirent* ent = (struct oe_dirent*)arg2;
+    unsigned int count = (unsigned int)arg3;
+    return oe_getdents64(fd, ent, count);
+}
+
+OE_DEFINE_SYSCALL0(SYS_getegid)
+{
+    oe_errno = 0;
+    return (long)oe_getegid();
+}
+
+OE_DEFINE_SYSCALL0(SYS_geteuid)
+{
+    oe_errno = 0;
+    return (long)oe_geteuid();
+}
+
+OE_DEFINE_SYSCALL2(SYS_getgroups)
+{
+    oe_errno = 0;
+    int size = (int)arg1;
+    oe_gid_t* list = (oe_gid_t*)arg2;
+    return (long)oe_getgroups(size, list);
+}
+
+OE_DEFINE_SYSCALL3(SYS_getpeername)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    struct sockaddr* addr = (struct sockaddr*)arg2;
+    oe_socklen_t* addrlen = (oe_socklen_t*)arg3;
+    return oe_getpeername(sockfd, (struct oe_sockaddr*)addr, addrlen);
+}
+
+OE_DEFINE_SYSCALL1(SYS_getpgid)
+{
+    oe_errno = 0;
+    int pid = (int)arg1;
+    return (long)oe_getpgid(pid);
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL0(SYS_getpgrp)
+{
+    oe_errno = 0;
+    return (long)oe_getpgrp();
+}
+#endif
+
+OE_DEFINE_SYSCALL0(SYS_getpid)
+{
+    oe_errno = 0;
+    return (long)oe_getpid();
+}
+
+OE_DEFINE_SYSCALL0(SYS_getgid)
+{
+    oe_errno = 0;
+    return (long)oe_getgid();
+}
+
+OE_DEFINE_SYSCALL0(SYS_getppid)
+{
+    oe_errno = 0;
+    return (long)oe_getppid();
+}
+
+OE_DEFINE_SYSCALL3(SYS_getsockname)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    struct sockaddr* addr = (struct sockaddr*)arg2;
+    oe_socklen_t* addrlen = (oe_socklen_t*)arg3;
+    return oe_getsockname(sockfd, (struct oe_sockaddr*)addr, addrlen);
+}
+
+OE_DEFINE_SYSCALL5(SYS_getsockopt)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    int level = (int)arg2;
+    int optname = (int)arg3;
+    void* optval = (void*)arg4;
+    oe_socklen_t* optlen = (oe_socklen_t*)arg5;
+    return oe_getsockopt(sockfd, level, optname, optval, optlen);
+}
+
+OE_DEFINE_SYSCALL0(SYS_getuid)
+{
+    oe_errno = 0;
+    return (long)oe_getuid();
+}
+
+OE_DEFINE_SYSCALL6(SYS_ioctl)
+{
+    oe_errno = 0;
+    int fd = (int)arg1;
+    unsigned long request = (unsigned long)arg2;
+    long p1 = arg3;
+    long p2 = arg4;
+    long p3 = arg5;
+    long p4 = arg6;
+
+    return oe_ioctl(fd, request, p1, p2, p3, p4);
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL2(SYS_link)
+{
+    oe_errno = 0;
+    const char* oldpath = (const char*)arg1;
+    const char* newpath = (const char*)arg2;
+    return oe_link(oldpath, newpath);
+}
+#endif
+
+OE_DEFINE_SYSCALL5(SYS_linkat)
+{
+    oe_errno = 0;
+    long ret = -1;
+    int olddirfd = (int)arg1;
+    const char* oldpath = (const char*)arg2;
+    int newdirfd = (int)arg3;
+    const char* newpath = (const char*)arg4;
+    int flags = (int)arg5;
+
+    if (olddirfd != OE_AT_FDCWD)
+    {
+        oe_errno = OE_EBADF;
+        goto done;
+    }
+
+    if (newdirfd != OE_AT_FDCWD)
+    {
+        oe_errno = OE_EBADF;
+        goto done;
+    }
+
+    if (flags != 0)
+    {
+        oe_errno = OE_EINVAL;
+        goto done;
+    }
+
+    ret = oe_link(oldpath, newpath);
+done:
+    return ret;
+}
+
+OE_DEFINE_SYSCALL2(SYS_listen)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    int backlog = (int)arg2;
+    return oe_listen(sockfd, backlog);
+}
+
+OE_DEFINE_SYSCALL3(SYS_lseek)
+{
+    oe_errno = 0;
+    int fd = (int)arg1;
+    ssize_t off = (ssize_t)arg2;
+    int whence = (int)arg3;
+    return oe_lseek(fd, off, whence);
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL2(SYS_mkdir)
+{
+    oe_errno = 0;
+    const char* pathname = (const char*)arg1;
+    uint32_t mode = (uint32_t)arg2;
+
+    return oe_mkdir(pathname, mode);
+}
+#endif
+
+OE_DEFINE_SYSCALL3(SYS_mkdirat)
+{
+    oe_errno = 0;
+    long ret = -1;
+    int dirfd = (int)arg1;
+    const char* pathname = (const char*)arg2;
+    uint32_t mode = (uint32_t)arg3;
+
+    if (dirfd != OE_AT_FDCWD)
+    {
+        oe_errno = OE_EBADF;
+        goto done;
+    }
+
+    ret = oe_mkdir(pathname, mode);
+done:
+    return ret;
+}
+
+OE_DEFINE_SYSCALL5(SYS_mount)
+{
+    oe_errno = 0;
+    const char* source = (const char*)arg1;
+    const char* target = (const char*)arg2;
+    const char* fstype = (const char*)arg3;
+    unsigned long flags = (unsigned long)arg4;
+    void* data = (void*)arg5;
+
+    return oe_mount(source, target, fstype, flags, data);
+}
+
+OE_DEFINE_SYSCALL2(SYS_nanosleep)
+{
+    oe_errno = 0;
+    struct oe_timespec* req = (struct oe_timespec*)arg1;
+    struct oe_timespec* rem = (struct oe_timespec*)arg2;
+    return (long)oe_nanosleep(req, rem);
+}
+
+OE_DEFINE_SYSCALL4(SYS_newfstatat)
+{
+    oe_errno = 0;
+    long ret = -1;
+    int dirfd = (int)arg1;
+    const char* pathname = (const char*)arg2;
+    struct oe_stat_t* buf = (struct oe_stat_t*)arg3;
+    int flags = (int)arg4;
+
+    if (dirfd != OE_AT_FDCWD)
+    {
+        oe_errno = OE_EBADF;
+        goto done;
+    }
+
+    if (flags != 0)
+    {
+        oe_errno = OE_EINVAL;
+        goto done;
+    }
+
+    ret = oe_stat(pathname, buf);
+done:
+    return ret;
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL3(SYS_open)
+{
+    oe_errno = 0;
+    long ret = -1;
+
+    const char* pathname = (const char*)arg1;
+    int flags = (int)arg2;
+    uint32_t mode = (uint32_t)arg3;
+
+    ret = oe_open(pathname, flags, mode);
+
+    if (ret < 0 && oe_errno == OE_ENOENT)
+        goto done;
+
+    goto done;
+done:
+    return ret;
+}
+#endif
+
+OE_DEFINE_SYSCALL4(SYS_openat)
+{
+    oe_errno = 0;
+    long ret = -1;
+    int dirfd = (int)arg1;
+    const char* pathname = (const char*)arg2;
+    int flags = (int)arg3;
+    uint32_t mode = (uint32_t)arg4;
+
+    if (dirfd != OE_AT_FDCWD)
+    {
+        oe_errno = OE_EBADF;
+        goto done;
+    }
+
+    ret = oe_open(pathname, flags, mode);
+
+    if (ret < 0 && oe_errno == OE_ENOENT)
+        goto done;
+
+    goto done;
+done:
+    return ret;
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL3(SYS_poll)
+{
+    oe_errno = 0;
+    struct oe_pollfd* fds = (struct oe_pollfd*)arg1;
+    oe_nfds_t nfds = (oe_nfds_t)arg2;
+    int millis = (int)arg3;
+    return oe_poll(fds, nfds, millis);
+}
+#endif
+
+OE_DEFINE_SYSCALL4(SYS_ppoll)
+{
+    oe_errno = 0;
+    long ret = -1;
+    struct oe_pollfd* fds = (struct oe_pollfd*)arg1;
+    oe_nfds_t nfds = (oe_nfds_t)arg2;
+    struct oe_timespec* ts = (struct oe_timespec*)arg3;
+    void* sigmask = (void*)arg4;
+    int timeout = -1;
+
+    if (sigmask != NULL)
+    {
+        oe_errno = OE_EINVAL;
+        goto done;
+    }
+
+    if (ts)
+    {
+        int64_t mul;
+        int64_t div;
+        int64_t sum;
+
+        if (oe_safe_mul_s64(ts->tv_sec, 1000, &mul) != OE_OK)
+        {
+            oe_errno = OE_EINVAL;
+            goto done;
+        }
+
+        div = ts->tv_nsec / 1000000;
+
+        if (oe_safe_add_s64(mul, div, &sum) != OE_OK)
+        {
+            oe_errno = OE_EINVAL;
+            goto done;
+        }
+
+        if (sum < OE_INT_MIN || sum > OE_INT_MAX)
+        {
+            oe_errno = OE_EINVAL;
+            goto done;
+        }
+
+        timeout = (int)sum;
+    }
+
+    ret = oe_poll(fds, nfds, timeout);
+done:
+    return ret;
+}
+
+OE_DEFINE_SYSCALL4(SYS_pread64)
+{
+    oe_errno = 0;
+    const int fd = (int)arg1;
+    void* const buf = (void*)arg2;
+    const size_t count = (size_t)arg3;
+    const oe_off_t offset = (oe_off_t)arg4;
+
+    return oe_pread(fd, buf, count, offset);
+}
+
+OE_DEFINE_SYSCALL5(SYS_pselect6)
+{
+    oe_errno = 0;
+    int nfds = (int)arg1;
+    oe_fd_set* readfds = (oe_fd_set*)arg2;
+    oe_fd_set* writefds = (oe_fd_set*)arg3;
+    oe_fd_set* exceptfds = (oe_fd_set*)arg4;
+    struct oe_timespec* ts = (struct oe_timespec*)arg5;
+    struct oe_timeval buf;
+    struct oe_timeval* tv = NULL;
+
+    if (ts)
+    {
+        tv = &buf;
+        tv->tv_sec = ts->tv_sec;
+        tv->tv_usec = ts->tv_nsec / 1000;
+    }
+
+    return oe_select(nfds, readfds, writefds, exceptfds, tv);
+}
+
+OE_DEFINE_SYSCALL4(SYS_pwrite64)
+{
+    oe_errno = 0;
+    const int fd = (int)arg1;
+    const void* const buf = (void*)arg2;
+    const size_t count = (size_t)arg3;
+    const oe_off_t offset = (oe_off_t)arg4;
+
+    return oe_pwrite(fd, buf, count, offset);
+}
+
+OE_DEFINE_SYSCALL3(SYS_read)
+{
+    oe_errno = 0;
+    int fd = (int)arg1;
+    void* buf = (void*)arg2;
+    size_t count = (size_t)arg3;
+
+    return oe_read(fd, buf, count);
+}
+
+OE_DEFINE_SYSCALL3(SYS_readv)
+{
+    oe_errno = 0;
+    int fd = (int)arg1;
+    const struct oe_iovec* iov = (const struct oe_iovec*)arg2;
+    int iovcnt = (int)arg3;
+
+    return oe_readv(fd, iov, iovcnt);
+}
+
+OE_DEFINE_SYSCALL6(SYS_recvfrom)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    void* buf = (void*)arg2;
+    size_t len = (size_t)arg3;
+    int flags = (int)arg4;
+    struct oe_sockaddr* dest_add = (struct oe_sockaddr*)arg5;
+    oe_socklen_t* addrlen = (oe_socklen_t*)arg6;
+
+    return oe_recvfrom(sockfd, buf, len, flags, dest_add, addrlen);
+}
+
+OE_DEFINE_SYSCALL3(SYS_recvmsg)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    struct msghdr* buf = (struct msghdr*)arg2;
+    int flags = (int)arg3;
+
+    return oe_recvmsg(sockfd, (struct oe_msghdr*)buf, flags);
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL2(SYS_rename)
+{
+    oe_errno = 0;
+    const char* oldpath = (const char*)arg1;
+    const char* newpath = (const char*)arg2;
+
+    return oe_rename(oldpath, newpath);
+}
+#endif
+
+OE_DEFINE_SYSCALL5(SYS_renameat)
+{
+    oe_errno = 0;
+    long ret = -1;
+    int olddirfd = (int)arg1;
+    const char* oldpath = (const char*)arg2;
+    int newdirfd = (int)arg3;
+    const char* newpath = (const char*)arg4;
+    int flags = (int)arg5;
+
+    if (olddirfd != OE_AT_FDCWD)
+    {
+        oe_errno = OE_EBADF;
+        goto done;
+    }
+
+    if (newdirfd != OE_AT_FDCWD)
+    {
+        oe_errno = OE_EBADF;
+        goto done;
+    }
+
+    if (flags != 0)
+    {
+        oe_errno = OE_EINVAL;
+        goto done;
+    }
+
+    ret = oe_rename(oldpath, newpath);
+done:
+    return ret;
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL1(SYS_rmdir)
+{
+    oe_errno = 0;
+    const char* pathname = (const char*)arg1;
+    return oe_rmdir(pathname);
+}
+#endif
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL5(SYS_select)
+{
+    oe_errno = 0;
+    int nfds = (int)arg1;
+    oe_fd_set* readfds = (oe_fd_set*)arg2;
+    oe_fd_set* writefds = (oe_fd_set*)arg3;
+    oe_fd_set* efds = (oe_fd_set*)arg4;
+    struct oe_timeval* timeout = (struct oe_timeval*)arg5;
+    return oe_select(nfds, readfds, writefds, efds, timeout);
+}
+#endif
+
+OE_DEFINE_SYSCALL6(SYS_sendto)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    const void* buf = (void*)arg2;
+    size_t len = (size_t)arg3;
+    int flags = (int)arg4;
+    const struct oe_sockaddr* dest_add = (const struct oe_sockaddr*)arg5;
+    oe_socklen_t addrlen = (oe_socklen_t)arg6;
+
+    return oe_sendto(sockfd, buf, len, flags, dest_add, addrlen);
+}
+
+OE_DEFINE_SYSCALL3(SYS_sendmsg)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    struct msghdr* buf = (struct msghdr*)arg2;
+    int flags = (int)arg3;
+
+    return oe_sendmsg(sockfd, (struct oe_msghdr*)buf, flags);
+}
+
+OE_DEFINE_SYSCALL5(SYS_setsockopt)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    int level = (int)arg2;
+    int optname = (int)arg3;
+    void* optval = (void*)arg4;
+    oe_socklen_t optlen = (oe_socklen_t)arg5;
+    return oe_setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+OE_DEFINE_SYSCALL2(SYS_shutdown)
+{
+    oe_errno = 0;
+    int sockfd = (int)arg1;
+    int how = (int)arg2;
+    return oe_shutdown(sockfd, how);
+}
+
+OE_DEFINE_SYSCALL3(SYS_socket)
+{
+    oe_errno = 0;
+    int domain = (int)arg1;
+    int type = (int)arg2;
+    int protocol = (int)arg3;
+    return oe_socket(domain, type, protocol);
+}
+
+OE_DEFINE_SYSCALL4(SYS_socketpair)
+{
+    oe_errno = 0;
+    int domain = (int)arg1;
+    int type = (int)arg2;
+    int protocol = (int)arg3;
+    int* sv = (int*)arg4;
+
+    return oe_socketpair(domain, type, protocol, sv);
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL2(SYS_stat)
+{
+    oe_errno = 0;
+    const char* pathname = (const char*)arg1;
+    struct oe_stat_t* buf = (struct oe_stat_t*)arg2;
+    return oe_stat(pathname, buf);
+}
+#endif
+
+OE_DEFINE_SYSCALL2(SYS_truncate)
+{
+    oe_errno = 0;
+    const char* path = (const char*)arg1;
+    ssize_t length = (ssize_t)arg2;
+
+    return oe_truncate(path, length);
+}
+
+OE_DEFINE_SYSCALL3(SYS_write)
+{
+    oe_errno = 0;
+    int fd = (int)arg1;
+    const void* buf = (void*)arg2;
+    size_t count = (size_t)arg3;
+
+    return oe_write(fd, buf, count);
+}
+
+OE_DEFINE_SYSCALL3(SYS_writev)
+{
+    oe_errno = 0;
+    int fd = (int)arg1;
+    const struct oe_iovec* iov = (const struct oe_iovec*)arg2;
+    int iovcnt = (int)arg3;
+
+    return oe_writev(fd, iov, iovcnt);
+}
+
+OE_DEFINE_SYSCALL1(SYS_uname)
+{
+    oe_errno = 0;
+    struct oe_utsname* buf = (struct oe_utsname*)arg1;
+    return oe_uname(buf);
+}
+
+#if __x86_64__ || _M_X64
+OE_DEFINE_SYSCALL1(SYS_unlink)
+{
+    oe_errno = 0;
+    const char* pathname = (const char*)arg1;
+
+    return oe_unlink(pathname);
+}
+#endif
+
+OE_DEFINE_SYSCALL3(SYS_unlinkat)
+{
+    oe_errno = 0;
+    long ret = -1;
+    int dirfd = (int)arg1;
+    const char* pathname = (const char*)arg2;
+    int flags = (int)arg3;
+
+    if (dirfd != OE_AT_FDCWD)
+    {
+        oe_errno = OE_EBADF;
+        goto done;
+    }
+
+    if (flags != OE_AT_REMOVEDIR && flags != 0)
+    {
+        oe_errno = OE_EINVAL;
+        goto done;
+    }
+
+    if (flags == OE_AT_REMOVEDIR)
+        ret = oe_rmdir(pathname);
+    else
+        ret = oe_unlink(pathname);
+done:
+    return ret;
+}
+
+OE_DEFINE_SYSCALL2(SYS_umount2)
+{
+    oe_errno = 0;
+    const char* target = (const char*)arg1;
+    int flags = (int)arg2;
+
+    (void)flags;
+
+    return oe_umount(target);
+}
+
 static long _syscall(
-    long num,
+    long number,
     long arg1,
     long arg2,
     long arg3,
@@ -42,839 +973,124 @@ static long _syscall(
     long arg5,
     long arg6)
 {
-    long ret = -1;
-    oe_errno = 0;
+    // Each of the syscall implementation functions must set oe_errno correctly
+    // since they can be called directly, bypassing this _sycall dispatching
+    // function.
 
-    /* Handle the software system call. */
-    switch (num)
+    switch (number)
     {
-#if defined(OE_SYS_creat)
-        case OE_SYS_creat:
-        {
-            const char* pathname = (const char*)arg1;
-            oe_mode_t mode = (oe_mode_t)arg2;
-            int flags = (OE_O_CREAT | OE_O_WRONLY | OE_O_TRUNC);
-
-            ret = oe_open(pathname, flags, mode);
-
-            if (oe_errno == OE_ENOENT)
-            {
-                /* If the file was not found, give the caller (libc) a chance
-                 * to handle this syscall.
-                 */
-                oe_errno = OE_ENOSYS;
-                goto done;
-            }
-
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_accept, arg1, arg2, arg3);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_access, arg1, arg2);
 #endif
-#if defined(OE_SYS_open)
-        case OE_SYS_open:
-        {
-            const char* pathname = (const char*)arg1;
-            int flags = (int)arg2;
-            uint32_t mode = (uint32_t)arg3;
-
-            ret = oe_open(pathname, flags, mode);
-
-            if (ret < 0 && oe_errno == OE_ENOENT)
-                goto done;
-
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_bind, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_chdir, arg1);
+        OE_SYSCALL_DISPATCH(SYS_close, arg1);
+        OE_SYSCALL_DISPATCH(SYS_connect, arg1, arg2, arg3);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_creat, arg1, arg2);
 #endif
-        case OE_SYS_openat:
-        {
-            int dirfd = (int)arg1;
-            const char* pathname = (const char*)arg2;
-            int flags = (int)arg3;
-            uint32_t mode = (uint32_t)arg4;
-
-            if (dirfd != OE_AT_FDCWD)
-            {
-                oe_errno = OE_EBADF;
-                goto done;
-            }
-
-            ret = oe_open(pathname, flags, mode);
-
-            if (ret < 0 && oe_errno == OE_ENOENT)
-                goto done;
-
-            goto done;
-        }
-        case OE_SYS_lseek:
-        {
-            int fd = (int)arg1;
-            ssize_t off = (ssize_t)arg2;
-            int whence = (int)arg3;
-            ret = oe_lseek(fd, off, whence);
-            goto done;
-        }
-        case OE_SYS_pread64:
-        {
-            const int fd = (int)arg1;
-            void* const buf = (void*)arg2;
-            const size_t count = (size_t)arg3;
-            const oe_off_t offset = (oe_off_t)arg4;
-
-            ret = oe_pread(fd, buf, count, offset);
-            goto done;
-        }
-        case OE_SYS_pwrite64:
-        {
-            const int fd = (int)arg1;
-            const void* const buf = (void*)arg2;
-            const size_t count = (size_t)arg3;
-            const oe_off_t offset = (oe_off_t)arg4;
-
-            ret = oe_pwrite(fd, buf, count, offset);
-            goto done;
-        }
-        case OE_SYS_readv:
-        {
-            int fd = (int)arg1;
-            const struct oe_iovec* iov = (const struct oe_iovec*)arg2;
-            int iovcnt = (int)arg3;
-
-            ret = oe_readv(fd, iov, iovcnt);
-            goto done;
-        }
-        case OE_SYS_writev:
-        {
-            int fd = (int)arg1;
-            const struct oe_iovec* iov = (const struct oe_iovec*)arg2;
-            int iovcnt = (int)arg3;
-
-            ret = oe_writev(fd, iov, iovcnt);
-            goto done;
-        }
-        case OE_SYS_read:
-        {
-            int fd = (int)arg1;
-            void* buf = (void*)arg2;
-            size_t count = (size_t)arg3;
-
-            ret = oe_read(fd, buf, count);
-            goto done;
-        }
-        case OE_SYS_write:
-        {
-            int fd = (int)arg1;
-            const void* buf = (void*)arg2;
-            size_t count = (size_t)arg3;
-
-            ret = oe_write(fd, buf, count);
-            goto done;
-        }
-        case OE_SYS_close:
-        {
-            int fd = (int)arg1;
-
-            ret = oe_close(fd);
-            goto done;
-        }
-        case OE_SYS_dup:
-        {
-            int fd = (int)arg1;
-
-            ret = oe_dup(fd);
-            goto done;
-        }
-        case OE_SYS_flock:
-        {
-            int fd = (int)arg1;
-            int operation = (int)arg2;
-
-            ret = oe_flock(fd, operation);
-            goto done;
-        }
-        case OE_SYS_fsync:
-        {
-            const int fd = (int)arg1;
-
-            ret = oe_fsync(fd);
-            goto done;
-        }
-        case OE_SYS_fdatasync:
-        {
-            const int fd = (int)arg1;
-
-            ret = oe_fdatasync(fd);
-            goto done;
-        }
-#if defined(OE_SYS_dup2)
-        case OE_SYS_dup2:
-        {
-            int oldfd = (int)arg1;
-            int newfd = (int)arg2;
-
-            ret = oe_dup2(oldfd, newfd);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_dup, arg1);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_dup2, arg1, arg2);
 #endif
-        case OE_SYS_dup3:
-        {
-            int oldfd = (int)arg1;
-            int newfd = (int)arg2;
-            int flags = (int)arg3;
-
-            if (flags != 0)
-            {
-                oe_errno = OE_EINVAL;
-                goto done;
-            }
-
-            ret = oe_dup2(oldfd, newfd);
-            goto done;
-        }
-#if defined(OE_SYS_stat)
-        case OE_SYS_stat:
-        {
-            const char* pathname = (const char*)arg1;
-            struct oe_stat_t* buf = (struct oe_stat_t*)arg2;
-            ret = oe_stat(pathname, buf);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_dup3, arg1, arg2, arg3);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_epoll_create, arg1);
 #endif
-        case OE_SYS_newfstatat:
-        {
-            int dirfd = (int)arg1;
-            const char* pathname = (const char*)arg2;
-            struct oe_stat_t* buf = (struct oe_stat_t*)arg3;
-            int flags = (int)arg4;
-
-            if (dirfd != OE_AT_FDCWD)
-            {
-                oe_errno = OE_EBADF;
-                goto done;
-            }
-
-            if (flags != 0)
-            {
-                oe_errno = OE_EINVAL;
-                goto done;
-            }
-
-            ret = oe_stat(pathname, buf);
-            goto done;
-        }
-        case OE_SYS_fstat:
-        {
-            const int fd = (int)arg1;
-            struct oe_stat_t* const buf = (struct oe_stat_t*)arg2;
-            ret = oe_fstat(fd, buf);
-            goto done;
-        }
-#if defined(OE_SYS_link)
-        case OE_SYS_link:
-        {
-            const char* oldpath = (const char*)arg1;
-            const char* newpath = (const char*)arg2;
-            ret = oe_link(oldpath, newpath);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_epoll_create1, arg1);
+        OE_SYSCALL_DISPATCH(SYS_epoll_ctl, arg1, arg2, arg3, arg4);
+        OE_SYSCALL_DISPATCH(SYS_epoll_pwait, arg1, arg2, arg3, arg4, arg5);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_epoll_wait, arg1, arg2, arg3, arg4);
 #endif
-        case OE_SYS_linkat:
-        {
-            int olddirfd = (int)arg1;
-            const char* oldpath = (const char*)arg2;
-            int newdirfd = (int)arg3;
-            const char* newpath = (const char*)arg4;
-            int flags = (int)arg5;
-
-            if (olddirfd != OE_AT_FDCWD)
-            {
-                oe_errno = OE_EBADF;
-                goto done;
-            }
-
-            if (newdirfd != OE_AT_FDCWD)
-            {
-                oe_errno = OE_EBADF;
-                goto done;
-            }
-
-            if (flags != 0)
-            {
-                oe_errno = OE_EINVAL;
-                goto done;
-            }
-
-            ret = oe_link(oldpath, newpath);
-            goto done;
-        }
-#if defined(OE_SYS_unlink)
-        case OE_SYS_unlink:
-        {
-            const char* pathname = (const char*)arg1;
-
-            ret = oe_unlink(pathname);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_exit, arg1);
+        OE_SYSCALL_DISPATCH(SYS_exit_group);
+        OE_SYSCALL_DISPATCH(SYS_faccessat, arg1, arg2, arg3, arg4);
+        OE_SYSCALL_DISPATCH(SYS_fcntl, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_fdatasync, arg1);
+        OE_SYSCALL_DISPATCH(SYS_flock, arg1, arg2);
+        OE_SYSCALL_DISPATCH(SYS_fstat, arg1, arg2);
+        OE_SYSCALL_DISPATCH(SYS_fsync, arg1);
+        OE_SYSCALL_DISPATCH(SYS_getcwd, arg1, arg2);
+        OE_SYSCALL_DISPATCH(SYS_getdents64, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_getegid);
+        OE_SYSCALL_DISPATCH(SYS_geteuid);
+        OE_SYSCALL_DISPATCH(SYS_getgid);
+        OE_SYSCALL_DISPATCH(SYS_getgroups, arg1, arg2);
+        OE_SYSCALL_DISPATCH(SYS_getpeername, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_getpgid, arg1);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_getpgrp);
 #endif
-        case OE_SYS_unlinkat:
-        {
-            int dirfd = (int)arg1;
-            const char* pathname = (const char*)arg2;
-            int flags = (int)arg3;
-
-            if (dirfd != OE_AT_FDCWD)
-            {
-                oe_errno = OE_EBADF;
-                goto done;
-            }
-
-            if (flags != OE_AT_REMOVEDIR && flags != 0)
-            {
-                oe_errno = OE_EINVAL;
-                goto done;
-            }
-
-            if (flags == OE_AT_REMOVEDIR)
-                ret = oe_rmdir(pathname);
-            else
-                ret = oe_unlink(pathname);
-
-            goto done;
-        }
-#if defined(OE_SYS_rename)
-        case OE_SYS_rename:
-        {
-            const char* oldpath = (const char*)arg1;
-            const char* newpath = (const char*)arg2;
-
-            ret = oe_rename(oldpath, newpath);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_getpid);
+        OE_SYSCALL_DISPATCH(SYS_getppid);
+        OE_SYSCALL_DISPATCH(SYS_getsockname, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_getsockopt, arg1, arg2, arg3, arg4, arg5);
+        OE_SYSCALL_DISPATCH(SYS_getuid);
+        OE_SYSCALL_DISPATCH(SYS_ioctl, arg1, arg2, arg3, arg4, arg5, arg6);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_link, arg1, arg2);
 #endif
-        case OE_SYS_renameat:
-        {
-            int olddirfd = (int)arg1;
-            const char* oldpath = (const char*)arg2;
-            int newdirfd = (int)arg3;
-            const char* newpath = (const char*)arg4;
-            int flags = (int)arg5;
-
-            if (olddirfd != OE_AT_FDCWD)
-            {
-                oe_errno = OE_EBADF;
-                goto done;
-            }
-
-            if (newdirfd != OE_AT_FDCWD)
-            {
-                oe_errno = OE_EBADF;
-                goto done;
-            }
-
-            if (flags != 0)
-            {
-                oe_errno = OE_EINVAL;
-                goto done;
-            }
-
-            ret = oe_rename(oldpath, newpath);
-            goto done;
-        }
-        case OE_SYS_truncate:
-        {
-            const char* path = (const char*)arg1;
-            ssize_t length = (ssize_t)arg2;
-
-            ret = oe_truncate(path, length);
-            goto done;
-        }
-#if defined(OE_SYS_mkdir)
-        case OE_SYS_mkdir:
-        {
-            const char* pathname = (const char*)arg1;
-            uint32_t mode = (uint32_t)arg2;
-
-            ret = oe_mkdir(pathname, mode);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_linkat, arg1, arg2, arg3, arg4, arg5);
+        OE_SYSCALL_DISPATCH(SYS_listen, arg1, arg2);
+        OE_SYSCALL_DISPATCH(SYS_lseek, arg1, arg2, arg3);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_mkdir, arg1, arg2);
 #endif
-        case OE_SYS_mkdirat:
-        {
-            int dirfd = (int)arg1;
-            const char* pathname = (const char*)arg2;
-            uint32_t mode = (uint32_t)arg3;
-
-            if (dirfd != OE_AT_FDCWD)
-            {
-                oe_errno = OE_EBADF;
-                goto done;
-            }
-
-            ret = oe_mkdir(pathname, mode);
-            goto done;
-        }
-#if defined(OE_SYS_rmdir)
-        case OE_SYS_rmdir:
-        {
-            const char* pathname = (const char*)arg1;
-            ret = oe_rmdir(pathname);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_mkdirat, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_mount, arg1, arg2, arg3, arg4, arg5);
+        OE_SYSCALL_DISPATCH(SYS_nanosleep, arg1, arg2);
+        OE_SYSCALL_DISPATCH(SYS_newfstatat, arg1, arg2, arg3, arg4);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_open, arg1, arg2, arg3);
 #endif
-#if defined(OE_SYS_access)
-        case OE_SYS_access:
-        {
-            const char* pathname = (const char*)arg1;
-            int mode = (int)arg2;
-
-            ret = oe_access(pathname, mode);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_openat, arg1, arg2, arg3, arg4);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_poll, arg1, arg2, arg3);
 #endif
-        case OE_SYS_faccessat:
-        {
-            int dirfd = (int)arg1;
-            const char* pathname = (const char*)arg2;
-            int mode = (int)arg3;
-            int flags = (int)arg4;
-
-            if (dirfd != OE_AT_FDCWD)
-            {
-                oe_errno = OE_EBADF;
-                goto done;
-            }
-
-            if (flags != 0)
-            {
-                oe_errno = OE_EINVAL;
-                goto done;
-            }
-
-            ret = oe_access(pathname, mode);
-            goto done;
-        }
-        case OE_SYS_getdents64:
-        {
-            unsigned int fd = (unsigned int)arg1;
-            struct oe_dirent* ent = (struct oe_dirent*)arg2;
-            unsigned int count = (unsigned int)arg3;
-            ret = oe_getdents64(fd, ent, count);
-            goto done;
-        }
-        case OE_SYS_ioctl:
-        {
-            int fd = (int)arg1;
-            unsigned long request = (unsigned long)arg2;
-            long p1 = arg3;
-            long p2 = arg4;
-            long p3 = arg5;
-            long p4 = arg6;
-
-            ret = oe_ioctl(fd, request, p1, p2, p3, p4);
-            goto done;
-        }
-        case OE_SYS_fcntl:
-        {
-            int fd = (int)arg1;
-            int cmd = (int)arg2;
-            uint64_t arg = (uint64_t)arg3;
-            ret = oe_fcntl(fd, cmd, arg);
-            goto done;
-        }
-        case OE_SYS_mount:
-        {
-            const char* source = (const char*)arg1;
-            const char* target = (const char*)arg2;
-            const char* fstype = (const char*)arg3;
-            unsigned long flags = (unsigned long)arg4;
-            void* data = (void*)arg5;
-
-            ret = oe_mount(source, target, fstype, flags, data);
-            goto done;
-        }
-        case OE_SYS_umount2:
-        {
-            const char* target = (const char*)arg1;
-            int flags = (int)arg2;
-
-            (void)flags;
-
-            ret = oe_umount(target);
-            goto done;
-        }
-        case OE_SYS_getcwd:
-        {
-            char* buf = (char*)arg1;
-            size_t size = (size_t)arg2;
-
-            if (!oe_getcwd(buf, size))
-            {
-                ret = -1;
-            }
-            else
-            {
-                ret = (long)size;
-            }
-
-            goto done;
-        }
-        case OE_SYS_chdir:
-        {
-            char* path = (char*)arg1;
-
-            ret = oe_chdir(path);
-            goto done;
-        }
-        case OE_SYS_socket:
-        {
-            int domain = (int)arg1;
-            int type = (int)arg2;
-            int protocol = (int)arg3;
-            ret = oe_socket(domain, type, protocol);
-            goto done;
-        }
-        case OE_SYS_connect:
-        {
-            int sd = (int)arg1;
-            const struct oe_sockaddr* addr = (const struct oe_sockaddr*)arg2;
-            oe_socklen_t addrlen = (oe_socklen_t)arg3;
-            ret = oe_connect(sd, addr, addrlen);
-            goto done;
-        }
-        case OE_SYS_setsockopt:
-        {
-            int sockfd = (int)arg1;
-            int level = (int)arg2;
-            int optname = (int)arg3;
-            void* optval = (void*)arg4;
-            oe_socklen_t optlen = (oe_socklen_t)arg5;
-            ret = oe_setsockopt(sockfd, level, optname, optval, optlen);
-            goto done;
-        }
-        case OE_SYS_getsockopt:
-        {
-            int sockfd = (int)arg1;
-            int level = (int)arg2;
-            int optname = (int)arg3;
-            void* optval = (void*)arg4;
-            oe_socklen_t* optlen = (oe_socklen_t*)arg5;
-            ret = oe_getsockopt(sockfd, level, optname, optval, optlen);
-            goto done;
-        }
-        case OE_SYS_getpeername:
-        {
-            int sockfd = (int)arg1;
-            struct sockaddr* addr = (struct sockaddr*)arg2;
-            oe_socklen_t* addrlen = (oe_socklen_t*)arg3;
-            ret = oe_getpeername(sockfd, (struct oe_sockaddr*)addr, addrlen);
-            goto done;
-        }
-        case OE_SYS_getsockname:
-        {
-            int sockfd = (int)arg1;
-            struct sockaddr* addr = (struct sockaddr*)arg2;
-            oe_socklen_t* addrlen = (oe_socklen_t*)arg3;
-            ret = oe_getsockname(sockfd, (struct oe_sockaddr*)addr, addrlen);
-            goto done;
-        }
-        case OE_SYS_bind:
-        {
-            int sockfd = (int)arg1;
-            struct oe_sockaddr* addr = (struct oe_sockaddr*)arg2;
-            oe_socklen_t addrlen = (oe_socklen_t)arg3;
-            ret = oe_bind(sockfd, addr, addrlen);
-            goto done;
-        }
-        case OE_SYS_listen:
-        {
-            int sockfd = (int)arg1;
-            int backlog = (int)arg2;
-            ret = oe_listen(sockfd, backlog);
-            goto done;
-        }
-        case OE_SYS_accept:
-        {
-            int sockfd = (int)arg1;
-            struct oe_sockaddr* addr = (struct oe_sockaddr*)arg2;
-            oe_socklen_t* addrlen = (oe_socklen_t*)arg3;
-            ret = oe_accept(sockfd, addr, addrlen);
-            goto done;
-        }
-        case OE_SYS_sendto:
-        {
-            int sockfd = (int)arg1;
-            const void* buf = (void*)arg2;
-            size_t len = (size_t)arg3;
-            int flags = (int)arg4;
-            const struct oe_sockaddr* dest_add =
-                (const struct oe_sockaddr*)arg5;
-            oe_socklen_t addrlen = (oe_socklen_t)arg6;
-
-            ret = oe_sendto(sockfd, buf, len, flags, dest_add, addrlen);
-            goto done;
-        }
-        case OE_SYS_recvfrom:
-        {
-            int sockfd = (int)arg1;
-            void* buf = (void*)arg2;
-            size_t len = (size_t)arg3;
-            int flags = (int)arg4;
-            struct oe_sockaddr* dest_add = (struct oe_sockaddr*)arg5;
-            oe_socklen_t* addrlen = (oe_socklen_t*)arg6;
-
-            ret = oe_recvfrom(sockfd, buf, len, flags, dest_add, addrlen);
-            goto done;
-        }
-        case OE_SYS_sendmsg:
-        {
-            int sockfd = (int)arg1;
-            struct msghdr* buf = (struct msghdr*)arg2;
-            int flags = (int)arg3;
-
-            ret = oe_sendmsg(sockfd, (struct oe_msghdr*)buf, flags);
-            goto done;
-        }
-        case OE_SYS_recvmsg:
-        {
-            int sockfd = (int)arg1;
-            struct msghdr* buf = (struct msghdr*)arg2;
-            int flags = (int)arg3;
-
-            ret = oe_recvmsg(sockfd, (struct oe_msghdr*)buf, flags);
-            goto done;
-        }
-        case OE_SYS_socketpair:
-        {
-            int domain = (int)arg1;
-            int type = (int)arg2;
-            int protocol = (int)arg3;
-            int* sv = (int*)arg4;
-
-            ret = oe_socketpair(domain, type, protocol, sv);
-            goto done;
-        }
-        case OE_SYS_shutdown:
-        {
-            int sockfd = (int)arg1;
-            int how = (int)arg2;
-            ret = oe_shutdown(sockfd, how);
-            goto done;
-        }
-        case OE_SYS_uname:
-        {
-            struct oe_utsname* buf = (struct oe_utsname*)arg1;
-            ret = oe_uname(buf);
-            goto done;
-        }
-#if defined(OE_SYS_select)
-        case OE_SYS_select:
-        {
-            int nfds = (int)arg1;
-            oe_fd_set* readfds = (oe_fd_set*)arg2;
-            oe_fd_set* writefds = (oe_fd_set*)arg3;
-            oe_fd_set* efds = (oe_fd_set*)arg4;
-            struct oe_timeval* timeout = (struct oe_timeval*)arg5;
-            ret = oe_select(nfds, readfds, writefds, efds, timeout);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_ppoll, arg1, arg2, arg3, arg4);
+        OE_SYSCALL_DISPATCH(SYS_pread64, arg1, arg2, arg3, arg4);
+        // TODO Issue #3580: Implement 6 argument version of pselect
+        OE_SYSCALL_DISPATCH(SYS_pselect6, arg1, arg2, arg3, arg4, arg5);
+        OE_SYSCALL_DISPATCH(SYS_pwrite64, arg1, arg2, arg3, arg4);
+        OE_SYSCALL_DISPATCH(SYS_read, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_readv, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_recvfrom, arg1, arg2, arg3, arg4, arg5, arg6);
+        OE_SYSCALL_DISPATCH(SYS_recvmsg, arg1, arg2, arg3);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_rename, arg1, arg2);
 #endif
-        case OE_SYS_pselect6:
-        {
-            int nfds = (int)arg1;
-            oe_fd_set* readfds = (oe_fd_set*)arg2;
-            oe_fd_set* writefds = (oe_fd_set*)arg3;
-            oe_fd_set* exceptfds = (oe_fd_set*)arg4;
-            struct oe_timespec* ts = (struct oe_timespec*)arg5;
-            struct oe_timeval buf;
-            struct oe_timeval* tv = NULL;
-
-            if (ts)
-            {
-                tv = &buf;
-                tv->tv_sec = ts->tv_sec;
-                tv->tv_usec = ts->tv_nsec / 1000;
-            }
-
-            ret = oe_select(nfds, readfds, writefds, exceptfds, tv);
-            goto done;
-        }
-#if defined(OE_SYS_poll)
-        case OE_SYS_poll:
-        {
-            struct oe_pollfd* fds = (struct oe_pollfd*)arg1;
-            oe_nfds_t nfds = (oe_nfds_t)arg2;
-            int millis = (int)arg3;
-            ret = oe_poll(fds, nfds, millis);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_renameat, arg1, arg2, arg3, arg4, arg5);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_rmdir, arg1);
 #endif
-        case OE_SYS_ppoll:
-        {
-            struct oe_pollfd* fds = (struct oe_pollfd*)arg1;
-            oe_nfds_t nfds = (oe_nfds_t)arg2;
-            struct oe_timespec* ts = (struct oe_timespec*)arg3;
-            void* sigmask = (void*)arg4;
-            int timeout = -1;
-
-            if (sigmask != NULL)
-            {
-                oe_errno = OE_EINVAL;
-                goto done;
-            }
-
-            if (ts)
-            {
-                int64_t mul;
-                int64_t div;
-                int64_t sum;
-
-                if (oe_safe_mul_s64(ts->tv_sec, 1000, &mul) != OE_OK)
-                {
-                    oe_errno = OE_EINVAL;
-                    goto done;
-                }
-
-                div = ts->tv_nsec / 1000000;
-
-                if (oe_safe_add_s64(mul, div, &sum) != OE_OK)
-                {
-                    oe_errno = OE_EINVAL;
-                    goto done;
-                }
-
-                if (sum < OE_INT_MIN || sum > OE_INT_MAX)
-                {
-                    oe_errno = OE_EINVAL;
-                    goto done;
-                }
-
-                timeout = (int)sum;
-            }
-
-            ret = oe_poll(fds, nfds, timeout);
-            goto done;
-        }
-#if defined(OE_SYS_epoll_create)
-        case OE_SYS_epoll_create:
-        {
-            int size = (int)arg1;
-            ret = oe_epoll_create(size);
-            goto done;
-        }
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_select, arg1, arg2, arg3, arg4, arg5);
 #endif
-        case OE_SYS_epoll_create1:
-        {
-            int flags = (int)arg1;
-            ret = oe_epoll_create1(flags);
-            goto done;
-        }
-#if defined(OE_SYS_epoll_wait)
-        case OE_SYS_epoll_wait:
-        {
-            int epfd = (int)arg1;
-            struct oe_epoll_event* events = (struct oe_epoll_event*)arg2;
-            int maxevents = (int)arg3;
-            int timeout = (int)arg4;
-            ret = oe_epoll_wait(epfd, events, maxevents, timeout);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_sendto, arg1, arg2, arg3, arg4, arg5, arg6);
+        OE_SYSCALL_DISPATCH(SYS_sendmsg, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_setsockopt, arg1, arg2, arg3, arg4, arg5);
+        OE_SYSCALL_DISPATCH(SYS_shutdown, arg1, arg2);
+        OE_SYSCALL_DISPATCH(SYS_socket, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_socketpair, arg1, arg2, arg3, arg4);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_stat, arg1, arg2);
 #endif
-        case OE_SYS_epoll_pwait:
-        {
-            int epfd = (int)arg1;
-            struct oe_epoll_event* events = (struct oe_epoll_event*)arg2;
-            int maxevents = (int)arg3;
-            int timeout = (int)arg4;
-            const oe_sigset_t* sigmask = (const oe_sigset_t*)arg5;
-            ret = oe_epoll_pwait(epfd, events, maxevents, timeout, sigmask);
-            goto done;
-        }
-        case OE_SYS_epoll_ctl:
-        {
-            int epfd = (int)arg1;
-            int op = (int)arg2;
-            int fd = (int)arg3;
-            struct oe_epoll_event* event = (struct oe_epoll_event*)arg4;
-            ret = oe_epoll_ctl(epfd, op, fd, event);
-            goto done;
-        }
-        case OE_SYS_exit_group:
-        {
-            ret = 0;
-            goto done;
-        }
-        case OE_SYS_exit:
-        {
-            int status = (int)arg1;
-            oe_exit(status);
-            goto done;
-        }
-        case OE_SYS_getpid:
-        {
-            ret = (long)oe_getpid();
-            goto done;
-        }
-        case OE_SYS_getuid:
-        {
-            ret = (long)oe_getuid();
-            goto done;
-        }
-        case OE_SYS_geteuid:
-        {
-            ret = (long)oe_geteuid();
-            goto done;
-        }
-        case OE_SYS_getgid:
-        {
-            ret = (long)oe_getgid();
-            goto done;
-        }
-        case OE_SYS_getpgid:
-        {
-            int pid = (int)arg1;
-            ret = (long)oe_getpgid(pid);
-            goto done;
-        }
-        case OE_SYS_getgroups:
-        {
-            int size = (int)arg1;
-            oe_gid_t* list = (oe_gid_t*)arg2;
-            ret = (long)oe_getgroups(size, list);
-            goto done;
-        }
-        case OE_SYS_getegid:
-        {
-            ret = (long)oe_getegid();
-            goto done;
-        }
-        case OE_SYS_getppid:
-        {
-            ret = (long)oe_getppid();
-            goto done;
-        }
-#if defined(OE_SYS_getpgrp)
-        case OE_SYS_getpgrp:
-        {
-            ret = (long)oe_getpgrp();
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_truncate, arg1, arg2);
+        OE_SYSCALL_DISPATCH(SYS_write, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_writev, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_uname, arg1);
+#if __x86_64__ || _M_X64
+        OE_SYSCALL_DISPATCH(SYS_unlink, arg1);
 #endif
-        case OE_SYS_nanosleep:
-        {
-            struct oe_timespec* req = (struct oe_timespec*)arg1;
-            struct oe_timespec* rem = (struct oe_timespec*)arg2;
-            ret = (long)oe_nanosleep(req, rem);
-            goto done;
-        }
-        default:
-        {
-            oe_errno = OE_ENOSYS;
-            OE_TRACE_WARNING("syscall num=%ld not handled", num);
-            goto done;
-        }
+        OE_SYSCALL_DISPATCH(SYS_unlinkat, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_umount2, arg1, arg2);
     }
 
-    /* Unreachable */
-done:
-    return ret;
+    oe_errno = OE_ENOSYS;
+    OE_TRACE_WARNING("syscall num=%ld not handled", number);
+    return -1;
 }
 
 long oe_syscall(long number, ...)

--- a/tests/crypto/enclave/enc/enc.c
+++ b/tests/crypto/enclave/enc/enc.c
@@ -12,7 +12,7 @@
 #include <openenclave/internal/malloc.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/rsa.h>
-#include <openenclave/internal/syscall.h>
+#include <openenclave/internal/syscall/hook.h>
 #include <openenclave/internal/tests.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/tests/mbed/enc/enc.c
+++ b/tests/mbed/enc/enc.c
@@ -7,7 +7,7 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>
-#include <openenclave/internal/syscall.h>
+#include <openenclave/internal/syscall/hook.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This PR refactors and cleans up the implementation of syscall dispatching.
It will be followed up with another PR that reduces the TCB.

### Description

Currently syscalls are dispatched via single ~800 line switch case in syscall/syscall.c.

In addition to resulting in a large function, and associated maintenance issues, a large switch case has the following drawback:

- **Larger TCB.** Enclaves that don't use a libc feature will still contain code for that feature.
  For example, echo enclave that just prints a hello world still has code for sockets, epoll and all the other
  syscalls it does not use.
  
- There is no easy way to figure out the **set of syscalls** supported by OE rather than perusing the syscall dispatch function.

- No **parameter checking** for syscalls.
  Different syscalls take different number of parameters. There are currently no checks to make sure that
  OE implementation of a syscall takes the necessary number of parameters.


Implementation:

- The list of supported syscalls are declared in syscall_decls.h

- Each syscall is declared via OE_DECLARE_SYSCALLn macro where n is the number of arguments the syscall expects.
  E.g:
     `OE_DECLARE_SYSCALL4(SYS_faccessat);`
     `OE_DECLARE_SYSCALL2(SYS_flock);`
  If the callsite (which is generally in MUSL) does not pass the expected number of parameters, there will be a compile error.

  Couple of syscalls may indeed expect varying number of parameters, these can be declared in their generic form.

- Each syscall is defined using the OE_DEFINE_SYSCALLn macro:
  E.g:
  ```c
  OE_DEFINE_SYSCALL5(SYS_epoll_pwait)
  {
     ....
  }
  ```

  Under the hood, this results in the function **oe_SYS_epoll_pwait_impl**

  This allows querying easily figuring out all the syscalls an enclave uses by searching for oe_SYS_ functions
  in the binary:
  ```bash
    objdump -t echo_enc | grep oe_SYS_
    00000000000fe950 l     F .text  00000000000000b0 oe_SYS_mount_impl
    00000000000fd7b0 l     F .text  0000000000000149 oe_SYS_faccessat_impl
    ...

- To retain current behavior, syscalls are still dispatched via a switchcase that is now much simpler.
   ```c
   static long _syscall(
    long num,
    long arg1,
    long arg2,
    long arg3,
    long arg4,
    long arg5,
    long arg6)
    {
       oe_errno = 0;

       switch (num)
       {
          OE_SYSCALL_DISPATCH(SYS_accept, arg1, arg2, arg3);
          OE_SYSCALL_DISPATCH(SYS_access, arg1, arg2);
  ```
  In the future the entire switch case will be avoided by the following strategy:

  A call to a specific syscall:
     `syscall(SYS_read, arg1, arg2)`

  will be transormed to:
     `oe_SYS_read_impl(arg1, arg2)`
     
  This completely avoids the switch case. As a result, only those syscalls that are
  actually used by a binary will get linked in.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>