### PR TITLE
Deprecate file validation

### DIFF
--- a/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/redhat/main.yml
@@ -11,8 +11,6 @@ intel_sgx_packages:
   - "libsgx-pce-logic"
 
 packages_validation_distribution_files:
-  - "/usr/include/sgx_attributes.h"
-  - "/usr/include/sgx_enclave_common.h"
   - "/usr/lib64/libsgx_enclave_common.so.1"
   - "/usr/lib64/libsgx_pce.signed.so"
   - "/usr/lib64/libsgx_qe3.signed.so"


### PR DESCRIPTION
Remove 2 header files leftover from libsgx-enclave-common-devel which was removed
in #3327

Signed-off-by: Chris Yan <chrisyan@microsoft.com>