### PR TITLE
Syscall TCB Reduction/Syscall Dispatching Rewrite

### DIFF
--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -6,9 +6,9 @@
 
 if (OE_SGX)
   set(ARCH "x86_64")
-else()
+else ()
   set(ARCH "aarch64")
-endif()
+endif ()
 
 # NOTE: MUSL is NOT built by the `ExternalProject_Add` command. These
 # C flags only apply to a configuration step that generates the MUSL
@@ -31,7 +31,7 @@ set(MUSL_DIR ${CMAKE_CURRENT_BINARY_DIR}/musl)
 set(MUSL_INCLUDES ${OE_INCDIR}/openenclave/libc)
 
 set(MUSL_APPEND_DEPRECATIONS
-  "${CMAKE_CURRENT_LIST_DIR}/append-deprecations ${MUSL_INCLUDES}")
+    "${CMAKE_CURRENT_LIST_DIR}/append-deprecations ${MUSL_INCLUDES}")
 if (USE_CLANGW)
   set(MUSL_CFLAGS "-target x86_64-pc-linux ${MUSL_CFLAGS}")
   set(MUSL_CC clang)
@@ -39,72 +39,59 @@ if (USE_CLANGW)
   set(MUSL_APPEND_DEPRECATIONS "echo 'Deprecations not applied on Windows'")
 endif ()
 
-include (ExternalProject)
-ExternalProject_Add(musl_includes
-  DOWNLOAD_COMMAND
-    ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_LIST_DIR}/musl
-    ${MUSL_DIR}
+include(ExternalProject)
+ExternalProject_Add(
+  musl_includes
+  DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory
+                   ${CMAKE_CURRENT_LIST_DIR}/musl ${MUSL_DIR}
   PATCH_COMMAND
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${MUSL_DIR}/arch/${ARCH}/syscall_arch.h
-      ${MUSL_DIR}/arch/${ARCH}/__syscall_arch.h
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${PATCHES_DIR}/syscall_arch.h
-      ${MUSL_DIR}/arch/${ARCH}/syscall_arch.h
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${PATCHES_DIR}/pthread_${ARCH}.h
-      ${MUSL_DIR}/arch/${ARCH}/pthread_arch.h
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${PATCHES_DIR}/setjmp.h
-      ${MUSL_DIR}/include/setjmp.h
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${PATCHES_DIR}/execinfo.h
-      ${MUSL_DIR}/include/execinfo.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${MUSL_DIR}/arch/${ARCH}/syscall_arch.h
+          ${MUSL_DIR}/arch/${ARCH}/__syscall_arch.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${PATCHES_DIR}/syscall.h
+          ${MUSL_DIR}/src/internal/syscall.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${PATCHES_DIR}/syscall_arch.h
+          ${MUSL_DIR}/arch/${ARCH}/syscall_arch.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${PATCHES_DIR}/pthread_${ARCH}.h
+          ${MUSL_DIR}/arch/${ARCH}/pthread_arch.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${PATCHES_DIR}/setjmp.h
+          ${MUSL_DIR}/include/setjmp.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${PATCHES_DIR}/execinfo.h
+          ${MUSL_DIR}/include/execinfo.h
   CONFIGURE_COMMAND
-    ${CMAKE_COMMAND} -E chdir ${MUSL_DIR}
-    ${OE_BASH} -x ./configure
-      --includedir=${MUSL_INCLUDES}
-      CFLAGS=${MUSL_CFLAGS}
-      CC=${MUSL_CC}
-      CXX=${MUSL_CXX}
+    ${CMAKE_COMMAND} -E chdir ${MUSL_DIR} ${OE_BASH} -x ./configure
+    --includedir=${MUSL_INCLUDES} CFLAGS=${MUSL_CFLAGS} CC=${MUSL_CC}
+    CXX=${MUSL_CXX}
   BUILD_COMMAND
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${MUSL_DIR}/include
-        ${MUSL_INCLUDES}
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${MUSL_DIR}/arch/generic/bits
-        ${MUSL_INCLUDES}/bits
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${MUSL_DIR}/arch/${ARCH}/bits
-        ${MUSL_INCLUDES}/bits
-    # bash -c requires the command string to be in a single line
-    COMMAND ${OE_BASH} -c "sed -f ${MUSL_DIR}/tools/mkalltypes.sed ${MUSL_DIR}/arch/${ARCH}/bits/alltypes.h.in ${MUSL_DIR}/include/alltypes.h.in > ${MUSL_INCLUDES}/bits/alltypes.h"
-    COMMAND ${CMAKE_COMMAND} -E copy
-        ${MUSL_DIR}/arch/${ARCH}/bits/syscall.h.in
-        ${MUSL_INCLUDES}/bits/syscall.h
-    # bash -c requires the command string to be in a single line
-    COMMAND ${OE_BASH} -c "sed -n -e s/__NR_/SYS_/p < ${MUSL_DIR}/arch/${ARCH}/bits/syscall.h.in >> ${MUSL_INCLUDES}/bits/syscall.h"
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${MUSL_INCLUDES}/endian.h
-      ${MUSL_INCLUDES}/__endian.h
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${PATCHES_DIR}/endian.h
-      ${MUSL_INCLUDES}/endian.h
-    # Append deprecations.h to all C header files.
-    COMMAND ${OE_BASH} -c "${MUSL_APPEND_DEPRECATIONS}"
-    # Copy local deprecations.h to include/bits/deprecated.h.
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${CMAKE_CURRENT_LIST_DIR}/deprecations.h
-      ${MUSL_INCLUDES}/bits/deprecations.h
-  BUILD_BYPRODUCTS
-    ${MUSL_INCLUDES} ${MUSL_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${MUSL_DIR}/include
+          ${MUSL_INCLUDES}
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${MUSL_DIR}/arch/generic/bits
+          ${MUSL_INCLUDES}/bits
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${MUSL_DIR}/arch/${ARCH}/bits
+          ${MUSL_INCLUDES}/bits
+  # bash -c requires the command string to be in a single line
+  COMMAND
+    ${OE_BASH} -c
+    "sed -f ${MUSL_DIR}/tools/mkalltypes.sed ${MUSL_DIR}/arch/${ARCH}/bits/alltypes.h.in ${MUSL_DIR}/include/alltypes.h.in > ${MUSL_INCLUDES}/bits/alltypes.h"
+  COMMAND ${CMAKE_COMMAND} -E copy ${MUSL_DIR}/arch/${ARCH}/bits/syscall.h.in
+          ${MUSL_INCLUDES}/bits/syscall.h
+  # bash -c requires the command string to be in a single line
+  COMMAND
+    ${OE_BASH} -c
+    "sed -n -e s/__NR_/SYS_/p < ${MUSL_DIR}/arch/${ARCH}/bits/syscall.h.in >> ${MUSL_INCLUDES}/bits/syscall.h"
+  COMMAND ${CMAKE_COMMAND} -E copy ${MUSL_INCLUDES}/endian.h
+          ${MUSL_INCLUDES}/__endian.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${PATCHES_DIR}/endian.h
+          ${MUSL_INCLUDES}/endian.h
+  # Append deprecations.h to all C header files.
+  COMMAND ${OE_BASH} -c "${MUSL_APPEND_DEPRECATIONS}"
+  # Copy local deprecations.h to include/bits/deprecated.h.
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/deprecations.h
+          ${MUSL_INCLUDES}/bits/deprecations.h
+  BUILD_BYPRODUCTS ${MUSL_INCLUDES} ${MUSL_DIR}
   INSTALL_COMMAND "")
 
-set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
-    ${MUSL_INCLUDES}
-    ${MUSL_DIR}
-)
+set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${MUSL_INCLUDES}
+                                ${MUSL_DIR})
 
 add_library(oelibc_includes INTERFACE)
 
@@ -124,15 +111,17 @@ add_dependencies(oelibc_includes musl_includes)
 #
 # TODO: Perhaps give this a less misleading name as it includes both C
 # and C++ headers (but the latter only when the language is C++).
-target_include_directories(oelibc_includes
+target_include_directories(
+  oelibc_includes
   INTERFACE
-  $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${LIBCXX_INCLUDES}>>
-  $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libcxx>>
-  $<BUILD_INTERFACE:${MUSL_INCLUDES}>
-  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libc>)
+    $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${LIBCXX_INCLUDES}>>
+    $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libcxx>>
+    $<BUILD_INTERFACE:${MUSL_INCLUDES}>
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libc>
+)
 
-if (CMAKE_C_COMPILER_ID MATCHES GNU AND
-    CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "7.1.0")
+if (CMAKE_C_COMPILER_ID MATCHES GNU AND CMAKE_C_COMPILER_VERSION
+                                        VERSION_GREATER_EQUAL "7.1.0")
   # NOTE: This disables a warning that is only present with newer
   # versions of GCC on Ubuntu 18.04.
   target_compile_options(oelibc_includes INTERFACE -Wno-implicit-fallthrough)
@@ -141,4 +130,4 @@ endif ()
 install(TARGETS oelibc_includes EXPORT openenclave-targets)
 
 install(DIRECTORY ${MUSL_INCLUDES}
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)

