### PR TITLE
Enable the Attested TLS sample with OpenSSL on CI and Update documentations

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -32,7 +32,8 @@ The following samples demonstrate how to develop enclave applications using OE A
 #### [File-Encryptor](file-encryptor/README.md)
 
 - Show how to encrypt and decrypt data inside an enclave
-- Use AES mbedTLS API to perform encryption and decryption
+- Use AES Mbed TLS API to perform encryption and decryption
+  - *Note:* this sample does not support OpenSSL yet.
 
 #### [Data-Sealing](data-sealing/README.md)
 
@@ -41,11 +42,15 @@ The following samples demonstrate how to develop enclave applications using OE A
 - Explore two supported seal polices
   - OE_SEAL_POLICY_UNIQUE
   - OE_SEAL_POLICY_PRODUCT
+- Use AES and MD Mbed TLS APIs to perform sealing and unsealing
+  - *Note:* this sample does not support OpenSSL yet.
 
 #### [Attestation](attestation/README.md)
 
 - Explain how OE attestation works
 - Demonstrate an implementation of attestation between two enclaves
+- Use SHA and PCKS1 Mbed TLS APIs to perform hashing and encryption
+  - *Note:* this sample does not support OpenSSL yet.
 
 #### [Attested TLS](attested_tls/README.md)
 
@@ -53,6 +58,7 @@ The following samples demonstrate how to develop enclave applications using OE A
 - Demonstrate an implementation for how to establish an Attested TLS channel
   - between two enclaves
   - between one non-enclave client and an enclave
+- Deomnstrate how to build the sample with either Mbed TLS or OpenSSL libraries
 
 #### [Switchless Calls](switchless/README.md)
 

--- a/samples/attestation/CMakeLists.txt
+++ b/samples/attestation/CMakeLists.txt
@@ -8,9 +8,9 @@ project("Attestation Sample" LANGUAGES C CXX)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-set(OE_CRYPTO_LIB mbedtls)
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(common)
 add_subdirectory(enclave_a)

--- a/samples/attestation/Makefile
+++ b/samples/attestation/Makefile
@@ -3,8 +3,6 @@
 
 .PHONY: all build clean run
 
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
 OE_CRYPTO_LIB := mbedtls
 export OE_CRYPTO_LIB
 

--- a/samples/attested_tls/CMakeLists.txt
+++ b/samples/attested_tls/CMakeLists.txt
@@ -7,7 +7,9 @@ project("Attested TLS sample" LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 11)
 # set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
 # OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-set(OE_CRYPTO_LIB mbedtls)
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 find_package(OpenEnclave CONFIG REQUIRED)
 

--- a/samples/attested_tls/README.md
+++ b/samples/attested_tls/README.md
@@ -71,7 +71,57 @@ Note: Both of them can run on the same machine or separate machines.
 
 ## Build and run
 
