### PR TITLE
[Experimental] Support deep-copy out parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased][Unreleased_log]
 --------------
-### Deprecated
+### Added
+- Add the deep-copy out parameter support as an experimental, SGX-only feature. To use the feature, pass `--experimental` when invoking oeedger8r. Refer to the [design document](docs/DesignDocs/DeepCopyOutParameters.md) for more detail.
 
+### Deprecated
 - Compiling Open Enclave SDK for Intel SGX from source with GCC is no longer supported. The recommended compiler is Clang.
 
 [v0.13.0][v0.13.0_log]

--- a/include/openenclave/edger8r/common.h
+++ b/include/openenclave/edger8r/common.h
@@ -153,6 +153,34 @@ done:
 
 #define OE_WRITE_IN_OUT_PARAM OE_WRITE_IN_PARAM
 
+#define OE_WRITE_DEEPCOPY_OUT_PARAM(argname, argsize)                          \
+    if (argname)                                                               \
+    {                                                                          \
+        void* p = (void*)(_deepcopy_out_buffer + _deepcopy_out_buffer_offset); \
+        OE_ADD_SIZE(_deepcopy_out_buffer_offset, (size_t)(argsize));           \
+        memcpy(p, argname, (size_t)(argsize));                                 \
+    }
+
+#define OE_SET_DEEPCOPY_OUT_PARAM(argname, argsize, argtype)               \
+    if (argname)                                                           \
+    {                                                                      \
+        argname = (argtype)malloc(argsize);                                \
+        if (!argname)                                                      \
+        {                                                                  \
+            _result = OE_OUT_OF_MEMORY;                                    \
+            goto done;                                                     \
+        }                                                                  \
+        argtype _ptr =                                                     \
+            (argtype)(_deepcopy_out_buffer + _deepcopy_out_buffer_offset); \
+        OE_ADD_SIZE(_deepcopy_out_buffer_offset, (size_t)(argsize));       \
+        if (_deepcopy_out_buffer_offset > _deepcopy_out_buffer_size)       \
+        {                                                                  \
+            _result = OE_BUFFER_TOO_SMALL;                                 \
+            goto done;                                                     \
+        }                                                                  \
+        memcpy(argname, _ptr, argsize);                                    \
+    }
+
 /**
  * Read an output parameter from output buffer.
  */

--- a/include/openenclave/edger8r/enclave.h
+++ b/include/openenclave/edger8r/enclave.h
@@ -156,6 +156,12 @@ void* oe_allocate_switchless_ocall_buffer(size_t size);
 void oe_free_switchless_ocall_buffer(void* buffer);
 
 /**
+ * Forward declarations of malloc and free for deep-copy out parameter support.
+ */
+void* malloc(size_t size);
+void free(void* buffer);
+
+/**
  * For hand-written enclaves, that use the older calling mechanism, define empty
  * ecall tables.
  */

--- a/include/openenclave/internal/calls.h
+++ b/include/openenclave/internal/calls.h
@@ -212,6 +212,21 @@ typedef struct _oe_call_host_function_args
 /*
 **==============================================================================
 **
+** oe_call_function_return_args_t
+**
+**==============================================================================
+*/
+
+typedef struct _oe_call_function_return_args
+{
+    oe_result_t result;
+    void* deepcopy_out_buffer;
+    size_t deepcopy_out_buffer_size;
+} oe_call_function_return_args_t;
+
+/*
+**==============================================================================
+**
 ** oe_call_host_function_internal()
 **
 **==============================================================================

--- a/tests/abi/enc/enc.cpp
+++ b/tests/abi/enc/enc.cpp
@@ -46,6 +46,8 @@ double enclave_check_abi()
     typedef struct _host_check_abi_args_t
     {
         oe_result_t _result;
+        void* deepcopy_out_buffer;
+        size_t deepcopy_out_buffer_size;
         double _retval;
     } host_check_abi_args_t;
 
@@ -69,7 +71,10 @@ double enclave_check_abi()
          .output_buffer_size = sizeof(args_template.check_abi_args),
          .output_bytes_written = 0,
          .result = OE_UNEXPECTED},
-        {._result = OE_UNEXPECTED, ._retval = 0}};
+        {._result = OE_UNEXPECTED,
+         .deepcopy_out_buffer = NULL,
+         .deepcopy_out_buffer_size = 0,
+         ._retval = 0}};
 
     /* Alloc and initialize host_check_abi OCALL args buffer */
     flat_ocall_args_t* args =

--- a/tests/abi/host/host.cpp
+++ b/tests/abi/host/host.cpp
@@ -46,6 +46,8 @@ oe_result_t test_abi_roundtrip(oe_enclave_t* enclave)
     typedef struct _enclave_check_abi_args_t
     {
         oe_result_t _result;
+        void* deepcopy_out_buffer;
+        size_t deepcopy_out_buffer_size;
         double _retval;
     } enclave_check_abi_args_t;
 
@@ -69,7 +71,10 @@ oe_result_t test_abi_roundtrip(oe_enclave_t* enclave)
          .output_buffer_size = sizeof(args_template.check_abi_args),
          .output_bytes_written = 0,
          .result = OE_UNEXPECTED},
-        {._result = OE_UNEXPECTED, ._retval = 0}};
+        {._result = OE_UNEXPECTED,
+         .deepcopy_out_buffer = NULL,
+         .deepcopy_out_buffer_size = 0,
+         ._retval = 0}};
 
     /* Skip the ABI state test in simulation mode since OE SDK doesn't
      * provide special ABI handling on simulated enclave transition */

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -22,6 +22,18 @@ enclave {
     [count=count] uint64_t* ptr;
   };
 