--- a/3rdparty/musl/patches/syscall.h
+++ b/3rdparty/musl/patches/syscall.h
@@ -1,0 +1,259 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/* This file is a patched version of musl/src/internal/syscall.h.
+   The PATCH_COMMAND step of musl_include target replaces the original
+   file with this patched version in the build folder.
+ */
+#ifndef _OE_MUSL_PATCHES_INTERNAL_SYSCALL_H
+#define _OE_MUSL_PATCHES_INTERNAL_SYSCALL_H
+
+#include <features.h>
+#include <openenclave/internal/syscall/declarations.h>
+#include <sys/syscall.h>
+#include "syscall_arch.h"
+
+#ifndef SYSCALL_RLIM_INFINITY
+#define SYSCALL_RLIM_INFINITY (~0ULL)
+#endif
+
+#ifndef SYSCALL_MMAP2_UNIT
+#define SYSCALL_MMAP2_UNIT 4096ULL
+#endif
+
+#ifndef __SYSCALL_LL_PRW
+#define __SYSCALL_LL_PRW(x) __SYSCALL_LL_O(x)
+#endif
+
+#ifndef __scc
+#define __scc(X) ((long)(X))
+typedef long syscall_arg_t;
+#endif
+
+hidden long __syscall_ret(unsigned long), __syscall(syscall_arg_t, ...),
+    __syscall_cp(
+        syscall_arg_t,
+        syscall_arg_t,
+        syscall_arg_t,
+        syscall_arg_t,
+        syscall_arg_t,
+        syscall_arg_t,
+        syscall_arg_t);
+
+#define SYSCALL_ARGS0()
+#define SYSCALL_ARGS1(a) __scc(a)
+#define SYSCALL_ARGS2(a, b) SYSCALL_ARGS1(a), __scc(b)
+#define SYSCALL_ARGS3(a, b, c) SYSCALL_ARGS2(a, b), __scc(c)
+#define SYSCALL_ARGS4(a, b, c, d) SYSCALL_ARGS3(a, b, c), __scc(d)
+#define SYSCALL_ARGS5(a, b, c, d, e) SYSCALL_ARGS4(a, b, c, d), __scc(e)
+#define SYSCALL_ARGS6(a, b, c, d, e, f) SYSCALL_ARGS5(a, b, c, d, e), __scc(f)
+#define SYSCALL_ARGS7(a, b, c, d, e, f, g) \
+    SYSCALL_ARGS6(a, b, c, d, e, f), __scc(g)
+
+#define SYSCALL_NARGS_X(a, b, c, d, e, f, g, h, n, ...) n
+#define SYSCALL_NARGS(...) \
+    SYSCALL_NARGS_X(_, ##__VA_ARGS__, 7, 6, 5, 4, 3, 2, 1, 0)
+#define SYSCALL_CONCAT_X(a, b) a##b
+#define SYSCALL_CONCAT(a, b) SYSCALL_CONCAT_X(a, b)
+
+#define SYSCALL_ARGS(...) \
+    SYSCALL_CONCAT(SYSCALL_ARGS, SYSCALL_NARGS(__VA_ARGS__))(__VA_ARGS__)
+
+#define __syscall(index, ...) \
+    OE_SYSCALL_NAME(_##index)(SYSCALL_ARGS(__VA_ARGS__))
+#define syscall(index, ...) \
+    __syscall_ret(OE_SYSCALL_NAME(_##index)(SYSCALL_ARGS(__VA_ARGS__)))
+
+#define socketcall __socketcall
+#define socketcall_cp __socketcall_cp
+
+#define SYSCALL_CP_ARGS_X(a, b, c, d, e, f, ...) SYSCALL_ARGS6(a, b, c, d, e, f)
+#define SYSCALL_CP_ARGS(...) SYSCALL_CP_ARGS_X(__VA_ARGS__, 0, 0, 0, 0, 0, 0)
+
+#define __syscall_cp(index, ...) \
+    OE_SYSCALL_NAME(_##index)(SYSCALL_CP_ARGS(__VA_ARGS__))
+#define syscall_cp(index, ...) \
+    __syscall_ret(OE_SYSCALL_NAME(_##index)(SYSCALL_CP_ARGS(__VA_ARGS__)))
+
+#ifndef SYSCALL_USE_SOCKETCALL
+#define __socketcall(nm, a, b, c, d, e, f) syscall(SYS_##nm, a, b, c, d, e, f)
+#define __socketcall_cp(nm, a, b, c, d, e, f) \
+    syscall_cp(SYS_##nm, a, b, c, d, e, f)
+#else
+#define __socketcall(nm, a, b, c, d, e, f) \
+    syscall(                               \
+        SYS_socketcall,                    \
+        __SC_##nm,                         \
+        ((long[6]){(long)a, (long)b, (long)c, (long)d, (long)e, (long)f}))
+#define __socketcall_cp(nm, a, b, c, d, e, f) \
+    syscall_cp(                               \
+        SYS_socketcall,                       \
+        __SC_##nm,                            \
+        ((long[6]){(long)a, (long)b, (long)c, (long)d, (long)e, (long)f}))
+#endif
+
+/* fixup legacy 16-bit junk */
+
+#ifdef SYS_getuid32
+#undef SYS_lchown
+#undef SYS_getuid
+#undef SYS_getgid
+#undef SYS_geteuid
+#undef SYS_getegid
+#undef SYS_setreuid
+#undef SYS_setregid
+#undef SYS_getgroups
+#undef SYS_setgroups
+#undef SYS_fchown
+#undef SYS_setresuid
+#undef SYS_getresuid
+#undef SYS_setresgid
+#undef SYS_getresgid
+#undef SYS_chown
+#undef SYS_setuid
+#undef SYS_setgid
+#undef SYS_setfsuid
+#undef SYS_setfsgid
+#define SYS_lchown SYS_lchown32
+#define SYS_getuid SYS_getuid32
+#define SYS_getgid SYS_getgid32
+#define SYS_geteuid SYS_geteuid32
+#define SYS_getegid SYS_getegid32
+#define SYS_setreuid SYS_setreuid32
+#define SYS_setregid SYS_setregid32
+#define SYS_getgroups SYS_getgroups32
+#define SYS_setgroups SYS_setgroups32
+#define SYS_fchown SYS_fchown32
+#define SYS_setresuid SYS_setresuid32
+#define SYS_getresuid SYS_getresuid32
+#define SYS_setresgid SYS_setresgid32
+#define SYS_getresgid SYS_getresgid32
+#define SYS_chown SYS_chown32
+#define SYS_setuid SYS_setuid32
+#define SYS_setgid SYS_setgid32
+#define SYS_setfsuid SYS_setfsuid32
+#define SYS_setfsgid SYS_setfsgid32
+#endif
+
+/* fixup legacy 32-bit-vs-lfs64 junk */
+
+#ifdef SYS_fcntl64
+#undef SYS_fcntl
+#define SYS_fcntl SYS_fcntl64
+#endif
+
+#ifdef SYS_getdents64
+#undef SYS_getdents
+#define SYS_getdents SYS_getdents64
+#endif
+
+#ifdef SYS_ftruncate64
+#undef SYS_ftruncate
+#undef SYS_truncate
+#define SYS_ftruncate SYS_ftruncate64
+#define SYS_truncate SYS_truncate64
+#endif
+
+#ifdef SYS_stat64
+#undef SYS_stat
+#define SYS_stat SYS_stat64
+#endif
+
+#ifdef SYS_fstat64
+#undef SYS_fstat
+#define SYS_fstat SYS_fstat64
+#endif
+
+#ifdef SYS_lstat64
+#undef SYS_lstat
+#define SYS_lstat SYS_lstat64
+#endif
+
+#ifdef SYS_statfs64
+#undef SYS_statfs
+#define SYS_statfs SYS_statfs64
+#endif
+
+#ifdef SYS_fstatfs64
+#undef SYS_fstatfs
+#define SYS_fstatfs SYS_fstatfs64
+#endif
+
+#if defined(SYS_newfstatat)
+#undef SYS_fstatat
+#define SYS_fstatat SYS_newfstatat
+#elif defined(SYS_fstatat64)
+#undef SYS_fstatat
+#define SYS_fstatat SYS_fstatat64
+#endif
+
+#ifdef SYS_ugetrlimit
+#undef SYS_getrlimit
+#define SYS_getrlimit SYS_ugetrlimit
+#endif
+
+#ifdef SYS__newselect
+#undef SYS_select
+#define SYS_select SYS__newselect
+#endif
+
+#ifdef SYS_pread64
+#undef SYS_pread
+#undef SYS_pwrite
+#define SYS_pread SYS_pread64
+#define SYS_pwrite SYS_pwrite64
+#endif
+
+#ifdef SYS_fadvise64_64
+#undef SYS_fadvise
+#define SYS_fadvise SYS_fadvise64_64
+#elif defined(SYS_fadvise64)
+#undef SYS_fadvise
+#define SYS_fadvise SYS_fadvise64
+#endif
+
+#ifdef SYS_sendfile64
+#undef SYS_sendfile
+#define SYS_sendfile SYS_sendfile64
+#endif
+
+/* socketcall calls */
+
+#define __SC_socket 1
+#define __SC_bind 2
+#define __SC_connect 3
+#define __SC_listen 4
+#define __SC_accept 5
+#define __SC_getsockname 6
+#define __SC_getpeername 7
+#define __SC_socketpair 8
+#define __SC_send 9
+#define __SC_recv 10
+#define __SC_sendto 11
+#define __SC_recvfrom 12
+#define __SC_shutdown 13
+#define __SC_setsockopt 14
+#define __SC_getsockopt 15
+#define __SC_sendmsg 16
+#define __SC_recvmsg 17
+#define __SC_accept4 18
+#define __SC_recvmmsg 19
+#define __SC_sendmmsg 20
+
+#ifdef SYS_open
+#define __sys_open(...) __syscall(SYS_open, __VA_ARGS__)
+#define sys_open(...) __syscall_ret(__sys_open(__VA_ARGS__))
+#define __sys_open_cp(...) __syscall_cp(SYS_open, __VA_ARGS__)
+#define sys_open_cp(...) __syscall_ret(__sys_open_cp(__VA_ARGS__))
+#else
+#define __sys_open(...) __syscall(SYS_openat, __VA_ARGS__)
+#define sys_open(...) __syscall_ret(__sys_open(__VA_ARGS__))
+#define __sys_open_cp(...) __syscall_cp(SYS_openat, __VA_ARGS__)
+#define sys_open_cp(...) __syscall_ret(__sys_open_cp(__VA_ARGS__))
+#endif
+
+hidden void __procfdname(char __buf[static 15 + 3 * sizeof(int)], unsigned);
+
+hidden void* __vdsosym(const char*, const char*);
+
+#endif /* _OE_MUSL_PATCHES_INTERNAL_SYSCALL_H */

--- a/include/openenclave/internal/syscall/declarations.h
+++ b/include/openenclave/internal/syscall/declarations.h
@@ -61,28 +61,74 @@ OE_EXTERNC_BEGIN
     OE_STATIC_ASSERT(index == OE_##index); \
     long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS7)
 
-#define OE_DEFINE_SYSCALL0 OE_DECLARE_SYSCALL0
-#define OE_DEFINE_SYSCALL1 OE_DECLARE_SYSCALL1
-#define OE_DEFINE_SYSCALL2 OE_DECLARE_SYSCALL2
-#define OE_DEFINE_SYSCALL3 OE_DECLARE_SYSCALL3
-#define OE_DEFINE_SYSCALL4 OE_DECLARE_SYSCALL4
-#define OE_DEFINE_SYSCALL5 OE_DECLARE_SYSCALL5
-#define OE_DEFINE_SYSCALL6 OE_DECLARE_SYSCALL6
-#define OE_DEFINE_SYSCALL7 OE_DECLARE_SYSCALL7
+#define OE_DECLARE_SYSCALL1_M(index)       \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS1, ...)
+#define OE_DECLARE_SYSCALL2_M(index)       \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS2, ...)
+#define OE_DECLARE_SYSCALL3_M(index)       \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS3, ...)
+#define OE_DECLARE_SYSCALL4_M(index)       \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS4, ...)
+#define OE_DECLARE_SYSCALL5_M(index)       \
+    OE_STATIC_ASSERT(index == OE_##index); \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS5, ...)
+
+#define OE_DEFINE_SYSCALL0(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS0)
+#define OE_DEFINE_SYSCALL1(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS1)
+#define OE_DEFINE_SYSCALL2(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS2)
+#define OE_DEFINE_SYSCALL3(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS3)
+#define OE_DEFINE_SYSCALL4(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS4)
+#define OE_DEFINE_SYSCALL5(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS5)
+#define OE_DEFINE_SYSCALL6(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS6)
+#define OE_DEFINE_SYSCALL7(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS7)
+
+#define OE_DEFINE_SYSCALL1_M(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS1, ...)
+#define OE_DEFINE_SYSCALL2_M(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS2, ...)
+#define OE_DEFINE_SYSCALL3_M(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS3, ...)
+#define OE_DEFINE_SYSCALL4_M(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS4, ...)
+#define OE_DEFINE_SYSCALL5_M(index) \
+    long OE_SYSCALL_NAME(_##index)(OE_SYSCALL_ARGS5, ...)
+
+#ifndef SYS_pread
+#define SYS_pread SYS_pread64
+#define OE_SYS_pread SYS_pread64
+#endif
+
+#ifndef SYS_pwrite
+#define SYS_pwrite SYS_pwrite64
+#define OE_SYS_pwrite SYS_pwrite64
+#endif
 
 /** List of syscalls that are supported within enclaves.
  ** In alphabetical order.
  ** Certain syscalls are available only in some platforms.
  **/
 
-OE_DECLARE_SYSCALL3(SYS_accept);
+OE_DECLARE_SYSCALL3_M(SYS_accept);
 #if __x86_64__ || _M_X64
 OE_DECLARE_SYSCALL2(SYS_access);
 #endif
-OE_DECLARE_SYSCALL3(SYS_bind);
+OE_DECLARE_SYSCALL3_M(SYS_bind);
 OE_DECLARE_SYSCALL1(SYS_chdir);
-OE_DECLARE_SYSCALL1(SYS_close);
-OE_DECLARE_SYSCALL3(SYS_connect);
+OE_DECLARE_SYSCALL2(SYS_clock_gettime);
+OE_DECLARE_SYSCALL1_M(SYS_close);
+OE_DECLARE_SYSCALL3_M(SYS_connect);
 #if __x86_64__ || _M_X64
 OE_DECLARE_SYSCALL2(SYS_creat);
 #endif
@@ -96,63 +142,83 @@ OE_DECLARE_SYSCALL1(SYS_epoll_create);
 #endif
 OE_DECLARE_SYSCALL1(SYS_epoll_create1);
 OE_DECLARE_SYSCALL4(SYS_epoll_ctl);
-OE_DECLARE_SYSCALL5(SYS_epoll_pwait);
+OE_DECLARE_SYSCALL5_M(SYS_epoll_pwait);
 #if __x86_64__ || _M_X64
-OE_DECLARE_SYSCALL4(SYS_epoll_wait);
+OE_DECLARE_SYSCALL4_M(SYS_epoll_wait);
 #endif
 OE_DECLARE_SYSCALL1(SYS_exit);
-OE_DECLARE_SYSCALL0(SYS_exit_group);
+OE_DECLARE_SYSCALL1(SYS_exit_group);
 OE_DECLARE_SYSCALL4(SYS_faccessat);
-OE_DECLARE_SYSCALL3(SYS_fcntl);
-OE_DECLARE_SYSCALL1(SYS_fdatasync);
+// SYS_fcntl is mostly called with 3 arguments.
+// Sometimes it is also called with 4 arguments.
+// See: musl/src/fcntl/fcntl.c
+// And called with 2 args in musl/src/stat/fstat.c
+OE_DECLARE_SYSCALL2_M(SYS_fcntl);
+OE_DECLARE_SYSCALL1_M(SYS_fdatasync);
 OE_DECLARE_SYSCALL2(SYS_flock);
 OE_DECLARE_SYSCALL2(SYS_fstat);
-OE_DECLARE_SYSCALL1(SYS_fsync);
+OE_DECLARE_SYSCALL1_M(SYS_fsync);
+// SYS_futex is needed for compiling musl/src/internal/pthread_impl.h
+// It doesn't have to be implemented.
+// It is called with 3 or 4 arguments.
+OE_DECLARE_SYSCALL3_M(SYS_futex);
 OE_DECLARE_SYSCALL2(SYS_getcwd);
+OE_DECLARE_SYSCALL3(SYS_getdents);
 OE_DECLARE_SYSCALL3(SYS_getdents64);
 OE_DECLARE_SYSCALL0(SYS_getegid);
 OE_DECLARE_SYSCALL0(SYS_geteuid);
 OE_DECLARE_SYSCALL0(SYS_getgid);
 OE_DECLARE_SYSCALL2(SYS_getgroups);
-OE_DECLARE_SYSCALL3(SYS_getpeername);
+OE_DECLARE_SYSCALL3_M(SYS_getpeername);
 OE_DECLARE_SYSCALL1(SYS_getpgid);
 #if __x86_64__ || _M_X64
 OE_DECLARE_SYSCALL0(SYS_getpgrp);
 #endif
 OE_DECLARE_SYSCALL0(SYS_getpid);
 OE_DECLARE_SYSCALL0(SYS_getppid);
-OE_DECLARE_SYSCALL3(SYS_getsockname);
-OE_DECLARE_SYSCALL5(SYS_getsockopt);
+OE_DECLARE_SYSCALL3_M(SYS_getsockname);
+OE_DECLARE_SYSCALL5_M(SYS_getsockopt);
+OE_DECLARE_SYSCALL2(SYS_gettimeofday);
 OE_DECLARE_SYSCALL0(SYS_getuid);
-OE_DECLARE_SYSCALL6(SYS_ioctl);
+// SYS_iocl is called with 3 or more args.
+// However OE only uses the first 3 args.
+OE_DECLARE_SYSCALL3_M(SYS_ioctl);
 #if __x86_64__ || _M_X64
 OE_DECLARE_SYSCALL2(SYS_link);
 #endif
 OE_DECLARE_SYSCALL5(SYS_linkat);
-OE_DECLARE_SYSCALL2(SYS_listen);
+OE_DECLARE_SYSCALL2_M(SYS_listen);
 OE_DECLARE_SYSCALL3(SYS_lseek);
 #if __x86_64__ || _M_X64
 OE_DECLARE_SYSCALL2(SYS_mkdir);
 #endif
 OE_DECLARE_SYSCALL3(SYS_mkdirat);
+// This is needed by musl/src/mman/mmap.c
+// It does not have to be implemented.
+OE_DECLARE_SYSCALL6(SYS_mmap);
+OE_DECLARE_SYSCALL2(SYS_munmap);
 OE_DECLARE_SYSCALL5(SYS_mount);
-OE_DECLARE_SYSCALL2(SYS_nanosleep);
+OE_DECLARE_SYSCALL2_M(SYS_nanosleep);
 OE_DECLARE_SYSCALL4(SYS_newfstatat);
 #if __x86_64__ || _M_X64
-OE_DECLARE_SYSCALL3(SYS_open);
+// Normally called with 3 args.
+// Called with 2 args in mustl/src/stdio/__fopen_rb_ca.c
+OE_DECLARE_SYSCALL2_M(SYS_open);
 #endif
 OE_DECLARE_SYSCALL4(SYS_openat);
 #if __x86_64__ || _M_X64
-OE_DECLARE_SYSCALL3(SYS_poll);
+OE_DECLARE_SYSCALL3_M(SYS_poll);
 #endif
-OE_DECLARE_SYSCALL4(SYS_ppoll);
+OE_DECLARE_SYSCALL4_M(SYS_ppoll);
+OE_DECLARE_SYSCALL4_M(SYS_pread);
 OE_DECLARE_SYSCALL4(SYS_pread64);
-OE_DECLARE_SYSCALL5(SYS_pselect6);
+OE_DECLARE_SYSCALL5_M(SYS_pselect6);
+OE_DECLARE_SYSCALL4_M(SYS_pwrite);
 OE_DECLARE_SYSCALL4(SYS_pwrite64);
-OE_DECLARE_SYSCALL3(SYS_read);
-OE_DECLARE_SYSCALL3(SYS_readv);
+OE_DECLARE_SYSCALL3_M(SYS_read);
+OE_DECLARE_SYSCALL3_M(SYS_readv);
 OE_DECLARE_SYSCALL6(SYS_recvfrom);
-OE_DECLARE_SYSCALL3(SYS_recvmsg);
+OE_DECLARE_SYSCALL3_M(SYS_recvmsg);
 #if __x86_64__ || _M_X64
 OE_DECLARE_SYSCALL2(SYS_rename);
 #endif
@@ -161,20 +227,22 @@ OE_DECLARE_SYSCALL5(SYS_renameat);
 OE_DECLARE_SYSCALL1(SYS_rmdir);
 #endif
 #if __x86_64__ || _M_X64
-OE_DECLARE_SYSCALL5(SYS_select);
+OE_DECLARE_SYSCALL5_M(SYS_select);
 #endif
 OE_DECLARE_SYSCALL6(SYS_sendto);
-OE_DECLARE_SYSCALL3(SYS_sendmsg);
-OE_DECLARE_SYSCALL5(SYS_setsockopt);
-OE_DECLARE_SYSCALL2(SYS_shutdown);
-OE_DECLARE_SYSCALL3(SYS_socket);
-OE_DECLARE_SYSCALL4(SYS_socketpair);
+OE_DECLARE_SYSCALL3_M(SYS_sendmsg);
+OE_DECLARE_SYSCALL5_M(SYS_setsockopt);
+OE_DECLARE_SYSCALL2_M(SYS_shutdown);
+OE_DECLARE_SYSCALL3_M(SYS_socket);
+OE_DECLARE_SYSCALL4_M(SYS_socketpair);
 #if __x86_64__ || _M_X64
 OE_DECLARE_SYSCALL2(SYS_stat);
 #endif
 OE_DECLARE_SYSCALL2(SYS_truncate);
-OE_DECLARE_SYSCALL3(SYS_write);
-OE_DECLARE_SYSCALL3(SYS_writev);
+// Needed by musl/src/stdio/pclose.c
+OE_DECLARE_SYSCALL4(SYS_wait4);
+OE_DECLARE_SYSCALL3_M(SYS_write);
+OE_DECLARE_SYSCALL3_M(SYS_writev);
 OE_DECLARE_SYSCALL1(SYS_uname);
 #if __x86_64__ || _M_X64
 OE_DECLARE_SYSCALL1(SYS_unlink);

--- a/libc/syscalls.c
+++ b/libc/syscalls.c
@@ -8,6 +8,7 @@
 #include <openenclave/corelibc/errno.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/calls.h>
+#include <openenclave/internal/syscall/declarations.h>
 #include <openenclave/internal/syscall/hook.h>
 #include <openenclave/internal/syscall/sys/stat.h>
 #include <openenclave/internal/syscall/sys/syscall.h>
@@ -29,21 +30,24 @@ static const uint64_t _SEC_TO_MSEC = 1000UL;
 static const uint64_t _MSEC_TO_USEC = 1000UL;
 static const uint64_t _MSEC_TO_NSEC = 1000000UL;
 
-static long _syscall_mmap(long n, ...)
+OE_DEFINE_SYSCALL6(SYS_mmap)
 {
     /* Always fail */
-    OE_UNUSED(n);
     return EPERM;
 }
 
-static long _syscall_clock_gettime(long n, long x1, long x2)
+OE_DEFINE_SYSCALL2(SYS_munmap)
 {
-    clockid_t clk_id = (clockid_t)x1;
-    struct timespec* tp = (struct timespec*)x2;
+    /* Always fail */
+    return EPERM;
+}
+
+OE_DEFINE_SYSCALL2(SYS_clock_gettime)
+{
+    clockid_t clk_id = (clockid_t)arg1;
+    struct timespec* tp = (struct timespec*)arg2;
     int ret = -1;
     uint64_t msec;
-
-    OE_UNUSED(n);
 
     if (!tp)
         goto done;
@@ -68,14 +72,12 @@ done:
     return ret;
 }
 
-static long _syscall_gettimeofday(long n, long x1, long x2)
+OE_DEFINE_SYSCALL2(SYS_gettimeofday)
 {
-    struct timeval* tv = (struct timeval*)x1;
-    void* tz = (void*)x2;
+    struct timeval* tv = (struct timeval*)arg1;
+    void* tz = (void*)arg2;
     int ret = -1;
     uint64_t msec;
-
-    OE_UNUSED(n);
 
     if (tv)
         memset(tv, 0, sizeof(struct timeval));
@@ -211,12 +213,10 @@ long __syscall(long n, long x1, long x2, long x3, long x4, long x5, long x6)
     /* Handle syscall internally if possible. */
     switch (n)
     {
-        case SYS_gettimeofday:
-            return _syscall_gettimeofday(n, x1, x2);
-        case SYS_clock_gettime:
-            return _syscall_clock_gettime(n, x1, x2);
-        case SYS_mmap:
-            return _syscall_mmap(n, x1, x2, x3, x4, x5, x6);
+        OE_SYSCALL_DISPATCH(SYS_clock_gettime, x1, x2);
+        OE_SYSCALL_DISPATCH(SYS_gettimeofday, x1, x2);
+        OE_SYSCALL_DISPATCH(SYS_mmap, x1, x2, x3, x4, x5, x6);
+
         default:
             /* Drop through and let the code below handle the syscall. */
             break;
@@ -239,12 +239,6 @@ long __syscall(long n, long x1, long x2, long x3, long x4, long x5, long x6)
     /* All other MUSL-initiated syscalls are aborted. */
     fprintf(stderr, "error: unhandled syscall: n=%lu\n", n);
     abort();
-}
-
-/* Intercept __syscalls_cp() from MUSL */
-long __syscall_cp(long n, long x1, long x2, long x3, long x4, long x5, long x6)
-{
-    return __syscall(n, x1, x2, x3, x4, x5, x6);
 }
 
 long syscall(long number, ...)

--- a/syscall/syscall.c
+++ b/syscall/syscall.c
@@ -34,7 +34,7 @@ typedef int (*ioctl_proc)(
     long arg3,
     long arg4);
 
-OE_DEFINE_SYSCALL3(SYS_accept)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_accept)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -44,7 +44,7 @@ OE_DEFINE_SYSCALL3(SYS_accept)
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL2(SYS_access)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_access)
 {
     oe_errno = 0;
     const char* pathname = (const char*)arg1;
@@ -54,7 +54,7 @@ OE_DEFINE_SYSCALL2(SYS_access)
 }
 #endif
 
-OE_DEFINE_SYSCALL3(SYS_bind)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_bind)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -63,7 +63,7 @@ OE_DEFINE_SYSCALL3(SYS_bind)
     return oe_bind(sockfd, addr, addrlen);
 }
 
-OE_DEFINE_SYSCALL1(SYS_chdir)
+OE_WEAK OE_DEFINE_SYSCALL1(SYS_chdir)
 {
     oe_errno = 0;
     char* path = (char*)arg1;
@@ -71,7 +71,7 @@ OE_DEFINE_SYSCALL1(SYS_chdir)
     return oe_chdir(path);
 }
 
-OE_DEFINE_SYSCALL1(SYS_close)
+OE_WEAK OE_DEFINE_SYSCALL1_M(SYS_close)
 {
     oe_errno = 0;
     int fd = (int)arg1;
@@ -79,7 +79,7 @@ OE_DEFINE_SYSCALL1(SYS_close)
     return oe_close(fd);
 }
 
-OE_DEFINE_SYSCALL3(SYS_connect)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_connect)
 {
     oe_errno = 0;
     int sd = (int)arg1;
@@ -89,7 +89,7 @@ OE_DEFINE_SYSCALL3(SYS_connect)
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL2(SYS_creat)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_creat)
 {
     oe_errno = 0;
     long ret = -1;
@@ -111,7 +111,7 @@ OE_DEFINE_SYSCALL2(SYS_creat)
 }
 #endif
 
-OE_DEFINE_SYSCALL1(SYS_dup)
+OE_WEAK OE_DEFINE_SYSCALL1(SYS_dup)
 {
     oe_errno = 0;
     int fd = (int)arg1;
@@ -120,7 +120,7 @@ OE_DEFINE_SYSCALL1(SYS_dup)
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL2(SYS_dup2)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_dup2)
 {
     oe_errno = 0;
     int oldfd = (int)arg1;
@@ -130,7 +130,7 @@ OE_DEFINE_SYSCALL2(SYS_dup2)
 }
 #endif
 
-OE_DEFINE_SYSCALL3(SYS_dup3)
+OE_WEAK OE_DEFINE_SYSCALL3(SYS_dup3)
 {
     oe_errno = 0;
     long ret = -1;
@@ -150,7 +150,7 @@ done:
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL1(SYS_epoll_create)
+OE_WEAK OE_DEFINE_SYSCALL1(SYS_epoll_create)
 {
     oe_errno = 0;
     int size = (int)arg1;
@@ -158,14 +158,14 @@ OE_DEFINE_SYSCALL1(SYS_epoll_create)
 }
 #endif
 
-OE_DEFINE_SYSCALL1(SYS_epoll_create1)
+OE_WEAK OE_DEFINE_SYSCALL1(SYS_epoll_create1)
 {
     oe_errno = 0;
     int flags = (int)arg1;
     return oe_epoll_create1(flags);
 }
 
-OE_DEFINE_SYSCALL4(SYS_epoll_ctl)
+OE_WEAK OE_DEFINE_SYSCALL4(SYS_epoll_ctl)
 {
     oe_errno = 0;
     int epfd = (int)arg1;
@@ -175,7 +175,7 @@ OE_DEFINE_SYSCALL4(SYS_epoll_ctl)
     return oe_epoll_ctl(epfd, op, fd, event);
 }
 
-OE_DEFINE_SYSCALL5(SYS_epoll_pwait)
+OE_WEAK OE_DEFINE_SYSCALL5_M(SYS_epoll_pwait)
 {
     oe_errno = 0;
     int epfd = (int)arg1;
@@ -187,7 +187,7 @@ OE_DEFINE_SYSCALL5(SYS_epoll_pwait)
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL4(SYS_epoll_wait)
+OE_WEAK OE_DEFINE_SYSCALL4_M(SYS_epoll_wait)
 {
     oe_errno = 0;
     int epfd = (int)arg1;
@@ -198,7 +198,7 @@ OE_DEFINE_SYSCALL4(SYS_epoll_wait)
 }
 #endif
 
-OE_DEFINE_SYSCALL1(SYS_exit)
+OE_WEAK OE_DEFINE_SYSCALL1(SYS_exit)
 {
     oe_errno = 0;
     int status = (int)arg1;
@@ -209,13 +209,14 @@ OE_DEFINE_SYSCALL1(SYS_exit)
     return -1;
 }
 
-OE_DEFINE_SYSCALL0(SYS_exit_group)
+OE_WEAK OE_DEFINE_SYSCALL1(SYS_exit_group)
 {
+    OE_UNUSED(arg1);
     oe_errno = 0;
     return 0;
 }
 
-OE_DEFINE_SYSCALL4(SYS_faccessat)
+OE_WEAK OE_DEFINE_SYSCALL4(SYS_faccessat)
 {
     oe_errno = 0;
     long ret = -1;
@@ -241,16 +242,19 @@ done:
     return ret;
 }
 
-OE_DEFINE_SYSCALL3(SYS_fcntl)
+OE_WEAK OE_DEFINE_SYSCALL2_M(SYS_fcntl)
 {
+    oe_va_list ap;
+    oe_va_start(ap, arg2);
     oe_errno = 0;
     int fd = (int)arg1;
     int cmd = (int)arg2;
-    uint64_t arg = (uint64_t)arg3;
+    uint64_t arg = oe_va_arg(ap, uint64_t);
+    oe_va_end(ap);
     return oe_fcntl(fd, cmd, arg);
 }
 
-OE_DEFINE_SYSCALL1(SYS_fdatasync)
+OE_WEAK OE_DEFINE_SYSCALL1_M(SYS_fdatasync)
 {
     oe_errno = 0;
     const int fd = (int)arg1;
@@ -258,7 +262,7 @@ OE_DEFINE_SYSCALL1(SYS_fdatasync)
     return oe_fdatasync(fd);
 }
 
-OE_DEFINE_SYSCALL2(SYS_flock)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_flock)
 {
     oe_errno = 0;
     int fd = (int)arg1;
@@ -267,7 +271,7 @@ OE_DEFINE_SYSCALL2(SYS_flock)
     return oe_flock(fd, operation);
 }
 
-OE_DEFINE_SYSCALL2(SYS_fstat)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_fstat)
 {
     oe_errno = 0;
     const int fd = (int)arg1;
@@ -275,7 +279,7 @@ OE_DEFINE_SYSCALL2(SYS_fstat)
     return oe_fstat(fd, buf);
 }
 
-OE_DEFINE_SYSCALL1(SYS_fsync)
+OE_WEAK OE_DEFINE_SYSCALL1_M(SYS_fsync)
 {
     oe_errno = 0;
     const int fd = (int)arg1;
@@ -283,7 +287,15 @@ OE_DEFINE_SYSCALL1(SYS_fsync)
     return oe_fsync(fd);
 }
 
-OE_DEFINE_SYSCALL2(SYS_getcwd)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_futex)
+{
+    OE_UNUSED(arg1);
+    OE_UNUSED(arg2);
+    OE_UNUSED(arg3);
+    return -1;
+}
+
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_getcwd)
 {
     oe_errno = 0;
     long ret = -1;
@@ -302,7 +314,7 @@ OE_DEFINE_SYSCALL2(SYS_getcwd)
     return ret;
 }
 
-OE_DEFINE_SYSCALL3(SYS_getdents64)
+OE_WEAK OE_DEFINE_SYSCALL3(SYS_getdents)
 {
     oe_errno = 0;
     unsigned int fd = (unsigned int)arg1;
@@ -311,19 +323,28 @@ OE_DEFINE_SYSCALL3(SYS_getdents64)
     return oe_getdents64(fd, ent, count);
 }
 
-OE_DEFINE_SYSCALL0(SYS_getegid)
+OE_WEAK OE_DEFINE_SYSCALL3(SYS_getdents64)
+{
+    oe_errno = 0;
+    unsigned int fd = (unsigned int)arg1;
+    struct oe_dirent* ent = (struct oe_dirent*)arg2;
+    unsigned int count = (unsigned int)arg3;
+    return oe_getdents64(fd, ent, count);
+}
+
+OE_WEAK OE_DEFINE_SYSCALL0(SYS_getegid)
 {
     oe_errno = 0;
     return (long)oe_getegid();
 }
 
-OE_DEFINE_SYSCALL0(SYS_geteuid)
+OE_WEAK OE_DEFINE_SYSCALL0(SYS_geteuid)
 {
     oe_errno = 0;
     return (long)oe_geteuid();
 }
 
-OE_DEFINE_SYSCALL2(SYS_getgroups)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_getgroups)
 {
     oe_errno = 0;
     int size = (int)arg1;
@@ -331,7 +352,7 @@ OE_DEFINE_SYSCALL2(SYS_getgroups)
     return (long)oe_getgroups(size, list);
 }
 
-OE_DEFINE_SYSCALL3(SYS_getpeername)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_getpeername)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -340,7 +361,7 @@ OE_DEFINE_SYSCALL3(SYS_getpeername)
     return oe_getpeername(sockfd, (struct oe_sockaddr*)addr, addrlen);
 }
 
-OE_DEFINE_SYSCALL1(SYS_getpgid)
+OE_WEAK OE_DEFINE_SYSCALL1(SYS_getpgid)
 {
     oe_errno = 0;
     int pid = (int)arg1;
@@ -348,32 +369,32 @@ OE_DEFINE_SYSCALL1(SYS_getpgid)
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL0(SYS_getpgrp)
+OE_WEAK OE_DEFINE_SYSCALL0(SYS_getpgrp)
 {
     oe_errno = 0;
     return (long)oe_getpgrp();
 }
 #endif
 
-OE_DEFINE_SYSCALL0(SYS_getpid)
+OE_WEAK OE_DEFINE_SYSCALL0(SYS_getpid)
 {
     oe_errno = 0;
     return (long)oe_getpid();
 }
 
-OE_DEFINE_SYSCALL0(SYS_getgid)
+OE_WEAK OE_DEFINE_SYSCALL0(SYS_getgid)
 {
     oe_errno = 0;
     return (long)oe_getgid();
 }
 
-OE_DEFINE_SYSCALL0(SYS_getppid)
+OE_WEAK OE_DEFINE_SYSCALL0(SYS_getppid)
 {
     oe_errno = 0;
     return (long)oe_getppid();
 }
 
-OE_DEFINE_SYSCALL3(SYS_getsockname)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_getsockname)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -382,7 +403,7 @@ OE_DEFINE_SYSCALL3(SYS_getsockname)
     return oe_getsockname(sockfd, (struct oe_sockaddr*)addr, addrlen);
 }
 
