### PR TITLE
Add basic KSS support (ISVFAMILYID and ISVEXTPRODID) to OE SDK

### DIFF
--- a/docs/GettingStartedDocs/buildandsign.md
+++ b/docs/GettingStartedDocs/buildandsign.md
@@ -97,9 +97,40 @@ NumHeapPages=1024
 NumStackPages=1024
 NumTCS=1
 ```
+Additionally, a developer can specify additional Key Sharing and Separation (KSS) identity properties
+for use on the platforms that support it (for SGX enclave only):
+- **FamilyID**: The product family identity (ISVFAMILYID for SGX) a developer can specify to group
+different enclaves under a common identity such as an identifier for the application suite
+which includes several enclave apps.
+- **ExtendedProductID**: The extended product identity (ISVEXTPRODID for SGX) value that a developer
+can use as 128-bit globally unique identifier for the enclave where the 16-bit ProductID proves too restrictive.
+For more details, see Table 37-19 of the
+[Intel's Software Developers Manual](https://software.intel.com/content/www/us/en/develop/articles/intel-sdm.html#combined/).
 
-As a convenience, you can also specify the enclave properties in code using the
-`OE_SET_ENCLAVE_SGX` macro.  For example, the equivalent properties could be
+For example, in kss_valid.conf:
+```
+FamilyID=47183823-2574-4bfd-b411-99ed177d3e43
+ExtendedProductID=2768c720-1e28-11eb-adc1-0242ac120002
+```
+
+As a convenience, you can specify the enclave properties in code using the
+`OE_SET_ENCLAVE_SGX_KSS` macro if KSS properties are included.  For example, the equivalent properties could be
+defined in any .c or .cpp file compiled into the enclave:
+
+```c
+OE_SET_ENCLAVE_SGX_KSS(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    1,    /* Debug */
+    47183823-2574-4bfd-b411-99ed177d3e43, /* FamilyID */
+    2768c720-1e28-11eb-adc1-0242ac120002, /* ExtendedProductID */
+    1024, /* NumHeapPages: heap size in units of 4KB pages */
+    1024, /* NumStackPages: stack size, in units of 4KB pages */
+    1);   /* NumTCS */
+```
+
+You can also specify the enclave properties in code using the
+`OE_SET_ENCLAVE_SGX` macro if no KSS properties needed.  For example, the equivalent properties could be
 defined in any .c or .cpp file compiled into the enclave:
 
 ```c

--- a/enclave/core/sgx/properties.c
+++ b/enclave/core/sgx/properties.c
@@ -17,13 +17,13 @@ OE_STATIC_ASSERT(
 
 OE_CHECK_SIZE(sizeof(oe_enclave_properties_header_t), 32);
 
-OE_CHECK_SIZE(sizeof(oe_sgx_enclave_config_t), 24);
+OE_CHECK_SIZE(sizeof(oe_sgx_enclave_config_t), 56);
 
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, header), 0);
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, config), 32);
-OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 56);
-OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 104);
-OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 1920);
+OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 88);
+OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 136);
+OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 1952);
 
 //
 // Declare an invalid oeinfo to ensure .oeinfo section exists

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -140,6 +140,8 @@ static sgx_secs_t* _new_secs(
     secs->flags = SGX_FLAGS_MODE64BIT;
     if (oe_sgx_is_debug_load_context(context))
         secs->flags |= SGX_FLAGS_DEBUG;
+    if (oe_sgx_is_kss_load_context(context))
+        secs->flags |= SGX_FLAGS_KSS;
 
     /* what the driver sees with SGX SDK */
     secs->xfrm = context->attributes.xfrm;
@@ -252,6 +254,8 @@ static oe_result_t _get_sig_struct(
             properties->config.security_version,
             OE_DEBUG_SIGN_KEY,
             OE_DEBUG_SIGN_KEY_SIZE,
+            properties->config.family_id,
+            properties->config.extended_product_id,
             sigstruct));
     }
     else

--- a/host/sgx/sgxload.h
+++ b/host/sgx/sgxload.h
@@ -22,6 +22,11 @@ OE_INLINE bool oe_sgx_is_debug_load_context(
     return (context && (context->attributes.flags & OE_ENCLAVE_FLAG_DEBUG));
 }
 
