### PR TITLE
Deprecate the support of building OE with GCC from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the deep-copy out parameter support as an experimental, SGX-only feature. To use the feature, pass `--experimental` when invoking oeedger8r. Refer to the [design document](docs/DesignDocs/DeepCopyOutParameters.md) for more detail.
 
 ### Deprecated
-- Compiling Open Enclave SDK for Intel SGX from source with GCC is no longer supported. The recommended compiler is Clang.
+- The support of building the SDK for Intel SGX with GCC from source is no longer supported. The recommended compiler is Clang.
 
 [v0.13.0][v0.13.0_log]
 --------------

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -11,6 +11,11 @@ if (CMAKE_C_COMPILER_ID MATCHES Clang)
   endif ()
 endif ()
 
+if (OE_SGX AND CMAKE_C_COMPILER_ID MATCHES GNU)
+  message(WARNING "The GCC support on x86 platforms has been deprecated. "
+                  "Build problems may occur. Consider using Clang instead.")
+endif ()
+
 if (NOT CMAKE_C_COMPILER_ID STREQUAL CMAKE_CXX_COMPILER_ID)
   message(FATAL_ERROR "Your C and C++ compilers have different vendors: "
                       "${CMAKE_C_COMPILER_ID} != ${CMAKE_CXX_COMPILER_ID}")

--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -11,53 +11,6 @@ endif ()
 # The list of tests requires `std=c++17`.
 file(STRINGS "tests.supported.cxx17" CXX_17_TEST_LIST)
 
-# List of unsupported tests with GCC.
-set(GCC_UNSUPPORTED_LIST
-    "libcxx_containers_unord_next_pow2.pass"
-    "libcxx_input.output_filesystems_convert_file_time.sh"
-    "libcxx_numerics_c.math_constexpr-fns.pass"
-    "std_containers_sequences_array_at.pass"
-    "std_depr_depr.c.headers_string_h.pass"
-    "std_depr_depr.c.headers_wchar_h.pass"
-    "std_strings_c.strings_cstring.pass"
-    "std_strings_c.strings_cwchar.pass"
-    "std_utilities_meta_meta.unary_meta.unary.prop_is_trivially_copyable.pass"
-    "std_utilities_optional_optional.object_optional.object.assign_emplace_initializer_list.pass"
-    "std_utilities_optional_optional.object_optional.object.ctor_copy.pass"
-    "std_utilities_template.bitset_bitset.members_count.pass"
-    "std_utilities_variant_variant.variant_variant.ctor_in_place_index_init_list_args.pass"
-    # The following tests require the revision of "template argument deduction for class templates" feature
-    # supported by gcc 8 (SD-6 feature test: __cpp_deduction_guides >= 201611).
-    # Refer to https://gcc.gnu.org/projects/cxx-status.html#cxx17 for C++ standard support in gcc.
-    "std_containers_container.adaptors_priority.queue_priqueue.cons_deduct.pass"
-    "std_containers_container.adaptors_queue_queue.cons_deduct.pass"
-    "std_containers_container.adaptors_stack_stack.cons_deduct.pass"
-    "std_containers_sequences_array_array.cons_deduct.pass"
-    "std_containers_sequences_deque_deque.cons_deduct.pass"
-    "std_containers_sequences_forwardlist_forwardlist.cons_deduct.pass"
-    "std_containers_sequences_list_list.cons_deduct.pass"
-    "std_containers_sequences_vector_vector.cons_deduct.pass"
-    "std_re_re.regex_re.regex.construct_deduct.pass"
-    "std_strings_basic.string_string.cons_implicit_deduction_guides.pass"
-    "std_strings_basic.string_string.cons_iter_alloc_deduction.pass"
-    "std_strings_basic.string_string.cons_string_view_deduction.pass"
-    "std_strings_basic.string_string.cons_string_view_size_size_deduction.pass"
-    "std_utilities_optional_optional.object_optional.object.ctor_deduct.pass"
-    "std_utilities_tuple_tuple.tuple_tuple.cnstr_implicit_deduction_guides.pass"
-    "std_utilities_utility_pairs_pairs.pair_implicit_deduction_guides.pass")
-
-# List the unsupported on GCC version less than 7.
-# Refer to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77446 for the issue.
-set(GCC_LESS_7_UNSUPPORTED_LIST
-    "std_strings_string.view_string.view.find_find_char_size.pass"
-    "std_strings_string.view_string.view.find_find_first_not_of_pointer_size.pass"
-    "std_strings_string.view_string.view.find_find_first_not_of_pointer_size_size.pass"
-    "std_strings_string.view_string.view.find_find_first_of_char_size.pass"
-    "std_strings_string.view_string.view.find_find_last_not_of_pointer_size.pass"
-    "std_strings_string.view_string.view.find_find_last_of_pointer_size.pass"
-    "std_strings_string.view_string.view.find_find_last_of_pointer_size_size.pass"
-)
-
 add_subdirectory(host)
 
 if (BUILD_ENCLAVES)
