### PR TITLE
Fix for codeql alert - Query ID:cpp/wrong-number-format-arguments

### DIFF
--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -343,7 +343,7 @@ static oe_result_t _handle_ocall(
 
     oe_log(
         OE_LOG_LEVEL_VERBOSE,
-        "%s 0x%x %s: %s\n",
+        "%s 0x%llx %s: %s\n",
         enclave->path,
         enclave->addr,
         func == OE_OCALL_CALL_HOST_FUNCTION ? "EDL_OCALL" : "OE_OCALL",
@@ -602,7 +602,7 @@ oe_result_t oe_ecall(
 
     oe_log(
         OE_LOG_LEVEL_VERBOSE,
-        "%s 0x%x %s: %s\n",
+        "%s 0x%llx %s: %s\n",
         enclave->path,
         enclave->addr,
         func == OE_ECALL_CALL_ENCLAVE_FUNCTION ? "EDL_ECALL" : "OE_ECALL",

--- a/include/openenclave/internal/raise.h
+++ b/include/openenclave/internal/raise.h
@@ -134,18 +134,10 @@ OE_EXTERNC_BEGIN
         result = (RESULT);                                           \
         if (result != OE_OK)                                         \
         {                                                            \
-            if (!_strcmp(#__VA_ARGS__, "NULL"))                      \
-            {                                                        \
-                OE_TRACE_ERROR(                                      \
-                    fmt " (oe_result_t=%s)", oe_result_str(result)); \
-            }                                                        \
-            else                                                     \
-            {                                                        \
-                OE_TRACE_ERROR(                                      \
-                    fmt " (oe_result_t=%s)",                         \
-                    ##__VA_ARGS__,                                   \
-                    oe_result_str(result));                          \
-            }                                                        \
+            OE_TRACE_ERROR(                                          \
+                fmt " (oe_result_t=%s)",                             \
+                ##__VA_ARGS__,                                       \
+                oe_result_str(result));                              \
         }                                                            \
         goto done;                                                   \
     } while (0)


### PR DESCRIPTION
The IF block in OE_RAISE_MSG macro is causing ~160 security errors in CodeQL scans for "Too few arguments to formatting functions".
gcc/clang handles ##VA_ARGS internally. When ##VA_ARGS is empty the comma before the ‘##’ will be deleted.
This IF block is dead code even when in empty arguments scenario.

Signed-off-by: Ragavan <mrragava@gmail.com>
