### PR TITLE
Allow internal code to call "timegm" on Windows

### DIFF
--- a/common/datetime.c
+++ b/common/datetime.c
@@ -285,11 +285,7 @@ oe_result_t oe_datetime_to_time_t(const oe_datetime_t* datetime, time_t* value)
     timeinfo.tm_min = (int)datetime->minutes;
     timeinfo.tm_sec = (int)datetime->seconds;
 
-#ifdef _WIN32
-    tmp = _mkgmtime(&timeinfo);
-#else
     tmp = timegm(&timeinfo);
-#endif
 
     *value = tmp;
 

--- a/include/openenclave/internal/datetime.h
+++ b/include/openenclave/internal/datetime.h
@@ -18,6 +18,7 @@ OE_EXTERNC_BEGIN
 
 #ifdef _WIN32
 #define gmtime_r(now, timeinfo) gmtime_s(timeinfo, now)
+#define timegm(tm) _mkgmtime(tm)
 #endif
 
 /**

--- a/tests/crypto/crl_tests.c
+++ b/tests/crypto/crl_tests.c
@@ -16,9 +16,6 @@
 #include <time.h>
 #include "readfile.h"
 #include "tests.h"
-#if defined(_WIN32)
-#define timegm _mkgmtime
-#endif
 
 #define ACCEPTABLE_ERROR_IN_SECONDS 60
 


### PR DESCRIPTION
Fixes #3646

This is code cleanup left over from the review of PR #3544