### PR TITLE
Drop opt_params condition for ECDSA/EPID case

### DIFF
--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -708,8 +708,8 @@ oe_result_t oe_sgx_qe_get_quote(
         }
         else // ECDSA
         {
-            // For EPID, no opt_params is taken.
-            if (opt_params || opt_params_size)
+            // For EPID, opt_params_size should be zero.
+            if (opt_params_size)
                 OE_RAISE(OE_INVALID_PARAMETER);
         }
 


### PR DESCRIPTION
Drop the `opt_params` condition to resolve the issue where the attestation sample could not be run after installing quote-ex library.

Fix #3742 .

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>