### PR TITLE
Add EXPORT openenclave-hostverify-targets and different target files 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,7 +388,7 @@ include(add_enclave_test)
 add_subdirectory(include)
 add_subdirectory(host)
 
-if (BUILD_TESTS AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (BUILD_TESTS)
   add_subdirectory(tests)
 endif ()
 
@@ -398,11 +398,9 @@ if (NOT CODE_COVERAGE)
   add_subdirectory(samples)
 endif ()
 
-if (NOT COMPONENT MATCHES OEHOSTVERFIY)
-  add_subdirectory(tools)
-endif ()
+add_subdirectory(tools)
 
-if (BUILD_ENCLAVES AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (BUILD_ENCLAVES)
   add_subdirectory(enclave)
   add_subdirectory(3rdparty)
   add_subdirectory(libc)
@@ -410,7 +408,7 @@ if (BUILD_ENCLAVES AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
   add_subdirectory(syscall)
 endif ()
 
-if (OE_SGX AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (OE_SGX)
   add_subdirectory(debugger)
 endif ()
 
@@ -425,11 +423,14 @@ if (WIN32)
   install(FILES ./scripts/install-windows-prereqs.ps1
           DESTINATION ${CMAKE_INSTALL_BINDIR}/scripts/)
   install(FILES ./cmake/maybe_build_using_clangw.cmake
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake)
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
+          COMPONENT OEHOSTVERIFY)
   install(FILES ./cmake/add_dcap_client_target.cmake
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake)
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
+          COMPONENT OEHOSTVERIFY)
   install(FILES ./cmake/copy_oedebugrt_target.cmake
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake)
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
+          COMPONENT OEHOSTVERIFY)
 endif ()
 
 # Install necessary files for LVI mitigation.

--- a/cmake/openenclave-config.cmake.in
+++ b/cmake/openenclave-config.cmake.in
@@ -14,7 +14,6 @@ set_and_check(OE_DATADIR "@PACKAGE_CMAKE_INSTALL_DATADIR@")
 set_and_check(OE_INCLUDEDIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 set(OE_SCRIPTSDIR "@PACKAGE_CMAKE_INSTALL_BINDIR@/scripts")
 set(OE_SGX "@OE_SGX@")
-set(COMPONENT "@COMPONENT@")
 
 if (WIN32)
   set(USE_CLANGW ON)
@@ -74,14 +73,18 @@ elseif (WIN32)
 endif ()
 
 # Include the automatically exported targets.
-include("${CMAKE_CURRENT_LIST_DIR}/openenclave-targets.cmake")
-if (WIN32 AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (COMPONENT MATCHES "OEHOSTVERIFY")
+  include("${CMAKE_CURRENT_LIST_DIR}/openenclave-hostverify-targets.cmake")
+else ()
+  include("${CMAKE_CURRENT_LIST_DIR}/openenclave-targets.cmake")
+endif ()
+if (WIN32)
   include("${CMAKE_CURRENT_LIST_DIR}/add_dcap_client_target.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/copy_oedebugrt_target.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/maybe_build_using_clangw.cmake")
 endif ()
 
-if (OE_SGX AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (OE_SGX)
   if (NOT TARGET openenclave::sgx_dcap_ql)
     if (UNIX)
       find_library(SGX_DCAP_QL_LIB NAMES sgx_dcap_ql HINTS "/usr")
@@ -105,35 +108,33 @@ if (OE_SGX AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
   endif ()
 endif ()
 
-if(NOT COMPONENT MATCHES OEHOSTVERIFY)
-  # This target is an external project, so we have to manually
-  # "export" it here for users of the package.
-  if(NOT TARGET openenclave::oeedger8r)
-    add_executable(openenclave::oeedger8r IMPORTED)
-    set_target_properties(openenclave::oeedger8r PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oeedger8r)
-  endif ()
+# This target is an external project, so we have to manually
+# "export" it here for users of the package.
+if(NOT TARGET openenclave::oeedger8r)
+  add_executable(openenclave::oeedger8r IMPORTED)
+  set_target_properties(openenclave::oeedger8r PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oeedger8r)
+endif ()
 
-  # Similarly, this is a shell script.
-  if(NOT TARGET openenclave::oegdb)
-    add_executable(openenclave::oegdb IMPORTED)
-    set_target_properties(openenclave::oegdb PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oegdb)
-  endif ()
+# Similarly, this is a shell script.
+if(NOT TARGET openenclave::oegdb)
+  add_executable(openenclave::oegdb IMPORTED)
+  set_target_properties(openenclave::oegdb PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oegdb)
+endif ()
 
-  # Apply Spectre mitigations if available.
-  set(OE_SPECTRE_MITIGATION_FLAGS "@SPECTRE_MITIGATION_FLAGS@")
+# Apply Spectre mitigations if available.
+set(OE_SPECTRE_MITIGATION_FLAGS "@SPECTRE_MITIGATION_FLAGS@")
 
-  # Check for compiler flags support.
-  if (CMAKE_C_COMPILER)
-    include(CheckCCompilerFlag)
-    check_c_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED)
-  endif ()
+# Check for compiler flags support.
+if (CMAKE_C_COMPILER)
+  include(CheckCCompilerFlag)
+  check_c_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED)
+endif ()
 
-  if (CMAKE_CXX_COMPILER)
-    include(CheckCXXCompilerFlag)
-    check_cxx_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
-  endif ()
+if (CMAKE_CXX_COMPILER)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
+endif ()
 
-  if (OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED OR OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
-    target_compile_options(openenclave::oecore INTERFACE ${OE_SPECTRE_MITIGATION_FLAGS})
-  endif ()
+if (OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED OR OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
+  target_compile_options(openenclave::oecore INTERFACE ${OE_SPECTRE_MITIGATION_FLAGS})
 endif ()

--- a/cmake/package_settings.cmake
+++ b/cmake/package_settings.cmake
@@ -48,7 +48,6 @@ file(
   ${OE_BINDIR}
   ${OE_DATADIR}
   ${OE_DOCDIR}
-  ${OE_DOCDIR}
   ${OE_INCDIR}
   ${OE_LIBDIR})
 
@@ -78,7 +77,14 @@ install(
   # Note that this is used in `openenclaverc` to set the path for
   # users of the SDK and so must remain consistent.
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
-  FILE openenclave-targets.cmake
+  FILE openenclave-targets.cmake)
+install(
+  EXPORT openenclave-hostverify-targets
+  NAMESPACE openenclave::
+  # Note that this is used in `openenclaverc` to set the path for
+  # users of the SDK and so must remain consistent.
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
+  FILE openenclave-hostverify-targets.cmake
   COMPONENT OEHOSTVERIFY)
 install(
   FILES ${PROJECT_SOURCE_DIR}/cmake/sdk_cmake_targets_readme.md

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -469,15 +469,37 @@ if (CMAKE_C_COMPILER_ID MATCHES GNU)
 endif ()
 
 # Use the same the compile options and definitions from oehost.
-target_compile_options(
-  oehostverify
-  PRIVATE $<TARGET_PROPERTY:oehost,COMPILE_OPTIONS>
-  INTERFACE $<TARGET_PROPERTY:oehost,INTERFACE_COMPILE_OPTIONS>)
-
 target_compile_definitions(
   oehostverify
-  PRIVATE $<TARGET_PROPERTY:oehost,COMPILE_DEFINITIONS>
-  INTERFACE $<TARGET_PROPERTY:oehost,INTERFACE_COMPILE_DEFINITIONS>)
+  PUBLIC # NOTE: This definition is public to the rest of our project's
+         # targets, but should not yet be exposed to consumers of our
+         # package.
+         $<BUILD_INTERFACE:OE_API_VERSION=2>
+  PRIVATE OE_BUILD_UNTRUSTED OE_REPO_BRANCH_NAME="${GIT_BRANCH}"
+          OE_REPO_LAST_COMMIT="${GIT_COMMIT}")
+
+if (USE_DEBUG_MALLOC)
+  target_compile_definitions(oehostverify PRIVATE OE_USE_DEBUG_MALLOC)
+endif ()
+
+if (WITH_EEID)
+  target_compile_definitions(oehostverify PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+endif ()
+
+if (UNIX)
+  target_compile_options(
+    oehostverify
+    PRIVATE -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS}
+    PUBLIC -fstack-protector-strong)
+  target_compile_definitions(
+    oehostverify
+    PRIVATE _GNU_SOURCE
+    PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
+endif ()
+
+if (CMAKE_C_COMPILER_ID MATCHES GNU)
+  target_compile_options(oehostverify PRIVATE -Wjump-misses-init)
+endif ()
 
 target_compile_definitions(oehostverify PUBLIC OE_BUILD_HOST_VERIFY)
 
@@ -494,6 +516,11 @@ endif ()
 install(
   TARGETS oehost
   EXPORT openenclave-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host)
+
+install(
+  TARGETS oehostverify
+  EXPORT openenclave-hostverify-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host
           COMPONENT OEHOSTVERIFY)
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -47,6 +47,10 @@ install(
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/attestation/sgx/
   COMPONENT OEHOSTVERIFY)
 install(TARGETS oe_includes EXPORT openenclave-targets)
+install(
+  TARGETS oe_includes
+  EXPORT openenclave-hostverify-targets
+  COMPONENT OEHOSTVERIFY)
 
 # Install parts of oelibc needed by edger8r-generated code
 list(

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -234,14 +234,8 @@ set(LVI_MITIGATION_PACKAGE_CONFIG_FILES_LIST
 ##==============================================================================
 
 set(HOST_VERIFY_PACKAGE_CONFIG_FILES_LIST
-    oehost-gcc.pc
-    oehost-g++.pc
-    oehostverify-gcc.pc
-    oehostverify-g++.pc
-    oehost-clang.pc
-    oehost-clang++.pc
-    oehostverify-clang.pc
-    oehostverify-clang++.pc)
+    oehostverify-gcc.pc oehostverify-g++.pc
+    oehostverify-clang.pc oehostverify-clang++.pc)
 
 foreach (file_name ${PACKAGE_CONFIG_FILES_LIST})
   configure_and_install_pkg_config(${file_name} "")

--- a/samples/attested_tls/Makefile
+++ b/samples/attested_tls/Makefile
@@ -10,6 +10,12 @@ export OE_CRYPTO_LIB
 
 all: build
 
+# set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
+# OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
+
+OE_CRYPTO_LIB := mbedtls
+export OE_CRYPTO_LIB
+
 build:
 	$(MAKE) -C server
 	$(MAKE) -C client

--- a/samples/attested_tls/client/enc/CMakeLists.txt
+++ b/samples/attested_tls/client/enc/CMakeLists.txt
@@ -19,28 +19,13 @@ add_custom_command(
     ${CMAKE_SOURCE_DIR}/client/enc/enc.conf -k
     ${CMAKE_SOURCE_DIR}/client/enc/private.pem)
 
-if (${OE_CRYPTO_LIB} MATCHES "openssl")
-  add_executable(
-    tls_client_enc
-    ecalls.cpp
-    openssl_client.cpp
-    cert_verify_config.cpp
-    ../../common/verify_callback.cpp
-    ../../common/utility.cpp
-    ../../common/openssl_utility.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/tls_client_t.c)
-elseif (${OE_CRYPTO_LIB} MATCHES "mbedtls")
-  add_executable(
-    tls_client_enc
-    ecalls.cpp
-    mbedtls_client.cpp
-    cert_verify_config.cpp
-    ../../common/cert_verifier.cpp
-    ../../common/identity_verifier.cpp
-    ../../common/utility.cpp
-    ../../common/mbedtls_utility.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/tls_client_t.c)
-endif ()
+add_definitions(-DCLIENT_CERT_VERIFY_CALLBACK)
+
+add_executable(
+  tls_client_enc
+  ecalls.cpp client.cpp ../../common/cert_verifier.cpp
+  ../../common/identity_verifier.cpp ../../common/utility.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/tls_client_t.c)
 
 add_dependencies(tls_client_enc tls_server_sign_enc)
 
@@ -55,14 +40,8 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
           ${CMAKE_BINARY_DIR}/client/enc)
 
-if (${OE_CRYPTO_LIB} MATCHES "openssl")
-  target_link_libraries(
-    tls_client_enc openenclave::oeenclave openenclave::oecryptoopenssl
-    openenclave::oelibcxx openenclave::oehostsock openenclave::oehostresolver)
-elseif (${OE_CRYPTO_LIB} MATCHES "mbedtls")
-  target_link_libraries(
-    tls_client_enc openenclave::oeenclave openenclave::oecryptombedtls
-    openenclave::oelibcxx openenclave::oehostsock openenclave::oehostresolver)
-endif ()
+target_link_libraries(
+  tls_client_enc openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB}
+  openenclave::oelibcxx openenclave::oehostsock openenclave::oehostresolver)
 
 add_custom_target(tls_client_sign_enc ALL DEPENDS tls_client_enc.signed)

--- a/samples/attested_tls/client/enc/Makefile
+++ b/samples/attested_tls/client/enc/Makefile
@@ -11,14 +11,6 @@ CRYPTO_LDFLAGS=$(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_L
 
 .PHONY: all build clean run
 
-SRC_FILES = ecalls.cpp mbedtls_client.cpp cert_verify_config.cpp ../../common/cert_verifier.cpp ../../common/identity_verifier.cpp ../../common/utility.cpp ../../common/mbedtls_utility.cpp
-OBJ_FILES = ecalls.o mbedtls_client.o cert_verify_config.o cert_verifier.o identity_verifier.o utility.o mbedtls_utility.o tls_client_t.o
-
-ifeq (${OE_CRYPTO_LIB}, openssl)
-	SRC_FILES = ecalls.cpp openssl_client.cpp cert_verify_config.cpp ../../common/verify_callback.cpp ../../common/utility.cpp ../../common/openssl_utility.cpp
-	OBJ_FILES = ecalls.o openssl_client.o cert_verify_config.o verify_callback.o utility.o openssl_utility.o tls_client_t.o
-endif
-
 all:
 	$(MAKE) build
 	$(MAKE) sign
@@ -28,10 +20,9 @@ build:
 	oeedger8r ../tls_client.edl --trusted --trusted-dir . \
 		--search-path $(INCDIR) \
 		--search-path $(INCDIR)/openenclave/edl/sgx
-
-	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I. -std=c++11 $(SRC_FILES)
-	$(CC) -c $(CFLAGS) $(CINCLUDES) -I. ./tls_client_t.c
-	$(CXX) -o tls_client_enclave $(OBJ_FILES) $(LDFLAGS) $(CRYPTO_LDFLAGS) -loehostsock -loehostresolver
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 -DCLIENT_CERT_VERIFY_CALLBACK ecalls.cpp client.cpp ../../common/cert_verifier.cpp ../../common/identity_verifier.cpp ../../common/utility.cpp
+	$(CC) -c $(CFLAGS) $(CINCLUDES) ./tls_client_t.c
+	$(CXX) -o tls_client_enclave ecalls.o client.o cert_verifier.o identity_verifier.o utility.o tls_client_t.o $(LDFLAGS) $(CRYPTO_LDFLAGS) -loehostsock -loehostresolver
 
 sign:
 	oesign sign -e tls_client_enclave -c  enc.conf -k private.pem

--- a/samples/attested_tls/server/enc/CMakeLists.txt
+++ b/samples/attested_tls/server/enc/CMakeLists.txt
@@ -25,28 +25,13 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E sleep 1
   COMMAND ${CMAKE_COMMAND} -E remove temp.dmp)
 
-if (${OE_CRYPTO_LIB} MATCHES "openssl")
-  add_executable(
-    tls_server_enc
-    ecalls.cpp
-    openssl_server.cpp
-    cert_verify_config.cpp
-    ../../common/verify_callback.cpp
-    ../../common/utility.cpp
-    ../../common/openssl_utility.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/tls_server_t.c)
-elseif (${OE_CRYPTO_LIB} MATCHES "mbedtls")
-  add_executable(
-    tls_server_enc
-    ecalls.cpp
-    mbedtls_server.cpp
-    cert_verify_config.cpp
-    ../../common/cert_verifier.cpp
-    ../../common/identity_verifier.cpp
-    ../../common/utility.cpp
-    ../../common/mbedtls_utility.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/tls_server_t.c)
-endif ()
+add_definitions(-DSERVER_CERT_VERIFY_CALLBACK)
+
+add_executable(
+  tls_server_enc
+  ecalls.cpp server.cpp ../../common/cert_verifier.cpp
+  ../../common/identity_verifier.cpp ../../common/utility.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/tls_server_t.c)
 
 if (WIN32)
   maybe_build_using_clangw(tls_server_enc)
@@ -59,15 +44,9 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
           ${CMAKE_BINARY_DIR}/server/enc)
 
-if (${OE_CRYPTO_LIB} MATCHES "openssl")
-  target_link_libraries(
-    tls_server_enc openenclave::oeenclave openenclave::oecryptoopenssl
-    openenclave::oelibcxx openenclave::oehostsock openenclave::oehostresolver)
-elseif (${OE_CRYPTO_LIB} MATCHES "mbedtls")
-  target_link_libraries(
-    tls_server_enc openenclave::oeenclave openenclave::oecryptombedtls
-    openenclave::oelibcxx openenclave::oehostsock openenclave::oehostresolver)
-endif ()
+target_link_libraries(
+  tls_server_enc openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB}
+  openenclave::oelibcxx openenclave::oehostsock openenclave::oehostresolver)
 
 add_custom_target(tls_server_sign_enc ALL DEPENDS tls_server_enc.signed
                                                   tls_server_enc_mrenclave.h)

--- a/samples/attested_tls/server/enc/Makefile
+++ b/samples/attested_tls/server/enc/Makefile
@@ -11,14 +11,6 @@ CRYPTO_LDFLAGS=$(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_L
 
 .PHONY: all build clean run
 
-SRC_FILES = ecalls.cpp mbedtls_server.cpp cert_verify_config.cpp ../../common/identity_verifier.cpp ../../common/cert_verifier.cpp ../../common/utility.cpp ../../common/mbedtls_utility.cpp
-OBJ_FILES = ecalls.o mbedtls_server.o cert_verify_config.o cert_verifier.o identity_verifier.o utility.o mbedtls_utility.o tls_server_t.o
-
-ifeq (${OE_CRYPTO_LIB}, openssl)
-	SRC_FILES = ecalls.cpp openssl_server.cpp cert_verify_config.cpp ../../common/verify_callback.cpp ../../common/utility.cpp ../../common/openssl_utility.cpp
-	OBJ_FILES = ecalls.o openssl_server.o cert_verify_config.o verify_callback.o utility.o openssl_utility.o tls_server_t.o
-endif
-
 all:
 	$(MAKE) build
 	$(MAKE) sign
@@ -29,11 +21,9 @@ build:
 		--trusted-dir . \
 		--search-path $(INCDIR) \
 		--search-path $(INCDIR)/openenclave/edl/sgx
-
-
-	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I. -std=c++11 ${SRC_FILES}
-	$(CC) -c $(CFLAGS) $(CINCLUDES) -I. tls_server_t.c
-	$(CXX) -o tls_server_enc $(OBJ_FILES) $(LDFLAGS) $(CRYPTO_LDFLAGS) -loehostsock -loehostresolver
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 -DSERVER_CERT_VERIFY_CALLBACK ecalls.cpp server.cpp ../../common/identity_verifier.cpp ../../common/cert_verifier.cpp ../../common/utility.cpp
+	$(CC) -c $(CFLAGS) $(CINCLUDES) tls_server_t.c
+	$(CXX) -o tls_server_enc ecalls.o server.o cert_verifier.o identity_verifier.o utility.o tls_server_t.o $(LDFLAGS) $(CRYPTO_LDFLAGS) -loehostsock -loehostresolver
 
 sign:
 	oesign sign -e tls_server_enc -c enc.conf -k private.pem

--- a/samples/host_verify/CMakeLists.txt
+++ b/samples/host_verify/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required(VERSION 3.11)
 
 project("Remote Host-side Enclave Verification Sample" LANGUAGES C CXX)
 
+set(COMPONENT "OEHOSTVERIFY")
+
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -63,3 +65,5 @@ else ()
     endif ()
   endif ()
 endif ()
+
+unset(COMPONENT)

--- a/samples/host_verify/Makefile
+++ b/samples/host_verify/Makefile
@@ -3,8 +3,8 @@
 
 include ../config.mk
 
-CFLAGS=$(shell pkg-config oehost-$(COMPILER) --cflags)
-LDFLAGS=$(shell pkg-config oehost-$(COMPILER) --libs)
+CFLAGS=$(shell pkg-config oehostverify-$(COMPILER) --cflags)
+LDFLAGS=$(shell pkg-config oehostverify-$(COMPILER) --libs)
 
 EXISTS_FILE=0
 EXISTS_SGX_CERT_EC=0

--- a/tests/tools/oesign/CMakeLists.txt
+++ b/tests/tools/oesign/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # oesign tests need to build a target enclave to sign
-if (BUILD_ENCLAVES AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (BUILD_ENCLAVES)
   add_subdirectory(test-enclave)
   add_subdirectory(test-digest)
   add_subdirectory(test-inputs)

--- a/tools/oesign/CMakeLists.txt
+++ b/tools/oesign/CMakeLists.txt
@@ -22,31 +22,29 @@ if (NOT HAVE_GETOPT_LONG)
   list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/getopt_long.c)
 endif ()
 
-if (NOT COMPONENT MATCHES OEHOSTVERIFY)
-  add_executable(oesign ${SOURCES})
+add_executable(oesign ${SOURCES})
 
-  if (NOT HAVE_GETOPT_LONG)
-    target_include_directories(oesign PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-  endif ()
+if (NOT HAVE_GETOPT_LONG)
+  target_include_directories(oesign PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+endif ()
 
-  # Link oesign against liboehostmr, which has no dependency on
-  # lib_sgx_enclave_common and libsgx_dcap_ql.
-  target_link_libraries(oesign oehostmr)
+# Link oesign against liboehostmr, which has no dependency on
+# lib_sgx_enclave_common and libsgx_dcap_ql.
+target_link_libraries(oesign oehostmr)
 
-  # assemble into proper collector dir
-  set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
+# assemble into proper collector dir
+set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
-  if (WIN32)
-    set_target_properties(oesign PROPERTIES LINK_FLAGS "/Guard:CF")
-  endif ()
+if (WIN32)
+  set_target_properties(oesign PROPERTIES LINK_FLAGS "/Guard:CF")
+endif ()
 
-  # install rule
-  install(
-    TARGETS oesign
-    EXPORT openenclave-targets
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
+# install rule
+install(
+  TARGETS oesign
+  EXPORT openenclave-targets
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-  if (WITH_EEID)
-    target_compile_definitions(oesign PRIVATE OE_WITH_EXPERIMENTAL_EEID)
-  endif ()
+if (WITH_EEID)
+  target_compile_definitions(oesign PRIVATE OE_WITH_EXPERIMENTAL_EEID)
 endif ()


### PR DESCRIPTION
Add a new export, `openenclave-hostverify-targets`, while using the same namespace, `openenclave::`, to deal with the building issue of the independent `open-enclave-hostverify` package.

Also remove unnecessary `COMPONENT NOT MATCHES OEHOSTVERIFY`s and only retain the one that switches between different target files generated by the new export.

Resolve #2263, #3161, #3181 and #3300.