### PR TITLE
Update BuildSamplesLinux.md

### DIFF
--- a/samples/BuildSamplesLinux.md
+++ b/samples/BuildSamplesLinux.md
@@ -85,6 +85,7 @@ For example, for the helloworld sample:
 ```
 
 ### Build the samples using CMake
+The current version requires CMake 3.11 or higher. 
 
 To build a sample using CMake, change directory to your target sample directory and execute the following commands:
 


### PR DESCRIPTION
Added a line item to specify the Cmake version required as Ubuntu 18.04 default apt install version of CMake is not a supported one for this package.

Needs Cmake 3.11 or higher. 