### PR TITLE
Make tcbinfo parsing more expandable to future versions.

### DIFF
--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -387,34 +387,47 @@ static void _move_to_end_of_tcb_levels(const uint8_t** itr, const uint8_t* end)
 static oe_result_t _read_tcb_info_tcb_level_v1(
     const uint8_t** itr,
     const uint8_t* end,
-    oe_tcb_info_tcb_level_t* platform_tcb_level)
+    oe_tcb_info_tcb_level_t* platform_tcb_level,
+    oe_tcb_info_tcb_level_t* tcb_level)
 {
     oe_result_t result = OE_JSON_INFO_PARSE_ERROR;
-    oe_tcb_info_tcb_level_t tcb_level = {{0}};
     const uint8_t* status = NULL;
     size_t status_length = 0;
 
-    OE_CHECK(_read('{', itr, end));
+    OE_CHECK(_read_property_name_and_colon("tcbLevels", itr, end));
+    OE_CHECK(_read('[', itr, end));
 
-    OE_TRACE_VERBOSE("Reading tcb");
-    OE_CHECK(_read_property_name_and_colon("tcb", itr, end));
-    OE_CHECK(_read_tcb_info_tcb_level(itr, end, &tcb_level));
-    OE_CHECK(_read(',', itr, end));
-
-    OE_TRACE_VERBOSE("Reading status");
-    OE_CHECK(_read_property_name_and_colon("status", itr, end));
-    OE_CHECK(_read_string(itr, end, &status, &status_length));
-    OE_CHECK(_trace_json_string(status, status_length));
-
-    OE_CHECK(_read('}', itr, end));
-
-    tcb_level.status = _parse_tcb_status(status, status_length);
-    if (tcb_level.status.AsUINT32 != OE_TCB_LEVEL_STATUS_UNKNOWN)
+    // Read each tcbLevel
+    while (*itr < end)
     {
-        _determine_platform_tcb_info_tcb_level(platform_tcb_level, &tcb_level);
-        result = OE_OK;
+        OE_CHECK(_read('{', itr, end));
+
+        OE_TRACE_VERBOSE("Reading tcb");
+        OE_CHECK(_read_property_name_and_colon("tcb", itr, end));
+        OE_CHECK(_read_tcb_info_tcb_level(itr, end, tcb_level));
+        OE_CHECK(_read(',', itr, end));
+
+        OE_TRACE_VERBOSE("Reading status");
+        OE_CHECK(_read_property_name_and_colon("status", itr, end));
+        OE_CHECK(_read_string(itr, end, &status, &status_length));
+        OE_CHECK(_trace_json_string(status, status_length));
+
+        OE_CHECK(_read('}', itr, end));
+
+        tcb_level->status = _parse_tcb_status(status, status_length);
+        if (tcb_level->status.AsUINT32 != OE_TCB_LEVEL_STATUS_UNKNOWN)
+        {
+            _determine_platform_tcb_info_tcb_level(
+                platform_tcb_level, tcb_level);
+        }
+        // Read end of array or comma separator.
+        if (*itr < end && **itr == ']')
+            break;
+        OE_CHECK(_read(',', itr, end));
     }
 
+    OE_CHECK(_read(']', itr, end));
+    result = OE_OK;
 done:
     return result;
 }
