### PR TITLE
Enabling CFG for oesgx.exe, oesign.exe & oedebugrt.dll

### DIFF
--- a/debugger/debugrt/host/CMakeLists.txt
+++ b/debugger/debugrt/host/CMakeLists.txt
@@ -20,7 +20,7 @@ else ()
   # is temporary.
   set_target_properties(
     oedebugrt PROPERTIES COMPILE_FLAGS "/Zi" # Compile with debug information
-                         LINK_FLAGS "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF"
+                         LINK_FLAGS "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF /Guard:CF"
   )# Create pdb
   install(FILES $<TARGET_PDB_FILE:oedebugrt>
           DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/oesgx/CMakeLists.txt
+++ b/tools/oesgx/CMakeLists.txt
@@ -8,7 +8,9 @@ target_include_directories(oesgx PRIVATE ${PROJECT_SOURCE_DIR}/include)
 # assemble into proper collector dir
 set_property(TARGET oesgx PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
-set_target_properties(oesgx PROPERTIES LINK_FLAGS "/Guard:CF")
+if (WIN32)
+  set_target_properties(oesgx PROPERTIES LINK_FLAGS "/Guard:CF")
+endif ()
 
 # install rule
 install(TARGETS oesgx DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/oesgx/CMakeLists.txt
+++ b/tools/oesgx/CMakeLists.txt
@@ -8,5 +8,7 @@ target_include_directories(oesgx PRIVATE ${PROJECT_SOURCE_DIR}/include)
 # assemble into proper collector dir
 set_property(TARGET oesgx PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
+set_target_properties(oesgx PROPERTIES LINK_FLAGS "/Guard:CF")
+
 # install rule
 install(TARGETS oesgx DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/oesign/CMakeLists.txt
+++ b/tools/oesign/CMakeLists.txt
@@ -36,7 +36,9 @@ if (NOT COMPONENT MATCHES OEHOSTVERIFY)
   # assemble into proper collector dir
   set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
-  set_target_properties(oesign PROPERTIES LINK_FLAGS "/Guard:CF")
+  if (WIN32)
+    set_target_properties(oesign PROPERTIES LINK_FLAGS "/Guard:CF")
+  endif ()
 
   # install rule
   install(

--- a/tools/oesign/CMakeLists.txt
+++ b/tools/oesign/CMakeLists.txt
@@ -36,6 +36,8 @@ if (NOT COMPONENT MATCHES OEHOSTVERIFY)
   # assemble into proper collector dir
   set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
+  set_target_properties(oesign PROPERTIES LINK_FLAGS "/Guard:CF")
+
   # install rule
   install(
     TARGETS oesign


### PR DESCRIPTION
Signed-off-by: Swamy Shivaganga Nagaraju <gaswamy@microsoft.com>

Adding linker flag /Guard:CF to enable Control Flow Guard (CFG) to oesgx.exe, oesign.exe & oedebugrt.dll. This makes the binaries compliant to security on Windows platform. 

More details about the linker flag can be found here: https://docs.microsoft.com/en-us/cpp/build/reference/guard-enable-control-flow-guard?view=vs-2019