### PR TITLE
Fix the missing include paths when linking against OpenSSL library

### DIFF
--- a/3rdparty/openssl/CMakeLists.txt
+++ b/3rdparty/openssl/CMakeLists.txt
@@ -911,13 +911,16 @@ add_enclave_library(
 
 enclave_include_directories(
   opensslcrypto PRIVATE $<BUILD_INTERFACE:${OPENSSL_BUILD_INCLUDES}>
-  $<BUILD_INTERFACE:${OPENSSL_DIR}> $<BUILD_INTERFACE:${OPENSSL_DIR}/include>
+  $<BUILD_INTERFACE:${OPENSSL_DIR}> $<BUILD_INTERFACE:${OPENSSL_DIR}/include>)
+
+# Only mark the directories that include headers to be published as PUBLIC.
+enclave_include_directories(
+  opensslcrypto PUBLIC $<BUILD_INTERFACE:${OE_INCDIR}/openenclave>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty>)
 
 enclave_include_directories(
   opensslssl PRIVATE $<BUILD_INTERFACE:${OPENSSL_BUILD_INCLUDES}>
-  $<BUILD_INTERFACE:${OPENSSL_DIR}> $<BUILD_INTERFACE:${OPENSSL_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty>)
+  $<BUILD_INTERFACE:${OPENSSL_DIR}> $<BUILD_INTERFACE:${OPENSSL_DIR}/include>)
 
 maybe_build_using_clangw(opensslcrypto)
 maybe_build_using_clangw(opensslssl)

--- a/tests/openssl_unsupported/enc/CMakeLists.txt
+++ b/tests/openssl_unsupported/enc/CMakeLists.txt
@@ -23,9 +23,8 @@ function (add_unsupported_test NAME)
 
   enclave_compile_definitions(openssl_unsupported_${NAME}_enc PRIVATE ${DEFINE})
 
-  enclave_include_directories(
-    openssl_unsupported_${NAME}_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-    ${OE_INCDIR}/openenclave)
+  enclave_include_directories(openssl_unsupported_${NAME}_enc PRIVATE
+                              ${CMAKE_CURRENT_BINARY_DIR})
 
   enclave_link_libraries(openssl_unsupported_${NAME}_enc openssl oelibc
                          oehostsock oehostfs oehostresolver)


### PR DESCRIPTION
This PR ensures that the include path is added when linking against OpenSSL library.


Fixes #3745

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>