-OE_DEFINE_SYSCALL5(SYS_getsockopt)
+OE_WEAK OE_DEFINE_SYSCALL5_M(SYS_getsockopt)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -393,27 +414,30 @@ OE_DEFINE_SYSCALL5(SYS_getsockopt)
     return oe_getsockopt(sockfd, level, optname, optval, optlen);
 }
 
-OE_DEFINE_SYSCALL0(SYS_getuid)
+OE_WEAK OE_DEFINE_SYSCALL0(SYS_getuid)
 {
     oe_errno = 0;
     return (long)oe_getuid();
 }
 
-OE_DEFINE_SYSCALL6(SYS_ioctl)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_ioctl)
 {
+    oe_va_list ap;
+    oe_va_start(ap, arg3);
     oe_errno = 0;
     int fd = (int)arg1;
     unsigned long request = (unsigned long)arg2;
     long p1 = arg3;
-    long p2 = arg4;
-    long p3 = arg5;
-    long p4 = arg6;
+    long p2 = oe_va_arg(ap, long);
+    long p3 = oe_va_arg(ap, long);
+    long p4 = oe_va_arg(ap, long);
+    oe_va_end(ap);
 
     return oe_ioctl(fd, request, p1, p2, p3, p4);
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL2(SYS_link)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_link)
 {
     oe_errno = 0;
     const char* oldpath = (const char*)arg1;
@@ -422,7 +446,7 @@ OE_DEFINE_SYSCALL2(SYS_link)
 }
 #endif
 