@@ -447,54 +460,76 @@ static oe_result_t _read_tcb_info_tcb_level_v2(
     const uint8_t* date_str = NULL;
     size_t date_size = 0;
 
-    OE_CHECK(_read('{', itr, end));
+    OE_CHECK(_read_property_name_and_colon("tcbLevels", itr, end));
+    OE_CHECK(_read('[', itr, end));
 
-    OE_TRACE_VERBOSE("Reading tcb");
-    OE_CHECK(_read_property_name_and_colon("tcb", itr, end));
-    OE_CHECK(_read_tcb_info_tcb_level(itr, end, tcb_level));
-    OE_CHECK(_read(',', itr, end));
-
-    OE_TRACE_VERBOSE("Reading tcbDate");
-    OE_CHECK(_read_property_name_and_colon("tcbDate", itr, end));
-    OE_CHECK(_read_string(itr, end, &date_str, &date_size));
-    if (oe_datetime_from_string(
-            (const char*)date_str, date_size, &tcb_level->tcb_date) != OE_OK)
-        OE_RAISE(OE_JSON_INFO_PARSE_ERROR);
-    OE_CHECK(_read(',', itr, end));
-
-    OE_TRACE_VERBOSE("Reading tcbStatus");
-    OE_CHECK(_read_property_name_and_colon("tcbStatus", itr, end));
-    OE_CHECK(_read_string(itr, end, &status, &status_length));
-    OE_CHECK(_trace_json_string(status, status_length));
-
-    // Optional advisoryIDs field
-    if (OE_JSON_INFO_PARSE_ERROR != _read(',', itr, end))
+    // Read each tcbLevel
+    while (*itr < end)
     {
-        OE_TRACE_VERBOSE("Reading advisoryIDs");
-        OE_CHECK(_read_property_name_and_colon("advisoryIDs", itr, end));
-        OE_CHECK(_read('[', itr, end));
+        OE_CHECK(_read('{', itr, end));
 
-        tcb_level->advisory_ids_offset = (size_t)(*itr - info_json);
-        size_t size = 0;
+        OE_TRACE_VERBOSE("Reading tcb");
+        OE_CHECK(_read_property_name_and_colon("tcb", itr, end));
+        OE_CHECK(_read_tcb_info_tcb_level(itr, end, tcb_level));
+        OE_CHECK(_read(',', itr, end));
 
-        while (*itr < end && **itr != ']')
+        OE_TRACE_VERBOSE("Reading tcbDate");
+        OE_CHECK(_read_property_name_and_colon("tcbDate", itr, end));
+        OE_CHECK(_read_string(itr, end, &date_str, &date_size));
+        if (oe_datetime_from_string(
+                (const char*)date_str, date_size, &tcb_level->tcb_date) !=
+            OE_OK)
+            OE_RAISE(OE_JSON_INFO_PARSE_ERROR);
+        OE_CHECK(_read(',', itr, end));
+
+        OE_TRACE_VERBOSE("Reading tcbStatus");
+        OE_CHECK(_read_property_name_and_colon("tcbStatus", itr, end));
+        OE_CHECK(_read_string(itr, end, &status, &status_length));
+        OE_CHECK(_trace_json_string(status, status_length));
+
+        // Optional advisoryIDs field
+        if (OE_JSON_INFO_PARSE_ERROR != _read(',', itr, end))
         {
-            (*itr)++;
-            size++;
+            OE_TRACE_VERBOSE("Reading advisoryIDs");
+            OE_CHECK(_read_property_name_and_colon("advisoryIDs", itr, end));
+            OE_CHECK(_read('[', itr, end));
+
+            tcb_level->advisory_ids_offset = (size_t)(*itr - info_json);
+            size_t size = 0;
+
+            while (*itr < end && **itr != ']')
+            {
+                (*itr)++;
+                size++;
+            }
+            OE_CHECK(_read(']', itr, end));
+            tcb_level->advisory_ids_size = size;
         }
-        OE_CHECK(_read(']', itr, end));
-        tcb_level->advisory_ids_size = size;
+
+        OE_CHECK(_read('}', itr, end));
+
+        tcb_level->status = _parse_tcb_status(status, status_length);
+        if (tcb_level->status.AsUINT32 != OE_TCB_LEVEL_STATUS_UNKNOWN)
+        {
+            _determine_platform_tcb_info_tcb_level(
+                platform_tcb_level, tcb_level);
+        }
+
+        // Optimization
+        if (platform_tcb_level->status.AsUINT32 != OE_TCB_LEVEL_STATUS_UNKNOWN)
+        {
+            // Found matching TCB level, go to the end of the array.
+            _move_to_end_of_tcb_levels(itr, end);
+        }
+
+        // Read end of array or comma separator.
+        if (*itr < end && **itr == ']')
+            break;
+        OE_CHECK(_read(',', itr, end));
     }
 
-    OE_CHECK(_read('}', itr, end));
-
-    tcb_level->status = _parse_tcb_status(status, status_length);
-    if (tcb_level->status.AsUINT32 != OE_TCB_LEVEL_STATUS_UNKNOWN)
-    {
-        _determine_platform_tcb_info_tcb_level(platform_tcb_level, tcb_level);
-        result = OE_OK;
-    }
-
+    OE_CHECK(_read(']', itr, end));
+    result = OE_OK;
 done:
     return result;
 }
