### PR TITLE
re-enable code coverage test

### DIFF
--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -520,8 +520,7 @@ try{
                 "ACC1804 clang-7 Release LVI FULL Tests":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
                 "ACC1804 gcc Debug LVI":                           { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
                 "ACC1804 gcc Release LVI":                         { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                // re-add once https://github.com/openenclave/openenclave/issues/3648 is resolved
-                //"ACC1804 Code Coverage Test" :                     { ACCCodeCoverageTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug') },
+                "ACC1804 Code Coverage Test" :                     { ACCCodeCoverageTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug') },
 
                 "ACC1604 clang-7 Release LVI snmalloc":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON', '-DUSE_SNMALLOC=ON']) },
                 "ACC1804 clang-7 Release LVI FULL Tests snmalloc": { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },


### PR DESCRIPTION
This PR re-enables the code coverage tests. They were initially disabled due to some backend ci issues where the machines would not spawn and errored out during the dependency installation.

Fixes #3648  