### PR TITLE
VS Extension v0.12.33 Release

### DIFF
--- a/devex/cross-nuget/README.md
+++ b/devex/cross-nuget/README.md
@@ -94,7 +94,7 @@ packaged as well as the version of the NuGet package itself:
 
 1. Change the name of the output NuGet package in all the instructions that
    follow;
-2. Change the `OE_CROSS_PLAT_VERSION` in `devex/cross-nuget/extras/open-enclave.nuspec` - refer to the [NuGet page](https://www.nuget.org/packages/open-enclave-cross/) for the current version;
+2. Change the `OE_CROSS_PLATFORM_VERSION` in `devex/cross-nuget/extras/open-enclave.nuspec` - refer to the [NuGet page](https://www.nuget.org/packages/open-enclave-cross/) for the current version;
 3. Change `OE_SDK_TAG` in `devex/cross-nuget/linux/driver.sh` or run with the `--oe_sdk_tag <sdk tag>` argument during the build phase of the [Ubuntu section](#Ubuntu);
 4. Change `OE_SDK_TAG` in `devex/cross-nuget/windows/build.ps1` or run with the `-OE_SDK_TAG <sdk tag>` argument during the build phase of the [Windows section](#Windows).
 

--- a/devex/cross-nuget/README.md
+++ b/devex/cross-nuget/README.md
@@ -94,9 +94,9 @@ packaged as well as the version of the NuGet package itself:
 
 1. Change the name of the output NuGet package in all the instructions that
    follow;
-2. Change the value in `devex/cross-nuget/extras/open-enclave.nuspec`;
-3. Change `OE_SDK_TAG` in `devex/cross-nuget/linux/driver.sh`;
-4. Change `OE_SDK_TAG` in `devex/cross-nuget/windows/build.ps1`.
+2. Change the `OE_CROSS_PLAT_VERSION` in `devex/cross-nuget/extras/open-enclave.nuspec` - refer to the [NuGet page](https://www.nuget.org/packages/open-enclave-cross/) for the current version;
+3. Change `OE_SDK_TAG` in `devex/cross-nuget/linux/driver.sh` or run with the `--oe_sdk_tag <sdk tag>` argument during the build phase of the [Ubuntu section](#Ubuntu);
+4. Change `OE_SDK_TAG` in `devex/cross-nuget/windows/build.ps1` or run with the `-OE_SDK_TAG <sdk tag>` argument during the build phase of the [Windows section](#Windows).
 
 ### Windows
 

--- a/devex/cross-nuget/README.md
+++ b/devex/cross-nuget/README.md
@@ -46,7 +46,7 @@ This section explains how to set up both environments.
    containers.
 4. Clone the SDK:
    ```bash
-   git clone -b v0.11.0 --recursive --depth=1 https://github.com/openenclave/openenclave sdk
+   git clone -b <latest release tag, eg. 'v0.12.x'> --recursive --depth=1 https://github.com/openenclave/openenclave sdk
    ```
 5. Open `scripts/ansible/oe-contributors-setup.yml` and comment out the step
    that installs the Intel SGX driver because drivers cannot be installed inside

--- a/devex/cross-nuget/extras/open-enclave-cross.nuspec
+++ b/devex/cross-nuget/extras/open-enclave-cross.nuspec
@@ -5,7 +5,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>open-enclave-cross</id>
-    <version>OE_CROSS_PLAT_VERSION</version>
+    <version>OE_CROSS_PLATFORM_VERSION</version>
     <authors>Open Enclave SDK Contributors</authors>
     <owners>Open Enclave SDK Contributors</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/devex/cross-nuget/extras/open-enclave-cross.nuspec
+++ b/devex/cross-nuget/extras/open-enclave-cross.nuspec
@@ -5,7 +5,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>open-enclave-cross</id>
-    <version>0.11.0</version>
+    <version>0.12.0.1</version>
     <authors>Open Enclave SDK Contributors</authors>
     <owners>Open Enclave SDK Contributors</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/devex/cross-nuget/extras/open-enclave-cross.nuspec
+++ b/devex/cross-nuget/extras/open-enclave-cross.nuspec
@@ -5,7 +5,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>open-enclave-cross</id>
-    <version>0.12.0.1</version>
+    <version>OE_CROSS_PLAT_VERSION</version>
     <authors>Open Enclave SDK Contributors</authors>
     <owners>Open Enclave SDK Contributors</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/devex/cross-nuget/linux/driver.sh
+++ b/devex/cross-nuget/linux/driver.sh
@@ -3,7 +3,23 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-OE_SDK_TAG=v0.11.0
+OE_SDK_TAG="master"
+
+options=$(getopt -l "oe_sdk_tag:" -o "t:" -- "$@")
+eval set -- "$options"
+
+while true ; do
+  case $1 in
+  -t|--oe_sdk_tag)
+      shift
+      export OE_SDK_TAG=$1
+      ;;
+  --)
+      shift
+      break;;
+  esac
+  shift
+done
 
 # Clone the SDK
 if [ ! -d sdk ]; then

--- a/devex/cross-nuget/linux/driver.sh
+++ b/devex/cross-nuget/linux/driver.sh
@@ -23,7 +23,7 @@ done
 
 # Clone the SDK
 if [ ! -d sdk ]; then
-    git clone --recursive --depth=1 https://github.com/openenclave/openenclave sdk -b $OE_SDK_TAG
+    git clone --recursive --depth=1 https://github.com/openenclave/openenclave sdk -b "$OE_SDK_TAG"
 fi
 
 # Delete all previous output

--- a/devex/cross-nuget/linux/runner.sh
+++ b/devex/cross-nuget/linux/runner.sh
@@ -5,7 +5,7 @@
 
 WORKING_DIR=$1
 
-OS_CODENAME=$(grep UBUNTU_CODENAME /etc/os-release | cut -d= -f2)
+OS_CODENAME=$('grep UBUNTU_CODENAME /etc/os-release | cut -d= -f2')
 
 cd "$WORKING_DIR" || exit 1
 

--- a/devex/cross-nuget/linux/standalone-build/pack.sh
+++ b/devex/cross-nuget/linux/standalone-build/pack.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+OS_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d= -f2)
+if [[ $OS_CODENAME == "" ]]; then
+    OS_CODENAME="xenial"
+fi
+
+if [ -d pack ]; then
+    rm -rf pack
+fi
+
+function copy-includes {
+    OS_CODENAME=$1
+    PLATFORM=$2
+    SUBPLATOFRM=$3
+    BUILD_TYPE=$4
+    PLATFORM_VERSION=$5
+
+    SRC_BASE=$PWD/build/$OS_CODENAME/sdk/$PLATFORM/$PLATFORM_VERSION/$SUBPLATOFRM/$BUILD_TYPE/expand/opt/openenclave
+    DST_BASE=$PWD/pack/build/native/linux/$OS_CODENAME/$PLATFORM/$SUBPLATOFRM/$BUILD_TYPE
+
+    mkdir -p $DST_BASE
+    cp -r $SRC_BASE/include $DST_BASE/
+}
+
+function copy-sgx-libs {
+    OS_CODENAME=$1
+    SGX_PLATFORM=$2
+    BUILD_TYPE=$3
+    CLANG_VERSION=$4
+
+    SRC_BASE=$PWD/build/$OS_CODENAME/sdk/sgx/$SGX_PLATFORM/$BUILD_TYPE/expand/opt/openenclave
+    DST_BASE=$PWD/pack/lib/native/linux/$OS_CODENAME/sgx/$SGX_PLATFORM/$BUILD_TYPE
+
+    mkdir -p $DST_BASE/cmake
+    mkdir -p $DST_BASE/debugger
+    mkdir -p $DST_BASE/enclave/clang-$CLANG_VERSION
+    mkdir -p $DST_BASE/host/clang-$CLANG_VERSION
+
+    cp -r $SRC_BASE/lib/openenclave/cmake/* $DST_BASE/cmake
+    cp -r $SRC_BASE/lib/openenclave/debugger/* $DST_BASE/debugger
+    cp -r $SRC_BASE/lib/openenclave/enclave/* $DST_BASE/enclave/clang-$CLANG_VERSION
+    cp -r $SRC_BASE/lib/openenclave/host/* $DST_BASE/host/clang-$CLANG_VERSION
+}
+
+function copy-optee-libs {
+    OS_CODENAME=$1
+    OPTEE_PLATFORM=$2
+    BUILD_TYPE=$3
+    GCC_VERSION=$4
+
+    SRC_BASE=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/$OPTEE_PLATFORM/$BUILD_TYPE/expand/opt/openenclave
+    DST_BASE=$PWD/pack/lib/native/linux/$OS_CODENAME/optee/v3.6.0/$OPTEE_PLATFORM/$BUILD_TYPE
+
+    mkdir -p $DST_BASE/cmake
+    mkdir -p $DST_BASE/devkit
+    mkdir -p $DST_BASE/enclave/gcc-$GCC_VERSION
+    mkdir -p $DST_BASE/host/gcc-$GCC_VERSION
+
+    cp -r $PWD/build/optee/3.6.0/$OPTEE_PLATFORM/debug/export-ta_arm64/* $DST_BASE/devkit/
+
+    cp -r $SRC_BASE/lib/openenclave/cmake/* $DST_BASE/cmake/
+    cp -r $SRC_BASE/lib/openenclave/enclave/* $DST_BASE/enclave/gcc-$GCC_VERSION/
+    cp -r $SRC_BASE/lib/openenclave/optee/libteec/* $DST_BASE/enclave/gcc-$GCC_VERSION/
+    cp -r $SRC_BASE/lib/openenclave/host/* $DST_BASE/host/gcc-$GCC_VERSION/
+}
+
+function copy-sgx-tools {
+    OS_CODENAME=$1
+    SGX_PLATFORM=$2
+
+    SRC_BASE=$PWD/build/$OS_CODENAME/sdk/sgx/$SGX_PLATFORM/release/expand/opt/openenclave
+    DST_BASE=$PWD/pack/tools/linux/$OS_CODENAME/sgx/$SGX_PLATFORM
+
+    mkdir -p $DST_BASE
+    cp -r $SRC_BASE/bin/* $DST_BASE/
+}
+
+function copy-optee-tools {
+    OS_CODENAME=$1
+
+    SRC_ARM64_BASE=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/vexpress-qemu_armv8a/release/expand/opt/openenclave
+    SRC_X64_BASE=$PWD/build/$OS_CODENAME/sdk/sgx/default/release/expand/opt/openenclave
+    DST_BASE=$PWD/pack/tools/linux/$OS_CODENAME/optee
+
+    mkdir -p $DST_BASE/arm64
+    mkdir -p $DST_BASE/x64
+
+    cp -r $SRC_ARM64_BASE/bin/oeedger8r $DST_BASE/arm64/
+    cp -r $SRC_X64_BASE/bin/oeedger8r $DST_BASE/x64/
+}
+
+# Copy libraries
+copy-optee-libs $OS_CODENAME ls-ls1012grapeboard debug 5
+copy-optee-libs $OS_CODENAME ls-ls1012grapeboard release 5
+copy-optee-libs $OS_CODENAME vexpress-qemu_armv8a debug 5
+copy-optee-libs $OS_CODENAME vexpress-qemu_armv8a release 5
+
+copy-sgx-libs $OS_CODENAME default debug 7
+copy-sgx-libs $OS_CODENAME default release 7
+
+# Copy tools
+copy-sgx-tools $OS_CODENAME default
+
+copy-optee-tools $OS_CODENAME
+
+
+# Copy includes
+copy-includes $OS_CODENAME sgx default debug
+copy-includes $OS_CODENAME sgx default release
+
+copy-includes $OS_CODENAME optee ls-ls1012grapeboard debug 3.6.0
+copy-includes $OS_CODENAME optee ls-ls1012grapeboard release 3.6.0
+copy-includes $OS_CODENAME optee vexpress-qemu_armv8a debug 3.6.0
+copy-includes $OS_CODENAME optee vexpress-qemu_armv8a release 3.6.0

--- a/devex/cross-nuget/linux/standalone-build/pack.sh
+++ b/devex/cross-nuget/linux/standalone-build/pack.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-OS_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d= -f2)
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+OS_CODENAME=$('cat /etc/os-release | grep UBUNTU_CODENAME | cut -d= -f2')
 if [[ $OS_CODENAME == "" ]]; then
     OS_CODENAME="xenial"
 fi
@@ -19,8 +22,8 @@ function copy-includes {
     SRC_BASE=$PWD/build/$OS_CODENAME/sdk/$PLATFORM/$PLATFORM_VERSION/$SUBPLATOFRM/$BUILD_TYPE/expand/opt/openenclave
     DST_BASE=$PWD/pack/build/native/linux/$OS_CODENAME/$PLATFORM/$SUBPLATOFRM/$BUILD_TYPE
 
-    mkdir -p $DST_BASE
-    cp -r $SRC_BASE/include $DST_BASE/
+    mkdir -p "$DST_BASE"
+    cp -r "$SRC_BASE/include" "$DST_BASE/"
 }
 
 function copy-sgx-libs {
@@ -32,15 +35,15 @@ function copy-sgx-libs {
     SRC_BASE=$PWD/build/$OS_CODENAME/sdk/sgx/$SGX_PLATFORM/$BUILD_TYPE/expand/opt/openenclave
     DST_BASE=$PWD/pack/lib/native/linux/$OS_CODENAME/sgx/$SGX_PLATFORM/$BUILD_TYPE
 
-    mkdir -p $DST_BASE/cmake
-    mkdir -p $DST_BASE/debugger
-    mkdir -p $DST_BASE/enclave/clang-$CLANG_VERSION
-    mkdir -p $DST_BASE/host/clang-$CLANG_VERSION
+    mkdir -p "$DST_BASE/cmake"
+    mkdir -p "$DST_BASE/debugger"
+    mkdir -p "$DST_BASE/enclave/clang-$CLANG_VERSION"
+    mkdir -p "$DST_BASE/host/clang-$CLANG_VERSION"
 
-    cp -r $SRC_BASE/lib/openenclave/cmake/* $DST_BASE/cmake
-    cp -r $SRC_BASE/lib/openenclave/debugger/* $DST_BASE/debugger
-    cp -r $SRC_BASE/lib/openenclave/enclave/* $DST_BASE/enclave/clang-$CLANG_VERSION
-    cp -r $SRC_BASE/lib/openenclave/host/* $DST_BASE/host/clang-$CLANG_VERSION
+    cp -r "$SRC_BASE/lib/openenclave/cmake/*" "$DST_BASE/cmake"
+    cp -r "$SRC_BASE/lib/openenclave/debugger/*" "$DST_BASE/debugger"
+    cp -r "$SRC_BASE/lib/openenclave/enclave/*" "$DST_BASE/enclave/clang-$CLANG_VERSION"
+    cp -r "$SRC_BASE/lib/openenclave/host/*" "$DST_BASE/host/clang-$CLANG_VERSION"
 }
 
 function copy-optee-libs {
@@ -52,17 +55,17 @@ function copy-optee-libs {
     SRC_BASE=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/$OPTEE_PLATFORM/$BUILD_TYPE/expand/opt/openenclave
     DST_BASE=$PWD/pack/lib/native/linux/$OS_CODENAME/optee/v3.6.0/$OPTEE_PLATFORM/$BUILD_TYPE
 
-    mkdir -p $DST_BASE/cmake
-    mkdir -p $DST_BASE/devkit
-    mkdir -p $DST_BASE/enclave/gcc-$GCC_VERSION
-    mkdir -p $DST_BASE/host/gcc-$GCC_VERSION
+    mkdir -p "$DST_BASE/cmake"
+    mkdir -p "$DST_BASE/devkit"
+    mkdir -p "$DST_BASE/enclave/gcc-$GCC_VERSION"
+    mkdir -p "$DST_BASE/host/gcc-$GCC_VERSION"
 
-    cp -r $PWD/build/optee/3.6.0/$OPTEE_PLATFORM/debug/export-ta_arm64/* $DST_BASE/devkit/
+    cp -r "$PWD/build/optee/3.6.0/$OPTEE_PLATFORM/debug/export-ta_arm64/*" "$DST_BASE/devkit/"
 
-    cp -r $SRC_BASE/lib/openenclave/cmake/* $DST_BASE/cmake/
-    cp -r $SRC_BASE/lib/openenclave/enclave/* $DST_BASE/enclave/gcc-$GCC_VERSION/
-    cp -r $SRC_BASE/lib/openenclave/optee/libteec/* $DST_BASE/enclave/gcc-$GCC_VERSION/
-    cp -r $SRC_BASE/lib/openenclave/host/* $DST_BASE/host/gcc-$GCC_VERSION/
+    cp -r "$SRC_BASE/lib/openenclave/cmake/*" "$DST_BASE/cmake/"
+    cp -r "$SRC_BASE/lib/openenclave/enclave/*" "$DST_BASE/enclave/gcc-$GCC_VERSION/"
+    cp -r "$SRC_BASE/lib/openenclave/optee/libteec/*" "$DST_BASE/enclave/gcc-$GCC_VERSION/"
+    cp -r "$SRC_BASE/lib/openenclave/host/*" "$DST_BASE/host/gcc-$GCC_VERSION/"
 }
 
 function copy-sgx-tools {
@@ -72,8 +75,8 @@ function copy-sgx-tools {
     SRC_BASE=$PWD/build/$OS_CODENAME/sdk/sgx/$SGX_PLATFORM/release/expand/opt/openenclave
     DST_BASE=$PWD/pack/tools/linux/$OS_CODENAME/sgx/$SGX_PLATFORM
 
-    mkdir -p $DST_BASE
-    cp -r $SRC_BASE/bin/* $DST_BASE/
+    mkdir -p "$DST_BASE"
+    cp -r "$SRC_BASE/bin/*" "$DST_BASE/"
 }
 
 function copy-optee-tools {
@@ -83,33 +86,33 @@ function copy-optee-tools {
     SRC_X64_BASE=$PWD/build/$OS_CODENAME/sdk/sgx/default/release/expand/opt/openenclave
     DST_BASE=$PWD/pack/tools/linux/$OS_CODENAME/optee
 
-    mkdir -p $DST_BASE/arm64
-    mkdir -p $DST_BASE/x64
+    mkdir -p "$DST_BASE/arm64"
+    mkdir -p "$DST_BASE/x64"
 
-    cp -r $SRC_ARM64_BASE/bin/oeedger8r $DST_BASE/arm64/
-    cp -r $SRC_X64_BASE/bin/oeedger8r $DST_BASE/x64/
+    cp -r "$SRC_ARM64_BASE/bin/oeedger8r" "$DST_BASE/arm64/"
+    cp -r "$SRC_X64_BASE/bin/oeedger8r" "$DST_BASE/x64/"
 }
 
 # Copy libraries
-copy-optee-libs $OS_CODENAME ls-ls1012grapeboard debug 5
-copy-optee-libs $OS_CODENAME ls-ls1012grapeboard release 5
-copy-optee-libs $OS_CODENAME vexpress-qemu_armv8a debug 5
-copy-optee-libs $OS_CODENAME vexpress-qemu_armv8a release 5
+copy-optee-libs "$OS_CODENAME" ls-ls1012grapeboard debug 5
+copy-optee-libs "$OS_CODENAME" ls-ls1012grapeboard release 5
+copy-optee-libs "$OS_CODENAME" vexpress-qemu_armv8a debug 5
+copy-optee-libs "$OS_CODENAME" vexpress-qemu_armv8a release 5
 
-copy-sgx-libs $OS_CODENAME default debug 7
-copy-sgx-libs $OS_CODENAME default release 7
+copy-sgx-libs "$OS_CODENAME" default debug 7
+copy-sgx-libs "$OS_CODENAME" default release 7
 
 # Copy tools
-copy-sgx-tools $OS_CODENAME default
+copy-sgx-tools "$OS_CODENAME" default
 
-copy-optee-tools $OS_CODENAME
+copy-optee-tools "$OS_CODENAME"
 
 
 # Copy includes
-copy-includes $OS_CODENAME sgx default debug
-copy-includes $OS_CODENAME sgx default release
+copy-includes "$OS_CODENAME" sgx default debug
+copy-includes "$OS_CODENAME" sgx default release
 
-copy-includes $OS_CODENAME optee ls-ls1012grapeboard debug 3.6.0
-copy-includes $OS_CODENAME optee ls-ls1012grapeboard release 3.6.0
-copy-includes $OS_CODENAME optee vexpress-qemu_armv8a debug 3.6.0
-copy-includes $OS_CODENAME optee vexpress-qemu_armv8a release 3.6.0
+copy-includes "$OS_CODENAME" optee ls-ls1012grapeboard debug 3.6.0
+copy-includes "$OS_CODENAME" optee ls-ls1012grapeboard release 3.6.0
+copy-includes "$OS_CODENAME" optee vexpress-qemu_armv8a debug 3.6.0
+copy-includes "$OS_CODENAME" optee vexpress-qemu_armv8a release 3.6.0

--- a/devex/cross-nuget/linux/standalone-build/runner.sh
+++ b/devex/cross-nuget/linux/standalone-build/runner.sh
@@ -1,0 +1,283 @@
+set -o xtrace
+
+OS_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d= -f2)
+if [[ $OS_CODENAME == "" ]]; then
+    OS_CODENAME="xenial"
+fi
+
+# OP-TEE Build Output Folders
+OPTEE_DEBUG_QEMU_ARMV8_OUT_PATH=$PWD/build/optee/3.6.0/vexpress-qemu_armv8a/debug
+OPTEE_DEBUG_GRAPEBOARD_OUT_PATH=$PWD/build/optee/3.6.0/ls-ls1012grapeboard/debug
+
+OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH=$PWD/build/optee/3.6.0/vexpress-qemu_armv8a/release
+OPTEE_RELEASE_GRAPEBOARD_OUT_PATH=$PWD/build/optee/3.6.0/ls-ls1012grapeboard/release
+
+mkdir -p $OPTEE_DEBUG_QEMU_ARMV8_OUT_PATH
+mkdir -p $OPTEE_DEBUG_GRAPEBOARD_OUT_PATH
+mkdir -p $OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH
+mkdir -p $OPTEE_RELEASE_GRAPEBOARD_OUT_PATH
+
+# SDK Build Output (SGX)
+SDK_DEBUG_SGX_DEFAULT_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/sgx/default/debug
+SDK_RELEASE_SGX_DEFAULT_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/sgx/default/release
+
+mkdir -p $SDK_DEBUG_SGX_DEFAULT_OUT_PATH
+mkdir -p $SDK_RELEASE_SGX_DEFAULT_OUT_PATH
+
+# SDK Build Output (OP-TEE)
+SDK_DEBUG_OPTEE_QEMU_ARMV8_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/vexpress-qemu_armv8a/debug
+SDK_DEBUG_OPTEE_GRAPEBOARD_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/ls-ls1012grapeboard/debug
+
+SDK_RELEASE_OPTEE_QEMU_ARMV8_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/vexpress-qemu_armv8a/release
+SDK_RELEASE_OPTEE_GRAPEBOARD_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/ls-ls1012grapeboard/release
+
+mkdir -p $SDK_DEBUG_OPTEE_QEMU_ARMV8_OUT_PATH
+mkdir -p $SDK_DEBUG_OPTEE_GRAPEBOARD_OUT_PATH
+mkdir -p $SDK_RELEASE_OPTEE_QEMU_ARMV8_OUT_PATH
+mkdir -p $SDK_RELEASE_OPTEE_GRAPEBOARD_OUT_PATH
+
+# Source Paths
+OE_SDK_PATH=$PWD/sdk
+OPTEE_PATH=$OE_SDK_PATH/3rdparty/optee/optee_os
+
+## ========================================
+## Build OP-TEE
+## ========================================
+
+# OP-TEE fails to build on Ubuntu 16.04 (Xenial) due to a bug in the version of
+# binutils that ships with that release.
+if [[ $OS_CODENAME == "bionic" ]]; then
+    # OP-TEE Build Debug Flags
+    OPTEE_DEBUG_FLAGS=$(cat << EOF
+platform-cflags-optimization=-O0 
+CFG_CRYPTO_SIZE_OPTIMIZATION=y 
+CFG_PAGED_USER_TA=n 
+CFG_REE_FS=n 
+CFG_RPMB_FS=y 
+CFG_RPMB_TESTKEY=y 
+CFG_RPMB_WRITE_KEY=n 
+CFG_RPMB_RESET_FAT=n 
+CFG_TEE_CORE_DEBUG=y 
+CFG_WITH_PAGER=n 
+CFG_UNWIND=n 
+CFG_TEE_CORE_LOG_LEVEL=2 
+CFG_TEE_TA_LOG_LEVEL=4 
+CFG_WITH_USER_TA=y 
+CFG_GRPC=y
+EOF
+)
+
+    # OP-TEE Build Release Flags
+    OPTEE_DEBUG_FLAGS=$(cat << EOF
+platform-cflags-optimization=-Os 
+CFG_CRYPTO_SIZE_OPTIMIZATION=y 
+CFG_PAGED_USER_TA=n 
+CFG_REE_FS=n 
+CFG_RPMB_FS=y 
+CFG_RPMB_TESTKEY=y 
+CFG_RPMB_WRITE_KEY=n 
+CFG_RPMB_RESET_FAT=n 
+CFG_TEE_CORE_DEBUG=n 
+CFG_WITH_PAGER=n 
+CFG_UNWIND=n 
+CFG_TEE_CORE_LOG_LEVEL=0 
+CFG_TEE_TA_LOG_LEVEL=0 
+CFG_WITH_USER_TA=y 
+CFG_GRPC=y
+EOF
+)
+
+    # Cross-compiler Prefixes
+    CROSS_COMPILE=aarch64-linux-gnu-
+    TA_CROSS_COMPILE=aarch64-linux-gnu-
+    TA_CROSS_COMPILE_32=arm-linux-gnueabi-
+
+    if hash ccache 2>/dev/null; then
+        CROSS_COMPILE="ccache $CROSS_COMPILE"
+        TA_CROSS_COMPILE="ccache $TA_CROSS_COMPILE"
+        TA_CROSS_COMPILE_32="ccache $TA_CROSS_COMPILE_32"
+    fi
+
+    # Build OP-TEE for QEMU ARMv8 Debug
+    echo "Building: OP-TEE/QEMU/Debug" >> runner.$OS_CODENAME
+    pushd $OPTEE_DEBUG_QEMU_ARMV8_OUT_PATH
+    ARCH=arm make -j$(nproc) -C $OPTEE_PATH            \
+        PLATFORM=vexpress-qemu_armv8a                  \
+        O=$PWD                                         \
+        $OPTEE_DEBUG_FLAGS                             \
+        CROSS_COMPILE="$CROSS_COMPILE"                 \
+        CROSS_COMPILE_core="$CROSS_COMPILE"            \
+        CROSS_COMPILE_ta_arm64="$TA_CROSS_COMPILE"     \
+        CROSS_COMPILE_ta_arm32="$TA_CROSS_COMPILE_32"  \
+        CFG_ARM64_core=y || exit 1
+    popd
+
+    # Build OP-TEE for the Scalys Grapeboard Debug
+    echo "Building: OP-TEE/Grapeboard/Debug" >> runner.$OS_CODENAME
+    pushd $OPTEE_DEBUG_GRAPEBOARD_OUT_PATH
+    ARCH=arm make -j$(nproc) -C $OPTEE_PATH            \
+        PLATFORM=ls-ls1012grapeboard                   \
+        O=$PWD                                         \
+        $OPTEE_DEBUG_FLAGS                             \
+        CROSS_COMPILE="$CROSS_COMPILE"                 \
+        CROSS_COMPILE_core="$CROSS_COMPILE"            \
+        CROSS_COMPILE_ta_arm64="$TA_CROSS_COMPILE"     \
+        CROSS_COMPILE_ta_arm32="$TA_CROSS_COMPILE_32"  \
+        CFG_ARM64_core=y || exit 1
+    popd
+
+    # Build OP-TEE for QEMU ARMv8 Release
+    echo "Building: OP-TEE/QEMU/Release" >> runner.$OS_CODENAME
+    pushd $OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH
+    ARCH=arm make -j$(nproc) -C $OPTEE_PATH            \
+        PLATFORM=vexpress-qemu_armv8a                  \
+        O=$PWD                                         \
+        $OPTEE_RELEASE_FLAGS                           \
+        CROSS_COMPILE="$CROSS_COMPILE"                 \
+        CROSS_COMPILE_core="$CROSS_COMPILE"            \
+        CROSS_COMPILE_ta_arm64="$TA_CROSS_COMPILE"     \
+        CROSS_COMPILE_ta_arm32="$TA_CROSS_COMPILE_32"  \
+        CFG_ARM64_core=y || exit 1
+    popd
+
+    # Build OP-TEE for the Scalys Grapeboard Release
+    echo "Building: OP-TEE/Grapeboard/Release" >> runner.$OS_CODENAME
+    pushd $OPTEE_RELEASE_GRAPEBOARD_OUT_PATH
+    ARCH=arm make -j$(nproc) -C $OPTEE_PATH            \
+        PLATFORM=ls-ls1012grapeboard                   \
+        O=$PWD                                         \
+        $OPTEE_RELEASE_FLAGS                           \
+        CROSS_COMPILE="$CROSS_COMPILE"                 \
+        CROSS_COMPILE_core="$CROSS_COMPILE"            \
+        CROSS_COMPILE_ta_arm64="$TA_CROSS_COMPILE"     \
+        CROSS_COMPILE_ta_arm32="$TA_CROSS_COMPILE_32"  \
+        CFG_ARM64_core=y || exit 1
+    popd
+
+    # Clear OP-TEE build variables
+    unset OPTEE_DEBUG_FLAGS
+    unset OPTEE_RELEASE_FLAGS
+    unset CROSS_COMPILE
+    unset TA_CROSS_COMPILE
+    unset TA_CROSS_COMPILE_32
+fi
+
+## ========================================
+## Build SDK (SGX)
+## ========================================
+
+# Build the SDK for Intel SGX Default Debug
+echo "Building: SDK/SGX/Default/Debug" >> runner.$OS_CODENAME
+pushd $SDK_DEBUG_SGX_DEFAULT_OUT_PATH
+cmake -G Ninja $OE_SDK_PATH                                  \
+    -DLVI_MITIGATION=ControlFlow                             \
+    -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
+    -DCMAKE_BUILD_TYPE=Debug                                 \
+    -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'           \
+    -DCPACK_GENERATOR=DEB || exit 1
+ninja package || exit 1
+
+mkdir expand
+pushd expand
+7z x ../*.deb || exit 1
+tar xf data.tar || exit 1
+popd
+popd  # SDK Build Done
+
+# Build the SDK for Intel SGX Default Release
+echo "Building: SDK/SGX/Default/Release" >> runner.$OS_CODENAME
+pushd $SDK_RELEASE_SGX_DEFAULT_OUT_PATH
+cmake -G Ninja $OE_SDK_PATH                                  \
+    -DLVI_MITIGATION=ControlFlow                             \
+    -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
+    -DCMAKE_BUILD_TYPE=Release                               \
+    -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'           \
+    -DCPACK_GENERATOR=DEB || exit 1
+ninja package || exit 1
+
+mkdir expand
+pushd expand
+7z x ../*.deb || exit 1
+tar xf data.tar || exit 1
+popd
+popd  # SDK Build Done
+
+## ========================================
+## Build SDK (OP-TEE)
+## ========================================
+
+# Build the SDK for OP-TEE on QEMU ARMv8 Debug
+echo "Building: SDK/OP-TEE/QEMU/Debug" >> runner.$OS_CODENAME
+pushd $SDK_DEBUG_OPTEE_QEMU_ARMV8_OUT_PATH
+DEV_KIT=$OPTEE_DEBUG_QEMU_ARMV8_OUT_PATH
+cmake -G Ninja $OE_SDK_PATH                                    \
+    -DCMAKE_BUILD_TYPE=Debug                                   \
+    -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'             \
+    -DCPACK_GENERATOR=DEB                                      \
+    -DCMAKE_TOOLCHAIN_FILE=$OE_SDK_PATH/cmake/arm-cross.cmake  \
+    -DOE_TA_DEV_KIT_DIR=$DEV_KIT/export-ta_arm64 || exit 1
+ninja package || exit 1
+
+mkdir expand
+pushd expand
+7z x ../*.deb || exit 1
+tar xf data.tar || exit 1
+popd
+popd  # SDK Build Done
+
+# Build the SDK for OP-TEE on the Scalys Grapeboard Debug
+echo "Building: SDK/OP-TEE/Grapeboard/Debug" >> runner.$OS_CODENAME
+pushd $SDK_DEBUG_OPTEE_GRAPEBOARD_OUT_PATH
+DEV_KIT=$OPTEE_DEBUG_GRAPEBOARD_OUT_PATH
+cmake -G Ninja $OE_SDK_PATH                                    \
+    -DCMAKE_BUILD_TYPE=Debug                                   \
+    -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'             \
+    -DCPACK_GENERATOR=DEB                                      \
+    -DCMAKE_TOOLCHAIN_FILE=$OE_SDK_PATH/cmake/arm-cross.cmake  \
+    -DOE_TA_DEV_KIT_DIR=$DEV_KIT/export-ta_arm64 || exit 1
+ninja package || exit 1
+
+mkdir expand
+pushd expand
+7z x ../*.deb || exit 1
+tar xf data.tar || exit 1
+popd
+popd  # SDK Build Done
+
+# Build the SDK for OP-TEE on QEMU ARMv8 Release
+echo "Building: SDK/OP-TEE/QEMU/Release" >> runner.$OS_CODENAME
+pushd $SDK_RELEASE_OPTEE_QEMU_ARMV8_OUT_PATH
+DEV_KIT=$OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH
+cmake -G Ninja $OE_SDK_PATH                                    \
+    -DCMAKE_BUILD_TYPE=Release                                 \
+    -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'             \
+    -DCPACK_GENERATOR=DEB                                      \
+    -DCMAKE_TOOLCHAIN_FILE=$OE_SDK_PATH/cmake/arm-cross.cmake  \
+    -DOE_TA_DEV_KIT_DIR=$DEV_KIT/export-ta_arm64 || exit 1
+ninja package || exit 1
+
+mkdir expand
+pushd expand
+7z x ../*.deb || exit 1
+tar xf data.tar || exit 1
+popd
+popd  # SDK Build Done
+
+# Build the SDK for OP-TEE on the Scalys Grapeboard Release
+echo "Building: SDK/OP-TEE/Grapeboard/Release" >> runner.$OS_CODENAME
+pushd $SDK_RELEASE_OPTEE_GRAPEBOARD_OUT_PATH
+DEV_KIT=$OPTEE_RELEASE_GRAPEBOARD_OUT_PATH
+cmake -G Ninja $OE_SDK_PATH                                    \
+    -DCMAKE_BUILD_TYPE=Release                                 \
+    -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'             \
+    -DCPACK_GENERATOR=DEB                                      \
+    -DCMAKE_TOOLCHAIN_FILE=$OE_SDK_PATH/cmake/arm-cross.cmake  \
+    -DOE_TA_DEV_KIT_DIR=$DEV_KIT/export-ta_arm64 || exit 1
+ninja package || exit 1
+
+mkdir expand
+pushd expand
+7z x ../*.deb || exit 1
+tar xf data.tar || exit 1
+popd
+popd  # SDK Build Done

--- a/devex/cross-nuget/linux/standalone-build/runner.sh
+++ b/devex/cross-nuget/linux/standalone-build/runner.sh
@@ -1,6 +1,9 @@
-set -o xtrace
+#!/usr/bin/env bash
 
-OS_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d= -f2)
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+OS_CODENAME=$('cat /etc/os-release | grep UBUNTU_CODENAME | cut -d= -f2')
 if [[ $OS_CODENAME == "" ]]; then
     OS_CODENAME="xenial"
 fi
@@ -12,17 +15,17 @@ OPTEE_DEBUG_GRAPEBOARD_OUT_PATH=$PWD/build/optee/3.6.0/ls-ls1012grapeboard/debug
 OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH=$PWD/build/optee/3.6.0/vexpress-qemu_armv8a/release
 OPTEE_RELEASE_GRAPEBOARD_OUT_PATH=$PWD/build/optee/3.6.0/ls-ls1012grapeboard/release
 
-mkdir -p $OPTEE_DEBUG_QEMU_ARMV8_OUT_PATH
-mkdir -p $OPTEE_DEBUG_GRAPEBOARD_OUT_PATH
-mkdir -p $OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH
-mkdir -p $OPTEE_RELEASE_GRAPEBOARD_OUT_PATH
+mkdir -p "$OPTEE_DEBUG_QEMU_ARMV8_OUT_PATH"
+mkdir -p "$OPTEE_DEBUG_GRAPEBOARD_OUT_PATH"
+mkdir -p "$OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH"
+mkdir -p "$OPTEE_RELEASE_GRAPEBOARD_OUT_PATH"
 
 # SDK Build Output (SGX)
 SDK_DEBUG_SGX_DEFAULT_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/sgx/default/debug
 SDK_RELEASE_SGX_DEFAULT_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/sgx/default/release
 
-mkdir -p $SDK_DEBUG_SGX_DEFAULT_OUT_PATH
-mkdir -p $SDK_RELEASE_SGX_DEFAULT_OUT_PATH
+mkdir -p "$SDK_DEBUG_SGX_DEFAULT_OUT_PATH"
+mkdir -p "$SDK_RELEASE_SGX_DEFAULT_OUT_PATH"
 
 # SDK Build Output (OP-TEE)
 SDK_DEBUG_OPTEE_QEMU_ARMV8_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/vexpress-qemu_armv8a/debug
@@ -31,14 +34,14 @@ SDK_DEBUG_OPTEE_GRAPEBOARD_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/ls-l
 SDK_RELEASE_OPTEE_QEMU_ARMV8_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/vexpress-qemu_armv8a/release
 SDK_RELEASE_OPTEE_GRAPEBOARD_OUT_PATH=$PWD/build/$OS_CODENAME/sdk/optee/3.6.0/ls-ls1012grapeboard/release
 
-mkdir -p $SDK_DEBUG_OPTEE_QEMU_ARMV8_OUT_PATH
-mkdir -p $SDK_DEBUG_OPTEE_GRAPEBOARD_OUT_PATH
-mkdir -p $SDK_RELEASE_OPTEE_QEMU_ARMV8_OUT_PATH
-mkdir -p $SDK_RELEASE_OPTEE_GRAPEBOARD_OUT_PATH
+mkdir -p "$SDK_DEBUG_OPTEE_QEMU_ARMV8_OUT_PATH"
+mkdir -p "$SDK_DEBUG_OPTEE_GRAPEBOARD_OUT_PATH"
+mkdir -p "$SDK_RELEASE_OPTEE_QEMU_ARMV8_OUT_PATH"
+mkdir -p "$SDK_RELEASE_OPTEE_GRAPEBOARD_OUT_PATH"
 
 # Source Paths
-OE_SDK_PATH=$PWD/sdk
-OPTEE_PATH=$OE_SDK_PATH/3rdparty/optee/optee_os
+OE_SDK_PATH="$PWD/sdk"
+OPTEE_PATH="$OE_SDK_PATH/3rdparty/optee/optee_os"
 
 ## ========================================
 ## Build OP-TEE
@@ -100,59 +103,59 @@ EOF
 
     # Build OP-TEE for QEMU ARMv8 Debug
     echo "Building: OP-TEE/QEMU/Debug" >> runner.$OS_CODENAME
-    pushd $OPTEE_DEBUG_QEMU_ARMV8_OUT_PATH
-    ARCH=arm make -j$(nproc) -C $OPTEE_PATH            \
+    pushd "$OPTEE_DEBUG_QEMU_ARMV8_OUT_PATH" || exit 1
+    ARCH=arm make -j"$(nproc)" -C "$OPTEE_PATH"        \
         PLATFORM=vexpress-qemu_armv8a                  \
-        O=$PWD                                         \
-        $OPTEE_DEBUG_FLAGS                             \
+        O="$PWD"                                       \
+        "$OPTEE_DEBUG_FLAGS"                           \
         CROSS_COMPILE="$CROSS_COMPILE"                 \
         CROSS_COMPILE_core="$CROSS_COMPILE"            \
         CROSS_COMPILE_ta_arm64="$TA_CROSS_COMPILE"     \
         CROSS_COMPILE_ta_arm32="$TA_CROSS_COMPILE_32"  \
         CFG_ARM64_core=y || exit 1
-    popd
+    popd || exit 1
 
     # Build OP-TEE for the Scalys Grapeboard Debug
     echo "Building: OP-TEE/Grapeboard/Debug" >> runner.$OS_CODENAME
-    pushd $OPTEE_DEBUG_GRAPEBOARD_OUT_PATH
-    ARCH=arm make -j$(nproc) -C $OPTEE_PATH            \
+    pushd "$OPTEE_DEBUG_GRAPEBOARD_OUT_PATH" || exit 1
+    ARCH=arm make -j"$(nproc)" -C "$OPTEE_PATH"        \
         PLATFORM=ls-ls1012grapeboard                   \
-        O=$PWD                                         \
-        $OPTEE_DEBUG_FLAGS                             \
+        O="$PWD"                                       \
+        "$OPTEE_DEBUG_FLAGS"                           \
         CROSS_COMPILE="$CROSS_COMPILE"                 \
         CROSS_COMPILE_core="$CROSS_COMPILE"            \
         CROSS_COMPILE_ta_arm64="$TA_CROSS_COMPILE"     \
         CROSS_COMPILE_ta_arm32="$TA_CROSS_COMPILE_32"  \
         CFG_ARM64_core=y || exit 1
-    popd
+    popd || exit 1
 
     # Build OP-TEE for QEMU ARMv8 Release
     echo "Building: OP-TEE/QEMU/Release" >> runner.$OS_CODENAME
-    pushd $OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH
-    ARCH=arm make -j$(nproc) -C $OPTEE_PATH            \
+    pushd "$OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH" || exit 1
+    ARCH=arm make -j"$(nproc)" -C "$OPTEE_PATH"        \
         PLATFORM=vexpress-qemu_armv8a                  \
-        O=$PWD                                         \
-        $OPTEE_RELEASE_FLAGS                           \
+        O="$PWD"                                       \
+        "$OPTEE_RELEASE_FLAGS"                         \
         CROSS_COMPILE="$CROSS_COMPILE"                 \
         CROSS_COMPILE_core="$CROSS_COMPILE"            \
         CROSS_COMPILE_ta_arm64="$TA_CROSS_COMPILE"     \
         CROSS_COMPILE_ta_arm32="$TA_CROSS_COMPILE_32"  \
         CFG_ARM64_core=y || exit 1
-    popd
+    popd || exit 1
 
     # Build OP-TEE for the Scalys Grapeboard Release
     echo "Building: OP-TEE/Grapeboard/Release" >> runner.$OS_CODENAME
-    pushd $OPTEE_RELEASE_GRAPEBOARD_OUT_PATH
-    ARCH=arm make -j$(nproc) -C $OPTEE_PATH            \
+    pushd "$OPTEE_RELEASE_GRAPEBOARD_OUT_PATH" || exit 1
+    ARCH=arm make -j"$(nproc)" -C "$OPTEE_PATH"        \
         PLATFORM=ls-ls1012grapeboard                   \
-        O=$PWD                                         \
-        $OPTEE_RELEASE_FLAGS                           \
+        O="$PWD"                                       \
+        "$OPTEE_RELEASE_FLAGS"                         \
         CROSS_COMPILE="$CROSS_COMPILE"                 \
         CROSS_COMPILE_core="$CROSS_COMPILE"            \
         CROSS_COMPILE_ta_arm64="$TA_CROSS_COMPILE"     \
         CROSS_COMPILE_ta_arm32="$TA_CROSS_COMPILE_32"  \
         CFG_ARM64_core=y || exit 1
-    popd
+    popd || exit 1
 
     # Clear OP-TEE build variables
     unset OPTEE_DEBUG_FLAGS
@@ -168,8 +171,8 @@ fi
 
 # Build the SDK for Intel SGX Default Debug
 echo "Building: SDK/SGX/Default/Debug" >> runner.$OS_CODENAME
-pushd $SDK_DEBUG_SGX_DEFAULT_OUT_PATH
-cmake -G Ninja $OE_SDK_PATH                                  \
+pushd "$SDK_DEBUG_SGX_DEFAULT_OUT_PATH" || exit 1
+cmake -G Ninja "$OE_SDK_PATH"                                \
     -DLVI_MITIGATION=ControlFlow                             \
     -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
     -DCMAKE_BUILD_TYPE=Debug                                 \
@@ -178,16 +181,16 @@ cmake -G Ninja $OE_SDK_PATH                                  \
 ninja package || exit 1
 
 mkdir expand
-pushd expand
+pushd expand || exit 1
 7z x ../*.deb || exit 1
 tar xf data.tar || exit 1
-popd
-popd  # SDK Build Done
+popd || exit 1
+popd || exit 1  # SDK Build Done
 
 # Build the SDK for Intel SGX Default Release
 echo "Building: SDK/SGX/Default/Release" >> runner.$OS_CODENAME
-pushd $SDK_RELEASE_SGX_DEFAULT_OUT_PATH
-cmake -G Ninja $OE_SDK_PATH                                  \
+pushd "$SDK_RELEASE_SGX_DEFAULT_OUT_PATH" || exit 1
+cmake -G Ninja "$OE_SDK_PATH"                                \
     -DLVI_MITIGATION=ControlFlow                             \
     -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
     -DCMAKE_BUILD_TYPE=Release                               \
@@ -196,11 +199,11 @@ cmake -G Ninja $OE_SDK_PATH                                  \
 ninja package || exit 1
 
 mkdir expand
-pushd expand
+pushd expand || exit 1
 7z x ../*.deb || exit 1
 tar xf data.tar || exit 1
-popd
-popd  # SDK Build Done
+popd || exit 1
+popd || exit 1  # SDK Build Done
 
 ## ========================================
 ## Build SDK (OP-TEE)
@@ -208,76 +211,76 @@ popd  # SDK Build Done
 
 # Build the SDK for OP-TEE on QEMU ARMv8 Debug
 echo "Building: SDK/OP-TEE/QEMU/Debug" >> runner.$OS_CODENAME
-pushd $SDK_DEBUG_OPTEE_QEMU_ARMV8_OUT_PATH
-DEV_KIT=$OPTEE_DEBUG_QEMU_ARMV8_OUT_PATH
-cmake -G Ninja $OE_SDK_PATH                                    \
+pushd "$SDK_DEBUG_OPTEE_QEMU_ARMV8_OUT_PATH" || exit 1
+DEV_KIT="$OPTEE_DEBUG_QEMU_ARMV8_OUT_PATH"
+cmake -G Ninja "$OE_SDK_PATH"                                  \
     -DCMAKE_BUILD_TYPE=Debug                                   \
     -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'             \
     -DCPACK_GENERATOR=DEB                                      \
-    -DCMAKE_TOOLCHAIN_FILE=$OE_SDK_PATH/cmake/arm-cross.cmake  \
-    -DOE_TA_DEV_KIT_DIR=$DEV_KIT/export-ta_arm64 || exit 1
+    -DCMAKE_TOOLCHAIN_FILE="$OE_SDK_PATH"/cmake/arm-cross.cmake\
+    -DOE_TA_DEV_KIT_DIR="$DEV_KIT"/export-ta_arm64 || exit 1
 ninja package || exit 1
 
 mkdir expand
-pushd expand
+pushd expand || exit 1
 7z x ../*.deb || exit 1
 tar xf data.tar || exit 1
-popd
-popd  # SDK Build Done
+popd || exit 1
+popd || exit 1  # SDK Build Done
 
 # Build the SDK for OP-TEE on the Scalys Grapeboard Debug
 echo "Building: SDK/OP-TEE/Grapeboard/Debug" >> runner.$OS_CODENAME
-pushd $SDK_DEBUG_OPTEE_GRAPEBOARD_OUT_PATH
-DEV_KIT=$OPTEE_DEBUG_GRAPEBOARD_OUT_PATH
-cmake -G Ninja $OE_SDK_PATH                                    \
+pushd "$SDK_DEBUG_OPTEE_GRAPEBOARD_OUT_PATH" || exit 1
+DEV_KIT="$OPTEE_DEBUG_GRAPEBOARD_OUT_PATH"
+cmake -G Ninja "$OE_SDK_PATH"                                  \
     -DCMAKE_BUILD_TYPE=Debug                                   \
     -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'             \
     -DCPACK_GENERATOR=DEB                                      \
-    -DCMAKE_TOOLCHAIN_FILE=$OE_SDK_PATH/cmake/arm-cross.cmake  \
-    -DOE_TA_DEV_KIT_DIR=$DEV_KIT/export-ta_arm64 || exit 1
+    -DCMAKE_TOOLCHAIN_FILE="$OE_SDK_PATH"/cmake/arm-cross.cmake\
+    -DOE_TA_DEV_KIT_DIR="$DEV_KIT"/export-ta_arm64 || exit 1
 ninja package || exit 1
 
 mkdir expand
-pushd expand
+pushd expand || exit 1
 7z x ../*.deb || exit 1
 tar xf data.tar || exit 1
-popd
-popd  # SDK Build Done
+popd || exit 1
+popd || exit 1  # SDK Build Done
 
 # Build the SDK for OP-TEE on QEMU ARMv8 Release
 echo "Building: SDK/OP-TEE/QEMU/Release" >> runner.$OS_CODENAME
-pushd $SDK_RELEASE_OPTEE_QEMU_ARMV8_OUT_PATH
-DEV_KIT=$OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH
-cmake -G Ninja $OE_SDK_PATH                                    \
+pushd "$SDK_RELEASE_OPTEE_QEMU_ARMV8_OUT_PATH" || exit 1
+DEV_KIT="$OPTEE_RELEASE_QEMU_ARMV8_OUT_PATH"
+cmake -G Ninja "$OE_SDK_PATH"                                  \
     -DCMAKE_BUILD_TYPE=Release                                 \
     -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'             \
     -DCPACK_GENERATOR=DEB                                      \
-    -DCMAKE_TOOLCHAIN_FILE=$OE_SDK_PATH/cmake/arm-cross.cmake  \
-    -DOE_TA_DEV_KIT_DIR=$DEV_KIT/export-ta_arm64 || exit 1
+    -DCMAKE_TOOLCHAIN_FILE="$OE_SDK_PATH"/cmake/arm-cross.cmake\
+    -DOE_TA_DEV_KIT_DIR="$DEV_KIT"/export-ta_arm64 || exit 1
 ninja package || exit 1
 
 mkdir expand
-pushd expand
+pushd expand || exit 1
 7z x ../*.deb || exit 1
 tar xf data.tar || exit 1
-popd
-popd  # SDK Build Done
+popd || exit 1
+popd || exit 1  # SDK Build Done
 
 # Build the SDK for OP-TEE on the Scalys Grapeboard Release
 echo "Building: SDK/OP-TEE/Grapeboard/Release" >> runner.$OS_CODENAME
-pushd $SDK_RELEASE_OPTEE_GRAPEBOARD_OUT_PATH
-DEV_KIT=$OPTEE_RELEASE_GRAPEBOARD_OUT_PATH
-cmake -G Ninja $OE_SDK_PATH                                    \
+pushd "$SDK_RELEASE_OPTEE_GRAPEBOARD_OUT_PATH" || exit 1
+DEV_KIT="$OPTEE_RELEASE_GRAPEBOARD_OUT_PATH"
+cmake -G Ninja "$OE_SDK_PATH"                                  \
     -DCMAKE_BUILD_TYPE=Release                                 \
     -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave'             \
     -DCPACK_GENERATOR=DEB                                      \
-    -DCMAKE_TOOLCHAIN_FILE=$OE_SDK_PATH/cmake/arm-cross.cmake  \
-    -DOE_TA_DEV_KIT_DIR=$DEV_KIT/export-ta_arm64 || exit 1
+    -DCMAKE_TOOLCHAIN_FILE="$OE_SDK_PATH"/cmake/arm-cross.cmake\
+    -DOE_TA_DEV_KIT_DIR="$DEV_KIT"/export-ta_arm64 || exit 1
 ninja package || exit 1
 
 mkdir expand
-pushd expand
+pushd expand || exit 1
 7z x ../*.deb || exit 1
 tar xf data.tar || exit 1
-popd
-popd  # SDK Build Done
+popd || exit 1
+popd || exit 1  # SDK Build Done

--- a/devex/cross-nuget/windows/build.ps1
+++ b/devex/cross-nuget/windows/build.ps1
@@ -6,9 +6,11 @@
 #    |- Debug
 #    |- Release
 
-$ErrorActionPreference = "Stop"
+Param(
+  [string]$OE_SDK_TAG = 'master'
+)
 
-$OE_SDK_TAG=v0.11.0
+$ErrorActionPreference = "Stop"
 
 If (-not (Test-Path -Path SDK))
 {

--- a/devex/cross-nuget/windows/pack.ps1
+++ b/devex/cross-nuget/windows/pack.ps1
@@ -37,6 +37,27 @@ Function Copy-Tools([String]$SgxPlatform)
     Copy-Item -Path "$($Bin.FullName)\*" -Destination .\Pack\tools\win\default -Recurse -Force
 }
 
+Function Copy-DebugTools()
+{
+
+    $Locations = @(
+        New-Object PSObject -Property @{folder="$PWD\Build\Default\Debug\host\CMakeFiles\oehost.dir";file="oehost.pdb";destination="$PWD\Pack\lib\native\win\sgx\default\debug\host\msvc-14.16.27023"}
+        New-Object PSObject -Property @{folder="$PWD\Build\Default\Release\debugger\debugrt\host";file="oedebugrt.*";destination="$PWD\Pack\tools\win\default"}
+    )
+
+    foreach ($location in $Locations) {
+        Push-Location $location.folder
+        $Bin = (Get-ChildItem -Recurse $location.file | Where { ! $_.FullName.Contains("manifest") } )
+        Pop-Location
+        foreach ($file in $Bin)
+        {
+            Copy-Item -Path "$($file.FullName)" -Destination $location.destination -Force
+        }
+    }
+
+}
+
+
 Function Copy-Includes([String]$SgxPlatform, [String]$BuildType)
 {
     Push-Location $PWD\Build\$SgxPlatform\$BuildType\_CPack_Packages\win64\NuGet
@@ -72,3 +93,4 @@ Copy-Includes Default Debug
 Copy-Includes Default Release
 
 Copy-Tools Default
+Copy-DebugTools

--- a/devex/vsextension/ItemTemplates/oehost/host.vstemplate
+++ b/devex/vsextension/ItemTemplates/oehost/host.vstemplate
@@ -17,7 +17,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.12.0.1" />
+      <package id="open-enclave-cross" version="0.12.0.2" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ItemTemplates/oehost/host.vstemplate
+++ b/devex/vsextension/ItemTemplates/oehost/host.vstemplate
@@ -17,7 +17,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.11.0-rc1-cbe4dedc-2" />
+      <package id="open-enclave-cross" version="0.12.0.1" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
@@ -169,12 +169,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\open-enclave-cross.0.12.0.1\build\native\open-enclave-cross.targets" Condition="Exists('..\packages\open-enclave-cross.0.12.0.1\build\native\open-enclave-cross.targets')" />
+    <Import Project="..\packages\open-enclave-cross.0.12.0.2\build\native\open-enclave-cross.targets" Condition="Exists('..\packages\open-enclave-cross.0.12.0.2\build\native\open-enclave-cross.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\open-enclave-cross.0.12.0.1\build\native\open-enclave-cross.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\open-enclave-cross.0.12.0.1\build\native\open-enclave-cross.targets'))" />
+    <Error Condition="!Exists('..\packages\open-enclave-cross.0.12.0.2\build\native\open-enclave-cross.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\open-enclave-cross.0.12.0.2\build\native\open-enclave-cross.targets'))" />
   </Target>
 </Project>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
@@ -169,12 +169,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2\build\native\open-enclave-cross.targets" Condition="Exists('..\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2\build\native\open-enclave-cross.targets')" />
+    <Import Project="..\packages\open-enclave-cross.0.12.0.1\build\native\open-enclave-cross.targets" Condition="Exists('..\packages\open-enclave-cross.0.12.0.1\build\native\open-enclave-cross.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2\build\native\open-enclave-cross.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2\build\native\open-enclave-cross.targets'))" />
+    <Error Condition="!Exists('..\packages\open-enclave-cross.0.12.0.1\build\native\open-enclave-cross.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\open-enclave-cross.0.12.0.1\build\native\open-enclave-cross.targets'))" />
   </Target>
 </Project>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
@@ -32,7 +32,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.12.0.1" />
+      <package id="open-enclave-cross" version="0.12.0.2" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
@@ -32,7 +32,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.11.0-rc1-cbe4dedc-2" />
+      <package id="open-enclave-cross" version="0.12.0.1" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/packages.config
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="open-enclave-cross" version="0.11.0-rc1-cbe4dedc-2" targetFramework="native" />
+  <package id="open-enclave-cross" version="0.12.0.1" targetFramework="native" />
 </packages>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/packages.config
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="open-enclave-cross" version="0.12.0.1" targetFramework="native" />
+  <package id="open-enclave-cross" version="0.12.0.2" targetFramework="native" />
 </packages>

--- a/devex/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
+++ b/devex/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
@@ -33,7 +33,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.11.0-rc1-cbe4dedc-2" />
+      <package id="open-enclave-cross" version="0.12.0.1" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
+++ b/devex/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
@@ -33,7 +33,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.12.0.1" />
+      <package id="open-enclave-cross" version="0.12.0.2" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectWizard/ImportEnclaveCommand.cs
+++ b/devex/vsextension/ProjectWizard/ImportEnclaveCommand.cs
@@ -345,7 +345,7 @@ namespace OpenEnclaveSDK
                     // Add nuget package to project.
                     // See https://stackoverflow.com/questions/41803738/how-to-programmatically-install-a-nuget-package/41895490#41895490
                     // and more particularly https://docs.microsoft.com/en-us/nuget/visual-studio-extensibility/nuget-api-in-visual-studio
-                    var packageVersions = new Dictionary<string, string>() { { "open-enclave-cross", "0.11.0-rc1-cbe4dedc-2" } };
+                    var packageVersions = new Dictionary<string, string>() { { "open-enclave-cross", "0.12.0.1" } };
                     var componentModel = (IComponentModel)(await this.ServiceProvider.GetServiceAsync(typeof(SComponentModel)));
                     var packageInstaller = componentModel.GetService<IVsPackageInstaller2>();
                     packageInstaller.InstallPackagesFromVSExtensionRepository(

--- a/devex/vsextension/ProjectWizard/ImportEnclaveCommand.cs
+++ b/devex/vsextension/ProjectWizard/ImportEnclaveCommand.cs
@@ -345,7 +345,7 @@ namespace OpenEnclaveSDK
                     // Add nuget package to project.
                     // See https://stackoverflow.com/questions/41803738/how-to-programmatically-install-a-nuget-package/41895490#41895490
                     // and more particularly https://docs.microsoft.com/en-us/nuget/visual-studio-extensibility/nuget-api-in-visual-studio
-                    var packageVersions = new Dictionary<string, string>() { { "open-enclave-cross", "0.12.0.1" } };
+                    var packageVersions = new Dictionary<string, string>() { { "open-enclave-cross", "0.12.0.2" } };
                     var componentModel = (IComponentModel)(await this.ServiceProvider.GetServiceAsync(typeof(SComponentModel)));
                     var packageInstaller = componentModel.GetService<IVsPackageInstaller2>();
                     packageInstaller.InstallPackagesFromVSExtensionRepository(

--- a/devex/vsextension/ProjectWizard/VSExtension.csproj
+++ b/devex/vsextension/ProjectWizard/VSExtension.csproj
@@ -154,7 +154,7 @@
       <ResourceName>Menus.ctmenu</ResourceName>
       <SubType>Designer</SubType>
     </VSCTCompile>
-    <Content Include="Packages\open-enclave-cross.0.12.0.1.nupkg">
+    <Content Include="Packages\open-enclave-cross.0.12.0.2.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="VCTargets\OpenEnclave.Cpp.Common.props">
@@ -487,7 +487,7 @@
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
   <PropertyGroup>
-    <PreBuildEvent>curl --proto "=https" --tlsv1.2 -sSfL https://www.nuget.org/api/v2/package/open-enclave-cross/0.12.0.1 --output $(ProjectDir)\packages\open-enclave-cross.0.12.0.1.nupkg -z $(ProjectDir)\packages\open-enclave-cross.0.12.0.1.nupkg</PreBuildEvent>
+    <PreBuildEvent>curl --proto "=https" --tlsv1.2 -sSfL https://www.nuget.org/api/v2/package/open-enclave-cross/0.12.0.2 --output $(ProjectDir)\packages\open-enclave-cross.0.12.0.2.nupkg -z $(ProjectDir)\packages\open-enclave-cross.0.12.0.2.nupkg</PreBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />

--- a/devex/vsextension/ProjectWizard/VSExtension.csproj
+++ b/devex/vsextension/ProjectWizard/VSExtension.csproj
@@ -154,7 +154,7 @@
       <ResourceName>Menus.ctmenu</ResourceName>
       <SubType>Designer</SubType>
     </VSCTCompile>
-    <Content Include="Packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2.nupkg">
+    <Content Include="Packages\open-enclave-cross.0.12.0.1.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="VCTargets\OpenEnclave.Cpp.Common.props">
@@ -487,7 +487,7 @@
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
   <PropertyGroup>
-    <PreBuildEvent>curl --proto "=https" --tlsv1.2 -sSfL https://www.nuget.org/api/v2/package/open-enclave-cross/0.11.0-rc1-cbe4dedc-2 --output $(ProjectDir)\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2.nupkg -z $(ProjectDir)\packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2.nupkg</PreBuildEvent>
+    <PreBuildEvent>curl --proto "=https" --tlsv1.2 -sSfL https://www.nuget.org/api/v2/package/open-enclave-cross/0.12.0.1 --output $(ProjectDir)\packages\open-enclave-cross.0.12.0.1.nupkg -z $(ProjectDir)\packages\open-enclave-cross.0.12.0.1.nupkg</PreBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />

--- a/devex/vsextension/ProjectWizard/WizardImplementation.cs
+++ b/devex/vsextension/ProjectWizard/WizardImplementation.cs
@@ -135,7 +135,7 @@ namespace OpenEnclaveSDK
                 // User picked a specific board for which we have binaries in the nuget package.
                 string solutionDirectory;
                 replacementsDictionary.TryGetValue("$solutiondirectory$", out solutionDirectory);
-                oeFolder = Path.Combine(solutionDirectory, "packages\\open-enclave-cross.0.11.0-rc1-cbe4dedc-2\\lib\\native\\linux\\optee\\v3.6.0\\" + board);
+                oeFolder = Path.Combine(solutionDirectory, "packages\\open-enclave-cross.0.12.0.1\\lib\\native\\linux\\optee\\v3.6.0\\" + board);
             }
             else
             {

--- a/devex/vsextension/ProjectWizard/WizardImplementation.cs
+++ b/devex/vsextension/ProjectWizard/WizardImplementation.cs
@@ -135,7 +135,7 @@ namespace OpenEnclaveSDK
                 // User picked a specific board for which we have binaries in the nuget package.
                 string solutionDirectory;
                 replacementsDictionary.TryGetValue("$solutiondirectory$", out solutionDirectory);
-                oeFolder = Path.Combine(solutionDirectory, "packages\\open-enclave-cross.0.12.0.1\\lib\\native\\linux\\optee\\v3.6.0\\" + board);
+                oeFolder = Path.Combine(solutionDirectory, "packages\\open-enclave-cross.0.12.0.2\\lib\\native\\linux\\optee\\v3.6.0\\" + board);
             }
             else
             {

--- a/devex/vsextension/ProjectWizard/source.extension.vsixmanifest
+++ b/devex/vsextension/ProjectWizard/source.extension.vsixmanifest
@@ -19,7 +19,7 @@
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveWindowsProject.zip" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveLinuxProject.zip" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
-        <Asset Type="open-enclave-cross.0.12.0.1.nupkg" d:Source="File" Path="Packages\open-enclave-cross.0.12.0.1.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="open-enclave-cross.0.12.0.2.nupkg" d:Source="File" Path="Packages\open-enclave-cross.0.12.0.2.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="ItemTemplates\Built\OEHostItem.zip" />
     </Assets>

--- a/devex/vsextension/ProjectWizard/source.extension.vsixmanifest
+++ b/devex/vsextension/ProjectWizard/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
   -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="OpenEnclaveVisualStudioExtension-1" Version="0.11.30" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="OpenEnclaveVisualStudioExtension-1" Version="0.12.33" Language="en-US" Publisher="Microsoft" />
         <DisplayName>Open Enclave - Preview</DisplayName>
         <Description xml:space="preserve">Support for developing and debugging Trusted Execution Environment enclaves that can run on both SGX and TrustZone, and using them from your own applications.</Description>
         <MoreInfo>https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/visualstudio_dev.md</MoreInfo>
@@ -19,7 +19,7 @@
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveWindowsProject.zip" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveLinuxProject.zip" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
-        <Asset Type="open-enclave-cross.0.11.0-rc1-cbe4dedc-2.nupkg" d:Source="File" Path="Packages\open-enclave-cross.0.11.0-rc1-cbe4dedc-2.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="open-enclave-cross.0.12.0.1.nupkg" d:Source="File" Path="Packages\open-enclave-cross.0.12.0.1.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="ItemTemplates\Built\OEHostItem.zip" />
     </Assets>

--- a/devex/vsextension/vsix-release-process.md
+++ b/devex/vsextension/vsix-release-process.md
@@ -6,10 +6,11 @@ a Microsoft signature generated using the Microsoft [PODSS](https://aka.ms/podss
 In the future, this process will change to a use a non-Microsoft
 signature once another signing process is defined for Open Enclave.
 
-1. Build the latest [Cross-Platform Open Enclave SDK NuGet Package](../cross-nuget/README.md).
-   Make a note of the new version number for use in step 4.
+1. Take note of the latest published version of the [Cross-Platform Open Enclave SDK NuGet Package](https://www.nuget.org/packages/open-enclave-cross). The latest published
+   version of the package should be used when building the VS Extension.
 
-2. Copy the resulting `open-enclave-cross.*.nupkg` NuGet package
+2. In the steps below, modify the references to the Cross-Platform Open Enclave
+   SDK NuGet Package. During the build process, the package will be [downloaded](https://github.com/openenclave/openenclave/blob/master/devex/vsextension/ProjectWizard/VSExtension.csproj#L490)
    into your local `openenclave\devex\vsextension\ProjectWizard\Packages\`
    directory in the open-enclave repository, where the VS extension solution
    will look for it.


### PR DESCRIPTION
Updated the documentation regarding the cross platform package, and VS extension release process.

Cross platform package changes:
- Updated .nuspec file to be easier to automate
- Create `standalone` linux folder to build on-host instead of using LXD
- Updated the `driver.sh` Linux, and `build.ps1` Windows scripts to use the `master` branch by default; also takes an optional tag argument to an OE SDK tag
- Pull in files that were present in the v0.8.x package which were not include in v0.11+ builds, namely `oehost.pdb`, and `oedebugrt.*` library files

VS extension changes:
- Updated project files to reference the latest `0.12.0.2` cross platform package, and reflect the VS extension build for version `0.12.33`
- Update documentation reflecting the automatic pull of the cross platform package from NuGet, instead of manually placing said package in the proper directory (Step 2 in devex/vsextension/vsix-release-process.md)

Fixes #3725 