-OE_DEFINE_SYSCALL5(SYS_linkat)
+OE_WEAK OE_DEFINE_SYSCALL5(SYS_linkat)
 {
     oe_errno = 0;
     long ret = -1;
@@ -455,7 +479,7 @@ done:
     return ret;
 }
 
-OE_DEFINE_SYSCALL2(SYS_listen)
+OE_WEAK OE_DEFINE_SYSCALL2_M(SYS_listen)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -463,7 +487,7 @@ OE_DEFINE_SYSCALL2(SYS_listen)
     return oe_listen(sockfd, backlog);
 }
 
-OE_DEFINE_SYSCALL3(SYS_lseek)
+OE_WEAK OE_WEAK OE_DEFINE_SYSCALL3(SYS_lseek)
 {
     oe_errno = 0;
     int fd = (int)arg1;
@@ -473,7 +497,7 @@ OE_DEFINE_SYSCALL3(SYS_lseek)
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL2(SYS_mkdir)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_mkdir)
 {
     oe_errno = 0;
     const char* pathname = (const char*)arg1;
@@ -483,7 +507,7 @@ OE_DEFINE_SYSCALL2(SYS_mkdir)
 }
 #endif
 
-OE_DEFINE_SYSCALL3(SYS_mkdirat)
+OE_WEAK OE_DEFINE_SYSCALL3(SYS_mkdirat)
 {
     oe_errno = 0;
     long ret = -1;
@@ -502,7 +526,7 @@ done:
     return ret;
 }
 
