### PR TITLE
Update oeedger8r submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Initial implementation of the [Malloc Info API](docs/DesignDocs/Mallinfo.md) for dlmalloc (default allocator), and snmalloc.
+- Added missing attribute validations to oeedger8r C++ implementation.
 
 ### Deprecated
 
@@ -22,6 +23,13 @@ https://github.com/openenclave/openenclave/issues/3539 tracks this.
 - The Open Enclave SDK is deprecating support for gcc while *building the SDK from source* after Dec 2020.
 The recommended compiler while building the SDK from source is Clang.
 https://github.com/openenclave/openenclave/issues/3555 tracks this.
+
+### Security
+- Security fixes in oeedger8r
+     - Fix TOCTOU vulnerability in NULL terminator checks for ocall in/out string parameters.
+     - Count/size properties in deep-copied in/out structs are treated as readonly to prevent the host
+	   from changing corrupting enclave memory by changing these properties.
+
 
 [v0.11.0][v0.11.0_log]
 --------------

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -115,13 +115,6 @@ enclave {
     // should take place.
     public void deepcopy_inout_count([in, out, count=1] CountStruct* s);
 
-    // Deep copy of one `CountStruct` with an embedded array out
-    // should take place.
-    public void deepcopy_out_count([out, count=1] CountStruct* s);
-
-    // Test for recursive copying for out structure.
-    public void deepcopy_nested_out([out, count=1] NestedStruct* n);
-
     // Test a real-world scenario.
     public void deepcopy_iovec([in, out, count=n] IOVEC* iov, size_t n);
   };

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -188,40 +188,6 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
     }
 
     {
-        CountStruct s{};
-        uint64_t p[3] = {0, 0, 0};
-        s.ptr = p;
-        OE_TEST(deepcopy_out_count(enclave, &s) == OE_OK);
-        OE_TEST(s.count == 7);
-        OE_TEST(s.size == 64);
-        test_struct(s, 3);
-    }
-
-    {
-        auto s = init_struct<CountStruct>();
-        int ints[]{0, 1, 2, 3};
-        ShallowStruct shallow{1, 8, nullptr};
-        CountStruct counts[]{s, s, s};
-        NestedStruct n{13, ints, &shallow, counts};
-        OE_TEST(deepcopy_nested_out(enclave, &n) == OE_OK);
-
-        for (size_t i = 0; i < 4; ++i)
-            OE_TEST(n.array_of_int[i] == static_cast<int>(i));
-
-        // Out-only deepcopy does not support shallow pointer passing.
-        OE_TEST(n.shallow_struct != &shallow);
-        OE_TEST(n.array_of_struct == counts);
-
-        for (size_t i = 0; i < 3; ++i)
-            for (size_t j = 0; j < 8; ++j)
-            {
-                OE_TEST(n.array_of_struct[i].count == 7);
-                OE_TEST(n.array_of_struct[i].size == 64);
-                OE_TEST(n.array_of_struct[i].ptr[j] == data[j]);
-            }
-    }
-
-    {
         IOVEC iov[2];
         char buf0[8] = "red";
 


### PR DESCRIPTION
- Remove tests for deep-copy out parameters.
  These were never properly supported.
- Various fixes
  - Validations
  - Retain lhs size/count
  - String null checking

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>