@@ -94,44 +47,10 @@ foreach (testcase ${alltests})
     endif ()
   endif ()
 
-  # Few functions invoked in these tests are not supported in gnu -- Skip running these tests
-  if ("${name}" IN_LIST GCC_UNSUPPORTED_LIST)
-    if (ENCLAVE_CXX_COMPILER_ID MATCHES GNU)
-      continue()
-    endif ()
-  endif ()
-
   # The following test fails when built with clang, see #830 -- Skipping this test in clang
   if ("${name}" MATCHES
       "array_sized_delete_array_calls_unsized_delete_array.pass")
     if (ENCLAVE_CXX_COMPILER_ID MATCHES Clang)
-      continue()
-    endif ()
-  endif ()
-
-  # The following test fails on GCC version 7, see  #1523 -- Skipping this test in GCC 7.0 -> 8.0
-  if ("${name}" MATCHES
-      "std_utilities_function.objects_comparisons_constexpr_init.pass")
-    if (ENCLAVE_CXX_COMPILER_ID MATCHES GNU
-        AND ENCLAVE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7
-        AND ENCLAVE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
-      continue()
-    endif ()
-  endif ()
-
-  # The following test fails on GCC 7 or newer, see #1559 -- Skip this test on GCC 7.0 and above in non debug builds
-  if ("${name}" MATCHES "std_containers_associative_map_map.access_at.pass")
-    string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
-    if (ENCLAVE_CXX_COMPILER_ID MATCHES GNU AND BUILD_TYPE_UPPER MATCHES REL)
-      continue()
-    endif ()
-  endif ()
-
-  # Skip the following tests on GCC version less than 7 because a bug is not fixed or C++17 features are not supported.
-  if ("${name}" IN_LIST GCC_LESS_7_UNSUPPORTED_LIST OR "${testcase}" IN_LIST
-                                                       CXX_17_TEST_LIST)
-    if (ENCLAVE_CXX_COMPILER_ID MATCHES GNU AND ENCLAVE_CXX_COMPILER_VERSION
-                                                VERSION_LESS 7.0)
       continue()
     endif ()
   endif ()

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -29,12 +29,6 @@ if (ENABLE_FULL_LIBCXX_TESTS)
   enclave_compile_definitions(libcxxtest-support PRIVATE FULL_LIBCXX_TESTS)
 endif ()
 
-if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
-  enclave_compile_options(
-    libcxxtest-support PRIVATE -Wno-error=maybe-uninitialized
-    -Wno-error=unused-but-set-variable)
-endif ()
-
 enclave_link_libraries(libcxxtest-support PRIVATE oelibcxx oeenclave)
 enclave_link_libraries(libcxxtest-support INTERFACE -Wl,--undefined=Test)
 
@@ -84,7 +78,7 @@ function (add_libcxx_test_enc NAME CXXFILE)
     -UNDEBUG)
 
   # Clang does not support variants of operator delete[] taking size_t in C++14 unless
-  # -fsized-deallocation is passed explicity. (Note, gcc 4.7/4.8/4.9 do not support this either.)
+  # -fsized-deallocation is passed explicity.
   # NOTE: This only matters when `ENABLE_FULL_LIBCXX_TESTS=ON`.
   if (NAME MATCHES "sized_delete")
     enclave_compile_options(libcxxtest-${NAME}_enc PRIVATE -fsized-deallocation)
