### PR TITLE
Add EXPORT openenclave-hostverify-targets and different target files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,7 +388,7 @@ include(add_enclave_test)
 add_subdirectory(include)
 add_subdirectory(host)
 
-if (BUILD_TESTS AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (BUILD_TESTS)
   add_subdirectory(tests)
 endif ()
 
@@ -398,11 +398,9 @@ if (NOT CODE_COVERAGE)
   add_subdirectory(samples)
 endif ()
 
-if (NOT COMPONENT MATCHES OEHOSTVERFIY)
-  add_subdirectory(tools)
-endif ()
+add_subdirectory(tools)
 
-if (BUILD_ENCLAVES AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (BUILD_ENCLAVES)
   add_subdirectory(enclave)
   add_subdirectory(3rdparty)
   add_subdirectory(libc)
@@ -410,7 +408,7 @@ if (BUILD_ENCLAVES AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
   add_subdirectory(syscall)
 endif ()
 
-if (OE_SGX AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (OE_SGX)
   add_subdirectory(debugger)
 endif ()
 
@@ -425,11 +423,14 @@ if (WIN32)
   install(FILES ./scripts/install-windows-prereqs.ps1
           DESTINATION ${CMAKE_INSTALL_BINDIR}/scripts/)
   install(FILES ./cmake/maybe_build_using_clangw.cmake
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake)
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
+          COMPONENT OEHOSTVERIFY)
   install(FILES ./cmake/add_dcap_client_target.cmake
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake)
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
+          COMPONENT OEHOSTVERIFY)
   install(FILES ./cmake/copy_oedebugrt_target.cmake
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake)
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
+          COMPONENT OEHOSTVERIFY)
 endif ()
 
 # Install necessary files for LVI mitigation.

--- a/cmake/openenclave-config.cmake.in
+++ b/cmake/openenclave-config.cmake.in
@@ -14,7 +14,6 @@ set_and_check(OE_DATADIR "@PACKAGE_CMAKE_INSTALL_DATADIR@")
 set_and_check(OE_INCLUDEDIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 set(OE_SCRIPTSDIR "@PACKAGE_CMAKE_INSTALL_BINDIR@/scripts")
 set(OE_SGX "@OE_SGX@")
-set(COMPONENT "@COMPONENT@")
 
 if (WIN32)
   set(USE_CLANGW ON)
@@ -74,14 +73,18 @@ elseif (WIN32)
 endif ()
 
 # Include the automatically exported targets.
-include("${CMAKE_CURRENT_LIST_DIR}/openenclave-targets.cmake")
-if (WIN32 AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (COMPONENT MATCHES "OEHOSTVERIFY")
+  include("${CMAKE_CURRENT_LIST_DIR}/openenclave-hostverify-targets.cmake")
+else ()
+  include("${CMAKE_CURRENT_LIST_DIR}/openenclave-targets.cmake")
+endif ()
+if (WIN32)
   include("${CMAKE_CURRENT_LIST_DIR}/add_dcap_client_target.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/copy_oedebugrt_target.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/maybe_build_using_clangw.cmake")
 endif ()
 
-if (OE_SGX AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (OE_SGX)
   if (NOT TARGET openenclave::sgx_dcap_ql)
     if (UNIX)
       find_library(SGX_DCAP_QL_LIB NAMES sgx_dcap_ql HINTS "/usr")
@@ -105,35 +108,33 @@ if (OE_SGX AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
   endif ()
 endif ()
 
-if(NOT COMPONENT MATCHES OEHOSTVERIFY)
-  # This target is an external project, so we have to manually
-  # "export" it here for users of the package.
-  if(NOT TARGET openenclave::oeedger8r)
-    add_executable(openenclave::oeedger8r IMPORTED)
-    set_target_properties(openenclave::oeedger8r PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oeedger8r)
-  endif ()
+# This target is an external project, so we have to manually
+# "export" it here for users of the package.
+if(NOT TARGET openenclave::oeedger8r)
+  add_executable(openenclave::oeedger8r IMPORTED)
+  set_target_properties(openenclave::oeedger8r PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oeedger8r)
+endif ()
 
-  # Similarly, this is a shell script.
-  if(NOT TARGET openenclave::oegdb)
-    add_executable(openenclave::oegdb IMPORTED)
-    set_target_properties(openenclave::oegdb PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oegdb)
-  endif ()
+# Similarly, this is a shell script.
+if(NOT TARGET openenclave::oegdb)
+  add_executable(openenclave::oegdb IMPORTED)
+  set_target_properties(openenclave::oegdb PROPERTIES IMPORTED_LOCATION ${OE_BINDIR}/oegdb)
+endif ()
 
-  # Apply Spectre mitigations if available.
-  set(OE_SPECTRE_MITIGATION_FLAGS "@SPECTRE_MITIGATION_FLAGS@")
+# Apply Spectre mitigations if available.
+set(OE_SPECTRE_MITIGATION_FLAGS "@SPECTRE_MITIGATION_FLAGS@")
 
-  # Check for compiler flags support.
-  if (CMAKE_C_COMPILER)
-    include(CheckCCompilerFlag)
-    check_c_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED)
-  endif ()
+# Check for compiler flags support.
+if (CMAKE_C_COMPILER)
+  include(CheckCCompilerFlag)
+  check_c_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED)
+endif ()
 
-  if (CMAKE_CXX_COMPILER)
-    include(CheckCXXCompilerFlag)
-    check_cxx_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
-  endif ()
+if (CMAKE_CXX_COMPILER)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
+endif ()
 
-  if (OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED OR OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
-    target_compile_options(openenclave::oecore INTERFACE ${OE_SPECTRE_MITIGATION_FLAGS})
-  endif ()
+if (TARGET openenclave::oecore AND (OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED OR OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED))
+  target_compile_options(openenclave::oecore INTERFACE ${OE_SPECTRE_MITIGATION_FLAGS})
 endif ()

--- a/cmake/package_settings.cmake
+++ b/cmake/package_settings.cmake
@@ -48,7 +48,6 @@ file(
   ${OE_BINDIR}
   ${OE_DATADIR}
   ${OE_DOCDIR}
-  ${OE_DOCDIR}
   ${OE_INCDIR}
   ${OE_LIBDIR})
 
@@ -78,7 +77,14 @@ install(
   # Note that this is used in `openenclaverc` to set the path for
   # users of the SDK and so must remain consistent.
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
-  FILE openenclave-targets.cmake
+  FILE openenclave-targets.cmake)
+install(
+  EXPORT openenclave-hostverify-targets
+  NAMESPACE openenclave::
+  # Note that this is used in `openenclaverc` to set the path for
+  # users of the SDK and so must remain consistent.
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
+  FILE openenclave-hostverify-targets.cmake
   COMPONENT OEHOSTVERIFY)
 install(
   FILES ${PROJECT_SOURCE_DIR}/cmake/sdk_cmake_targets_readme.md

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -435,7 +435,7 @@ endif ()
 # For including edge routines.
 target_include_directories(oehost PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-# Compile definitions and options
+# Compile definitions and options for oehost and oehostverify
 target_compile_definitions(
   oehost
   PUBLIC # NOTE: This definition is public to the rest of our project's
@@ -444,13 +444,23 @@ target_compile_definitions(
          $<BUILD_INTERFACE:OE_API_VERSION=2>
   PRIVATE OE_BUILD_UNTRUSTED OE_REPO_BRANCH_NAME="${GIT_BRANCH}"
           OE_REPO_LAST_COMMIT="${GIT_COMMIT}")
+target_compile_definitions(
+  oehostverify
+  PUBLIC # NOTE: This definition is public to the rest of our project's
+         # targets, but should not be exposed to consumers of our
+         # package.
+         $<BUILD_INTERFACE:OE_API_VERSION=2>
+  PRIVATE OE_BUILD_UNTRUSTED OE_REPO_BRANCH_NAME="${GIT_BRANCH}"
+          OE_REPO_LAST_COMMIT="${GIT_COMMIT}")
 
 if (USE_DEBUG_MALLOC)
   target_compile_definitions(oehost PRIVATE OE_USE_DEBUG_MALLOC)
+  target_compile_definitions(oehostverify PRIVATE OE_USE_DEBUG_MALLOC)
 endif ()
 
 if (WITH_EEID)
   target_compile_definitions(oehost PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+  target_compile_definitions(oehostverify PRIVATE OE_WITH_EXPERIMENTAL_EEID)
 endif ()
 
 if (UNIX)
@@ -462,22 +472,20 @@ if (UNIX)
     oehost
     PRIVATE _GNU_SOURCE
     PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
+  target_compile_options(
+    oehostverify
+    PRIVATE -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS}
+    PUBLIC -fstack-protector-strong)
+  target_compile_definitions(
+    oehostverify
+    PRIVATE _GNU_SOURCE
+    PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
 endif ()
 
 if (CMAKE_C_COMPILER_ID MATCHES GNU)
   target_compile_options(oehost PRIVATE -Wjump-misses-init)
+  target_compile_options(oehostverify PRIVATE -Wjump-misses-init)
 endif ()
-
-# Use the same the compile options and definitions from oehost.
-target_compile_options(
-  oehostverify
-  PRIVATE $<TARGET_PROPERTY:oehost,COMPILE_OPTIONS>
-  INTERFACE $<TARGET_PROPERTY:oehost,INTERFACE_COMPILE_OPTIONS>)
-
-target_compile_definitions(
-  oehostverify
-  PRIVATE $<TARGET_PROPERTY:oehost,COMPILE_DEFINITIONS>
-  INTERFACE $<TARGET_PROPERTY:oehost,INTERFACE_COMPILE_DEFINITIONS>)
 
 target_compile_definitions(oehostverify PUBLIC OE_BUILD_HOST_VERIFY)
 
@@ -494,12 +502,11 @@ endif ()
 install(
   TARGETS oehost
   EXPORT openenclave-targets
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host
-          COMPONENT OEHOSTVERIFY)
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host)
 
 install(
   TARGETS oehostverify
-  EXPORT openenclave-targets
+  EXPORT openenclave-hostverify-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host
           COMPONENT OEHOSTVERIFY)
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -47,6 +47,10 @@ install(
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/attestation/sgx/
   COMPONENT OEHOSTVERIFY)
 install(TARGETS oe_includes EXPORT openenclave-targets)
+install(
+  TARGETS oe_includes
+  EXPORT openenclave-hostverify-targets
+  COMPONENT OEHOSTVERIFY)
 
 # Install parts of oelibc needed by edger8r-generated code
 list(

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -214,7 +214,9 @@ endfunction ()
 ##
 ##==============================================================================
 
-set(PACKAGE_CONFIG_FILES_LIST oeenclave-gcc.pc oeenclave-g++.pc
+set(PACKAGE_CONFIG_FILES_LIST oehost-gcc.pc oehost-g++.pc
+                              oehost-clang.pc oehost-clang++.pc
+                              oeenclave-gcc.pc oeenclave-g++.pc
                               oeenclave-clang.pc oeenclave-clang++.pc)
 
 ##==============================================================================
@@ -234,14 +236,8 @@ set(LVI_MITIGATION_PACKAGE_CONFIG_FILES_LIST
 ##==============================================================================
 
 set(HOST_VERIFY_PACKAGE_CONFIG_FILES_LIST
-    oehost-gcc.pc
-    oehost-g++.pc
-    oehostverify-gcc.pc
-    oehostverify-g++.pc
-    oehost-clang.pc
-    oehost-clang++.pc
-    oehostverify-clang.pc
-    oehostverify-clang++.pc)
+    oehostverify-gcc.pc oehostverify-g++.pc
+    oehostverify-clang.pc oehostverify-clang++.pc)
 
 foreach (file_name ${PACKAGE_CONFIG_FILES_LIST})
   configure_and_install_pkg_config(${file_name} "")

--- a/samples/host_verify/CMakeLists.txt
+++ b/samples/host_verify/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required(VERSION 3.11)
 
 project("Remote Host-side Enclave Verification Sample" LANGUAGES C CXX)
 
+set(COMPONENT "OEHOSTVERIFY")
+
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -63,3 +65,5 @@ else ()
     endif ()
   endif ()
 endif ()
+
+unset(COMPONENT)

--- a/samples/host_verify/Makefile
+++ b/samples/host_verify/Makefile
@@ -3,8 +3,8 @@
 
 include ../config.mk
 
-CFLAGS=$(shell pkg-config oehost-$(COMPILER) --cflags)
-LDFLAGS=$(shell pkg-config oehost-$(COMPILER) --libs)
+CFLAGS=$(shell pkg-config oehostverify-$(COMPILER) --cflags)
+LDFLAGS=$(shell pkg-config oehostverify-$(COMPILER) --libs)
 
 EXISTS_FILE=0
 EXISTS_SGX_CERT_EC=0

--- a/tests/tools/oesign/CMakeLists.txt
+++ b/tests/tools/oesign/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # oesign tests need to build a target enclave to sign
-if (BUILD_ENCLAVES AND (NOT COMPONENT MATCHES OEHOSTVERIFY))
+if (BUILD_ENCLAVES)
   add_subdirectory(test-enclave)
   add_subdirectory(test-digest)
   add_subdirectory(test-inputs)

--- a/tools/oesign/CMakeLists.txt
+++ b/tools/oesign/CMakeLists.txt
@@ -22,31 +22,29 @@ if (NOT HAVE_GETOPT_LONG)
   list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/getopt_long.c)
 endif ()
 
-if (NOT COMPONENT MATCHES OEHOSTVERIFY)
-  add_executable(oesign ${SOURCES})
+add_executable(oesign ${SOURCES})
 
-  if (NOT HAVE_GETOPT_LONG)
-    target_include_directories(oesign PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-  endif ()
+if (NOT HAVE_GETOPT_LONG)
+  target_include_directories(oesign PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+endif ()
 
-  # Link oesign against liboehostmr, which has no dependency on
-  # lib_sgx_enclave_common and libsgx_dcap_ql.
-  target_link_libraries(oesign oehostmr)
+# Link oesign against liboehostmr, which has no dependency on
+# lib_sgx_enclave_common and libsgx_dcap_ql.
+target_link_libraries(oesign oehostmr)
 
-  # assemble into proper collector dir
-  set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
+# assemble into proper collector dir
+set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
-  if (WIN32)
-    set_target_properties(oesign PROPERTIES LINK_FLAGS "/Guard:CF")
-  endif ()
+if (WIN32)
+  set_target_properties(oesign PROPERTIES LINK_FLAGS "/Guard:CF")
+endif ()
 
-  # install rule
-  install(
-    TARGETS oesign
-    EXPORT openenclave-targets
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
+# install rule
+install(
+  TARGETS oesign
+  EXPORT openenclave-targets
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-  if (WITH_EEID)
-    target_compile_definitions(oesign PRIVATE OE_WITH_EXPERIMENTAL_EEID)
-  endif ()
+if (WITH_EEID)
+  target_compile_definitions(oesign PRIVATE OE_WITH_EXPERIMENTAL_EEID)
 endif ()


### PR DESCRIPTION
Add a new export, `openenclave-hostverify-targets`, while using the same namespace, `openenclave::`, to deal with the building issue of the independent `open-enclave-hostverify` package.

Also remove unnecessary `COMPONENT NOT MATCHES OEHOSTVERIFY`s and only retain the one that switches between different target files generated by the new export.

Explicitly write out the compile options and definitions for `oehostverify` in `host/CMakeLists.txt`.

Resolve #2263, resolve #3160, resolve #3181, and resolve #3300.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>