### PR TITLE
Fix failure in nightly builds on Ubuntu 16.04 GCC

### DIFF
--- a/tests/abi/enc/CMakeLists.txt
+++ b/tests/abi/enc/CMakeLists.txt
@@ -15,10 +15,10 @@ add_enclave(
   abi_enc
   UUID
   7B7FB79E-2B73-46C5-8C30-3A71C014BD85
+  CXX
   SOURCES
   enc.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/abi_t.c)
 
 enclave_include_directories(abi_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                             ${CMAKE_CURRENT_SOURCE_DIR})
-enclave_link_libraries(abi_enc oelibc)


### PR DESCRIPTION
Add oelibcxx dependency. Without this, abi_enc build is launched befre libcxx headers are generated at correct location.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>