+  struct SizeStruct {
+    uint64_t count;
+    size_t size;
+    [size=16] uint64_t* ptr;
+  };
+
+  struct CountSizeStruct {
+    uint64_t count;
+    size_t size;
+    [count=2, size=12] uint64_t* ptr;
+  };
+
   struct SizeParamStruct {
     uint64_t count;
     size_t size;
@@ -44,6 +56,24 @@ enclave {
   struct SuperNestedStruct {
     // TODO: We should eventually support count being a member of the struct.
     [count=2] NestedStruct* more_structs;
+  };
+
+  struct CountParamNestedStruct
+  {
+    size_t num;
+    [count=num] CountParamStruct* array_of_struct;
+  };
+
+  struct MultipleNestedStruct
+  {
+    size_t num_1;
+    [count=num_1] CountParamStruct* array_of_struct_1;
+    size_t num_2;
+    [count=num_2] SizeParamStruct* array_of_struct_2;
+    size_t num_3;
+    [count=num_3] CountSizeParamStruct* array_of_struct_3;
+    size_t num_4;
+    [count=num_4] CountParamNestedStruct* array_of_struct_4;
   };
 
   struct IOVEC
@@ -70,6 +100,8 @@ enclave {
 
     // TODO: We should have a `SizeStruct` to test deep copying where
     // the size attribute is correctly used with a hard-coded value.
+    public void deepcopy_size([in, out, count=1] SizeStruct* s);
+    public void deepcopy_countsize([in, out, count=1] CountSizeStruct* s);
 
     // Deep copy of one `SizeParamStruct` with an embedded array
     // should take place.
@@ -117,5 +149,82 @@ enclave {
 
     // Test a real-world scenario.
     public void deepcopy_iovec([in, out, count=n] IOVEC* iov, size_t n);
+
+    // Expect the callee to set a large count value on return.
+    public void deepcopy_countparam_return_large([in, out, count=1] CountParamStruct* s);
+
+    // Expect the callee to set a large size value on return.
+    public void deepcopy_sizeparam_return_large([in, out, count=1] SizeParamStruct* s);
+
+    // Expect the callee to set a large size and count value on return.
+    public void deepcopy_countsizeparam_return_large([in, out, count=1] CountSizeParamStruct* s);
+
+    // Expect the callee to set a large size and count value on return.
+    public void deepcopy_countsize_return_large([in, out, count=1] CountSizeStruct* s);
+
+    public void test_deepcopy_ocalls();
+
+    public void deepcopy_countparam_out([out, count=1] CountParamStruct* s) transition_using_threads;
+    public void deepcopy_countparamarray_out([out, count=2] CountParamStruct* s) transition_using_threads;
+    public void deepcopy_countparamarray_partial_out([out, count=2] CountParamStruct* s) transition_using_threads;
+    public void deepcopy_sizeparam_out([out, count=1] SizeParamStruct* s) transition_using_threads;
+    public void deepcopy_countsizeparam_out([out, count=1] CountSizeParamStruct* s) transition_using_threads;
+    public void deepcopy_countsize_out([out, count=1] CountSizeStruct* s) transition_using_threads;
+    public void deepcopy_nested_out([out, count=1] NestedStruct* n) transition_using_threads;
+    public void deepcopy_nested_countparam_out([out, count=1] CountParamNestedStruct* n) transition_using_threads;
+    public void deepcopy_multiple_nested_out([out, count=1] MultipleNestedStruct* n) transition_using_threads;
+    public void deepcopy_multiple_nested_partial_out([out, count=1] MultipleNestedStruct* n) transition_using_threads;
+    public void deepcopy_mix([in, count=1] SizeParamStruct* s_in,
+                             [in, out, count=1] SizeParamStruct* s_inout,
+                             [out, count=1] SizeParamStruct* s_out,
+                             [user_check] SizeParamStruct* s_user_check,
+                             [out, count=1] SizeParamStruct* s_out_2) transition_using_threads;
+  };
+
+  untrusted
+  {
+    // Deep copy of one `CountParamStruct` with an embedded array
+    // should take place.
+    void ocall_deepcopy_countparam([in, out, count=1] CountParamStruct* s);
+
+    // Deep copy of one `SizeParamStruct` with an embedded array
+    // should take place.
+    void ocall_deepcopy_sizeparam([in, out, count=1] SizeParamStruct* s);
+
+    // Deep copy of two `CountSizeParamStruct`s each with an embedded
+    // array and different counts should take place.
+    void ocall_deepcopy_countsizeparam([in, out, count=1] CountSizeParamStruct* s);
+
+    // Deep copy of one `CountSizeStruct` with an embedded
+    // array should take place.
+    void ocall_deepcopy_countsize([in, out, count=1] CountSizeStruct* s);
+
+    // Expect the callee to set a large count value on return.
+    void ocall_deepcopy_countparam_return_large([in, out, count=1] CountParamStruct* s);
+
+    // Expect the callee to set a large count value on return.
+    void ocall_deepcopy_sizeparam_return_large([in, out, count=1] SizeParamStruct* s);
+
+    // Expect the callee to set a large count value on return.
+    void ocall_deepcopy_countsizeparam_return_large([in, out, count=1] CountSizeParamStruct* s);
+
+    // Expect the callee to set a large count value on return.
+    void ocall_deepcopy_countsize_return_large([in, out, count=1] CountSizeStruct* s);
+
+    void ocall_deepcopy_countparam_out([out, count=1] CountParamStruct* s) transition_using_threads;
+    void ocall_deepcopy_countparamarray_out([out, count=2] CountParamStruct* s) transition_using_threads;
+    void ocall_deepcopy_countparamarray_partial_out([out, count=2] CountParamStruct* s) transition_using_threads;
+    void ocall_deepcopy_sizeparam_out([out, count=1] SizeParamStruct* s) transition_using_threads;
+    void ocall_deepcopy_countsizeparam_out([out, count=1] CountSizeParamStruct* s) transition_using_threads;
+    void ocall_deepcopy_countsize_out([out, count=1] CountSizeStruct* s) transition_using_threads;
+    void ocall_deepcopy_nested_out([out, count=1] NestedStruct* n) transition_using_threads;
+    void ocall_deepcopy_nested_countparam_out([out, count=1] CountParamNestedStruct* n) transition_using_threads;
+    void ocall_deepcopy_multiple_nested_out([out, count=1] MultipleNestedStruct* n) transition_using_threads;
+    void ocall_deepcopy_multiple_nested_partial_out([out, count=1] MultipleNestedStruct* n) transition_using_threads;
+    void ocall_deepcopy_mix([in, count=1] SizeParamStruct* s_in,
+                            [in, out, count=1] SizeParamStruct* s_inout,
+                            [out, count=1] SizeParamStruct* s_out,
+                            [user_check] SizeParamStruct* s_user_check,
+                            [out, count=1] SizeParamStruct* s_out_2) transition_using_threads;
   };
 };

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -7,6 +7,7 @@
 #include <openenclave/corelibc/string.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/tests.h>
+#include <stdlib.h>
 #include <string.h>
 #include "all_t.h"
 
@@ -60,6 +61,63 @@ void deepcopy_countparam(CountParamStruct* s)
     for (size_t i = 0; i < s->count; ++i)
         OE_TEST(s->ptr[i] == data[i]);
     OE_TEST(oe_is_within_enclave(s->ptr, s->count * sizeof(uint64_t)));
+    // Modify the member used by the size attribute, which should
+    // not affect the value on the caller side.
+    s->count = 5;
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    s->size = 200;
+}
+
+void deepcopy_countparam_return_large(CountParamStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < s->count; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, s->count * sizeof(uint64_t)));
+    // Set the value to the member used by the count attribute larger
+    // than the supplied value. Expect to fail.
+    s->count = 100;
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    s->size = 200;
+}
+
+void deepcopy_size(SizeStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < 2; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, 16));
+}
+
+void deepcopy_countsize(CountSizeStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < 3; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, 24));
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    s->count = 5;
+    s->size = 32;
+}
+
+void deepcopy_countsize_return_large(CountSizeStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < 3; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, 24));
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    // Setting larger value is allowed in this case.
+    s->count = 100;
+    s->size = 200;
 }
 
 // Assert that the struct is deep-copied such that `s->ptr` has a copy
@@ -71,6 +129,27 @@ void deepcopy_sizeparam(SizeParamStruct* s)
     for (size_t i = 0; i < s->size / sizeof(uint64_t); ++i)
         OE_TEST(s->ptr[i] == data[i]);
     OE_TEST(oe_is_within_enclave(s->ptr, s->size));
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    s->count = 100;
+    // Modify the member used by the size attribute, which should
+    // not affect the value on the caller side.
+    s->size = 32;
+}
+
+void deepcopy_sizeparam_return_large(SizeParamStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < s->size / sizeof(uint64_t); ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, s->size));
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    s->count = 100;
+    // Set the value to the member used by the size attribute larger
+    // than the supplied value. Expect to fail.
+    s->size = 200;
 }
 
 // Assert that the struct is deep-copied such that `s->ptr` has a copy
@@ -82,6 +161,23 @@ void deepcopy_countsizeparam(CountSizeParamStruct* s)
     for (size_t i = 0; i < (s->count * s->size) / sizeof(uint64_t); ++i)
         OE_TEST(s->ptr[i] == data[i]);
     OE_TEST(oe_is_within_enclave(s->ptr, s->count * s->size));
+    // Modify the member used by size/count attributes, which should
+    // not affect the value on the caller side.
+    s->count = 4;
+    s->size = 2;
+}
+
+void deepcopy_countsizeparam_return_large(CountSizeParamStruct* s)
+{
+    OE_TEST(s->count == 8);
+    OE_TEST(s->size == 4);
+    for (size_t i = 0; i < (s->count * s->size) / sizeof(uint64_t); ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, s->count * s->size));
+    // Set the value to the member used by the size attribute larger
+    // than the supplied value. Expect to fail.
+    s->count = 100;
+    s->size = 200;
 }
 
 // Assert that the struct is deep-copied such that `s->ptr` has a copy
@@ -216,25 +312,6 @@ void deepcopy_inout_count(CountStruct* s)
         s->ptr[i] = data[i];
 }
 
-void deepcopy_out_count(CountStruct* s)
-{
-    s->count = 7;
-    s->size = 64;
-    for (size_t i = 0; i < 3; ++i)
-        s->ptr[i] = data[i];
-}
-
-void deepcopy_nested_out(NestedStruct* n)
-{
-    OE_TEST(oe_is_within_enclave(n, sizeof(NestedStruct)));
-    OE_TEST(oe_is_within_enclave(n->array_of_int, 4 * sizeof(int)));
-    for (int i = 0; i < 4; ++i)
-        n->array_of_int[i] = i;
-    OE_TEST(oe_is_within_enclave(n->array_of_struct, 3 * sizeof(CountStruct)));
-    for (size_t i = 0; i < 3; ++i)
-        deepcopy_out_count(&(n->array_of_struct[i]));
-}
-
 void deepcopy_iovec(IOVEC* iov, size_t n)
 {
     OE_TEST(!(n && !iov));
@@ -260,5 +337,767 @@ void deepcopy_iovec(IOVEC* iov, size_t n)
                 OE_TEST(false);
                 break;
         }