-To build and run the samples, refer to documentation in the main [README file](../README.md#building-the-samples.md).
+### Linux
+
+#### CMake
+- Use Mbed TLS
+  ```bash
+  mkdir build
+  cd build
+  cmake -DOE_CRYPTO_LIB=mbedtls ..
+  make
+  make run
+  ```
+- Use OpenSSL
+  ```bash
+  mkdir build
+  cd build
+  cmake -DOE_CRYPTO_LIB=openssl ..
+  make
+  make run
+  ```
+
+#### GNU Make
+- Use Mbed TLS
+  ```bash
+  make OE_CRYPTO_LIB=mbedtls build
+  make run
+  ```
+- Use OpenSSL
+  ```bash
+  make OE_CRYPTO_LIB=openssl build
+  make run
+  ```
+
+### Windows
+
+#### CMake
+- Use Mbed TLS
+  ```bash
+  mkdir build
+  cd build
+  cmake -G Ninja -DOE_CRYPTO_LIB=mbedtls ..
+  ninja
+  ninja run
+  ```
+- Use OpenSSL
+  ```bash
+  mkdir build
+  cd build
+  cmake -G Ninja -DOE_CRYPTO_LIB=openssl ..
+  ninja
+  ninja run
+  ```
 
 Note: This sample has a dependency on the [socket support](../../docs/UsingTheIOSubsystem.md#a-socket-example) added in the OE SDK v0.6.0 release, so it needs to be linked against the liboehostsock and libhostresolver libraries. For more details, see [Using the Open Enclave I/O subsystem](../../docs/UsingTheIOSubsystem.md#opting-in).
 

--- a/samples/data-sealing/CMakeLists.txt
+++ b/samples/data-sealing/CMakeLists.txt
@@ -8,9 +8,9 @@ project("Data Sealing Sample" LANGUAGES C CXX)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-set(OE_CRYPTO_LIB mbedtls)
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(common)
 add_subdirectory(enclave_a_v1)

--- a/samples/data-sealing/Makefile
+++ b/samples/data-sealing/Makefile
@@ -3,9 +3,6 @@
 
 .PHONY: all build clean run
 
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-
 OE_CRYPTO_LIB := mbedtls
 export OE_CRYPTO_LIB
 

--- a/samples/debugmalloc/CMakeLists.txt
+++ b/samples/debugmalloc/CMakeLists.txt
@@ -15,9 +15,9 @@ project("Debug Malloc Sample" LANGUAGES C CXX)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-set(OE_CRYPTO_LIB mbedtls)
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(enclave)
 add_subdirectory(host)

--- a/samples/debugmalloc/Makefile
+++ b/samples/debugmalloc/Makefile
@@ -3,9 +3,6 @@
 
 .PHONY: all build clean run simulate
 
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-
 OE_CRYPTO_LIB := mbedtls
 export OE_CRYPTO_LIB
 

--- a/samples/file-encryptor/CMakeLists.txt
+++ b/samples/file-encryptor/CMakeLists.txt
@@ -8,9 +8,9 @@ project("File Encryptor Sample" LANGUAGES C CXX)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-set(OE_CRYPTO_LIB mbedtls)
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(enclave)
 add_subdirectory(host)

--- a/samples/file-encryptor/Makefile
+++ b/samples/file-encryptor/Makefile
@@ -3,9 +3,6 @@
 
 .PHONY: all build clean run simulate
 
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-
 OE_CRYPTO_LIB := mbedtls
 export OE_CRYPTO_LIB
 

--- a/samples/helloworld/CMakeLists.txt
+++ b/samples/helloworld/CMakeLists.txt
@@ -15,9 +15,9 @@ project("Hello World Sample" LANGUAGES C CXX)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-set(OE_CRYPTO_LIB mbedtls)
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(enclave)
 add_subdirectory(host)

--- a/samples/helloworld/Makefile
+++ b/samples/helloworld/Makefile
@@ -3,9 +3,6 @@
 
 .PHONY: all build clean run simulate
 
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-
 OE_CRYPTO_LIB := mbedtls
 export OE_CRYPTO_LIB
 

--- a/samples/log_callback/CMakeLists.txt
+++ b/samples/log_callback/CMakeLists.txt
@@ -15,9 +15,9 @@ project("log_callback Sample" LANGUAGES C CXX)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-set(OE_CRYPTO_LIB mbedtls)
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(enclave)
 add_subdirectory(host)

--- a/samples/log_callback/Makefile
+++ b/samples/log_callback/Makefile
@@ -3,9 +3,6 @@
 
 .PHONY: all build clean run simulate
 
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-
 OE_CRYPTO_LIB := mbedtls
 export OE_CRYPTO_LIB
 

--- a/samples/pluggable_allocator/CMakeLists.txt
+++ b/samples/pluggable_allocator/CMakeLists.txt
@@ -15,9 +15,9 @@ project("Pluggable Allocator Sample" LANGUAGES C CXX)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-set(OE_CRYPTO_LIB mbedtls)
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(enclave)
 add_subdirectory(host)

--- a/samples/pluggable_allocator/Makefile
+++ b/samples/pluggable_allocator/Makefile
@@ -3,9 +3,6 @@
 
 .PHONY: all build clean run simulate
 
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-
 OE_CRYPTO_LIB := mbedtls
 export OE_CRYPTO_LIB
 

--- a/samples/switchless/CMakeLists.txt
+++ b/samples/switchless/CMakeLists.txt
@@ -8,9 +8,9 @@ project("Switchless Call Sample" LANGUAGES C CXX)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-set(OE_CRYPTO_LIB mbedtls)
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(enclave)
 add_subdirectory(host)

--- a/samples/switchless/Makefile
+++ b/samples/switchless/Makefile
@@ -3,9 +3,6 @@
 
 .PHONY: all build clean run simulate
 
-# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
-# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
-
 OE_CRYPTO_LIB := mbedtls
 export OE_CRYPTO_LIB
 


### PR DESCRIPTION
This PR enables the attested TLS sample test on CI. In addition, the PR does the following
- Fix a bug that `OE_CRYPTO_LIB=openssl` does not work with cmake
- Update the README.md on the attested tls sample and comments CMakelists.txt/Makefile samples to reflect that setting `OE_CRYPTO_LIB` currently only works with the former.


Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>