### PR TITLE
Temporarily pinning cryptography to 3.2.1

### DIFF
--- a/scripts/ansible/requirements.txt
+++ b/scripts/ansible/requirements.txt
@@ -1,5 +1,6 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
+cryptography==3.2.1
 ansible==2.8.8
 cmake_format==0.6.9
 pywinrm==0.2.1


### PR DESCRIPTION
This is to address the recent release of python library Cryptography-3.3 which upgraded to [OpenSSL 1.1.1i to address a severe vulnerability](https://www.openssl.org/news/secadv/20201208.txt) 

OpenSSL 1.1.1i will need to be compiled from source on Ubuntu 16.04, and Ubuntu 18.04 in order to support Cryptography-3.3 but it may not be prudent to compile OpenSSL libraries on each host system. Therefore, temporarily pinning Cryptography to 3.2.1 will bring builds back to working order for now.