+OE_INLINE bool oe_sgx_is_kss_load_context(const oe_sgx_load_context_t* context)
+{
+    return (context && (context->attributes.flags & OE_ENCLAVE_FLAG_SGX_KSS));
+}
+
 oe_result_t oe_sgx_create_enclave(
     oe_sgx_load_context_t* context,
     size_t enclave_size,

--- a/host/sgx/sgxsign.c
+++ b/host/sgx/sgxsign.c
@@ -571,6 +571,8 @@ static oe_result_t _init_sigstruct(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const uint8_t* family_id,
+    const uint8_t* extended_product_id,
     sgx_sigstruct_t* sigstruct)
 {
     oe_result_t result = OE_UNEXPECTED;
@@ -639,6 +641,23 @@ static oe_result_t _init_sigstruct(
         mrenclave,
         sizeof(*mrenclave)));
 
+    if (attributes & SGX_FLAGS_KSS)
+    {
+        if (family_id)
+            OE_CHECK(oe_memcpy_s(
+                sigstruct->isvfamilyid,
+                sizeof(sigstruct->isvfamilyid),
+                family_id,
+                sizeof(*family_id)));
+        if (extended_product_id)
+            OE_CHECK(oe_memcpy_s(
+                sigstruct->isvextprodid,
+                sizeof(sigstruct->isvextprodid),
+                extended_product_id,
+                sizeof(*extended_product_id)));
+        sigstruct->attributemask.flags |= SGX_FLAGS_KSS;
+    }
+
     /* sgx_sigstruct_t.isvprodid */
     sigstruct->isvprodid = product_id;
 
@@ -665,6 +684,8 @@ oe_result_t oe_sgx_sign_enclave_from_engine(
     const char* engine_id,
     const char* engine_load_path,
     const char* key_id,
+    const uint8_t* family_id,
+    const uint8_t* extended_product_id,
     sgx_sigstruct_t* sigstruct)
 {
     oe_rsa_private_key_t rsa;
@@ -684,7 +705,13 @@ oe_result_t oe_sgx_sign_enclave_from_engine(
 
     /* Initialize & sign the sigstruct */
     OE_CHECK(_init_sigstruct(
-        mrenclave, attributes, product_id, security_version, sigstruct));
+        mrenclave,
+        attributes,
+        product_id,
+        security_version,
+        family_id,
+        extended_product_id,
+        sigstruct));
     OE_CHECK(_sign_sigstruct(&rsa, sigstruct));
 
     result = OE_OK;
@@ -703,6 +730,8 @@ oe_result_t oe_sgx_sign_enclave(
     uint16_t security_version,
     const uint8_t* pem_data,
     size_t pem_size,
+    const uint8_t* family_id,
+    const uint8_t* extended_product_id,
     sgx_sigstruct_t* sigstruct)
 {
     oe_rsa_private_key_t rsa;
@@ -722,7 +751,13 @@ oe_result_t oe_sgx_sign_enclave(
 
     /* Initialize & sign the sigstruct */
     OE_CHECK(_init_sigstruct(
-        mrenclave, attributes, product_id, security_version, sigstruct));
+        mrenclave,
+        attributes,
+        product_id,
+        security_version,
+        family_id,
+        extended_product_id,
+        sigstruct));
     OE_CHECK(_sign_sigstruct(&rsa, sigstruct));
 
     result = OE_OK;
@@ -739,6 +774,8 @@ oe_result_t oe_sgx_get_sigstruct_digest(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const uint8_t* family_id,
+    const uint8_t* extended_product_id,
     OE_SHA256* digest)
 {
     oe_result_t result = OE_UNEXPECTED;
@@ -753,7 +790,13 @@ oe_result_t oe_sgx_get_sigstruct_digest(
 
     /* Initialize & sign the sigstruct */
     OE_CHECK(_init_sigstruct(
-        mrenclave, attributes, product_id, security_version, &sigstruct));
+        mrenclave,
+        attributes,
+        product_id,
+        security_version,
+        family_id,
+        extended_product_id,
+        &sigstruct));
     OE_CHECK(_hash_sigstruct(&sigstruct, digest));
 
     result = OE_OK;
@@ -771,6 +814,8 @@ oe_result_t oe_sgx_digest_sign_enclave(
     size_t cert_pem_size,
     const uint8_t* digest_signature,
     size_t digest_signature_size,
+    const uint8_t* family_id,
+    const uint8_t* extended_product_id,
     sgx_sigstruct_t* sigstruct)
 {
     oe_result_t result = OE_UNEXPECTED;
@@ -796,7 +841,13 @@ oe_result_t oe_sgx_digest_sign_enclave(
 
     /* Initialize the sigstruct with the provided parameters */
     OE_CHECK(_init_sigstruct(
-        mrenclave, attributes, product_id, security_version, sigstruct));
+        mrenclave,
+        attributes,
+        product_id,
+        security_version,
+        family_id,
+        extended_product_id,
+        sigstruct));
 
     /* Verify that the digest of the resulting sigstruct still
      * matches the expected signature */

--- a/include/openenclave/bits/sgx/sgxtypes.h
+++ b/include/openenclave/bits/sgx/sgxtypes.h
@@ -24,6 +24,7 @@ OE_EXTERNC_BEGIN
 #define SGX_FLAGS_MODE64BIT 0x0000000000000004ULL
 #define SGX_FLAGS_PROVISION_KEY 0x0000000000000010ULL
 #define SGX_FLAGS_EINITTOKEN_KEY 0x0000000000000020ULL
+#define SGX_FLAGS_KSS 0x0000000000000080ULL
 
 /* Legacy XFRM which includes basic feature bits required by SGX i.e. X87
  * (bit 0) and SSE state (bit 1)
@@ -192,7 +193,10 @@ typedef struct _sgx_sigstruct
     uint32_t miscmask;
 
     /* (908) Reserved. Must be 0. */
-    uint8_t reserved2[20];
+    uint8_t reserved2[4];
+
+    /* (912) ISV assigned Product Family Id, must be 0 for SGX1 devices*/
+    uint8_t isvfamilyid[16];
 
     /* (928) Enclave Attributes that must be set */
     sgx_attributes_t attributes;
@@ -204,7 +208,10 @@ typedef struct _sgx_sigstruct
     uint8_t enclavehash[OE_SHA256_SIZE];
 
     /* (992) Must be 0 */
-    uint8_t reserved3[32];
+    uint8_t reserved3[16];
+
+    /* (1008) ISV assigned extended Product ID, must be 0 for SGX1 devices */
+    uint8_t isvextprodid[16];
 
     /* (1024) ISV assigned Product ID */
     uint16_t isvprodid;
@@ -579,7 +586,10 @@ typedef struct _sgx_report_body
     uint32_t miscselect;
 
     /* (20) Reserved */
-    uint8_t reserved1[28];
+    uint8_t reserved1[12];
+
+    /* (32) Enclave extended product ID */
+    uint8_t isvextprodid[16];
 
     /* (48) Enclave attributes */
     sgx_attributes_t attributes;
@@ -603,7 +613,10 @@ typedef struct _sgx_report_body
     uint16_t isvsvn;
 
     /* (260) Reserved */
-    uint8_t reserved4[60];
+    uint8_t reserved4[44];
+
+    /* (304) Enclave family ID */
+    uint8_t isvfamilyid[16];
 
     /* (320) User report data */
     sgx_report_data_t report_data;

--- a/include/openenclave/host.h
+++ b/include/openenclave/host.h
@@ -68,6 +68,13 @@ OE_EXTERNC_BEGIN
 /**
  * @cond DEV
  */
+
+/**
+ *  Flag reserved for internal use to indicate the enclave was configured to run
+ * in kss mode
+ */
+#define OE_ENCLAVE_FLAG_SGX_KSS 0x00000004u
+
 #define OE_ENCLAVE_FLAG_RESERVED \
     (~(OE_ENCLAVE_FLAG_DEBUG | OE_ENCLAVE_FLAG_SIMULATE))
 

--- a/include/openenclave/internal/sgx/sgxproperties.h
+++ b/include/openenclave/internal/sgx/sgxproperties.h
@@ -3,6 +3,7 @@
 
 #ifndef _OE_INTERNAL_SGX_PROPERTIES_H
 #define _OE_INTERNAL_SGX_PROPERTIES_H
+#include <string.h>
 
 OE_INLINE bool oe_sgx_is_valid_product_id(uint16_t x)
 {
@@ -29,10 +30,16 @@ OE_INLINE bool oe_sgx_is_valid_num_tcs(uint64_t x)
     return x <= OE_SGX_MAX_TCS;
 }
 
+OE_INLINE bool oe_sgx_is_unset_uuid(uint8_t* x)
+{
+    uint8_t zeros[16] = {0};
+    return memcmp(x, zeros, sizeof(zeros)) == 0;
+}
+
 OE_INLINE bool oe_sgx_is_valid_attributes(uint64_t x)
 {
     /* Check for illegal bits */
-    if (x & ~(OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT))
+    if (x & ~(OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT | OE_SGX_FLAGS_KSS))
         return false;
 
     /* Check for missing MODE64BIT */

--- a/include/openenclave/internal/sgxsign.h
+++ b/include/openenclave/internal/sgxsign.h
@@ -25,6 +25,8 @@ OE_EXTERNC_BEGIN
  * @param security_version[in] ISVSVN value for the SGX sigstruct
  * @param pem_data[in] PEM buffer containing the signing key
  * @param pem_size[in] size of the PEM buffer
+ * @param family_id[in] ISVFAMILYID value for the SGX sigstruct
+ * @param extended_product_id[in] ISVEXTPRODID value for the SGX sigstruct
  * @param sigstruct[out] the SGX signature
  *
  * @return OE_OK success
@@ -36,6 +38,8 @@ oe_result_t oe_sgx_sign_enclave(
     uint16_t security_version,
     const uint8_t* pem_data,
     size_t pem_size,
+    const uint8_t* family_id,
+    const uint8_t* extended_product_id,
     sgx_sigstruct_t* sigstruct);
 
 /**
@@ -53,6 +57,8 @@ oe_result_t oe_sgx_sign_enclave(
  * @param engine_id[in] text name of the engine to use
  * @param engine_load_path[in] file path to the openssl engine to use
  * @param key_id[in] integer handle for the key to use
+ * @param family_id[in] ISVFAMILYID value for the SGX sigstruct
+ * @param extended_product_id[in] ISVEXTPRODID value for the SGX sigstruct
  * @param sigstruct[out] the SGX signature
  *
  * @return OE_OK success
@@ -65,6 +71,8 @@ oe_result_t oe_sgx_sign_enclave_from_engine(
     const char* engine_id,
     const char* engine_load_path,
     const char* key_id,
+    const uint8_t* family_id,
+    const uint8_t* extended_product_id,
     sgx_sigstruct_t* sigstruct);
 
 /**
@@ -75,6 +83,8 @@ oe_result_t oe_sgx_sign_enclave_from_engine(
  * @param attributes[in] ATTRIBUTES flag values for the SGX sigstruct
  * @param product_id[in] ISVPRODID value for the SGX sigstruct
  * @param security_version[in] ISVSVN value for the SGX sigstruct
+ * @param family_id[in] ISVFAMILYID value for the SGX sigstruct
+ * @param extended_product_id[in] ISVEXTPRODID value for the SGX sigstruct
  * @param digest[out] the digest of the sigstruct to be signed
  *
  * @return OE_OK success
@@ -84,6 +94,8 @@ oe_result_t oe_sgx_get_sigstruct_digest(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const uint8_t* family_id,
+    const uint8_t* extended_product_id,
     OE_SHA256* digest);
 
 /**
@@ -105,6 +117,8 @@ oe_result_t oe_sgx_get_sigstruct_digest(
  * @param cert_pem_size[in] size of the PEM buffer
  * @param digest_signature[in] binary data of the sigstruct digest signature
  * @param digest_signature_size[in] size of the sigstruct digest signature
+ * @param family_id[in] ISVFAMILYID value for the SGX sigstruct
+ * @param extended_product_id[in] ISVEXTPRODID value for the SGX sigstruct
  * @param sigstruct[out] the SGX signature
  *
  * @return OE_OK success
@@ -118,6 +132,8 @@ oe_result_t oe_sgx_digest_sign_enclave(
     size_t cert_pem_size,
     const uint8_t* digest_signature,
     size_t digest_signature_size,
+    const uint8_t* family_id,
+    const uint8_t* extended_product_id,
     sgx_sigstruct_t* sigstruct);
 
 OE_EXTERNC_END

--- a/tests/tools/oesign/sign-and-verify.py
+++ b/tests/tools/oesign/sign-and-verify.py
@@ -50,6 +50,6 @@ if __name__ == "__main__":
     call_subprocess(sign_cmd, "Sign succeeded")
 
     launch_cmd = [args.host_path, "{}.signed".format(args.enclave_path)]
-    call_subprocess(launch_cmd, "Launch of signed enclave succeeded")
+    call_subprocess(launch_cmd, "Signed enclave test app succeeded")
 
     sys.exit(0)

--- a/tests/tools/oesign/test-digest/CMakeLists.txt
+++ b/tests/tools/oesign/test-digest/CMakeLists.txt
@@ -65,7 +65,7 @@ add_test(
 
 set_tests_properties(
   tests/oesign-digest-valid-short-args
-  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Launch of signed enclave succeeded")
+  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Signed enclave test app succeeded")
 
 # Test digest sign commands with valid long form of arguments succeed
 set(OESIGN_SIGN_VALID_LONG_ARGS
@@ -86,7 +86,7 @@ add_test(
 
 set_tests_properties(
   tests/oesign-digest-valid-long-args
-  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Launch of signed enclave succeeded")
+  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Signed enclave test app succeeded")
 
 # Test digest sign commands without --config-file (-c) argument on preconfigured enclave succeeds
 set(OESIGN_PKEYUTL_DEV_CONFIG_ARGS
@@ -109,7 +109,7 @@ add_test(
 
 set_tests_properties(
   tests/oesign-digest-valid-dev-config-args
-  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Launch of signed enclave succeeded")
+  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Signed enclave test app succeeded")
 
 # Test digest command missing --enclave-image (-e) argument
 add_test(NAME tests/oesign-digest-missing-enclave-arg

--- a/tests/tools/oesign/test-enclave/enclave/enc.c
+++ b/tests/tools/oesign/test-enclave/enclave/enc.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <openenclave/internal/hexdump.h>
+#include <openenclave/internal/report.h>
 #include <stdio.h>
 #include <string.h>
 #include "oesign_test_t.h"
@@ -51,4 +52,66 @@ bool is_test_signed()
     }
 
     return is_test_signed;
+}
+
+oe_result_t check_kss_extended_ids(
+    oe_uuid_t* family_id,
+    oe_uuid_t* extended_product_id)
+{
+    /* Null-terminated hex string buffer size with 2 char per byte */
+    const size_t OE_KSS_ID_HEX_BUFFER_SIZE = sizeof(oe_uuid_t) * 2 + 1;
+
+    oe_result_t result = OE_UNEXPECTED;
+    size_t report_size = OE_MAX_REPORT_SIZE;
+    uint8_t* remote_report = NULL;
+    oe_report_header_t* header = NULL;
+    sgx_quote_t* quote = NULL;
+
+    char isvid_hex[OE_KSS_ID_HEX_BUFFER_SIZE];
+
+    printf("========== Getting report with KSS feature\n");
+
+    result = oe_get_report(
+        OE_REPORT_FLAGS_REMOTE_ATTESTATION,
+        NULL,
+        0,
+        NULL,
+        0,
+        (uint8_t**)&remote_report,
+        &report_size);
+
+    if (result == OE_OK)
+    {
+        printf("========== Got report, size = %zu\n", report_size);
+
+        header = (oe_report_header_t*)remote_report;
+        quote = (sgx_quote_t*)header->report;
+
+        sgx_report_body_t* report_body =
+            (sgx_report_body_t*)&quote->report_body;
+
+        oe_hex_string(
+            isvid_hex,
+            OE_KSS_ID_HEX_BUFFER_SIZE,
+            report_body->isvfamilyid,
+            sizeof(report_body->isvfamilyid));
+        printf("Enclave ISV Family ID = %s\n", isvid_hex);
+
+        oe_hex_string(
+            isvid_hex,
+            OE_KSS_ID_HEX_BUFFER_SIZE,
+            report_body->isvextprodid,
+            sizeof(report_body->isvextprodid));
+        printf("Enclave ISV Extended ProductID = %s\n", isvid_hex);
+
+        if (!memcmp(report_body->isvfamilyid, &family_id, sizeof(oe_uuid_t)) ||
+            !memcmp(
+                report_body->isvextprodid,
+                &extended_product_id,
+                sizeof(oe_uuid_t)))
+            result = OE_REPORT_PARSE_ERROR;
+    }
+    oe_free_report(remote_report);
+
+    return result;
 }

--- a/tests/tools/oesign/test-enclave/host/host.c
+++ b/tests/tools/oesign/test-enclave/host/host.c
@@ -3,14 +3,34 @@
 
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
+#include <openenclave/internal/load.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
+#include "../host/sgx/cpuid.h"
 
 #include "oesign_test_u.h"
+
+static bool _is_kss_supported()
+{
+    uint32_t eax, ebx, ecx, edx;
+    eax = ebx = ecx = edx = 0;
+
+    // Obtain feature information using CPUID
+    oe_get_cpuid(0x12, 0x1, &eax, &ebx, &ecx, &edx);
+
+    // Check if KSS (bit 7) is supported by the processor
+    if (!(eax & (1 << 7)))
+        return false;
+    else
+        return true;
+}
 
 int main(int argc, const char* argv[])
 {
     oe_result_t result;
+    oe_result_t ecall_result;
+    oe_enclave_image_t oeimage;
+    oe_sgx_enclave_properties_t properties;
     oe_enclave_t* enclave = NULL;
     bool is_signed = false;
 
@@ -20,12 +40,36 @@ int main(int argc, const char* argv[])
     }
 
     // Create the enclave
-    const uint32_t flags = oe_get_create_flags();
+    uint32_t flags = oe_get_create_flags();
+    bool is_kss_supported = _is_kss_supported();
+
+    /* Load the ELF image */
+    if ((result = oe_load_enclave_image(argv[1], &oeimage)) != OE_OK)
+    {
+        oe_put_err("oe_load_enclave_image(): result=%u", result);
+    }
+
+    /* Load the SGX enclave properties */
+    if ((result = oe_sgx_load_enclave_properties(
+             &oeimage, OE_INFO_SECTION_NAME, &properties)) != OE_OK)
+    {
+        oe_put_err("oe_sgx_load_enclave_properties(): result=%u", result);
+    }
 
     if ((result = oe_create_oesign_test_enclave(
              argv[1], OE_ENCLAVE_TYPE_AUTO, flags, NULL, 0, &enclave)) != OE_OK)
     {
-        oe_put_err("oe_create_crypto_enclave(): result=%u", result);
+        if (!is_kss_supported &&
+            (result == OE_UNSUPPORTED &&
+             properties.config.attributes & OE_SGX_FLAGS_KSS))
+        {
+            // Skip the test as it is not supported
+            printf("Skipping enclave test with kss as it is not supported by "
+                   "current platform...\n");
+            return 0;
+        }
+        else
+            oe_put_err("oe_create_crypto_enclave(): result=%u", result);
     }
 
     if (flags & OE_ENCLAVE_FLAG_SIMULATE)
@@ -46,6 +90,22 @@ int main(int argc, const char* argv[])
         if (!is_signed)
         {
             oe_put_err("%s is signed with a default debug signature", argv[1]);
+        }
+    }
+
+    if (_is_kss_supported())
+    {
+        result = check_kss_extended_ids(
+            enclave,
+            &ecall_result,
+            (oe_uuid_t*)properties.config.family_id,
+            (oe_uuid_t*)properties.config.extended_product_id);
+        if (result != OE_OK || ecall_result != OE_OK)
+        {
+            oe_put_err(
+                "verify_signed() failed: Enclave: %s, Host: %s\n",
+                oe_result_str(ecall_result),
+                oe_result_str(result));
         }
     }
 