-OE_DEFINE_SYSCALL5(SYS_mount)
+OE_WEAK OE_DEFINE_SYSCALL5(SYS_mount)
 {
     oe_errno = 0;
     const char* source = (const char*)arg1;
@@ -514,7 +538,7 @@ OE_DEFINE_SYSCALL5(SYS_mount)
     return oe_mount(source, target, fstype, flags, data);
 }
 
-OE_DEFINE_SYSCALL2(SYS_nanosleep)
+OE_WEAK OE_DEFINE_SYSCALL2_M(SYS_nanosleep)
 {
     oe_errno = 0;
     struct oe_timespec* req = (struct oe_timespec*)arg1;
@@ -522,7 +546,7 @@ OE_DEFINE_SYSCALL2(SYS_nanosleep)
     return (long)oe_nanosleep(req, rem);
 }
 
-OE_DEFINE_SYSCALL4(SYS_newfstatat)
+OE_WEAK OE_DEFINE_SYSCALL4(SYS_newfstatat)
 {
     oe_errno = 0;
     long ret = -1;
@@ -549,14 +573,17 @@ done:
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL3(SYS_open)
+OE_WEAK OE_DEFINE_SYSCALL2_M(SYS_open)
 {
+    oe_va_list ap;
+    oe_va_start(ap, arg2);
     oe_errno = 0;
     long ret = -1;
 
     const char* pathname = (const char*)arg1;
     int flags = (int)arg2;
-    uint32_t mode = (uint32_t)arg3;
+    uint32_t mode = (uint32_t)oe_va_arg(ap, long);
+    oe_va_end(ap);
 
     ret = oe_open(pathname, flags, mode);
 
@@ -569,7 +596,7 @@ done:
 }
 #endif
 
-OE_DEFINE_SYSCALL4(SYS_openat)
+OE_WEAK OE_DEFINE_SYSCALL4(SYS_openat)
 {
     oe_errno = 0;
     long ret = -1;
@@ -595,7 +622,7 @@ done:
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL3(SYS_poll)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_poll)
 {
     oe_errno = 0;
     struct oe_pollfd* fds = (struct oe_pollfd*)arg1;
@@ -605,7 +632,7 @@ OE_DEFINE_SYSCALL3(SYS_poll)
 }
 #endif
 
-OE_DEFINE_SYSCALL4(SYS_ppoll)
+OE_WEAK OE_DEFINE_SYSCALL4_M(SYS_ppoll)
 {
     oe_errno = 0;
     long ret = -1;
@@ -655,7 +682,7 @@ done:
     return ret;
 }
 
-OE_DEFINE_SYSCALL4(SYS_pread64)
+OE_WEAK OE_DEFINE_SYSCALL4_M(SYS_pread)
 {
     oe_errno = 0;
     const int fd = (int)arg1;
@@ -666,7 +693,18 @@ OE_DEFINE_SYSCALL4(SYS_pread64)
     return oe_pread(fd, buf, count, offset);
 }
 
-OE_DEFINE_SYSCALL5(SYS_pselect6)
+OE_WEAK OE_DEFINE_SYSCALL4(SYS_pread64)
+{
+    oe_errno = 0;
+    const int fd = (int)arg1;
+    void* const buf = (void*)arg2;
+    const size_t count = (size_t)arg3;
+    const oe_off_t offset = (oe_off_t)arg4;
+
+    return oe_pread(fd, buf, count, offset);
+}
+
+OE_WEAK OE_DEFINE_SYSCALL5_M(SYS_pselect6)
 {
     oe_errno = 0;
     int nfds = (int)arg1;
@@ -687,7 +725,7 @@ OE_DEFINE_SYSCALL5(SYS_pselect6)
     return oe_select(nfds, readfds, writefds, exceptfds, tv);
 }
 
-OE_DEFINE_SYSCALL4(SYS_pwrite64)
+OE_WEAK OE_DEFINE_SYSCALL4_M(SYS_pwrite)
 {
     oe_errno = 0;
     const int fd = (int)arg1;
@@ -698,7 +736,18 @@ OE_DEFINE_SYSCALL4(SYS_pwrite64)
     return oe_pwrite(fd, buf, count, offset);
 }
 
-OE_DEFINE_SYSCALL3(SYS_read)
+OE_WEAK OE_DEFINE_SYSCALL4(SYS_pwrite64)
+{
+    oe_errno = 0;
+    const int fd = (int)arg1;
+    const void* const buf = (void*)arg2;
+    const size_t count = (size_t)arg3;
+    const oe_off_t offset = (oe_off_t)arg4;
+
+    return oe_pwrite(fd, buf, count, offset);
+}
+
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_read)
 {
     oe_errno = 0;
     int fd = (int)arg1;
@@ -708,7 +757,7 @@ OE_DEFINE_SYSCALL3(SYS_read)
     return oe_read(fd, buf, count);
 }
 