+    }
+}
+
+void deepcopy_countparam_out(CountParamStruct* s)
+{
+    if (!s)
+        return;
+    OE_TEST(s->count == 0);
+    OE_TEST(s->size == 0);
+    OE_TEST(s->ptr == NULL);
+    s->count = 5;
+    s->size = 200;
+    s->ptr = (uint64_t*)malloc(s->count * sizeof(uint64_t));
+    for (size_t i = 0; i < 5; ++i)
+        s->ptr[i] = data[i];
+}
+
+void deepcopy_countparamarray_out(CountParamStruct* s)
+{
+    OE_TEST(s != NULL);
+    OE_TEST(s->count == 0);
+    OE_TEST(s->size == 0);
+    OE_TEST(s->ptr == NULL);
+    s[0].count = 5;
+    s[0].size = 64;
+    s[0].ptr = (uint64_t*)malloc(s[0].count * sizeof(uint64_t));
+    for (size_t i = 0; i < s[0].count; ++i)
+        s[0].ptr[i] = data[i];
+
+    s[1].count = 4;
+    s[1].size = 32;
+    s[1].ptr = (uint64_t*)malloc(s[1].count * sizeof(uint64_t));
+    for (size_t i = 0; i < s[1].count; ++i)
+        s[1].ptr[i] = data[i];
+}
+
+void deepcopy_countparamarray_partial_out(CountParamStruct* s)
+{
+    OE_TEST(s != NULL);
+    OE_TEST(s->count == 0);
+    OE_TEST(s->size == 0);
+    OE_TEST(s->ptr == NULL);
+    s[0].count = 5;
+    s[0].size = 64;
+    s[0].ptr = (uint64_t*)malloc(s[0].count * sizeof(uint64_t));
+    for (size_t i = 0; i < s[0].count; ++i)
+        s[0].ptr[i] = data[i];
+
+    s[1].count = 0;
+    s[1].size = 32;
+    s[1].ptr = NULL;
+}
+
+void deepcopy_sizeparam_out(SizeParamStruct* s)
+{
+    OE_TEST(s != NULL);
+    OE_TEST(s->count == 0);
+    OE_TEST(s->size == 0);
+    OE_TEST(s->ptr == NULL);
+    s->count = 100;
+    s->size = 5 * sizeof(uint64_t);
+    s->ptr = (uint64_t*)malloc(s->size);
+    for (size_t i = 0; i < 5; ++i)
+        s->ptr[i] = data[i];
+}
+
+void deepcopy_countsizeparam_out(CountSizeParamStruct* s)
+{
+    OE_TEST(s != NULL);
+    OE_TEST(s->count == 0);
+    OE_TEST(s->size == 0);
+    OE_TEST(s->ptr == NULL);
+    s->count = 5;
+    s->size = sizeof(uint64_t);
+    s->ptr = (uint64_t*)malloc(s->size * s->count);
+    for (size_t i = 0; i < 5; ++i)
+        s->ptr[i] = data[i];
+}
+
+void deepcopy_countsize_out(CountSizeStruct* s)
+{
+    OE_TEST(s != NULL);
+    OE_TEST(s->count == 0);
+    OE_TEST(s->size == 0);
+    OE_TEST(s->ptr == NULL);
+    s->ptr = (uint64_t*)malloc(2 * 12);
+    for (size_t i = 0; i < 3; ++i)
+        s->ptr[i] = data[i];
+    s->count = 100;
+    s->size = 200;
+}
+
+void deepcopy_nested_countparam_out(CountParamNestedStruct* n)
+{
+    OE_TEST(n != NULL);
+    OE_TEST(n->num == 0);
+    OE_TEST(n->array_of_struct == NULL);
+    n->num = 5;
+    n->array_of_struct =
+        (CountParamStruct*)malloc(n->num * sizeof(CountParamStruct));
+    for (size_t i = 0; i < n->num; i++)
+    {
+        CountParamStruct* s = &n->array_of_struct[i];
+        s->count = 10;
+        s->size = i;
+        s->ptr = (uint64_t*)malloc(s->count * sizeof(uint64_t));
+        for (size_t j = 0; j < s->count; j++)
+            s->ptr[j] = i;
+    }
+}
+
+void deepcopy_nested_out(NestedStruct* n)
+{
+    OE_TEST(n != NULL);
+    OE_TEST(n->plain_int == 0);
+    OE_TEST(n->array_of_int == NULL);
+    OE_TEST(n->shallow_struct == NULL);
+    OE_TEST(n->array_of_struct == NULL);
+    n->plain_int = 100;
+    n->array_of_int = (int*)malloc(4 * sizeof(int));
+    for (int i = 0; i < 4; i++)
+        n->array_of_int[i] = i;
+    n->shallow_struct = NULL;
+    n->array_of_struct = (CountStruct*)malloc(3 * sizeof(CountSizeStruct));
+    for (int i = 0; i < 3; i++)
+    {
+        n->array_of_struct[i].ptr = (uint64_t*)malloc(3 * sizeof(uint64_t));
+        n->array_of_struct[i].count = 100;
+        n->array_of_struct[i].size = 200;
+        for (int j = 0; j < 3; j++)
+            n->array_of_struct[i].ptr[j] = data[j];
+    }
+}
+
+void deepcopy_multiple_nested_out(MultipleNestedStruct* n)
+{
+    OE_TEST(n != NULL);
+    OE_TEST(n->num_1 == 0);
+    OE_TEST(n->array_of_struct_1 == NULL);
+    OE_TEST(n->num_2 == 0);
+    OE_TEST(n->array_of_struct_2 == NULL);
+    OE_TEST(n->num_3 == 0);
+    OE_TEST(n->array_of_struct_3 == NULL);
+    OE_TEST(n->num_4 == 0);
+    OE_TEST(n->array_of_struct_4 == NULL);
+
+    n->num_1 = 5;
+    n->array_of_struct_1 =
+        (CountParamStruct*)malloc(n->num_1 * sizeof(CountParamStruct));
+    for (size_t i = 0; i < n->num_1; i++)
+    {
+        CountParamStruct* s = &n->array_of_struct_1[i];
+        s->count = 10;
+        s->size = i;
+        s->ptr = (uint64_t*)malloc(s->count * sizeof(uint64_t));
+        for (size_t j = 0; j < s->count; j++)
+            s->ptr[j] = i;
+    }
+    n->num_2 = 6;
+    n->array_of_struct_2 =
+        (SizeParamStruct*)malloc(n->num_2 * sizeof(SizeParamStruct));
+    for (size_t i = 0; i < n->num_2; i++)
+    {
+        SizeParamStruct* s = &n->array_of_struct_2[i];
+        s->count = i;
+        s->size = 15 * sizeof(uint64_t);
+        s->ptr = (uint64_t*)malloc(s->size);
+        for (size_t j = 0; j < 15; j++)
+            s->ptr[j] = i;
+    }
+
+    n->num_3 = 7;
+    n->array_of_struct_3 =
+        (CountSizeParamStruct*)malloc(n->num_3 * sizeof(CountSizeParamStruct));
+    for (size_t i = 0; i < n->num_3; i++)
+    {
+        CountSizeParamStruct* s = &n->array_of_struct_3[i];
+        s->count = 20;
+        s->size = sizeof(uint64_t);
+        s->ptr = (uint64_t*)malloc(s->count * s->size);
+        for (size_t j = 0; j < s->count; j++)
+            s->ptr[j] = i;
+    }
+
+    n->num_4 = 3;
+    n->array_of_struct_4 = (CountParamNestedStruct*)malloc(
+        n->num_4 * sizeof(CountParamNestedStruct));
+    for (size_t i = 0; i < n->num_4; i++)
+    {
+        CountParamNestedStruct* s = &n->array_of_struct_4[i];
+        s->num = 4;
+        s->array_of_struct =
+            (CountParamStruct*)malloc(s->num * sizeof(CountParamStruct));
+        for (size_t j = 0; j < s->num; j++)
+        {
+            CountParamStruct* m = &s->array_of_struct[j];
+            m->count = 25;
+            m->size = j;
+            m->ptr = (uint64_t*)malloc(m->count * sizeof(uint64_t));
+            for (size_t k = 0; k < m->count; k++)
+                m->ptr[k] = j;
+        }
+    }
+}
+
+void deepcopy_multiple_nested_partial_out(MultipleNestedStruct* n)
+{
+    OE_TEST(n != NULL);
+    OE_TEST(n->num_1 == 0);
+    OE_TEST(n->array_of_struct_1 == NULL);
+    OE_TEST(n->num_2 == 0);
+    OE_TEST(n->array_of_struct_2 == NULL);
+    OE_TEST(n->num_3 == 0);
+    OE_TEST(n->array_of_struct_3 == NULL);
+    OE_TEST(n->num_4 == 0);
+    OE_TEST(n->array_of_struct_4 == NULL);
+
+    n->num_1 = 5;
+    n->array_of_struct_1 =
+        (CountParamStruct*)malloc(n->num_1 * sizeof(CountParamStruct));
+    for (size_t i = 0; i < n->num_1; i++)
+    {
+        CountParamStruct* s = &n->array_of_struct_1[i];
+        s->count = 10;
+        s->size = i;
+        s->ptr = (uint64_t*)malloc(s->count * sizeof(uint64_t));
+        for (size_t j = 0; j < s->count; j++)
+            s->ptr[j] = i;
+    }
+
+    n->num_2 = 6;
+    n->array_of_struct_2 = NULL;
+
+    n->num_3 = 7;
+    n->array_of_struct_3 =
+        (CountSizeParamStruct*)malloc(n->num_3 * sizeof(CountSizeParamStruct));
+    for (size_t i = 0; i < n->num_3; i++)
+    {
+        CountSizeParamStruct* s = &n->array_of_struct_3[i];
+        if (i == 3)
+        {
+            s->count = 10;
+            s->size = 5;
+            s->ptr = NULL;
+            continue;
+        }
+        s->count = 20;
+        s->size = sizeof(uint64_t);
+        s->ptr = (uint64_t*)malloc(s->count * s->size);
+        for (size_t j = 0; j < s->count; j++)
+            s->ptr[j] = i;
+    }
+
+    n->num_4 = 3;
+    n->array_of_struct_4 = (CountParamNestedStruct*)malloc(
+        n->num_4 * sizeof(CountParamNestedStruct));
+    for (size_t i = 0; i < n->num_4; i++)
+    {
+        CountParamNestedStruct* s = &n->array_of_struct_4[i];
+        if (i == 2)
+        {
+            s->num = 2;
+            s->array_of_struct = NULL;
+            continue;
+        }
+        s->num = 4;
+        s->array_of_struct =
+            (CountParamStruct*)malloc(s->num * sizeof(CountParamStruct));
+        for (size_t j = 0; j < s->num; j++)
+        {
+            CountParamStruct* m = &s->array_of_struct[j];
+            if (j == 1)
+            {
+                m->count = 30;
+                m->size = 15;
+                m->ptr = NULL;
+                continue;
+            }
+            m->count = 25;
+            m->size = j;
+            m->ptr = (uint64_t*)malloc(m->count * sizeof(uint64_t));
+            for (size_t k = 0; k < m->count; k++)
+                m->ptr[k] = j;
+        }
+    }
+}
+
+static void set_sizeparam(
+    SizeParamStruct* s,
+    size_t count,
+    size_t size,
+    int pattern,
+    bool in_enclave)
+{
+    s->count = count;
+    s->size = size;
+    if (in_enclave)
+        s->ptr = (uint64_t*)malloc(size);
+    else
+        s->ptr = (uint64_t*)oe_host_malloc(size);
+    memset(s->ptr, pattern, size);
+}
+
+static void check_sizeparam(
+    SizeParamStruct* s,
+    size_t count,
+    size_t size,
+    int pattern)
+{
+    OE_TEST(s->count == count);
+    OE_TEST(s->size == size);
+    for (size_t i = 0; i < size; i++)
+        OE_TEST(((char*)s->ptr)[i] == pattern);
+}
+
+void deepcopy_mix(
+    SizeParamStruct* s_in,
+    SizeParamStruct* s_inout,
+    SizeParamStruct* s_out,
+    SizeParamStruct* s_user_check,
+    SizeParamStruct* s_out_2)
+{
+    OE_TEST(s_in->count == 10);
+    OE_TEST(s_in->size == 10);
+    for (int i = 0; i < 10; i++)
+        OE_TEST(((char*)s_in->ptr)[i] == 'A');
+
+    OE_TEST(s_inout->count == 20);
+    OE_TEST(s_inout->size == 20);
+    for (int i = 0; i < 20; i++)
+        OE_TEST(((char*)s_inout->ptr)[i] == 'B');
+
+    s_inout->count = 10;
+    /* Setting the size to an inout struct should not affect the value on the
+     * host. */
+    s_inout->size = 10;
+    memset(s_inout->ptr, 'C', 20);
+
+    OE_TEST(s_out != NULL);
+    OE_TEST(s_out->count == 0);
+    OE_TEST(s_out->size == 0);
+    OE_TEST(s_out->ptr == 0);
+    set_sizeparam(s_out, 30, 30, 'D', true);
+    set_sizeparam(s_user_check, 40, 40, 'E', false);
+    OE_TEST(oe_is_outside_enclave(s_user_check, 40));
+    OE_TEST(s_out_2 != NULL);
+    OE_TEST(s_out_2->count == 0);
+    OE_TEST(s_out_2->size == 0);
+    OE_TEST(s_out_2->ptr == 0);
+    set_sizeparam(s_out_2, 50, 50, 'F', true);
+}
+
+template <typename T>
+void test_struct(const T& s, size_t size = 8, size_t offset = 0)
+{
+    for (size_t i = 0; i < size; ++i)
+        OE_TEST(s.ptr[i] == data[offset + i]);
+}
+
+template <typename T>
+T init_struct()
+{
+    T s = T{7ULL, 64ULL, data};
+    test_struct(s);
+    return s;
+}
+
+void test_deepcopy_ocalls()
+{
+    {
+        auto s = init_struct<CountParamStruct>();
+        OE_TEST(ocall_deepcopy_countparam(&s) == OE_OK);
+        // The members used by size/count attributes are expected to
+        // be consistent even if the callee modified them.
+        OE_TEST(s.count == 7);
+        // The members not used by size/count attributes are expected to
+        // match the value set by the callee.
+        OE_TEST(s.size == 200);
+        test_struct(s, s.count);
+    }
+
+    {
+        auto s = init_struct<SizeParamStruct>();
+        OE_TEST(ocall_deepcopy_sizeparam(&s) == OE_OK);
+        // The members used by size/count attributes are expected to
+        // be consistent even if the callee modified them.
+        OE_TEST(s.size == 64);
+        // The members not used by size/count attributes are expected to
+        // match the value set by the callee.
+        OE_TEST(s.count == 100);
+        test_struct(s, s.size / sizeof(uint64_t));
+    }
+
+    {
+        auto s = init_struct<CountSizeParamStruct>();
+        s.count = 8;
+        s.size = 4;
+        OE_TEST(ocall_deepcopy_countsizeparam(&s) == OE_OK);
+        // The members used by size/count attributes are expected to
+        // be consistent even if the callee modified them.
+        OE_TEST(s.count == 8);
+        OE_TEST(s.size == 4);
+        test_struct(s, (s.count * s.size) / sizeof(uint64_t));
+    }
+
+    {
+        auto s = init_struct<CountSizeStruct>();
+        OE_TEST(ocall_deepcopy_countsize(&s) == OE_OK);
+        test_struct(s, 3);
+        // The members not used by size/count attributes are expected to
+        // match the value set by the callee.
+        OE_TEST(s.count == 5);
+        OE_TEST(s.size == 32);
+    }
+
+    {
+        auto s = init_struct<CountParamStruct>();
+        OE_TEST(ocall_deepcopy_countparam_return_large(&s) == OE_FAILURE);
+    }
+
+    {
+        auto s = init_struct<SizeParamStruct>();
+        OE_TEST(ocall_deepcopy_sizeparam_return_large(&s) == OE_FAILURE);
+    }
+
+    {
+        auto s = init_struct<CountSizeParamStruct>();
+        s.count = 8;
+        s.size = 4;
+        OE_TEST(ocall_deepcopy_countsizeparam_return_large(&s) == OE_FAILURE);
+    }
+
+    {
+        auto s = init_struct<CountSizeStruct>();
+        OE_TEST(ocall_deepcopy_countsize_return_large(&s) == OE_OK);
+        test_struct(s, 3);
+        // The members not used by size/count attributes are expected to
+        // match the value set by the callee.
+        OE_TEST(s.count == 100);
+        OE_TEST(s.size == 200);
+    }
+
+    {
+        CountParamStruct s;
+        memset(&s, 0, sizeof(CountParamStruct));
+        OE_TEST(ocall_deepcopy_countparam_out(&s) == OE_OK);
+        test_struct(s, 5);
+        OE_TEST(s.count == 5);
+        OE_TEST(s.size == 200);
+        free(s.ptr);
+    }
+
+    {
+        OE_TEST(ocall_deepcopy_countparam_out(NULL) == OE_OK);
+    }
+
+    {
+        CountParamStruct s[2];
+        memset(s, 0, sizeof(CountParamStruct) * 2);
+        OE_TEST(ocall_deepcopy_countparamarray_out(s) == OE_OK);
+        test_struct(s[0], 5);
+        OE_TEST(s[0].count == 5);
+        OE_TEST(s[0].size == 64);
+        test_struct(s[1], 4);
+        OE_TEST(s[1].count == 4);
+        OE_TEST(s[1].size == 32);
+        for (int i = 0; i < 2; i++)
+            free(s[i].ptr);
+    }
+
+    {
+        CountParamStruct s[2];
+        memset(s, 0, sizeof(CountParamStruct) * 2);
+        OE_TEST(ocall_deepcopy_countparamarray_partial_out(s) == OE_OK);
+        test_struct(s[0], 5);
+        OE_TEST(s[0].count == 5);
+        OE_TEST(s[0].size == 64);
+        OE_TEST(s[1].count == 0);
+        OE_TEST(s[1].size == 32);
+        OE_TEST(s[1].ptr == NULL);
+        for (int i = 0; i < 1; i++)
+            free(s[i].ptr);
+    }
+
+    {
+        SizeParamStruct s;
+        memset(&s, 0, sizeof(SizeParamStruct));
+        OE_TEST(ocall_deepcopy_sizeparam_out(&s) == OE_OK);
+        test_struct(s, 5);
+        OE_TEST(s.count == 100);
+        OE_TEST(s.size == 5 * sizeof(uint64_t));
+        free(s.ptr);
+    }
+
+    {
+        CountSizeParamStruct s;
+        memset(&s, 0, sizeof(CountSizeParamStruct));
+        OE_TEST(ocall_deepcopy_countsizeparam_out(&s) == OE_OK);
+        test_struct(s, 5);
+        OE_TEST(s.count == 5);
+        OE_TEST(s.size == sizeof(uint64_t));
+        free(s.ptr);
+    }
+
+    {
+        CountSizeStruct s;
+        memset(&s, 0, sizeof(CountSizeStruct));
+        OE_TEST(ocall_deepcopy_countsize_out(&s) == OE_OK);
+        test_struct(s, 3);
+        OE_TEST(s.count == 100);
+        OE_TEST(s.size == 200);
+        free(s.ptr);
+    }
+
+    {
+        CountParamNestedStruct n;
+        memset(&n, 0, sizeof(CountParamNestedStruct));
+        OE_TEST(ocall_deepcopy_nested_countparam_out(&n) == OE_OK);
+        OE_TEST(n.num == 5);
+        for (size_t i = 0; i < n.num; i++)
+        {
+            CountParamStruct* s = &n.array_of_struct[i];
+            OE_TEST(s->count == 10);
+            OE_TEST(s->size == i);
+            for (size_t j = 0; j < s->count; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+        if (n.array_of_struct)
+        {
+            for (size_t i = 0; i < n.num; i++)
+                free(n.array_of_struct[i].ptr);
+            free(n.array_of_struct);
+        }
+    }
+
+    {
+        NestedStruct n;
+        memset(&n, 0, sizeof(NestedStruct));
+        OE_TEST(ocall_deepcopy_nested_out(&n) == OE_OK);
+        OE_TEST(n.plain_int == 100);
+        for (int i = 0; i < 4; i++)
+            OE_TEST(n.array_of_int[i] == i);
+        OE_TEST(n.shallow_struct == NULL);
+        for (int i = 0; i < 3; i++)
+        {
+            OE_TEST(n.array_of_struct[i].count == 100);
+            OE_TEST(n.array_of_struct[i].size == 200);
+            test_struct(n.array_of_struct[i], 3);
+        }
+        free(n.array_of_int);
+        for (int i = 0; i < 3; i++)
+            free(n.array_of_struct[i].ptr);
+        free(n.array_of_struct);
+    }
+
+    {
+        MultipleNestedStruct n;
+        memset(&n, 0, sizeof(MultipleNestedStruct));
+        OE_TEST(ocall_deepcopy_multiple_nested_out(&n) == OE_OK);
+        OE_TEST(n.num_1 == 5);
+        for (size_t i = 0; i < n.num_1; i++)
+        {
+            CountParamStruct* s = &n.array_of_struct_1[i];
+            OE_TEST(s->count == 10);
+            OE_TEST(s->size == i);
+            for (size_t j = 0; j < s->count; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+
+        OE_TEST(n.num_2 == 6);
+        for (size_t i = 0; i < n.num_2; i++)
+        {
+            SizeParamStruct* s = &n.array_of_struct_2[i];
+            OE_TEST(s->count == i);
+            OE_TEST(s->size == 15 * sizeof(uint64_t));
+            for (size_t j = 0; j < 15; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+
+        OE_TEST(n.num_3 == 7);
+        for (size_t i = 0; i < n.num_3; i++)
+        {
+            CountSizeParamStruct* s = &n.array_of_struct_3[i];
+            OE_TEST(s->count == 20);
+            OE_TEST(s->size == sizeof(uint64_t));
+            for (size_t j = 0; j < 20; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+
+        OE_TEST(n.num_4 == 3);
+        for (size_t i = 0; i < n.num_4; i++)
+        {
+            CountParamNestedStruct* s = &n.array_of_struct_4[i];
+            OE_TEST(s->num == 4);
+            for (size_t j = 0; j < s->num; j++)
+            {
+                CountParamStruct* m = &s->array_of_struct[j];
+                OE_TEST(m->count == 25);
+                OE_TEST(m->size == j);
+                for (size_t k = 0; k < m->count; k++)
+                {
+                    OE_TEST(m->ptr[k] == j);
+                }
+            }
+        }
+
+        if (n.array_of_struct_1)
+        {
+            for (size_t i = 0; i < n.num_1; i++)
+                free(n.array_of_struct_1[i].ptr);
+            free(n.array_of_struct_1);
+        }
+        if (n.array_of_struct_2)
+        {
+            for (size_t i = 0; i < n.num_2; i++)
+                free(n.array_of_struct_2[i].ptr);
+            free(n.array_of_struct_2);
+        }
+        if (n.array_of_struct_3)
+        {
+            for (size_t i = 0; i < n.num_3; i++)
+                free(n.array_of_struct_3[i].ptr);
+            free(n.array_of_struct_3);
+        }
+        if (n.array_of_struct_4)
+        {
+            for (size_t i = 0; i < n.num_4; i++)
+            {
+                if (n.array_of_struct_4[i].array_of_struct)
+                {
+                    for (size_t j = 0; j < n.array_of_struct_4[i].num; j++)
+                        free(n.array_of_struct_4[i].array_of_struct[j].ptr);
+                }
+                free(n.array_of_struct_4[i].array_of_struct);
+            }
+            free(n.array_of_struct_4);
+        }
+    }
+
+    {
+        MultipleNestedStruct n;
+        memset(&n, 0, sizeof(MultipleNestedStruct));
+        OE_TEST(ocall_deepcopy_multiple_nested_partial_out(&n) == OE_OK);
+        OE_TEST(n.num_1 == 5);
+        for (size_t i = 0; i < n.num_1; i++)
+        {
+            CountParamStruct* s = &n.array_of_struct_1[i];
+            OE_TEST(s->count == 10);
+            OE_TEST(s->size == i);
+            for (size_t j = 0; j < s->count; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+
+        OE_TEST(n.num_2 == 6);
+        OE_TEST(n.array_of_struct_2 == NULL);
+
+        OE_TEST(n.num_3 == 7);
+        for (size_t i = 0; i < n.num_3; i++)
+        {
+            CountSizeParamStruct* s = &n.array_of_struct_3[i];
+            if (i == 3)
+            {
+                OE_TEST(s->count == 10);
+                OE_TEST(s->size == 5);
+                OE_TEST(s->ptr == NULL);
+                continue;
+            }
+            OE_TEST(s->count == 20);
+            OE_TEST(s->size == sizeof(uint64_t));
+            for (size_t j = 0; j < 20; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+
+        OE_TEST(n.num_4 == 3);
+        for (size_t i = 0; i < n.num_4; i++)
+        {
+            CountParamNestedStruct* s = &n.array_of_struct_4[i];
+            if (i == 2)
+            {
+                OE_TEST(s->num == 2);
+                OE_TEST(s->array_of_struct == NULL);
+                continue;
+            }
+            OE_TEST(s->num == 4);
+            for (size_t j = 0; j < s->num; j++)
+            {
+                CountParamStruct* m = &s->array_of_struct[j];
+                if (j == 1)
+                {
+                    OE_TEST(m->count == 30);
+                    OE_TEST(m->size == 15);
+                    OE_TEST(m->ptr == NULL);
+                    continue;
+                }
+                OE_TEST(m->count == 25);
+                OE_TEST(m->size == j);
+                for (size_t k = 0; k < m->count; k++)
+                {
+                    OE_TEST(m->ptr[k] == j);
+                }
+            }
+        }
+
+        if (n.array_of_struct_1)
+        {
+            for (size_t i = 0; i < n.num_1; i++)
+                free(n.array_of_struct_1[i].ptr);
+            free(n.array_of_struct_1);
+        }
+        if (n.array_of_struct_2)
+        {
+            for (size_t i = 0; i < n.num_2; i++)
+                free(n.array_of_struct_2[i].ptr);
+            free(n.array_of_struct_2);
+        }
+        if (n.array_of_struct_3)
+        {
+            for (size_t i = 0; i < n.num_3; i++)
+                free(n.array_of_struct_3[i].ptr);
+            free(n.array_of_struct_3);
+        }
+        if (n.array_of_struct_4)
+        {
+            for (size_t i = 0; i < n.num_4; i++)
+            {
+                if (n.array_of_struct_4[i].array_of_struct)
+                {
+                    for (size_t j = 0; j < n.array_of_struct_4[i].num; j++)
+                        free(n.array_of_struct_4[i].array_of_struct[j].ptr);
+                }
+                free(n.array_of_struct_4[i].array_of_struct);
+            }
+            free(n.array_of_struct_4);
+        }
+    }
+
+    {
+        SizeParamStruct s_in, s_inout, s_out, s_user_check, s_out_2;
+        set_sizeparam(&s_in, 10, 10, (int)'A', true);
+        set_sizeparam(&s_inout, 20, 20, (int)'B', true);
+        OE_TEST(
+            ocall_deepcopy_mix(
+                &s_in, &s_inout, &s_out, &s_user_check, &s_out_2) == OE_OK);
+        check_sizeparam(&s_inout, 10, 20, 'C');
+        check_sizeparam(&s_out, 30, 30, 'D');
+        check_sizeparam(&s_out_2, 50, 50, 'F');
+        free(s_in.ptr);
+        free(s_inout.ptr);
+        free(s_out.ptr);
+        free(s_out_2.ptr);
     }
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -47,6 +47,414 @@ std::array<T, 2> init_structs()
     return s;
 }
 
+// Assert that the struct is deep-copied such that `s->ptr` has a copy
+// of `s->count` elements of `data`.
+void ocall_deepcopy_countparam(CountParamStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < s->count; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+
+    // Modify the member used by the size attribute, which should
+    // not affect the value on the caller side.
+    s->count = 5;
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    s->size = 200;
+}
+
+void ocall_deepcopy_countparam_return_large(CountParamStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < s->count; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+
+    // Set the value to the member used by the count attribute larger
+    // than the supplied value. Expect to fail.
+    s->count = 100;
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    s->size = 200;
+}
+
+// Assert that the struct is deep-copied such that `s->ptr` has a copy
+// of `s->size` bytes of `data`.
+void ocall_deepcopy_sizeparam(SizeParamStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < s->size / sizeof(uint64_t); ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    s->count = 100;
+    // Modify the member used by the size attribute, which should
+    // not affect the value on the caller side.
+    s->size = 32;
+}
+
+void ocall_deepcopy_sizeparam_return_large(SizeParamStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < s->size / sizeof(uint64_t); ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    s->count = 100;
+    // Set the value to the member used by the count attribute larger
+    // than the supplied value. Expect to fail.
+    s->size = 200;
+}
+
+// Assert that the struct is deep-copied such that `s->ptr` has a copy
+// of `s->count * s->size` bytes of `data`.
+void ocall_deepcopy_countsizeparam(CountSizeParamStruct* s)
+{
+    OE_TEST(s->count == 8);
+    OE_TEST(s->size == 4);
+    for (size_t i = 0; i < (s->count * s->size) / sizeof(uint64_t); ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+
+    // Modify the member used by size/count attributes, which should
+    // not affect the value on the caller side.
+    s->count = 4;
+    s->size = 2;
+}
+
+// Assert that the struct is deep-copied such that `s->ptr` has a copy
+// of `s->count * s->size` bytes of `data`.
+void ocall_deepcopy_countsizeparam_return_large(CountSizeParamStruct* s)
+{
+    OE_TEST(s->count == 8);
+    OE_TEST(s->size == 4);
+    for (size_t i = 0; i < (s->count * s->size) / sizeof(uint64_t); ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+
+    // Set the value to the member used by the count attribute larger
+    // than the supplied value. Expect to fail.
+    s->count = 100;
+    s->size = 200;
+}
+
+void ocall_deepcopy_countsize(CountSizeStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < 3; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    s->count = 5;
+    s->size = 32;
+}
+
+void ocall_deepcopy_countsize_return_large(CountSizeStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < 3; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+
+    // Modify the member not used by the size/count attributes,
+    // which should affect the value on the caller side.
+    // Setting larger value is allowed in this case.
+    s->count = 100;
+    s->size = 200;
+}
+
+void ocall_deepcopy_countparam_out(CountParamStruct* s)
+{
+    if (!s)
+        return;
+    s->count = 5;
+    s->size = 200;
+    s->ptr = (uint64_t*)malloc(s->count * sizeof(uint64_t));
+    for (size_t i = 0; i < 5; ++i)
+        s->ptr[i] = data[i];
+}
+
+void ocall_deepcopy_countparamarray_out(CountParamStruct* s)
+{
+    s[0].count = 5;
+    s[0].size = 64;
+    s[0].ptr = (uint64_t*)malloc(s[0].count * sizeof(uint64_t));
+    for (size_t i = 0; i < s[0].count; ++i)
+        s[0].ptr[i] = data[i];
+
+    s[1].count = 4;
+    s[1].size = 32;
+    s[1].ptr = (uint64_t*)malloc(s[1].count * sizeof(uint64_t));
+    for (size_t i = 0; i < s[1].count; ++i)
+        s[1].ptr[i] = data[i];
+}
+
+void ocall_deepcopy_countparamarray_partial_out(CountParamStruct* s)
+{
+    s[0].count = 5;
+    s[0].size = 64;
+    s[0].ptr = (uint64_t*)malloc(s[0].count * sizeof(uint64_t));
+    for (size_t i = 0; i < s[0].count; ++i)
+        s[0].ptr[i] = data[i];
+
+    s[1].count = 0;
+    s[1].size = 32;
+    s[1].ptr = NULL;
+}
+
+void ocall_deepcopy_sizeparam_out(SizeParamStruct* s)
+{
+    s->count = 100;
+    s->size = 5 * sizeof(uint64_t);
+    s->ptr = (uint64_t*)malloc(s->size);
+    for (size_t i = 0; i < 5; ++i)
+        s->ptr[i] = data[i];
+}
+
+void ocall_deepcopy_countsizeparam_out(CountSizeParamStruct* s)
+{
+    s->count = 5;
+    s->size = sizeof(uint64_t);
+    s->ptr = (uint64_t*)malloc(s->size * s->count);
+    for (size_t i = 0; i < 5; ++i)
+        s->ptr[i] = data[i];
+}
+
+void ocall_deepcopy_countsize_out(CountSizeStruct* s)
+{
+    s->ptr = (uint64_t*)malloc(2 * 12);
+    for (size_t i = 0; i < 3; ++i)
+        s->ptr[i] = data[i];
+    s->count = 100;
+    s->size = 200;
+}
+
+void ocall_deepcopy_nested_countparam_out(CountParamNestedStruct* n)
+{
+    OE_TEST(n != NULL);
+    n->num = 5;
+    n->array_of_struct =
+        (CountParamStruct*)malloc(n->num * sizeof(CountParamStruct));
+    for (size_t i = 0; i < n->num; i++)
+    {
+        CountParamStruct* s = &n->array_of_struct[i];
+        s->count = 10;
+        s->size = i;
+        s->ptr = (uint64_t*)malloc(s->count * sizeof(uint64_t));
+        for (size_t j = 0; j < s->count; j++)
+            s->ptr[j] = i;
+    }
+}
+
+void ocall_deepcopy_nested_out(NestedStruct* n)
+{
+    n->plain_int = 100;
+    n->array_of_int = (int*)malloc(4 * sizeof(int));
+    for (int i = 0; i < 4; i++)
+        n->array_of_int[i] = i;
+    n->shallow_struct = NULL;
+    n->array_of_struct = (CountStruct*)malloc(3 * sizeof(CountSizeStruct));
+    for (int i = 0; i < 3; i++)
+    {
+        n->array_of_struct[i].ptr = (uint64_t*)malloc(3 * sizeof(uint64_t));
+        n->array_of_struct[i].count = 100;
+        n->array_of_struct[i].size = 200;
+        for (int j = 0; j < 3; j++)
+            n->array_of_struct[i].ptr[j] = data[j];
+    }
+}
+
+void ocall_deepcopy_multiple_nested_out(MultipleNestedStruct* n)
+{
+    n->num_1 = 5;
+    n->array_of_struct_1 =
+        (CountParamStruct*)malloc(n->num_1 * sizeof(CountParamStruct));
+    for (size_t i = 0; i < n->num_1; i++)
+    {
+        CountParamStruct* s = &n->array_of_struct_1[i];
+        s->count = 10;
+        s->size = i;
+        s->ptr = (uint64_t*)malloc(s->count * sizeof(uint64_t));
+        for (size_t j = 0; j < s->count; j++)
+            s->ptr[j] = i;
+    }
+    n->num_2 = 6;
+    n->array_of_struct_2 =
+        (SizeParamStruct*)malloc(n->num_2 * sizeof(SizeParamStruct));
+    for (size_t i = 0; i < n->num_2; i++)
+    {
+        SizeParamStruct* s = &n->array_of_struct_2[i];
+        s->count = i;
+        s->size = 15 * sizeof(uint64_t);
+        s->ptr = (uint64_t*)malloc(s->size);
+        for (size_t j = 0; j < 15; j++)
+            s->ptr[j] = i;
+    }
+
+    n->num_3 = 7;
+    n->array_of_struct_3 =
+        (CountSizeParamStruct*)malloc(n->num_3 * sizeof(CountSizeParamStruct));
+    for (size_t i = 0; i < n->num_3; i++)
+    {
+        CountSizeParamStruct* s = &n->array_of_struct_3[i];
+        s->count = 20;
+        s->size = sizeof(uint64_t);
+        s->ptr = (uint64_t*)malloc(s->count * s->size);
+        for (size_t j = 0; j < s->count; j++)
+            s->ptr[j] = i;
+    }
+
+    n->num_4 = 3;
+    n->array_of_struct_4 = (CountParamNestedStruct*)malloc(
+        n->num_4 * sizeof(CountParamNestedStruct));
+    for (size_t i = 0; i < n->num_4; i++)
+    {
+        CountParamNestedStruct* s = &n->array_of_struct_4[i];
+        s->num = 4;
+        s->array_of_struct =
+            (CountParamStruct*)malloc(s->num * sizeof(CountParamStruct));
+        for (size_t j = 0; j < s->num; j++)
+        {
+            CountParamStruct* m = &s->array_of_struct[j];
+            m->count = 25;
+            m->size = j;
+            m->ptr = (uint64_t*)malloc(m->count * sizeof(uint64_t));
+            for (size_t k = 0; k < m->count; k++)
+                m->ptr[k] = j;
+        }
+    }
+}
+
+void ocall_deepcopy_multiple_nested_partial_out(MultipleNestedStruct* n)
+{
+    n->num_1 = 5;
+    n->array_of_struct_1 =
+        (CountParamStruct*)malloc(n->num_1 * sizeof(CountParamStruct));
+    for (size_t i = 0; i < n->num_1; i++)
+    {
+        CountParamStruct* s = &n->array_of_struct_1[i];
+        s->count = 10;
+        s->size = i;
+        s->ptr = (uint64_t*)malloc(s->count * sizeof(uint64_t));
+        for (size_t j = 0; j < s->count; j++)
+            s->ptr[j] = i;
+    }
+
+    n->num_2 = 6;
+    n->array_of_struct_2 = NULL;
+
+    n->num_3 = 7;
+    n->array_of_struct_3 =
+        (CountSizeParamStruct*)malloc(n->num_3 * sizeof(CountSizeParamStruct));
+    for (size_t i = 0; i < n->num_3; i++)
+    {
+        CountSizeParamStruct* s = &n->array_of_struct_3[i];
+        if (i == 3)
+        {
+            s->count = 10;
+            s->size = 5;
+            s->ptr = NULL;
+            continue;
+        }
+        s->count = 20;
+        s->size = sizeof(uint64_t);
+        s->ptr = (uint64_t*)malloc(s->count * s->size);
+        for (size_t j = 0; j < s->count; j++)
+            s->ptr[j] = i;
+    }
+
+    n->num_4 = 3;
+    n->array_of_struct_4 = (CountParamNestedStruct*)malloc(
+        n->num_4 * sizeof(CountParamNestedStruct));
+    for (size_t i = 0; i < n->num_4; i++)
+    {
+        CountParamNestedStruct* s = &n->array_of_struct_4[i];
+        if (i == 2)
+        {
+            s->num = 2;
+            s->array_of_struct = NULL;
+            continue;
+        }
+        s->num = 4;
+        s->array_of_struct =
+            (CountParamStruct*)malloc(s->num * sizeof(CountParamStruct));
+        for (size_t j = 0; j < s->num; j++)
+        {
+            CountParamStruct* m = &s->array_of_struct[j];
+            if (j == 1)
+            {
+                m->count = 30;
+                m->size = 15;
+                m->ptr = NULL;
+                continue;
+            }
+            m->count = 25;
+            m->size = j;
+            m->ptr = (uint64_t*)malloc(m->count * sizeof(uint64_t));
+            for (size_t k = 0; k < m->count; k++)
+                m->ptr[k] = j;
+        }
+    }
+}
+
+static void set_sizeparam(
+    SizeParamStruct* s,
+    size_t count,
+    size_t size,
+    int pattern)
+{
+    s->count = count;
+    s->size = size;
+    s->ptr = (uint64_t*)malloc(size);
+    memset(s->ptr, pattern, size);
+}
+
+static void check_sizeparam(
+    SizeParamStruct* s,
+    size_t count,
+    size_t size,
+    int pattern)
+{
+    OE_TEST(s->count == count);
+    OE_TEST(s->size == size);
+    for (size_t i = 0; i < size; i++)
+        OE_TEST(((char*)s->ptr)[i] == pattern);
+}
+
+void ocall_deepcopy_mix(
+    SizeParamStruct* s_in,
+    SizeParamStruct* s_inout,
+    SizeParamStruct* s_out,
+    SizeParamStruct* s_user_check,
+    SizeParamStruct* s_out_2)
+{
+    OE_TEST(s_in->count == 10);
+    OE_TEST(s_in->size == 10);
+    for (int i = 0; i < 10; i++)
+        OE_TEST(((char*)s_in->ptr)[i] == 'A');
+
+    OE_TEST(s_inout->count == 20);
+    OE_TEST(s_inout->size == 20);
+    for (int i = 0; i < 20; i++)
+        OE_TEST(((char*)s_inout->ptr)[i] == 'B');
+
+    s_inout->count = 10;
+    /* Setting the size to an inout struct should not affect the value on the
+     * enclave. */
+    s_inout->size = 10;
+    memset(s_inout->ptr, 'C', 20);
+
+    set_sizeparam(s_out, 30, 30, 'D');
+    /* Host cannot access enclave memory. */
+    (void)s_user_check;
+    set_sizeparam(s_out_2, 50, 50, 'F');
+}
+
 void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
 {
     {
@@ -68,14 +476,40 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
     {
         auto s = init_struct<CountParamStruct>();
         OE_TEST(deepcopy_countparam(enclave, &s) == OE_OK);
+        // The members used by size/count attributes are expected to
+        // be consistent even if the callee modified them.
         OE_TEST(s.count == 7);
+        // The members not used by size/count attributes are expected to
+        // match the value set by the callee.
+        OE_TEST(s.size == 200);
         test_struct(s, s.count);
+    }
+
+    {
+        auto s = init_struct<SizeStruct>();
+        OE_TEST(deepcopy_size(enclave, &s) == OE_OK);
+        test_struct(s, 2);
+    }
+
+    {
+        auto s = init_struct<CountSizeStruct>();
+        OE_TEST(deepcopy_countsize(enclave, &s) == OE_OK);
+        test_struct(s, 3);
+        // The members not used by size/count attributes are expected to
+        // match the value set by the callee.
+        OE_TEST(s.count == 5);
+        OE_TEST(s.size == 32);
     }
 
     {
         auto s = init_struct<SizeParamStruct>();
         OE_TEST(deepcopy_sizeparam(enclave, &s) == OE_OK);
+        // The members used by size/count attributes are expected to
+        // be consistent even if the callee modified them.
         OE_TEST(s.size == 64);
+        // The members not used by size/count attributes are expected to
+        // match the value set by the callee.
+        OE_TEST(s.count == 100);
         test_struct(s, s.size / sizeof(uint64_t));
     }
 
@@ -84,6 +518,8 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         s.count = 8;
         s.size = 4;
         OE_TEST(deepcopy_countsizeparam(enclave, &s) == OE_OK);
+        // The members used by size/count attributes are expected to
+        // be consistent even if the callee modified them.
         OE_TEST(s.count == 8);
         OE_TEST(s.size == 4);
         test_struct(s, (s.count * s.size) / sizeof(uint64_t));
@@ -198,6 +634,358 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
 
         OE_TEST(deepcopy_iovec(enclave, iov, OE_COUNTOF(iov)) == OE_OK);
         OE_TEST(memcmp(buf0, "0000000", 8) == 0);
+    }
+
+    {
+        auto s = init_struct<CountParamStruct>();
+        OE_TEST(deepcopy_countparam_return_large(enclave, &s) == OE_FAILURE);
+    }
+
+    {
+        auto s = init_struct<SizeParamStruct>();
+        OE_TEST(deepcopy_sizeparam_return_large(enclave, &s) == OE_FAILURE);
+    }
+
+    {
+        auto s = init_struct<CountSizeParamStruct>();
+        s.count = 8;
+        s.size = 4;
+        OE_TEST(
+            deepcopy_countsizeparam_return_large(enclave, &s) == OE_FAILURE);
+    }
+
+    {
+        auto s = init_struct<CountSizeStruct>();
+        OE_TEST(deepcopy_countsize_return_large(enclave, &s) == OE_OK);
+        test_struct(s, 3);
+        // The members not used by size/count attributes are expected to
+        // match the value set by the callee.
+        OE_TEST(s.count == 100);
+        OE_TEST(s.size == 200);
+    }
+
+    {
+        CountParamStruct s;
+        memset(&s, 0, sizeof(CountParamStruct));
+        OE_TEST(deepcopy_countparam_out(enclave, &s) == OE_OK);
+        test_struct(s, 5);
+        OE_TEST(s.count == 5);
+        OE_TEST(s.size == 200);
+        free(s.ptr);
+    }
+
+    {
+        OE_TEST(deepcopy_countparam_out(enclave, NULL) == OE_OK);
+    }
+
+    {
+        CountParamStruct s[2];
+        memset(s, 0, sizeof(CountParamStruct) * 2);
+        OE_TEST(deepcopy_countparamarray_out(enclave, s) == OE_OK);
+        test_struct(s[0], 5);
+        OE_TEST(s[0].count == 5);
+        OE_TEST(s[0].size == 64);
+        test_struct(s[1], 4);
+        OE_TEST(s[1].count == 4);
+        OE_TEST(s[1].size == 32);
+        for (int i = 0; i < 2; i++)
+            free(s[i].ptr);
+    }
+
+    {
+        CountParamStruct s[2];
+        memset(s, 0, sizeof(CountParamStruct) * 2);
+        OE_TEST(deepcopy_countparamarray_partial_out(enclave, s) == OE_OK);
+        test_struct(s[0], 5);
+        OE_TEST(s[0].count == 5);
+        OE_TEST(s[0].size == 64);
+        OE_TEST(s[1].count == 0);
+        OE_TEST(s[1].size == 32);
+        OE_TEST(s[1].ptr == NULL);
+        for (int i = 0; i < 1; i++)
+            free(s[i].ptr);
+    }
+
+    {
+        SizeParamStruct s;
+        memset(&s, 0, sizeof(SizeParamStruct));
+        OE_TEST(deepcopy_sizeparam_out(enclave, &s) == OE_OK);
+        test_struct(s, 5);
+        OE_TEST(s.count == 100);
+        OE_TEST(s.size == 5 * sizeof(uint64_t));
+        free(s.ptr);
+    }
+
+    {
+        CountSizeParamStruct s;
+        memset(&s, 0, sizeof(CountSizeParamStruct));
+        OE_TEST(deepcopy_countsizeparam_out(enclave, &s) == OE_OK);
+        test_struct(s, 5);
+        OE_TEST(s.count == 5);
+        OE_TEST(s.size == sizeof(uint64_t));
+        free(s.ptr);
+    }
+
+    {
+        CountSizeStruct s;
+        memset(&s, 0, sizeof(CountSizeStruct));
+        OE_TEST(deepcopy_countsize_out(enclave, &s) == OE_OK);
+        test_struct(s, 3);
+        OE_TEST(s.count == 100);
+        OE_TEST(s.size == 200);
+        free(s.ptr);
+    }
+
+    {
+        CountParamNestedStruct n;
+        memset(&n, 0, sizeof(CountParamNestedStruct));
+        OE_TEST(deepcopy_nested_countparam_out(enclave, &n) == OE_OK);
+        OE_TEST(n.num == 5);
+        for (size_t i = 0; i < n.num; i++)
+        {
+            CountParamStruct* s = &n.array_of_struct[i];
+            OE_TEST(s->count == 10);
+            OE_TEST(s->size == i);
+            for (size_t j = 0; j < s->count; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+        if (n.array_of_struct)
+        {
+            for (size_t i = 0; i < n.num; i++)
+                free(n.array_of_struct[i].ptr);
+            free(n.array_of_struct);
+        }
+    }
+
+    {
+        NestedStruct n;
+        memset(&n, 0, sizeof(NestedStruct));
+        OE_TEST(deepcopy_nested_out(enclave, &n) == OE_OK);
+        OE_TEST(n.plain_int == 100);
+        for (int i = 0; i < 4; i++)
+            OE_TEST(n.array_of_int[i] == i);
+        OE_TEST(n.shallow_struct == NULL);
+        for (int i = 0; i < 3; i++)
+        {
+            OE_TEST(n.array_of_struct[i].count == 100);
+            OE_TEST(n.array_of_struct[i].size == 200);
+            test_struct(n.array_of_struct[i], 3);
+        }
+        free(n.array_of_int);
+        for (int i = 0; i < 3; i++)
+            free(n.array_of_struct[i].ptr);
+    }
+
+    {
+        MultipleNestedStruct n;
+        memset(&n, 0, sizeof(MultipleNestedStruct));
+        OE_TEST(deepcopy_multiple_nested_out(enclave, &n) == OE_OK);
+        OE_TEST(n.num_1 == 5);
+        for (size_t i = 0; i < n.num_1; i++)
+        {
+            CountParamStruct* s = &n.array_of_struct_1[i];
+            OE_TEST(s->count == 10);
+            OE_TEST(s->size == i);
+            for (size_t j = 0; j < s->count; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+
+        OE_TEST(n.num_2 == 6);
+        for (size_t i = 0; i < n.num_2; i++)
+        {
+            SizeParamStruct* s = &n.array_of_struct_2[i];
+            OE_TEST(s->count == i);
+            OE_TEST(s->size == 15 * sizeof(uint64_t));
+            for (size_t j = 0; j < 15; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+
+        OE_TEST(n.num_3 == 7);
+        for (size_t i = 0; i < n.num_3; i++)
+        {
+            CountSizeParamStruct* s = &n.array_of_struct_3[i];
+            OE_TEST(s->count == 20);
+            OE_TEST(s->size == sizeof(uint64_t));
+            for (size_t j = 0; j < 20; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+
+        OE_TEST(n.num_4 == 3);
+        for (size_t i = 0; i < n.num_4; i++)
+        {
+            CountParamNestedStruct* s = &n.array_of_struct_4[i];
+            OE_TEST(s->num == 4);
+            for (size_t j = 0; j < s->num; j++)
+            {
+                CountParamStruct* m = &s->array_of_struct[j];
+                OE_TEST(m->count == 25);
+                OE_TEST(m->size == j);
+                for (size_t k = 0; k < m->count; k++)
+                {
+                    OE_TEST(m->ptr[k] == j);
+                }
+            }
+        }
+
+        if (n.array_of_struct_1)
+        {
+            for (size_t i = 0; i < n.num_1; i++)
+                free(n.array_of_struct_1[i].ptr);
+            free(n.array_of_struct_1);
+        }
+        if (n.array_of_struct_2)
+        {
+            for (size_t i = 0; i < n.num_2; i++)
+                free(n.array_of_struct_2[i].ptr);
+            free(n.array_of_struct_2);
+        }
+        if (n.array_of_struct_3)
+        {
+            for (size_t i = 0; i < n.num_3; i++)
+                free(n.array_of_struct_3[i].ptr);
+            free(n.array_of_struct_3);
+        }
+        if (n.array_of_struct_4)
+        {
+            for (size_t i = 0; i < n.num_4; i++)
+            {
+                if (n.array_of_struct_4[i].array_of_struct)
+                {
+                    for (size_t j = 0; j < n.array_of_struct_4[i].num; j++)
+                        free(n.array_of_struct_4[i].array_of_struct[j].ptr);
+                }
+                free(n.array_of_struct_4[i].array_of_struct);
+            }
+            free(n.array_of_struct_4);
+        }
+    }
+
+    {
+        MultipleNestedStruct n;
+        memset(&n, 0, sizeof(MultipleNestedStruct));
+        OE_TEST(deepcopy_multiple_nested_partial_out(enclave, &n) == OE_OK);
+        OE_TEST(n.num_1 == 5);
+        for (size_t i = 0; i < n.num_1; i++)
+        {
+            CountParamStruct* s = &n.array_of_struct_1[i];
+            OE_TEST(s->count == 10);
+            OE_TEST(s->size == i);
+            for (size_t j = 0; j < s->count; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+
+        OE_TEST(n.num_2 == 6);
+        OE_TEST(n.array_of_struct_2 == NULL);
+
+        OE_TEST(n.num_3 == 7);
+        for (size_t i = 0; i < n.num_3; i++)
+        {
+            CountSizeParamStruct* s = &n.array_of_struct_3[i];
+            if (i == 3)
+            {
+                OE_TEST(s->count == 10);
+                OE_TEST(s->size == 5);
+                OE_TEST(s->ptr == NULL);
+                continue;
+            }
+            OE_TEST(s->count == 20);
+            OE_TEST(s->size == sizeof(uint64_t));
+            for (size_t j = 0; j < 20; j++)
+            {
+                OE_TEST(s->ptr[j] == i);
+            }
+        }
+
+        OE_TEST(n.num_4 == 3);
+        for (size_t i = 0; i < n.num_4; i++)
+        {
+            CountParamNestedStruct* s = &n.array_of_struct_4[i];
+            if (i == 2)
+            {
+                OE_TEST(s->num == 2);
+                OE_TEST(s->array_of_struct == NULL);
+                continue;
+            }
+            OE_TEST(s->num == 4);
+            for (size_t j = 0; j < s->num; j++)
+            {
+                CountParamStruct* m = &s->array_of_struct[j];
+                if (j == 1)
+                {
+                    OE_TEST(m->count == 30);
+                    OE_TEST(m->size == 15);
+                    OE_TEST(m->ptr == NULL);
+                    continue;
+                }
+                OE_TEST(m->count == 25);
+                OE_TEST(m->size == j);
+                for (size_t k = 0; k < m->count; k++)
+                {
+                    OE_TEST(m->ptr[k] == j);
+                }
+            }
+        }
+
+        if (n.array_of_struct_1)
+        {
+            for (size_t i = 0; i < n.num_1; i++)
+                free(n.array_of_struct_1[i].ptr);
+            free(n.array_of_struct_1);
+        }
+        if (n.array_of_struct_2)
+        {
+            for (size_t i = 0; i < n.num_2; i++)
+                free(n.array_of_struct_2[i].ptr);
+            free(n.array_of_struct_2);
+        }
+        if (n.array_of_struct_3)
+        {
+            for (size_t i = 0; i < n.num_3; i++)
+                free(n.array_of_struct_3[i].ptr);
+            free(n.array_of_struct_3);
+        }
+        if (n.array_of_struct_4)
+        {
+            for (size_t i = 0; i < n.num_4; i++)
+            {
+                if (n.array_of_struct_4[i].array_of_struct)
+                {
+                    for (size_t j = 0; j < n.array_of_struct_4[i].num; j++)
+                        free(n.array_of_struct_4[i].array_of_struct[j].ptr);
+                }
+                free(n.array_of_struct_4[i].array_of_struct);
+            }
+            free(n.array_of_struct_4);
+        }
+    }
+    {
+        SizeParamStruct s_in, s_inout, s_out, s_user_check, s_out_2;
+        set_sizeparam(&s_in, 10, 10, (int)'A');
+        set_sizeparam(&s_inout, 20, 20, (int)'B');
+        OE_TEST(
+            deepcopy_mix(
+                enclave, &s_in, &s_inout, &s_out, &s_user_check, &s_out_2) ==
+            OE_OK);
+        check_sizeparam(&s_inout, 10, 20, 'C');
+        check_sizeparam(&s_out, 30, 30, 'D');
+        check_sizeparam(&s_user_check, 40, 40, 'E');
+        check_sizeparam(&s_out_2, 50, 50, 'F');
+        free(s_out.ptr);
+        free(s_out_2.ptr);
+    }
+
+    {
+        OE_TEST(test_deepcopy_ocalls(enclave) == OE_OK);
     }
 
     printf("=== test_deepcopy_edl_ecalls passed\n");

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -11,7 +11,7 @@ check_submodule_not_empty(oeedger8r-cpp)
 # would trigger a rebuild.
 include(ExternalProject)
 set(BINARY
-    ${CMAKE_CURRENT_BINARY_DIR}/oeedger8r-cpp/oeedger8r${CMAKE_EXECUTABLE_SUFFIX}
+    ${CMAKE_CURRENT_BINARY_DIR}/oeedger8r-cpp/src/oeedger8r${CMAKE_EXECUTABLE_SUFFIX}
 )
 
 ExternalProject_Add(


### PR DESCRIPTION
This PR adds the deep-copy out parameters support. The changes include
- Updated the oeedger8r
- Updated OE internals to handle the memory transition
- Added test cases
- Updated changelog