### PR TITLE
Expose sgx report body fields by oe claims

### DIFF
--- a/include/openenclave/attestation/sgx/evidence.h
+++ b/include/openenclave/attestation/sgx/evidence.h
@@ -122,8 +122,23 @@ OE_EXTERNC_BEGIN
             0x00, 0x00, 0x00, 0x00, 0x00                                  \
     }
 
-// SGX specific claims: SGX Quote verification collateral.
+// SGX specific claims
+// Required: SGX report body fields that every SQX Quote verification should
+// output.
+// 1 boolean flag indicated by "sgx_misc_select_t"
+#define OE_CLAIM_SGX_PF_GP_EXINFO_ENABLED "sgx_pf_gp_exit_info_enabled"
+#define OE_CLAIM_SGX_ISV_EXTENDED_PRODUCT_ID "sgx_isv_extended_product_id"
+// 4 boolean flags indicated by "sgx_attributes_t"
+#define OE_CLAIM_SGX_IS_MODE64BIT "sgx_is_mode64bit"
+#define OE_CLAIM_SGX_HAS_PROVISION_KEY "sgx_has_provision_key"
+#define OE_CLAIM_SGX_HAS_EINITTOKEN_KEY "sgx_has_einittoken_key"
+#define OE_CLAIM_SGX_USES_KSS "sgx_uses_kss"
+#define OE_CLAIM_SGX_CONFIG_ID "sgx_config_id"
+#define OE_CLAIM_SGX_CONFIG_SVN "sgx_config_svn"
+#define OE_CLAIM_SGX_ISV_FAMILY_ID "sgx_isv_family_id"
+#define OE_SGX_REQUIRED_CLAIMS_COUNT 9
 
+// Optional: SQX Quote verification collaterals.
 #define OE_CLAIM_SGX_TCB_INFO "sgx_tcb_info"
 #define OE_CLAIM_SGX_TCB_ISSUER_CHAIN "sgx_tcb_issuer_chain"
 #define OE_CLAIM_SGX_PCK_CRL "sgx_pck_crl"
@@ -131,7 +146,7 @@ OE_EXTERNC_BEGIN
 #define OE_CLAIM_SGX_CRL_ISSUER_CHAIN "sgx_crl_issuer_chain"
 #define OE_CLAIM_SGX_QE_ID_INFO "sgx_qe_id_info"
 #define OE_CLAIM_SGX_QE_ID_ISSUER_CHAIN "sgx_qe_id_issuer_chain"
-#define OE_SGX_CLAIMS_COUNT 7
+#define OE_SGX_OPTIONAL_CLAIMS_COUNT 7
 
 // Additional SGX specific claim: for the report data embedded in the SGX quote.
 

--- a/include/openenclave/bits/sgx/sgxtypes.h
+++ b/include/openenclave/bits/sgx/sgxtypes.h
@@ -597,14 +597,17 @@ typedef struct _sgx_report_body
     /* (64) Enclave measurement */
     uint8_t mrenclave[OE_SHA256_SIZE];
 
-    /* (96) */
+    /* (96) Reserved */
     uint8_t reserved2[32];
 
     /* (128) The value of the enclave's SIGNER measurement */
     uint8_t mrsigner[OE_SHA256_SIZE];
 
-    /* (160) */
-    uint8_t reserved3[96];
+    /* (160) Reserved */
+    uint8_t reserved3[32];
+
+    /* (192) Enclave Configuration ID*/
+    uint8_t configid[64];
 
     /* (256) Enclave product ID */
     uint16_t isvprodid;
@@ -612,8 +615,11 @@ typedef struct _sgx_report_body
     /* (258) Enclave security version */
     uint16_t isvsvn;
 
-    /* (260) Reserved */
-    uint8_t reserved4[44];
+    /* (260) Enclave Configuration Security Version*/
+    uint16_t configsvn;
+
+    /* (262) Reserved */
+    uint8_t reserved4[42];
 
     /* (304) Enclave family ID */
     uint8_t isvfamilyid[16];
@@ -1041,6 +1047,11 @@ typedef struct _sgx_key
 {
     uint8_t buf[16];
 } sgx_key_t;
+
+/* Enclave MISCSELECT Flags Bit Masks, additional information to an SSA frame */
+/* If set, then the enclave page fault and general protection exception are
+ * reported*/
+#define SGX_MISC_FLAGS_PF_GP_EXIT_INFO 0x0000000000000001ULL
 
 /* Enclave Flags Bit Masks */
 /* If set, then the enclave is initialized */


### PR DESCRIPTION
Fixes #3689 
Added two more fields in `sgx_report_body` struct that consistent with intel [SGX report structure](https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/master/QuoteGeneration/common/inc/internal/linux/arch.h#L55-L77)
```
uint8_t configid[64];    
uint16_t configsvn;
```
Added oe_claim entries to expose `sgx_report_body` fields. Flag fields as `misc_select` and `attributes` are converted to multiple booleans.

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>