-OE_DEFINE_SYSCALL3(SYS_readv)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_readv)
 {
     oe_errno = 0;
     int fd = (int)arg1;
@@ -718,7 +767,7 @@ OE_DEFINE_SYSCALL3(SYS_readv)
     return oe_readv(fd, iov, iovcnt);
 }
 
-OE_DEFINE_SYSCALL6(SYS_recvfrom)
+OE_WEAK OE_DEFINE_SYSCALL6(SYS_recvfrom)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -731,7 +780,7 @@ OE_DEFINE_SYSCALL6(SYS_recvfrom)
     return oe_recvfrom(sockfd, buf, len, flags, dest_add, addrlen);
 }
 
-OE_DEFINE_SYSCALL3(SYS_recvmsg)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_recvmsg)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -742,7 +791,7 @@ OE_DEFINE_SYSCALL3(SYS_recvmsg)
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL2(SYS_rename)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_rename)
 {
     oe_errno = 0;
     const char* oldpath = (const char*)arg1;
@@ -752,7 +801,7 @@ OE_DEFINE_SYSCALL2(SYS_rename)
 }
 #endif
 
-OE_DEFINE_SYSCALL5(SYS_renameat)
+OE_WEAK OE_DEFINE_SYSCALL5(SYS_renameat)
 {
     oe_errno = 0;
     long ret = -1;
@@ -786,7 +835,7 @@ done:
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL1(SYS_rmdir)
+OE_WEAK OE_DEFINE_SYSCALL1(SYS_rmdir)
 {
     oe_errno = 0;
     const char* pathname = (const char*)arg1;
@@ -795,7 +844,7 @@ OE_DEFINE_SYSCALL1(SYS_rmdir)
 #endif
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL5(SYS_select)
+OE_WEAK OE_DEFINE_SYSCALL5_M(SYS_select)
 {
     oe_errno = 0;
     int nfds = (int)arg1;
@@ -807,7 +856,7 @@ OE_DEFINE_SYSCALL5(SYS_select)
 }
 #endif
 
-OE_DEFINE_SYSCALL6(SYS_sendto)
+OE_WEAK OE_DEFINE_SYSCALL6(SYS_sendto)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -820,7 +869,7 @@ OE_DEFINE_SYSCALL6(SYS_sendto)
     return oe_sendto(sockfd, buf, len, flags, dest_add, addrlen);
 }
 
-OE_DEFINE_SYSCALL3(SYS_sendmsg)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_sendmsg)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -830,7 +879,7 @@ OE_DEFINE_SYSCALL3(SYS_sendmsg)
     return oe_sendmsg(sockfd, (struct oe_msghdr*)buf, flags);
 }
 
