### PR TITLE
Add basic support of config_id/config_svn on Ice Lake platform.

### DIFF
--- a/docs/GettingStartedDocs/buildandsign.md
+++ b/docs/GettingStartedDocs/buildandsign.md
@@ -129,6 +129,16 @@ OE_SET_ENCLAVE_SGX_KSS(
     1);   /* NumTCS */
 ```
 
+On the new platform that support kss, user can also add the config_id and config_svn. The config_id can be used to contain the hash of a signing key for verifying the additional content. Similar to the relationship between MRSIGNER and ISVSVN, config_id needs a version number config_svn. After defining these properties, at running time user can make use of the additional content.
+
+A typical sample of config_id/config_svn is as follows:
+```
+Config_id=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+Config_svn=02
+```
+
+These properties will be included on the sgx report, which are parts of the keys for attestation.
+
 You can also specify the enclave properties in code using the
 `OE_SET_ENCLAVE_SGX` macro if no KSS properties needed.  For example, the equivalent properties could be
 defined in any .c or .cpp file compiled into the enclave:

--- a/enclave/core/sgx/properties.c
+++ b/enclave/core/sgx/properties.c
@@ -17,13 +17,13 @@ OE_STATIC_ASSERT(
 
 OE_CHECK_SIZE(sizeof(oe_enclave_properties_header_t), 32);
 
-OE_CHECK_SIZE(sizeof(oe_sgx_enclave_config_t), 56);
+OE_CHECK_SIZE(sizeof(oe_sgx_enclave_config_t), 128);
 
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, header), 0);
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, config), 32);
-OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 88);
-OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 136);
-OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 1952);
+OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 160);
+OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 208);
+OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 2024);
 
 //
 // Declare an invalid oeinfo to ensure .oeinfo section exists

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -885,6 +885,14 @@ oe_result_t oe_sgx_build_enclave(
                 NULL);
         }
         context->attributes.flags |= OE_ENCLAVE_FLAG_SGX_KSS;
+
+        /* Update config_id and config_svn of context from props. */
+        memcpy(
+            context->config_id,
+            props.config.config_id,
+            sizeof(context->config_id));
+
+        context->config_svn = props.config.config_svn;
     }
 
     /* Perform the ECREATE operation */

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -152,6 +152,11 @@ static sgx_secs_t* _new_secs(
     /* secs->flags |= SGX_FLAGS_EINITTOKEN_KEY; */
     /* secs->flags |= SGX_FLAGS_PROVISION_KEY; */
 
+    /* Update config_id and config_svn of secs from context. */
+    memcpy(secs->config_id, context->config_id, sizeof(secs->config_id));
+
+    secs->config_svn = context->config_svn;
+
     return secs;
 }
 

--- a/include/openenclave/bits/sgx/sgxproperties.h
+++ b/include/openenclave/bits/sgx/sgxproperties.h
@@ -49,6 +49,10 @@ typedef struct oe_sgx_enclave_config_t
 
     /* XSave Feature Request Mask */
     uint64_t xfrm;
+
+    uint8_t config_id[64];
+    uint16_t config_svn;
+    uint16_t padding2[3];
 } oe_sgx_enclave_config_t;
 
 /* Extends oe_enclave_properties_header_t base type */
@@ -60,10 +64,10 @@ typedef struct _oe_sgx_enclave_properties
     /* (32) */
     oe_sgx_enclave_config_t config;
 
-    /* (48) */
+    /* (160) */
     oe_sgx_enclave_image_info_t image_info;
 
-    /* (96)  */
+    /* (208)  */
     uint8_t sigstruct[OE_SGX_SIGSTRUCT_SIZE];
 
     /* (1904) end-marker to make sure 0-filled signstruct doesn't get omitted */

--- a/include/openenclave/bits/sgx/sgxtypes.h
+++ b/include/openenclave/bits/sgx/sgxtypes.h
@@ -292,7 +292,10 @@ typedef struct _sgx_secs
     uint8_t reserved3[96];  /* 160 */
     uint16_t isvvprodid;    /* 256 */
     uint16_t isvsvn;        /* 258 */
-    uint8_t reserved[3836]; /* 260 */
+    uint8_t reserved4[20];  /* 260 */
+    uint8_t config_id[64];  /* 280 */
+    uint16_t config_svn;    /* 344 */
+    uint8_t reserved[3750]; /* 260 */
 } sgx_secs_t;
 
 OE_CHECK_SIZE(sizeof(sgx_secs_t), 4096);

--- a/include/openenclave/internal/sgxcreate.h
+++ b/include/openenclave/internal/sgxcreate.h
@@ -61,6 +61,10 @@ struct _oe_sgx_load_context
     /* Hash context used to measure enclave as it is loaded */
     oe_sha256_context_t hash_context;
 
+    /* config_id and config_svn. */
+    uint8_t config_id[64];
+    uint16_t config_svn;
+
 #ifdef OE_WITH_EXPERIMENTAL_EEID
     /* EEID data needed during enclave creation */
     oe_eeid_t* eeid;


### PR DESCRIPTION
Users can define such properties through config file while signing, and these properties will be included on the sgx report.

Signed-off-by: Alvin Chen <alvin@chen.asia>