### PR TITLE
Fix custom claims problem in SGX verifier plugin

### DIFF
--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -641,8 +641,11 @@ static oe_result_t _verify_evidence(
     {
         report_body = evidence_buffer;
         report_body_size = sizeof(sgx_report_t);
-        custom_claims_buffer = report_body + report_body_size;
-        custom_claims_buffer_size = evidence_buffer_size - report_body_size;
+        if (evidence_buffer_size > report_body_size)
+        {
+            custom_claims_buffer = report_body + report_body_size;
+            custom_claims_buffer_size = evidence_buffer_size - report_body_size;
+        }
 
         OE_CHECK(_verify_local_report(report_body, report_body_size));
     }
@@ -654,8 +657,12 @@ static oe_result_t _verify_evidence(
 
             report_body = evidence_buffer;
             report_body_size = sizeof(*quote) + quote->signature_len;
-            custom_claims_buffer = report_body + report_body_size;
-            custom_claims_buffer_size = evidence_buffer_size - report_body_size;
+            if (evidence_buffer_size > report_body_size)
+            {
+                custom_claims_buffer = report_body + report_body_size;
+                custom_claims_buffer_size =
+                    evidence_buffer_size - report_body_size;
+            }
         }
         else if (format_type == SGX_FORMAT_TYPE_LEGACY_REPORT)
         {

--- a/tests/attestation_plugin/host/host.c
+++ b/tests/attestation_plugin/host/host.c
@@ -111,11 +111,11 @@ int main(int argc, const char* argv[])
         argv[1], OE_ENCLAVE_TYPE_AUTO, flags, NULL, 0, &enclave);
     OE_TEST(result == OE_OK);
 
-    run_runtime_test(enclave);
-    register_sgx(enclave);
-    test_sgx(enclave);
-    unregister_sgx(enclave);
-    OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+    OE_TEST_CODE(run_runtime_test(enclave), OE_OK);
+    OE_TEST_CODE(register_sgx(enclave), OE_OK);
+    OE_TEST_CODE(test_sgx(enclave), OE_OK);
+    OE_TEST_CODE(unregister_sgx(enclave), OE_OK);
+    OE_TEST_CODE(oe_terminate_enclave(enclave), OE_OK);
 
     // Run runtime test on the host.
     test_runtime();


### PR DESCRIPTION
When there are no custom claims, `custom_claims_buffer` would point to after the report body and `custom_claims_buffer_size` would (correctly) be 0, but `oe_sgx_extract_claims` rejects that as invalid parameters ([here](https://github.com/openenclave/openenclave/blob/cf573c06adfbde75a3830a6dff119107b1ddee73/common/sgx/verifier.c#L461)).