-OE_DEFINE_SYSCALL5(SYS_setsockopt)
+OE_WEAK OE_DEFINE_SYSCALL5_M(SYS_setsockopt)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -841,7 +890,7 @@ OE_DEFINE_SYSCALL5(SYS_setsockopt)
     return oe_setsockopt(sockfd, level, optname, optval, optlen);
 }
 
-OE_DEFINE_SYSCALL2(SYS_shutdown)
+OE_WEAK OE_DEFINE_SYSCALL2_M(SYS_shutdown)
 {
     oe_errno = 0;
     int sockfd = (int)arg1;
@@ -849,7 +898,7 @@ OE_DEFINE_SYSCALL2(SYS_shutdown)
     return oe_shutdown(sockfd, how);
 }
 
-OE_DEFINE_SYSCALL3(SYS_socket)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_socket)
 {
     oe_errno = 0;
     int domain = (int)arg1;
@@ -858,7 +907,7 @@ OE_DEFINE_SYSCALL3(SYS_socket)
     return oe_socket(domain, type, protocol);
 }
 
-OE_DEFINE_SYSCALL4(SYS_socketpair)
+OE_WEAK OE_DEFINE_SYSCALL4_M(SYS_socketpair)
 {
     oe_errno = 0;
     int domain = (int)arg1;
@@ -870,7 +919,7 @@ OE_DEFINE_SYSCALL4(SYS_socketpair)
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL2(SYS_stat)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_stat)
 {
     oe_errno = 0;
     const char* pathname = (const char*)arg1;
@@ -879,7 +928,7 @@ OE_DEFINE_SYSCALL2(SYS_stat)
 }
 #endif
 
-OE_DEFINE_SYSCALL2(SYS_truncate)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_truncate)
 {
     oe_errno = 0;
     const char* path = (const char*)arg1;
@@ -888,7 +937,7 @@ OE_DEFINE_SYSCALL2(SYS_truncate)
     return oe_truncate(path, length);
 }
 
-OE_DEFINE_SYSCALL3(SYS_write)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_write)
 {
     oe_errno = 0;
     int fd = (int)arg1;
@@ -898,7 +947,7 @@ OE_DEFINE_SYSCALL3(SYS_write)
     return oe_write(fd, buf, count);
 }
 
-OE_DEFINE_SYSCALL3(SYS_writev)
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_writev)
 {
     oe_errno = 0;
     int fd = (int)arg1;
@@ -908,7 +957,7 @@ OE_DEFINE_SYSCALL3(SYS_writev)
     return oe_writev(fd, iov, iovcnt);
 }
 
-OE_DEFINE_SYSCALL1(SYS_uname)
+OE_WEAK OE_DEFINE_SYSCALL1(SYS_uname)
 {
     oe_errno = 0;
     struct oe_utsname* buf = (struct oe_utsname*)arg1;
@@ -916,7 +965,7 @@ OE_DEFINE_SYSCALL1(SYS_uname)
 }
 
 #if __x86_64__ || _M_X64
-OE_DEFINE_SYSCALL1(SYS_unlink)
+OE_WEAK OE_DEFINE_SYSCALL1(SYS_unlink)
 {
     oe_errno = 0;
     const char* pathname = (const char*)arg1;
@@ -925,7 +974,7 @@ OE_DEFINE_SYSCALL1(SYS_unlink)
 }
 #endif
 
-OE_DEFINE_SYSCALL3(SYS_unlinkat)
+OE_WEAK OE_DEFINE_SYSCALL3(SYS_unlinkat)
 {
     oe_errno = 0;
     long ret = -1;
@@ -953,7 +1002,7 @@ done:
     return ret;
 }
 
-OE_DEFINE_SYSCALL2(SYS_umount2)
+OE_WEAK OE_DEFINE_SYSCALL2(SYS_umount2)
 {
     oe_errno = 0;
     const char* target = (const char*)arg1;
@@ -1005,9 +1054,9 @@ static long _syscall(
         OE_SYSCALL_DISPATCH(SYS_epoll_wait, arg1, arg2, arg3, arg4);
 #endif
         OE_SYSCALL_DISPATCH(SYS_exit, arg1);
-        OE_SYSCALL_DISPATCH(SYS_exit_group);
+        OE_SYSCALL_DISPATCH(SYS_exit_group, arg1);
         OE_SYSCALL_DISPATCH(SYS_faccessat, arg1, arg2, arg3, arg4);
-        OE_SYSCALL_DISPATCH(SYS_fcntl, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_fcntl, arg1, arg2, arg3, arg4);
         OE_SYSCALL_DISPATCH(SYS_fdatasync, arg1);
         OE_SYSCALL_DISPATCH(SYS_flock, arg1, arg2);
         OE_SYSCALL_DISPATCH(SYS_fstat, arg1, arg2);

--- a/tests/mbed/enc/enc.c
+++ b/tests/mbed/enc/enc.c
@@ -7,6 +7,7 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/raise.h>
+#include <openenclave/internal/syscall/declarations.h>
 #include <openenclave/internal/syscall/hook.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -65,6 +66,114 @@ void test_checker(char* str)
     }
 }
 