--- a/tests/tools/oesign/test-enclave/oesign_test.edl
+++ b/tests/tools/oesign/test-enclave/oesign_test.edl
@@ -12,5 +12,6 @@ enclave {
 
     trusted {
         public bool is_test_signed();
+        public oe_result_t check_kss_extended_ids(oe_uuid_t* family_id, oe_uuid_t* extended_product_id);
     };
 };

--- a/tests/tools/oesign/test-engine/CMakeLists.txt
+++ b/tests/tools/oesign/test-engine/CMakeLists.txt
@@ -37,7 +37,7 @@ add_test(
 
 set_tests_properties(
   tests/oesign-engine-valid-short-args
-  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Launch of signed enclave succeeded")
+  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Signed enclave test app succeeded")
 
 # Test oesign succeeds with valid long form of engine signing parameters
 set(OESIGN_ENGINE_VALID_LONG_ARGS
@@ -53,7 +53,7 @@ add_test(
 
 set_tests_properties(
   tests/oesign-engine-valid-long-args
-  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Launch of signed enclave succeeded")
+  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Signed enclave test app succeeded")
 
 # Test invalid --load-path (-p) argument
 add_test(

--- a/tests/tools/oesign/test-inputs/CMakeLists.txt
+++ b/tests/tools/oesign/test-inputs/CMakeLists.txt
@@ -74,6 +74,45 @@ add_custom_command(
   COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file new_security_version.conf --security_version 2)
 
+add_custom_command(
+  OUTPUT kss_valid.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND
+    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    kss_valid.conf --extended_product_id 2768c720-1e28-11eb-adc1-0242ac120002
+    --family_id 57183823-2574-4bfd-b411-99ed177d3e43)
+
+add_custom_command(
+  OUTPUT ext_prod_id_too_long.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND
+    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    ext_prod_id_too_long.conf --extended_product_id
+    2768c720-1e28-11eb-adc1-0242ac1200023)
+
+add_custom_command(
+  OUTPUT ext_prod_id_too_short.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND
+    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    ext_prod_id_too_short.conf --extended_product_id
+    2768c720-1e28-11eb-adc1-0242ac12000)
+
+add_custom_command(
+  OUTPUT family_id_too_long.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND
+    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    family_id_too_long.conf --family_id
+    57183823-2574-4bfd-b411-99ed177d3e433e433)
+
+add_custom_command(
+  OUTPUT family_id_too_short.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND
+    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    family_id_too_short.conf --family_id 57183823-2574-4bfd-b411-99ed177d3e4)
+
 # Generate empty config file
 add_custom_command(
   OUTPUT empty.conf COMMAND cmake -E touch
@@ -97,6 +136,11 @@ add_custom_target(
           new_security_version.conf
           negative_num_heap_pages.conf
           non_debug.conf
+          kss_valid.conf
+          ext_prod_id_too_long.conf
+          ext_prod_id_too_short.conf
+          family_id_too_long.conf
+          family_id_too_short.conf
           valid.conf)
 
 # Generate a valid SGX signing key-pair and signing certificate

--- a/tests/tools/oesign/test-inputs/make-oesign-config.py
+++ b/tests/tools/oesign/test-inputs/make-oesign-config.py
@@ -15,6 +15,8 @@ if __name__ == "__main__":
     arg_parser.add_argument('--num_tcs', default="1", type=str, help="Value for the NumCS property. Defaults to 1.")
     arg_parser.add_argument('--product_id', default="1", type=str, help="Value for the ProductID property. Defaults to 1.")
     arg_parser.add_argument('--security_version', default="1", type=str, help="Value for the SecurityVersion property. Defaults to 1.")
+    arg_parser.add_argument('--extended_product_id', type=str, help="Value for the ExtendedProductID property. Defaults to empty string")
+    arg_parser.add_argument('--family_id', type=str, help="Value for the FamilyID property. Defaults to empty string.")
 
     args = arg_parser.parse_args()
     print("Generating {} ...".format(args.config_file))
@@ -27,4 +29,8 @@ if __name__ == "__main__":
     out_file.write("NumTCS={}\n".format(args.num_tcs))
     out_file.write("ProductID={}\n".format(args.product_id))
     out_file.write("SecurityVersion={}\n".format(args.security_version))
+    if args.extended_product_id:
+        out_file.write("ExtendedProductID={}\n".format(args.extended_product_id))
+    if args.family_id:
+        out_file.write("FamilyID={}\n".format(args.family_id))
     out_file.close()

--- a/tests/tools/oesign/test-sign/CMakeLists.txt
+++ b/tests/tools/oesign/test-sign/CMakeLists.txt
@@ -28,7 +28,7 @@ add_test(
 
 set_tests_properties(
   tests/oesign-sign-valid-short-args
-  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Launch of signed enclave succeeded")
+  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Signed enclave test app succeeded")
 
 # Test oesign succeeds with valid long form of engine signing parameters
 set(OESIGN_SIGN_VALID_LONG_ARGS
@@ -44,7 +44,7 @@ add_test(
 
 set_tests_properties(
   tests/oesign-sign-valid-long-args
-  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Launch of signed enclave succeeded")
+  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Signed enclave test app succeeded")
 
 # Test invalid --config-file (-c) argument
 add_test(
@@ -203,3 +203,67 @@ add_test(
 
 set_tests_properties(tests/oesign-sign-lowercase-debug-property
                      PROPERTIES PASS_REGULAR_EXPRESSION "unknown setting")
+
+# Test valid kss properties argument
+set(OESIGN_SIGN_VALID_KSS
+    "[-c,${OESIGN_TEST_INPUTS_DIR}/kss_valid.conf,-k,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem]"
+)
+
+add_test(
+  NAME tests/oesign-sign-valid-kss
+  COMMAND
+    python sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
+    --enclave-path $<TARGET_FILE:oesign_test_enc> --oesign-path
+    $<TARGET_FILE:oesign> --oesign-args ${OESIGN_SIGN_VALID_KSS})
+
+set_tests_properties(
+  tests/oesign-sign-valid-kss
+  PROPERTIES PASS_REGULAR_EXPRESSION "PASS: Signed enclave test app succeeded")
+
+# Test invalid kss properties argument ExtendedProductID too long
+add_test(
+  NAME tests/oesign-sign-extprodid-toolong
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/ext_prod_id_too_long.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-extprodid-toolong
+  PROPERTIES PASS_REGULAR_EXPRESSION "bad value for 'ExtendedProductID'")
+
+# Test invalid kss properties argument ExtendedProductID too short
+add_test(
+  NAME tests/oesign-sign-extprodid-tooshort
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/ext_prod_id_too_short.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-extprodid-tooshort
+  PROPERTIES PASS_REGULAR_EXPRESSION "bad value for 'ExtendedProductID'")
+
+# Test invalid kss properties argument ExtendedProductID too short
+add_test(
+  NAME tests/oesign-sign-familyid-toolong
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/family_id_too_long.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-familyid-toolong PROPERTIES PASS_REGULAR_EXPRESSION
+                                                "bad value for 'FamilyID'")
+
+# Test invalid kss properties argument FamilyID too short
+add_test(
+  NAME tests/oesign-sign-familyid-tooshort
+  COMMAND
+    oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+    ${OESIGN_TEST_INPUTS_DIR}/family_id_too_short.conf -k
+    ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+set_tests_properties(
+  tests/oesign-sign-familyid-tooshort PROPERTIES PASS_REGULAR_EXPRESSION
+                                                 "bad value for 'FamilyID'")

--- a/tools/oesgx/oesgx.c
+++ b/tools/oesgx/oesgx.c
@@ -13,6 +13,7 @@
 #define HAVE_FLC(regs) (((regs.ecx) >> 30) & 1)
 #define HAVE_SGX1(regs) (((regs.eax) & 1))
 #define HAVE_SGX2(regs) (((regs.eax) >> 1) & 1)
+#define HAVE_KSS(regs) (((regs.eax) >> 7) & 1)
 #define HAVE_EPC_SUBLEAF(regs) (((regs.eax) & 0x0f) == 0x01)
 
 typedef struct _regs
@@ -129,6 +130,24 @@ int main(int argc, const char* argv[])
             printf("SGX1\n");
         }
         printf("MaxEnclaveSize_64: 2^(%d)\n", (regs.edx >> 8) & 0xFF);
+    }
+
+    /* Enumeration of Intel SGX Capabilities: figure out whether CPU
+       supports KSS */
+    {
+        Regs regs = {SGX_CAPABILITY_ENUMERATION, 0, 0x1, 0};
+
+        result = _CPUID(&regs);
+        if (result)
+        {
+            printf("Read SGX_ATTRIBUTE_ENUMERATION failed:\n");
+            dump_regs(&regs);
+            return result;
+        }
+
+        printf(
+            "CPU supports Key Sharing & Separation (KSS): %s\n",
+            HAVE_KSS(regs) ? "true" : "false");
     }
 
     /* Enumeration of Intel SGX Capabilities: figure out EPC size */


### PR DESCRIPTION
Add the basic KSS support, the following changes are made in the OE SDK components:

SGX data structure definition to include KSS related fields.

Development tool to allow ISV to specify ISVFAMILYID, ISVEXTPRODID, and whether KSS feature is required by the Enclave through the KSS bit in SIGSTRUCT.ATTRIBUTES and SIGSTRUCT.ATTRIBUTEMASK, in SIGSTRUCT.

Enclave loader to detect whether the system support KSS