### PR TITLE
Jordan stepping down from CGC

### DIFF
--- a/docs/Community/governance/README.md
+++ b/docs/Community/governance/README.md
@@ -26,7 +26,6 @@ Members
 | Andrew Schwartzmeyer | Microsoft   | andrew@schwartzmeyer.com      | andschwa       |
 | Dave Thaler          | Microsoft   | dthaler@microsoft.com         | dthaler        |
 | John Kordich         | Independent | jkordich@gmail.com            | johnkord       |
-| Jordan Hand          | Microsoft   | jorhand@microsoft.com         | jhand2         |
 | Mike Brasher         | Microsoft   | mikbras@microsoft.com         | mikbras        |
 | Radhika Jandhyala    | Microsoft   | radhikaj@microsoft.com        | radhikaj       |
 | Simon Leet           | Microsoft   | simon.leet@microsoft.com      | CodeMonkeyLeet |


### PR DESCRIPTION
Much thanks for Jordan for the work he put in!  Today he stepped down
via email to the oesdkcgc list:
https://lists.confidentialcomputing.io/g/oesdkcgc/topic/farewell_from_jordan/77712035?p=,,,20,0,0,0::recentpostdate%2Fsticky,,,20,2,0,77712035

This PR just updates the CGC member list to remove him.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>