+// Tests need these syscall overrides.
+__thread oe_result_t tls_result;
+OE_DEFINE_SYSCALL2_M(SYS_open)
+{
+    oe_va_list ap;
+    oe_va_start(ap, arg2);
+    errno = 0;
+    const int flags = (const int)arg2;
+    long arg3 = oe_va_arg(ap, long);
+    oe_va_end(ap);
+    if (flags == O_RDONLY)
+    {
+        int rval = 0;
+        tls_result =
+            mbed_test_open(&rval, (char*)arg1, (int)arg2, (mode_t)arg3);
+        return rval;
+    }
+    return -1;
+}
+
+OE_DEFINE_SYSCALL3_M(SYS_read)
+{
+    errno = 0;
+    int ret = -1;
+    ssize_t rval = 0;
+    const size_t buf_len = (size_t)arg3;
+    char* host_buf = (char*)oe_host_malloc(buf_len);
+    tls_result = mbed_test_read(&rval, (int)arg1, host_buf, buf_len);
+    if (rval > 0)
+    {
+        char* enc_buf = (char*)arg2;
+        memcpy(enc_buf, host_buf, buf_len);
+    }
+    ret = (int)rval;
+    oe_host_free(host_buf);
+    return ret;
+}
+
+OE_DEFINE_SYSCALL3_M(SYS_writev)
+{
+    OE_UNUSED(arg1);
+    errno = 0;
+    int ret = -1;
+    char* str_full;
+    size_t total_buff_len = 0;
+    const struct iovec* iov = (const struct iovec*)arg2;
+    int iovcnt = (int)arg3;
+    // Calculating  buffer length
+    for (int i = 0; i < iovcnt; i++)
+    {
+        total_buff_len += iov[i].iov_len;
+    }
+    // Considering string terminating character
+    total_buff_len += 1;
+    str_full = (char*)calloc(total_buff_len, sizeof(char));
+    for (int i = 0; i < iovcnt; i++)
+    {
+        strncat(str_full, iov[i].iov_base, iov[i].iov_len);
+    }
+    test_checker(str_full);
+    free(str_full);
+    // expecting the runtime implementation of SYS_writev to also be
+    // called.
+    tls_result = OE_UNSUPPORTED;
+    return ret;
+}
+
+OE_DEFINE_SYSCALL1_M(SYS_close)
+{
+    errno = 0;
+    int rval = 0;
+    tls_result = mbed_test_close(&rval, (int)arg1);
+    return rval;
+}
+
+OE_DEFINE_SYSCALL3(SYS_lseek)
+{
+    errno = 0;
+    int rval = 0;
+    tls_result = mbed_test_lseek(&rval, (int)arg1, (int)arg2, (int)arg3);
+    return rval;
+}
+
+static long _syscall_dispatch(
+    long number,
+    long arg1,
+    long arg2,
+    long arg3,
+    long arg4,
+    long arg5,
+    long arg6)
+{
+    OE_UNUSED(arg4);
+    OE_UNUSED(arg5);
+    OE_UNUSED(arg6);
+
+    switch (number)
+    {
+        OE_SYSCALL_DISPATCH(SYS_open, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_read, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_writev, arg1, arg2, arg3);
+        OE_SYSCALL_DISPATCH(SYS_close, arg1);
+        OE_SYSCALL_DISPATCH(SYS_lseek, arg1, arg2, arg3);
+        default:
+            return -1;
+    }
+}
+
 static oe_result_t _syscall_hook(
     long number,
     long arg1,
@@ -75,92 +184,19 @@ static oe_result_t _syscall_hook(
     long arg6,
     long* ret)
 {
-    oe_result_t result = OE_UNEXPECTED;
-    OE_UNUSED(arg4);
-    OE_UNUSED(arg5);
-    OE_UNUSED(arg6);
-
+    tls_result = OE_UNEXPECTED;
     if (ret)
         *ret = -1;
 
     if (!ret)
-        OE_RAISE(OE_INVALID_PARAMETER);
-
-    switch (number)
     {
-        case SYS_open:
-        {
-            const int flags = (const int)arg2;
-            if (flags == O_RDONLY)
-            {
-                int rval = 0;
-                result =
-                    mbed_test_open(&rval, (char*)arg1, (int)arg2, (mode_t)arg3);
-                *ret = rval;
-            }
-            break;
-        }
-        case SYS_read:
-        {
-            ssize_t rval = 0;
-            const size_t buf_len = (size_t)arg3;
-            char* host_buf = (char*)oe_host_malloc(buf_len);
-            result = mbed_test_read(&rval, (int)arg1, host_buf, buf_len);
-            if (rval > 0)
-            {
-                char* enc_buf = (char*)arg2;
-                memcpy(enc_buf, host_buf, buf_len);
-            }
-            *ret = (int)rval;
-            oe_host_free(host_buf);
-            break;
-        }
-        case SYS_writev:
-        {
-            char* str_full;
-            size_t total_buff_len = 0;
-            const struct iovec* iov = (const struct iovec*)arg2;
-            int iovcnt = (int)arg3;
-            // Calculating  buffer length
-            for (int i = 0; i < iovcnt; i++)
-            {
-                total_buff_len += iov[i].iov_len;
-            }
-            // Considering string terminating character
-            total_buff_len += 1;
-            str_full = (char*)calloc(total_buff_len, sizeof(char));
-            for (int i = 0; i < iovcnt; i++)
-            {
-                strncat(str_full, iov[i].iov_base, iov[i].iov_len);
-            }
-            test_checker(str_full);
-            free(str_full);
-            // expecting the runtime implementation of SYS_writev to also be
-            // called.
-            result = OE_UNSUPPORTED;
-            break;
-        }
-        case SYS_close:
-        {
-            int rval = 0;
-            result = mbed_test_close(&rval, (int)arg1);
-            break;
-        }
-        case SYS_lseek:
-        {
-            int rval = 0;
-            result = mbed_test_lseek(&rval, (int)arg1, (int)arg2, (int)arg3);
-            break;
-        }
-        case SYS_readv:
-        default:
-        {
-            OE_RAISE(OE_UNSUPPORTED);
-        }
+        tls_result = OE_INVALID_PARAMETER;
+        goto done;
     }
 
+    *ret = _syscall_dispatch(number, arg1, arg2, arg3, arg4, arg5, arg6);
 done:
-    return result;
+    return tls_result;
 }
 
 int test(


### PR DESCRIPTION
Syscalls are routed directly to their implementations rather than via a switch-case.
This has the following benefits:

- Reduced TCB
  Switch-case causes all the syscalls to be retained in an enclave.
  Routing directly allows the linker to eliminate those syscalls that are not used by
  an enclave.
  For example echo enclave reports only the following syscalls:
  ❯ objdump -t echo_enc | grep oe_SYS_
  000000000003002b l     F .text  00000000000000bc oe_SYS_clock_gettime_impl
  00000000000300e7 l     F .text  00000000000000c6 oe_SYS_gettimeofday_impl
  0000000000067e10 l     F .text  000000000000005f oe_SYS_futex_impl

- Syscall callgraphs can be analyzed easily.
  Since syscall implementations are directly called rather than via a switch-case,
  the static callgraphs are simpler and more accurate.
  ❯ callgraph.py echo_enc oe_SYS_gettimeofday_impl
 oe_SYS_gettimeofday_impl 0x300e7 /home/anakrish/work/syscall/libc/syscalls.c:75
  └── __clock_gettime 0x67d97 /home/anakrish/work/syscall/3rdparty/musl/musl/src/time/clock_gettime.c:25
      └── time 0x67d3f /home/anakrish/work/syscall/3rdparty/musl/musl/src/time/time.c:4
          └── x509_get_current_time 0x38ff8 /home/anakrish/work/syscall/3rdparty/mbedtls/mbedtls/library/x509.c:929
              ├── mbedtls_x509_time_is_past 0x3927a /home/anakrish/work/syscall/3rdparty/mbedtls/mbedtls/library/x509.c:994
              │   ├── x509_crt_verifycrl 0x36d69 /home/anakrish/work/syscall/3rdparty/mbedtls/mbedtls/library/x509_crt.c:1832
              │   │   └── x509_crt_verify_chain 0x37491 /home/anakrish/work/syscall/3rdparty/mbedtls/mbedtls/library/x509_crt.c:2288
              │   │       └── mbedtls_x509_crt_verify_restartable 0x37a3f /home/anakrish/work/syscall/3rdparty/mbedtls/mbedtls/library/x509_crt.c:2562
              │   │           └── mbedtls_x509_crt_verify 0x379e4 /home/anakrish/work/syscall/3rdparty/mbedtls/mbedtls/library

- It is possible to figure out the list of syscalls retained in an enclave via:
  `objdump -t enclave-filename | grep oe_SYS_`

Details

- Syscalls are most often performed by libc (in our case MUSL) rather than the user code.
  A syscall in MUSL of the form
      syscall(SYS_open, a, b)
  is converted to
      oe_SYS_open_impl(a, b)
  avoiding the dispatch via switch-case.
  This is accomplished by patching musl/src/internal/syscall.h.

  Note: OE currently (prior to this PR) relies on SYSCALL_NO_INLINE define to get MUSL to
  not use SYSCALL instruction and instead call `syscall` function for dispatching syscalls.
  SYSCALL_NO_INLINE macro has been removed in newer versions of MUSL and MUSL no longer
  provides the above customization that we want. Therefore we'd anyways have to patch
  musl/src/internal/syscall.h when we upgrade MUSL.

- The existing switch-case based dispatching have been retained for
   - use by libOS. It may turn out that libOS does not need the switch-case based
     dispatching at which point we can remove it.
   - the case where user code directly makes a syscall instead relying of MUSL.
     Such cases ought to be quite rare.

- Syscall implementations are declared WEAK so that they can be overridden.
  This is intended for use by tests and not by users.
  This provides a (cleaner IMO) alternative to syscall hooks.
  The syscall function names have oe_SYS_ prefix and the chance of user accidentally
  overriding a syscall implementation is quite low. The chance can be further minimized
  by obfuscating the prefix.

- N_M (N or More) syscalls.
  Some syscalls take N or more parameters. Such syscalls are declared and defined using
  the N_M macros.
  E.g:
      OE_DEFINE_SYSCALL2_M(Sys_open)
  Sys_open is called with atleast 2 parameters; but sometimes with 3. There is no easy
  way to capture this in C. It C++ it is possible to provide overloads and capture all
  the calling patterns. As a reasonable alternative, we declare SYS_open to take 2 or
  more parameters.

  Tracking such syscalls will allows us in future to make sure that OE implementations
  of syscalls do indeed consume all the supplied parameters.

  MUSL sometimes calls certain syscalls with syscall_cp macro which always supplies
  6 parameters to the syscall - the original supplied parameters followed by zeros.
  It is not clear why MUSL does this. But this has the consequence that
  syscalls that are called thus must be declared using the N_M macros.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>