### PR TITLE
Enable clang-8 support.

### DIFF
--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -533,7 +533,13 @@ try{
                 "ACC1804 clang-7 Release LVI FULL Tests":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
                 "ACC1804 gcc Debug LVI":                           { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
                 "ACC1804 gcc Release LVI":                         { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'gcc',     'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                //"ACC1804 Code Coverage Test" :                     { ACCCodeCoverageTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug') },
+
+                "ACC1804 clang-8 Debug":                           { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-8', 'Debug',   ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+
+                "ACC1804 clang-8 Release":                         { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-8', 'Release', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+
+
+                 //"ACC1804 Code Coverage Test" :                     { ACCCodeCoverageTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Debug') },
 
                 "ACC1604 clang-7 Release LVI snmalloc":            { ACCTest(AGENTS_LABELS["acc-ubuntu-16.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON', '-DUSE_SNMALLOC=ON']) },
                 "ACC1804 clang-7 Release LVI FULL Tests snmalloc": { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-7', 'Release', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ endif ()
 # Set compiler search order to prefer Clang
 # This has to be done before `project`
 # http://cmake.3232098.n2.nabble.com/Prefer-clang-over-gcc-td7597742.html
-set(CMAKE_C_COMPILER_NAMES clang-7 cc)
-set(CMAKE_CXX_COMPILER_NAMES clang++-7 c++)
+set(CMAKE_C_COMPILER_NAMES clang-8 clang-7 cc)
+set(CMAKE_CXX_COMPILER_NAMES clang++-8 clang++-7 c++)
 
 # Will be overwritten during the cmake initialization.
 set(LVI_MITIGATION


### PR DESCRIPTION
- If clang-8 is available, use it to build the SDK.
- Workaround corner-case code-generation bug with clang-8 and above.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>