@@ -592,7 +627,7 @@ static oe_result_t _read_tcb_info(
 
     if (parsed_info->version == 2)
     {
-        OE_TRACE_VERBOSE("V2: Reading tcbType");
+        OE_TRACE_VERBOSE("Reading tcbType");
         OE_CHECK(_read_property_name_and_colon("tcbType", itr, end));
         OE_CHECK(_read_integer(itr, end, &value));
 
@@ -606,57 +641,25 @@ static oe_result_t _read_tcb_info(
         parsed_info->tcb_type = (uint32_t)value;
         OE_CHECK(_read(',', itr, end));
 
-        OE_TRACE_VERBOSE("V2: Reading tcbEvaluationDataNumber");
+        OE_TRACE_VERBOSE("Reading tcbEvaluationDataNumber");
         OE_CHECK(
             _read_property_name_and_colon("tcbEvaluationDataNumber", itr, end));
         OE_CHECK(_read_integer(itr, end, &value));
         parsed_info->tcb_evaluation_data_number = (uint32_t)value;
         OE_CHECK(_read(',', itr, end));
-
-        OE_TRACE_VERBOSE("Reading tcbLevels (V2)");
-        OE_CHECK(_read_property_name_and_colon("tcbLevels", itr, end));
-        OE_CHECK(_read('[', itr, end));
-        while (*itr < end)
-        {
-            OE_CHECK(_read_tcb_info_tcb_level_v2(
-                tcb_info_json,
-                itr,
-                end,
-                platform_tcb_level,
-                &parsed_info->tcb_level));
-
-            // Optimization
-            if (platform_tcb_level->status.AsUINT32 !=
-                OE_TCB_LEVEL_STATUS_UNKNOWN)
-            {
-                // Found matching TCB level, go to the end of the array.
-                _move_to_end_of_tcb_levels(itr, end);
-            }
-
-            // Read end of array or comma separator.
-            if (*itr < end && **itr == ']')
-                break;
-
-            OE_CHECK(_read(',', itr, end));
-        }
-        OE_CHECK(_read(']', itr, end));
     }
-    else if (parsed_info->version == 1)
-    {
-        OE_TRACE_VERBOSE("Reading tcbLevels (V1)");
-        OE_CHECK(_read_property_name_and_colon("tcbLevels", itr, end));
-        OE_CHECK(_read('[', itr, end));
-        while (*itr < end)
-        {
-            OE_CHECK(_read_tcb_info_tcb_level_v1(itr, end, platform_tcb_level));
-            // Read end of array or comma separator.
-            if (*itr < end && **itr == ']')
-                break;
 
-            OE_CHECK(_read(',', itr, end));
-        }
-        OE_CHECK(_read(']', itr, end));
-    }
+    OE_TRACE_VERBOSE("Reading tcbLevels");
+    if (parsed_info->version == 1)
+        OE_CHECK(_read_tcb_info_tcb_level_v1(
+            itr, end, platform_tcb_level, &parsed_info->tcb_level));
+    else if (parsed_info->version == 2)
+        OE_CHECK(_read_tcb_info_tcb_level_v2(
+            tcb_info_json,
+            itr,
+            end,
+            platform_tcb_level,
+            &parsed_info->tcb_level));
     else
     {
         OE_RAISE_MSG(

--- a/common/sgx/tcbinfo.h
+++ b/common/sgx/tcbinfo.h
@@ -73,6 +73,10 @@ typedef struct _oe_parsed_tcb_info
     uint8_t signature[64];
 
     // V2 fields
+    // HW representation of CPUSVN for a given FMSPC is not architecturally
+    // defined to provide designers more flexibility. SW needs "tcbType" to
+    // determine how to decompose the CPUSVN. Each FMSPC has its own
+    // tcbType. For now, there is only one tcbType(0) has been defined.
     uint32_t tcb_type;
     uint32_t tcb_evaluation_data_number;
     oe_tcb_info_tcb_level_t tcb_level;

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -27,12 +27,17 @@
 extern void TestVerifyTCBInfo(
     oe_enclave_t* enclave,
     const char* test_file_name);
+extern void TestVerifyTCBInfo_Negative(
+    oe_enclave_t* enclave,
+    const char* file_names[],
+    size_t file_cnt);
 extern void TestVerifyTCBInfoV2(
     oe_enclave_t* enclave,
     const char* test_filename);
-extern void TestVerifyTCBInfoV2_AdvisoryIDs(
+extern void TestVerifyTCBInfo_AdvisoryIDs(
     oe_enclave_t* enclave,
-    const char* test_filename);
+    const char* test_filename,
+    uint32_t version);
 extern int FileToBytes(const char* path, std::vector<uint8_t>* output);
 
 void generate_and_save_report(oe_enclave_t* enclave)
@@ -201,12 +206,101 @@ int main(int argc, const char* argv[])
 
         TestVerifyTCBInfo(enclave, "./data/tcbInfo.json");
         TestVerifyTCBInfo(enclave, "./data/tcbInfo_with_pceid.json");
+        const char* negative_files[] = {
+            // In the following files, a property in corresponding level has
+            // been
+            // capitalized. JSON is case sensitive and therefore schema
+            // validation
+            // should fail.
+            "./data/tcbInfoNegativePropertyMissingLevel0.json",
+            "./data/tcbInfoNegativePropertyMissingLevel1.json",
+            "./data/tcbInfoNegativePropertyMissingLevel2.json",
+            "./data/tcbInfoNegativePropertyMissingLevel3.json",
+            // In the following files, a property in corresponding level has
+            // wrong
+            // type.
+            "./data/tcbInfoNegativePropertyWrongTypeLevel0.json",
+            "./data/tcbInfoNegativePropertyWrongTypeLevel1.json",
+            "./data/tcbInfoNegativePropertyWrongTypeLevel2.json",
+            "./data/tcbInfoNegativePropertyWrongTypeLevel3.json",
+
+            // Comp Svn greater than uint8_t
+            "./data/tcbInfoNegativeCompSvn.json",
+
+            // pce Svn greater than uint16_t
+            "./data/tcbInfoNegativePceSvn.json",
+
+            // Invalid issueDate field.
+            "./data/tcbInfoNegativeInvalidIssueDate.json",
+
+            // Invalid nextUpdate field.
+            "./data/tcbInfoNegativeInvalidNextUpdate.json",
+
+            // Missing nextUpdate field.
+            "./data/tcbInfoNegativeMissingNextUpdate.json",
+
+            // Signature != 64 bytes
+            "./data/tcbInfoNegativeSignature.json",
+
+            // Unsupported JSON constructs
+            "./data/tcbInfoNegativeStringEscape.json",
+            "./data/tcbInfoNegativeIntegerOverflow.json",
+            "./data/tcbInfoNegativeIntegerWithSign.json",
+            "./data/tcbInfoNegativeFloat.json",
+        };
+        TestVerifyTCBInfo_Negative(
+            enclave, negative_files, OE_COUNTOF(negative_files));
 
         TestVerifyTCBInfoV2(enclave, "./data_v2/tcbInfo.json");
         TestVerifyTCBInfoV2(enclave, "./data_v2/tcbInfo_with_pceid.json");
-        TestVerifyTCBInfoV2_AdvisoryIDs(
-            enclave, "./data_v2/tcbInfoAdvisoryIds.json");
+        TestVerifyTCBInfo_AdvisoryIDs(
+            enclave, "./data_v2/tcbInfoAdvisoryIds.json", 2);
+        const char* negative_files_v2[] = {
+            // In the following files, a property in corresponding level has
+            // been
+            // capitalized. JSON is case sensitive and therefore schema
+            // validation
+            // should fail.
+            "./data_v2/tcbInfoNegativePropertyMissingLevel0.json",
+            "./data_v2/tcbInfoNegativePropertyMissingLevel1.json",
+            "./data_v2/tcbInfoNegativePropertyMissingLevel2.json",
+            "./data_v2/tcbInfoNegativePropertyMissingLevel3.json",
+            // In the following files, a property in corresponding level has
+            // wrong
+            // type.
+            "./data_v2/tcbInfoNegativePropertyWrongTypeLevel0.json",
+            "./data_v2/tcbInfoNegativePropertyWrongTypeLevel1.json",
+            "./data_v2/tcbInfoNegativePropertyWrongTypeLevel2.json",
+            "./data_v2/tcbInfoNegativePropertyWrongTypeLevel3.json",
 
+            // Comp Svn greater than uint8_t
+            "./data_v2/tcbInfoNegativeCompSvn.json",
+
+            // pce Svn greater than uint16_t
+            "./data_v2/tcbInfoNegativePceSvn.json",
+
+            // Invalid issueDate field.
+            "./data_v2/tcbInfoNegativeInvalidIssueDate.json",
+
+            // Invalid nextUpdate field.
+            "./data_v2/tcbInfoNegativeInvalidNextUpdate.json",
+
+            // Missing nextUpdate field.
+            "./data_v2/tcbInfoNegativeMissingNextUpdate.json",
+
+            // Signature != 64 bytes
+            "./data_v2/tcbInfoNegativeSignature.json",
+
+            // Unsupported JSON constructs
+            "./data_v2/tcbInfoNegativeStringEscape.json",
+            "./data_v2/tcbInfoNegativeIntegerOverflow.json",
+            "./data_v2/tcbInfoNegativeIntegerWithSign.json",
+            "./data_v2/tcbInfoNegativeFloat.json",
+            // TcbType != 0.
+            "./data_v2/tcbInfoNegativeTcbType.json",
+        };
+        TestVerifyTCBInfo_Negative(
+            enclave, negative_files_v2, OE_COUNTOF(negative_files_v2));
         {
             // Get current time and pass it to enclave.
             std::time_t t = std::time(0);

--- a/tests/report/host/tcbinfo.cpp
+++ b/tests/report/host/tcbinfo.cpp
@@ -199,52 +199,16 @@ void TestVerifyTCBInfo(oe_enclave_t* enclave, const char* test_filename)
     printf("Unknown TCB Level determination test passed.\n");
 
     printf("TestVerifyTCBInfo: Positive Tests passed\n");
-
-    const char* negative_files[] = {
-        // In the following files, a property in corresponding level has been
-        // capitalized. JSON is case sensitive and therefore schema validation
-        // should fail.
-        "./data/tcbInfoNegativePropertyMissingLevel0.json",
-        "./data/tcbInfoNegativePropertyMissingLevel1.json",
-        "./data/tcbInfoNegativePropertyMissingLevel2.json",
-        "./data/tcbInfoNegativePropertyMissingLevel3.json",
-        // In the following files, a property in corresponding level has wrong
-        // type.
-        "./data/tcbInfoNegativePropertyWrongTypeLevel0.json",
-        "./data/tcbInfoNegativePropertyWrongTypeLevel1.json",
-        "./data/tcbInfoNegativePropertyWrongTypeLevel2.json",
-        "./data/tcbInfoNegativePropertyWrongTypeLevel3.json",
-
-        // Comp Svn greater than uint8_t
-        "./data/tcbInfoNegativeCompSvn.json",
-
-        // pce Svn greater than uint16_t
-        "./data/tcbInfoNegativePceSvn.json",
-
-        // Invalid issueDate field.
-        "./data/tcbInfoNegativeInvalidIssueDate.json",
-
-        // Invalid nextUpdate field.
-        "./data/tcbInfoNegativeInvalidNextUpdate.json",
-
-        // Missing nextUpdate field.
-        "./data/tcbInfoNegativeMissingNextUpdate.json",
-
-        // Signature != 64 bytes
-        "./data/tcbInfoNegativeSignature.json",
-
-        // Unsupported JSON constructs
-        "./data/tcbInfoNegativeStringEscape.json",
-        "./data/tcbInfoNegativeIntegerOverflow.json",
-        "./data/tcbInfoNegativeIntegerWithSign.json",
-        "./data/tcbInfoNegativeFloat.json",
-    };
-
-    for (size_t i = 0; i < sizeof(negative_files) / sizeof(negative_files[0]);
-         ++i)
+}
+void TestVerifyTCBInfo_Negative(
+    oe_enclave_t* enclave,
+    const char* file_names[],
+    size_t file_cnt)
+{
+    for (size_t i = 0; i < file_cnt; ++i)
     {
         std::vector<uint8_t> tcbInfo;
-        OE_TEST(FileToBytes(negative_files[i], &tcbInfo) == 0);
+        OE_TEST(FileToBytes(file_names[i], &tcbInfo) == 0);
 
         oe_parsed_tcb_info_t parsed_info = {0};
         oe_tcb_info_tcb_level_t platform_tcb_level = {{0}};
@@ -257,8 +221,7 @@ void TestVerifyTCBInfo(oe_enclave_t* enclave, const char* test_filename)
                 &platform_tcb_level,
                 &parsed_info) == OE_OK);
         OE_TEST(ecall_result == OE_JSON_INFO_PARSE_ERROR);
-        printf(
-            "TestVerifyTCBInfo: Negative Test %s passed\n", negative_files[i]);
+        printf("TestVerifyTCBInfo: Negative Test %s passed\n", file_names[i]);
     }
 }
 
@@ -403,75 +366,12 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
     printf("Unknown TCB Level determination test passed.\n");
 
     printf("TestVerifyTCBInfo V2: Positive Tests passed\n");
-
-    const char* negative_files[] = {
-        // In the following files, a property in corresponding level has been
-        // capitalized. JSON is case sensitive and therefore schema validation
-        // should fail.
-        "./data_v2/tcbInfoNegativePropertyMissingLevel0.json",
-        "./data_v2/tcbInfoNegativePropertyMissingLevel1.json",
-        "./data_v2/tcbInfoNegativePropertyMissingLevel2.json",
-        "./data_v2/tcbInfoNegativePropertyMissingLevel3.json",
-        // In the following files, a property in corresponding level has wrong
-        // type.
-        "./data_v2/tcbInfoNegativePropertyWrongTypeLevel0.json",
-        "./data_v2/tcbInfoNegativePropertyWrongTypeLevel1.json",
-        "./data_v2/tcbInfoNegativePropertyWrongTypeLevel2.json",
-        "./data_v2/tcbInfoNegativePropertyWrongTypeLevel3.json",
-
-        // Comp Svn greater than uint8_t
-        "./data_v2/tcbInfoNegativeCompSvn.json",
-
-        // pce Svn greater than uint16_t
-        "./data_v2/tcbInfoNegativePceSvn.json",
-
-        // Invalid issueDate field.
-        "./data_v2/tcbInfoNegativeInvalidIssueDate.json",
-
-        // Invalid nextUpdate field.
-        "./data_v2/tcbInfoNegativeInvalidNextUpdate.json",
-
-        // Missing nextUpdate field.
-        "./data_v2/tcbInfoNegativeMissingNextUpdate.json",
-
-        // Signature != 64 bytes
-        "./data_v2/tcbInfoNegativeSignature.json",
-
-        // Unsupported JSON constructs
-        "./data_v2/tcbInfoNegativeStringEscape.json",
-        "./data_v2/tcbInfoNegativeIntegerOverflow.json",
-        "./data_v2/tcbInfoNegativeIntegerWithSign.json",
-        "./data_v2/tcbInfoNegativeFloat.json",
-        // TcbType != 0.
-        "./data_v2/tcbInfoNegativeTcbType.json",
-    };
-
-    for (size_t i = 0; i < sizeof(negative_files) / sizeof(negative_files[0]);
-         ++i)
-    {
-        std::vector<uint8_t> tcbInfo;
-        OE_TEST(FileToBytes(negative_files[i], &tcbInfo) == 0);
-
-        oe_parsed_tcb_info_t parsed_info = {0};
-        oe_tcb_info_tcb_level_t platform_tcb_level = {{0}};
-        oe_result_t ecall_result = OE_FAILURE;
-        OE_TEST(
-            test_verify_tcb_info(
-                enclave,
-                &ecall_result,
-                (const char*)&tcbInfo[0],
-                &platform_tcb_level,
-                &parsed_info) == OE_OK);
-        OE_TEST(ecall_result == OE_JSON_INFO_PARSE_ERROR);
-        printf(
-            "TestVerifyTCBInfoV2: Negative Test %s passed\n",
-            negative_files[i]);
-    }
 }
 
-void TestVerifyTCBInfoV2_AdvisoryIDs(
+void TestVerifyTCBInfo_AdvisoryIDs(
     oe_enclave_t* enclave,
-    const char* test_filename)
+    const char* test_filename,
+    uint32_t version)
 {
     std::vector<uint8_t> tcbInfo;
     oe_result_t ecall_result = OE_FAILURE;
@@ -499,7 +399,7 @@ void TestVerifyTCBInfoV2_AdvisoryIDs(
     OE_TEST(ecall_result == OE_OK);
     OE_TEST(platform_tcb_level.status.fields.up_to_date == 1);
 
-    AssertParsedValues(parsed_info, 2);
+    AssertParsedValues(parsed_info, version);
     oe_datetime_t nextUpdate = {2019, 6, 6, 10, 12, 17};
     OE_TEST(oe_datetime_compare(&parsed_info.next_update, &nextUpdate) == 0);
 
@@ -536,5 +436,5 @@ void TestVerifyTCBInfoV2_AdvisoryIDs(
                 expectedAdvisoryIDs[i],
                 advisoryIDs_length[i]) == 0);
     }
-    printf("TCB Info V2 positive test, with advisoryIDs. PASSED\n");
+    printf("TestVerifyTCBInfo: Positive Tests %s passed\n", test_filename);
 }


### PR DESCRIPTION
SGX V3 tcbinfo structure was revoked so PR #3386 is closed. But some of the changes are to make tcb parser more expandable to future versions so can be kept. This PR is to keep those changes, mostly

1. A while loop was implemented in `_read_tcb_info` to parse a list of tcbLevel entries. Now this while loop was moved into `_read_tcb_info_tcb_level` so that code can be cleaner in `_read_tcb_info`, considering more versions could be added to `_read_tcb_info` in the future.
2. The negative tests were isolated from the positive test function so that those negative tests do not need to be repeated in the `tcbInfo_with_pceid.json` positive test after the `tcbInfo.json` positive test was tested. So now all negative tests are tested once instead of twice.

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>