### PR TITLE
Fix the bug of the openssl unsupported headers appending

### DIFF
--- a/3rdparty/openssl/append-unsupported
+++ b/3rdparty/openssl/append-unsupported
@@ -29,14 +29,16 @@ fi
 
 headers=`find ${directory} -name '*.h'`
 
-## Append the inclusion of unsupported.h */
+## Append the inclusion of *_unsupported.h
 for i in ${headers}
 do
     if [[ "${i}" != *"crypto.h" ]] && [[ "${i}" != *"ssl.h" ]] && [[ "${i}" != *"x509_vfy.h" ]]; then
         continue
     fi
     name="$(basename -s .h $i)"
-    echo "#include <openssl/${name}_unsupported.h>" >> ${i}
+    # We assume that every header ends with #endif, which is the case for OpenSSL.
+    sed -i '$d' ${i}
+    echo -e "#include <openssl/${name}_unsupported.h>\n#endif" >> ${i}
     if [ "$?" != "0" ]; then
         echo "$0: failed to append ${string}"
         exit 1

--- a/tests/openssl_unsupported/enc/CMakeLists.txt
+++ b/tests/openssl_unsupported/enc/CMakeLists.txt
@@ -41,21 +41,26 @@ function (add_unsupported_test NAME)
             --config $<CONFIGURATION>
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
-  # In addition to expecting the compilation to fail, checking whether the log includes
-  # the specific error message, which indicates the unsupported.h header is
-  # correctly included.
-  set_tests_properties(
-    openssl_unsupported_${NAME}
-    PROPERTIES
-      WILL_FAIL
-      TRUE
-      FAIL_REGULAR_EXPRESSION
-      "warning: .* is deprecated: The function|macro may be unsafe inside an enclave"
-  )
+  # The compilation of the baseline case (i.e., not linking against any of unsupported APIs
+  # but simply including the headers) is expected to succeed.
+  if (NOT ${NAME} STREQUAL "baseline")
+    # In addition to expecting the compilation to fail, checking whether the log includes
+    # the specific error message, which indicates the unsupported.h header is
+    # correctly included.
+    set_tests_properties(
+      openssl_unsupported_${NAME}
+      PROPERTIES
+        WILL_FAIL
+        TRUE
+        FAIL_REGULAR_EXPRESSION
+        "warning: .* is deprecated: The function|macro may be unsafe inside an enclave"
+    )
+  endif ()
 
 endfunction (add_unsupported_test)
 
 set(UNSUPPORTED_LIST
+    BASELINE
     OPENSSL_INIT_LOAD_CONFIG
     SSL_CTX_set_default_verify_paths
     SSL_CTX_set_default_verify_dir


### PR DESCRIPTION
This PR fixes #3706, which places the inclusion of _supported header inside the scope of `#ifndef HEADER_XXX_H`.
Also the PR adds a test case (as part of the `openssl_unsupported` test) that validates that the inclusion of `ssl.h` should not cause compilation errors.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>