@@ -166,44 +160,10 @@ foreach (testcase ${alltests})
     endif ()
   endif ()
 
-  # Few functions invoked in these tests are not supported in gnu and excluded from GCC builds
-  if ("${name}" IN_LIST GCC_UNSUPPORTED_LIST)
-    if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
-      continue()
-    endif ()
-  endif ()
-
   # The following test fails when built with clang, see #830 -- Skipping this test in clang
   if ("${name}" MATCHES
       "array_sized_delete_array_calls_unsized_delete_array.pass")
     if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
-      continue()
-    endif ()
-  endif ()
-
-  # The following test fails on GCC version 7, see  #1523 -- Skipping this test in GCC 7.0 -> 8.0
-  if ("${name}" MATCHES
-      "std_utilities_function.objects_comparisons_constexpr_init.pass")
-    if (CMAKE_CXX_COMPILER_ID MATCHES GNU
-        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7
-        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
-      continue()
-    endif ()
-  endif ()
-
-  # The following test fails on GCC 7 or newer, see #1559 -- Skip this test on GCC 7.0 and above in non debug builds
-  if ("${name}" MATCHES "std_containers_associative_map_map.access_at.pass")
-    string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
-    if (CMAKE_CXX_COMPILER_ID MATCHES GNU AND BUILD_TYPE_UPPER MATCHES REL)
-      continue()
-    endif ()
-  endif ()
-
-  # Skip the following tests on GCC version less than 7 because a bug is not fixed or C++17 features are not supported.
-  if ("${name}" IN_LIST GCC_LESS_7_UNSUPPORTED_LIST OR "${testcase}" IN_LIST
-                                                       CXX_17_TEST_LIST)
-    if (CMAKE_CXX_COMPILER_ID MATCHES GNU AND CMAKE_CXX_COMPILER_VERSION
-                                              VERSION_LESS 7.0)
       continue()
     endif ()
   endif ()

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -59,15 +59,11 @@ add_enclave(
 
 # The tests intentionally use floats etc in size context.
 # Disable warnings.
-if (CMAKE_CXX_COMPILER_ID MATCHES GNU
-    OR CMAKE_CXX_COMPILER_ID MATCHES Clang
-    OR USE_CLANGW)
-  set_source_files_properties(
-    all_t_wrapper.cpp PROPERTIES COMPILE_FLAGS
-                                 "-Wno-conversion -Wno-sign-compare")
-  set_source_files_properties(testpointer.cpp
-                              PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
-endif ()
+set_source_files_properties(
+  all_t_wrapper.cpp PROPERTIES COMPILE_FLAGS
+                               "-Wno-conversion -Wno-sign-compare")
+set_source_files_properties(testpointer.cpp PROPERTIES COMPILE_FLAGS
+                                                       "-Wno-unused-parameter")
 
 enclave_include_directories(edl_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                             ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -58,7 +58,7 @@ add_executable(
 
 # The tests intentionally use floats etc in size context.
 # Disable warnings.
-if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
+if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
   set_source_files_properties(
     all_u_wrapper.cpp PROPERTIES COMPILE_FLAGS
                                  "-Wno-conversion -Wno-sign-compare")

--- a/tests/print/enc/CMakeLists.txt
+++ b/tests/print/enc/CMakeLists.txt
@@ -23,9 +23,5 @@ enclave_compile_options(
   print_enc PRIVATE -fno-builtin-strcpy -fno-builtin-strcat -fno-builtin-memcpy
   -fno-builtin-memset)
 
-if (CMAKE_C_COMPILER_ID MATCHES GNU)
-  enclave_compile_options(print_enc PRIVATE -Wno-error=unused-but-set-variable)
-endif ()
-
 enclave_include_directories(print_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 enclave_link_libraries(print_enc oelibc)


### PR DESCRIPTION
This PR adds warning messages when users try to build the SDK with GCC. Also, removing the test cases that explicitly check the GCC version.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>