### PR TITLE
add initial approvers/reviewers for prow integration

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,24 @@
+approvers:
+  - AevaOnline
+  - gupta-ak
+  - achamayou
+  - anakrish
+  - andschwa
+  - dthaler
+  - johnkord
+  - jhand2
+  - mikbras
+  - radhikaj
+  - CodeMonkeyLeet
+reviewers:
+  - AevaOnline
+  - gupta-ak
+  - achamayou
+  - anakrish
+  - andschwa
+  - dthaler
+  - johnkord
+  - jhand2
+  - mikbras
+  - radhikaj
+  - CodeMonkeyLeet

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -79,6 +79,7 @@ docs/CODEOWNERS
 LICENSE
 THIRD_PARTY_NOTICES
 VERSION
+OWNERS
 \.check-license\.ignore
 \.clang-format
 \.cspellignore


### PR DESCRIPTION
This PR adds the CGC as the initial owners/reviewers as part of https://github.com/openenclave/openenclave/issues/3640