### PR TITLE
compiler-rt for enclaves

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -7,6 +7,7 @@
 # details.
 set(LIBCXX_INCLUDES ${OE_INCDIR}/openenclave/libcxx)
 
+add_subdirectory(compiler-rt)
 add_subdirectory(dlmalloc)
 add_subdirectory(libcxx)
 add_subdirectory(libcxxrt)

--- a/3rdparty/compiler-rt/CMakeLists.txt
+++ b/3rdparty/compiler-rt/CMakeLists.txt
@@ -1,0 +1,115 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# Create a custom command to workaround a likely cmake dependency bug.
+# See 3rdparty/snmalloc/CMakeLists.txt for explanation of the issue
+# and the workaround.
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/deprecations.h
+         ${CMAKE_CURRENT_BINARY_DIR}/__config.h
+  COMMAND
+    ${CMAKE_COMMAND} -E copy
+    ${PROJECT_BINARY_DIR}/output/include/openenclave/libc/bits/deprecations.h
+    ${CMAKE_CURRENT_BINARY_DIR}/deprecations.h
+  DEPENDS musl_includes)
+
+add_enclave_library(
+  oecompilerrt_obj
+  OBJECT
+  # List the following as a source in order to ensure that musl_includes is
+  # built before the build for oecompilerrt_obj is started.
+  # started.
+  deprecations.h
+  # compiler-rt implementation.
+  compiler-rt/addtf3.c
+  compiler-rt/ashldi3.c
+  compiler-rt/ashlti3.c
+  compiler-rt/ashrdi3.c
+  compiler-rt/ashrti3.c
+  compiler-rt/clear_cache.c
+  compiler-rt/clzdi2.c
+  compiler-rt/clzsi2.c
+  compiler-rt/clzti2.c
+  compiler-rt/cmpdi2.c
+  compiler-rt/cmpti2.c
+  compiler-rt/comparetf2.c
+  compiler-rt/ctzdi2.c
+  compiler-rt/ctzsi2.c
+  compiler-rt/ctzti2.c
+  compiler-rt/divdi3.c
+  compiler-rt/divsi3.c
+  compiler-rt/divtf3.c
+  compiler-rt/divti3.c
+  compiler-rt/extenddftf2.c
+  compiler-rt/extendsftf2.c
+  compiler-rt/ffsdi2.c
+  compiler-rt/ffsti2.c
+  compiler-rt/fixtfsi.c
+  compiler-rt/floatsitf.c
+  compiler-rt/floatunsitf.c
+  compiler-rt/lshrdi3.c
+  compiler-rt/lshrti3.c
+  compiler-rt/moddi3.c
+  compiler-rt/modsi3.c
+  compiler-rt/modti3.c
+  compiler-rt/muldi3.c
+  compiler-rt/multf3.c
+  compiler-rt/multi3.c
+  compiler-rt/negdi2.c
+  compiler-rt/negti2.c
+  compiler-rt/paritydi2.c
+  compiler-rt/paritysi2.c
+  compiler-rt/parityti2.c
+  compiler-rt/popcountdi2.c
+  compiler-rt/popcountsi2.c
+  compiler-rt/popcountti2.c
+  # OE has a custom implementation of stack protector that works
+  # within enclaves.
+  # compiler-rt/stack_chk.c
+  compiler-rt/subtf3.c
+  compiler-rt/trunctfdf2.c
+  compiler-rt/trunctfsf2.c
+  compiler-rt/ucmpdi2.c
+  compiler-rt/ucmpti2.c
+  compiler-rt/udivdi3.c
+  compiler-rt/udivmoddi4.c
+  compiler-rt/udivmodti4.c
+  compiler-rt/udivsi3.c
+  compiler-rt/udivti3.c
+  compiler-rt/umoddi3.c
+  compiler-rt/umodsi3.c
+  compiler-rt/umodti3.c)
+
+if (OE_TRUSTZONE)
+  set(TEE_C_FLAGS ${OE_TZ_TA_C_FLAGS})
+else ()
+  set(TEE_C_FLAGS -mcx16)
+endif ()
+
+enclave_compile_options(
+  oecompilerrt_obj
+  PRIVATE
+  # compiler-rt depends on C headers
+  -I${PROJECT_BINARY_DIR}/output/include/openenclave/libc
+  # Prevent warnings treated as errors
+  -Wno-conversion
+  -Wno-unused-parameter
+  # Enclave compiler options
+  -ftls-model=local-exec
+  -nostdinc
+  -fPIE
+  -ffreestanding
+  ${TEE_C_FLAGS}
+  -fno-exceptions
+  -fvisibility=hidden)
+
+maybe_build_using_clangw(oecompilerrt_obj)
+
+install_enclaves(
+  TARGETS
+  oecompilerrt_obj
+  EXPORT
+  openenclave-targets
+  ARCHIVE
+  DESTINATION
+  ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/3rdparty/compiler-rt/compiler-rt/LICENSE.TXT
+++ b/3rdparty/compiler-rt/compiler-rt/LICENSE.TXT
@@ -1,0 +1,98 @@
+==============================================================================
+compiler_rt License
+==============================================================================
+
+The compiler_rt library is dual licensed under both the University of Illinois
+"BSD-Like" license and the MIT license.  As a user of this code you may choose
+to use it under either license.  As a contributor, you agree to allow your code
+to be used under both.
+
+Full text of the relevant licenses is included below.
+
+==============================================================================
+
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2009-2010 by the contributors listed in CREDITS.TXT
+
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+
+==============================================================================
+
+Copyright (c) 2009-2010 by the contributors listed in CREDITS.TXT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==============================================================================
+Copyrights and Licenses for Third Party Software Distributed with LLVM:
+==============================================================================
+The LLVM software contains code written by third parties.  Such software will
+have its own individual LICENSE.TXT file in the directory in which it appears.
+This file will describe the copyrights, license, and restrictions which apply
+to that code.
+
+The disclaimer of warranty in the University of Illinois Open Source License
+applies to all code in the LLVM Distribution, and nothing in any of the
+other licenses gives permission to use the names of the LLVM Team or the
+University of Illinois to endorse or promote products derived from this
+Software.
+
+The following pieces of software have additional or alternate copyrights,
+licenses, and/or restrictions:
+
+Program             Directory
+-------             ---------
+sysinfo             lib/asan/sysinfo
+mach_override       lib/asan/mach_override

--- a/3rdparty/compiler-rt/compiler-rt/Makefile
+++ b/3rdparty/compiler-rt/compiler-rt/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+include ../../buildenv.mk
+
+CFLAGS   += $(ENCLAVE_CFLAGS)
+CPPFLAGS += $(ADDED_INC)                \
+            -I$(COMMON_DIR)/inc/tlibc/
+
+SRCS := $(wildcard *.c)
+OBJS := $(sort $(SRCS:.c=.o))
+
+TARGET  := libcompiler-rt.a
+
+.PHONY: all
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(AR) rcsD $@ $^
+
+$(OBJS): %.o: %.c
+	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
+
+.PHONY: clean
+clean:
+	@$(RM) $(OBJS) $(TARGET)

--- a/3rdparty/compiler-rt/compiler-rt/addtf3.c
+++ b/3rdparty/compiler-rt/compiler-rt/addtf3.c
@@ -1,0 +1,26 @@
+//===-- lib/addtf3.c - Quad-precision addition --------------------*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements quad-precision soft-float addition with the IEEE-754
+// default rounding (to nearest, ties to even).
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#include "fp_add_impl.inc"
+
+COMPILER_RT_ABI long double __addtf3(long double a, long double b)
+{
+    return __addXf3__(a, b);
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/ashldi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/ashldi3.c
@@ -1,0 +1,43 @@
+/* ====-- ashldi3.c - Implement __ashldi3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ashldi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: a << b */
+
+/* Precondition:  0 <= b < bits_in_dword */
+
+ARM_EABI_FNALIAS(llsl, ashldi3)
+
+COMPILER_RT_ABI di_int __ashldi3(di_int a, si_int b)
+{
+    const int bits_in_word = (int)(sizeof(si_int) * CHAR_BIT);
+    dwords input;
+    dwords result;
+    input.all = a;
+    if (b & bits_in_word) /* bits_in_word <= b < bits_in_dword */
+    {
+        result.s.low = 0;
+        result.s.high = input.s.low << (b - bits_in_word);
+    }
+    else /* 0 <= b < bits_in_word */
+    {
+        if (b == 0)
+            return a;
+        result.s.low = input.s.low << b;
+        result.s.high =
+            (input.s.high << b) | (input.s.low >> (bits_in_word - b));
+    }
+    return result.all;
+}

--- a/3rdparty/compiler-rt/compiler-rt/ashlti3.c
+++ b/3rdparty/compiler-rt/compiler-rt/ashlti3.c
@@ -1,0 +1,45 @@
+/* ===-- ashlti3.c - Implement __ashlti3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ashlti3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: a << b */
+
+/* Precondition:  0 <= b < bits_in_tword */
+
+COMPILER_RT_ABI ti_int __ashlti3(ti_int a, si_int b)
+{
+    const int bits_in_dword = (int)(sizeof(di_int) * CHAR_BIT);
+    twords input;
+    twords result;
+    input.all = a;
+    if (b & bits_in_dword) /* bits_in_dword <= b < bits_in_tword */
+    {
+        result.s.low = 0;
+        result.s.high = input.s.low << (b - bits_in_dword);
+    }
+    else /* 0 <= b < bits_in_dword */
+    {
+        if (b == 0)
+            return a;
+        result.s.low = input.s.low << b;
+        result.s.high =
+            (input.s.high << b) | (input.s.low >> (bits_in_dword - b));
+    }
+    return result.all;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/ashrdi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/ashrdi3.c
@@ -1,0 +1,44 @@
+/*===-- ashrdi3.c - Implement __ashrdi3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ashrdi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: arithmetic a >> b */
+
+/* Precondition:  0 <= b < bits_in_dword */
+
+ARM_EABI_FNALIAS(lasr, ashrdi3)
+
+COMPILER_RT_ABI di_int __ashrdi3(di_int a, si_int b)
+{
+    const int bits_in_word = (int)(sizeof(si_int) * CHAR_BIT);
+    dwords input;
+    dwords result;
+    input.all = a;
+    if (b & bits_in_word) /* bits_in_word <= b < bits_in_dword */
+    {
+        /* result.s.high = input.s.high < 0 ? -1 : 0 */
+        result.s.high = input.s.high >> (bits_in_word - 1);
+        result.s.low = input.s.high >> (b - bits_in_word);
+    }
+    else /* 0 <= b < bits_in_word */
+    {
+        if (b == 0)
+            return a;
+        result.s.high = input.s.high >> b;
+        result.s.low =
+            (input.s.high << (bits_in_word - b)) | (input.s.low >> b);
+    }
+    return result.all;
+}

--- a/3rdparty/compiler-rt/compiler-rt/ashrti3.c
+++ b/3rdparty/compiler-rt/compiler-rt/ashrti3.c
@@ -1,0 +1,46 @@
+/* ===-- ashrti3.c - Implement __ashrti3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ashrti3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: arithmetic a >> b */
+
+/* Precondition:  0 <= b < bits_in_tword */
+
+COMPILER_RT_ABI ti_int __ashrti3(ti_int a, si_int b)
+{
+    const int bits_in_dword = (int)(sizeof(di_int) * CHAR_BIT);
+    twords input;
+    twords result;
+    input.all = a;
+    if (b & bits_in_dword) /* bits_in_dword <= b < bits_in_tword */
+    {
+        /* result.s.high = input.s.high < 0 ? -1 : 0 */
+        result.s.high = input.s.high >> (bits_in_dword - 1);
+        result.s.low = input.s.high >> (b - bits_in_dword);
+    }
+    else /* 0 <= b < bits_in_dword */
+    {
+        if (b == 0)
+            return a;
+        result.s.high = input.s.high >> b;
+        result.s.low =
+            (input.s.high << (bits_in_dword - b)) | (input.s.low >> b);
+    }
+    return result.all;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/clear_cache.c
+++ b/3rdparty/compiler-rt/compiler-rt/clear_cache.c
@@ -1,0 +1,99 @@
+/* ===-- clear_cache.c - Implement __clear_cache ---------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#if __APPLE__
+#include <libkern/OSCacheControl.h>
+#endif
+#if defined(__NetBSD__) && defined(__arm__)
+#include <machine/sysarch.h>
+#endif
+
+#if defined(ANDROID) && defined(__mips__)
+#include <sys/cachectl.h>
+#endif
+
+#if defined(ANDROID) && defined(__arm__)
+#include <asm/unistd.h>
+#endif
+
+/*
+ * The compiler generates calls to __clear_cache() when creating
+ * trampoline functions on the stack for use with nested functions.
+ * It is expected to invalidate the instruction cache for the
+ * specified range.
+ */
+
+void __clear_cache(void* start, void* end)
+{
+#if __i386__ || __x86_64__
+/*
+ * Intel processors have a unified instruction and data cache
+ * so there is nothing to do
+ */
+#elif defined(__arm__) && !defined(__APPLE__)
+#if defined(__NetBSD__)
+    struct arm_sync_icache_args arg;
+
+    arg.addr = (uintptr_t)start;
+    arg.len = (uintptr_t)end - (uintptr_t)start;
+
+    sysarch(ARM_SYNC_ICACHE, &arg);
+#elif defined(ANDROID)
+    const register int start_reg __asm("r0") = (int)(intptr_t)start;
+    const register int end_reg __asm("r1") = (int)(intptr_t)end;
+    const register int flags __asm("r2") = 0;
+    const register int syscall_nr __asm("r7") = __ARM_NR_cacheflush;
+    __asm __volatile("svc 0x0"
+                     : "=r"(start_reg)
+                     : "r"(syscall_nr), "r"(start_reg), "r"(end_reg), "r"(flags)
+                     : "r0");
+    if (start_reg != 0)
+    {
+        compilerrt_abort();
+    }
+#else
+    compilerrt_abort();
+#endif
+#elif defined(ANDROID) && defined(__mips__)
+    const uintptr_t start_int = (uintptr_t)start;
+    const uintptr_t end_int = (uintptr_t)end;
+    _flush_cache(start, (end_int - start_int), BCACHE);
+#elif defined(__aarch64__) && !defined(__APPLE__)
+    uint64_t xstart = (uint64_t)(uintptr_t)start;
+    uint64_t xend = (uint64_t)(uintptr_t)end;
+
+    // Get Cache Type Info
+    uint64_t ctr_el0;
+    __asm __volatile("mrs %0, ctr_el0" : "=r"(ctr_el0));
+
+    /*
+     * dc & ic instructions must use 64bit registers so we don't use
+     * uintptr_t in case this runs in an IPL32 environment.
+     */
+    const size_t dcache_line_size = 4 << ((ctr_el0 >> 16) & 15);
+    for (uint64_t addr = xstart; addr < xend; addr += dcache_line_size)
+        __asm __volatile("dc cvau, %0" ::"r"(addr));
+    __asm __volatile("dsb ish");
+
+    const size_t icache_line_size = 4 << ((ctr_el0 >> 0) & 15);
+    for (uint64_t addr = xstart; addr < xend; addr += icache_line_size)
+        __asm __volatile("ic ivau, %0" ::"r"(addr));
+    __asm __volatile("isb sy");
+#else
+#if __APPLE__
+    /* On Darwin, sys_icache_invalidate() provides this functionality */
+    sys_icache_invalidate(start, end - start);
+#else
+    compilerrt_abort();
+#endif
+#endif
+}

--- a/3rdparty/compiler-rt/compiler-rt/clzdi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/clzdi2.c
@@ -1,0 +1,28 @@
+/* ===-- clzdi2.c - Implement __clzdi2 -------------------------------------===
+ *
+ *               The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __clzdi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: the number of leading 0-bits */
+
+/* Precondition: a != 0 */
+
+COMPILER_RT_ABI si_int __clzdi2(di_int a)
+{
+    dwords x;
+    x.all = a;
+    const si_int f = -(x.s.high == 0);
+    return __builtin_clz((x.s.high & ~f) | (x.s.low & f)) +
+           (f & ((si_int)(sizeof(si_int) * CHAR_BIT)));
+}

--- a/3rdparty/compiler-rt/compiler-rt/clzsi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/clzsi2.c
@@ -1,0 +1,52 @@
+/* ===-- clzsi2.c - Implement __clzsi2 -------------------------------------===
+ *
+ *               The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __clzsi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: the number of leading 0-bits */
+
+/* Precondition: a != 0 */
+
+COMPILER_RT_ABI si_int __clzsi2(si_int a)
+{
+    su_int x = (su_int)a;
+    si_int t = ((x & 0xFFFF0000) == 0) << 4; /* if (x is small) t = 16 else 0 */
+    x >>= 16 - t;                            /* x = [0 - 0xFFFF] */
+    su_int r = t;                            /* r = [0, 16] */
+    /* return r + clz(x) */
+    t = ((x & 0xFF00) == 0) << 3;
+    x >>= 8 - t; /* x = [0 - 0xFF] */
+    r += t;      /* r = [0, 8, 16, 24] */
+    /* return r + clz(x) */
+    t = ((x & 0xF0) == 0) << 2;
+    x >>= 4 - t; /* x = [0 - 0xF] */
+    r += t;      /* r = [0, 4, 8, 12, 16, 20, 24, 28] */
+    /* return r + clz(x) */
+    t = ((x & 0xC) == 0) << 1;
+    x >>= 2 - t; /* x = [0 - 3] */
+    r += t;      /* r = [0 - 30] and is even */
+    /* return r + clz(x) */
+    /*     switch (x)
+     *     {
+     *     case 0:
+     *         return r + 2;
+     *     case 1:
+     *         return r + 1;
+     *     case 2:
+     *     case 3:
+     *         return r;
+     *     }
+     */
+    return r + ((2 - x) & -((x & 2) == 0));
+}

--- a/3rdparty/compiler-rt/compiler-rt/clzti2.c
+++ b/3rdparty/compiler-rt/compiler-rt/clzti2.c
@@ -1,0 +1,32 @@
+/* ===-- clzti2.c - Implement __clzti2 -------------------------------------===
+ *
+ *      	       The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __clzti2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: the number of leading 0-bits */
+
+/* Precondition: a != 0 */
+
+COMPILER_RT_ABI si_int __clzti2(ti_int a)
+{
+    twords x;
+    x.all = a;
+    const di_int f = -(x.s.high == 0);
+    return __builtin_clzll((x.s.high & ~f) | (x.s.low & f)) +
+           ((si_int)f & ((si_int)(sizeof(di_int) * CHAR_BIT)));
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/cmpdi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/cmpdi2.c
@@ -1,0 +1,48 @@
+/* ===-- cmpdi2.c - Implement __cmpdi2 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __cmpdi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: if (a <  b) returns 0
+ *           if (a == b) returns 1
+ *           if (a >  b) returns 2
+ */
+
+COMPILER_RT_ABI si_int __cmpdi2(di_int a, di_int b)
+{
+    dwords x;
+    x.all = a;
+    dwords y;
+    y.all = b;
+    if (x.s.high < y.s.high)
+        return 0;
+    if (x.s.high > y.s.high)
+        return 2;
+    if (x.s.low < y.s.low)
+        return 0;
+    if (x.s.low > y.s.low)
+        return 2;
+    return 1;
+}
+
+#ifdef __ARM_EABI__
+/* Returns: if (a <  b) returns -1
+ *           if (a == b) returns  0
+ *           if (a >  b) returns  1
+ */
+COMPILER_RT_ABI si_int __aeabi_lcmp(di_int a, di_int b)
+{
+    return __cmpdi2(a, b) - 1;
+}
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/cmpti2.c
+++ b/3rdparty/compiler-rt/compiler-rt/cmpti2.c
@@ -1,0 +1,41 @@
+/* ===-- cmpti2.c - Implement __cmpti2 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __cmpti2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns:  if (a <  b) returns 0
+ *           if (a == b) returns 1
+ *           if (a >  b) returns 2
+ */
+
+COMPILER_RT_ABI si_int __cmpti2(ti_int a, ti_int b)
+{
+    twords x;
+    x.all = a;
+    twords y;
+    y.all = b;
+    if (x.s.high < y.s.high)
+        return 0;
+    if (x.s.high > y.s.high)
+        return 2;
+    if (x.s.low < y.s.low)
+        return 0;
+    if (x.s.low > y.s.low)
+        return 2;
+    return 1;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/comparetf2.c
+++ b/3rdparty/compiler-rt/compiler-rt/comparetf2.c
@@ -1,0 +1,161 @@
+//===-- lib/comparetf2.c - Quad-precision comparisons -------------*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// // This file implements the following soft-float comparison routines:
+//
+//   __eqtf2   __getf2   __unordtf2
+//   __letf2   __gttf2
+//   __lttf2
+//   __netf2
+//
+// The semantics of the routines grouped in each column are identical, so there
+// is a single implementation for each, and wrappers to provide the other names.
+//
+// The main routines behave as follows:
+//
+//   __letf2(a,b) returns -1 if a < b
+//                         0 if a == b
+//                         1 if a > b
+//                         1 if either a or b is NaN
+//
+//   __getf2(a,b) returns -1 if a < b
+//                         0 if a == b
+//                         1 if a > b
+//                        -1 if either a or b is NaN
+//
+//   __unordtf2(a,b) returns 0 if both a and b are numbers
+//                           1 if either a or b is NaN
+//
+// Note that __letf2( ) and __getf2( ) are identical except in their handling of
+// NaN values.
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+enum LE_RESULT
+{
+    LE_LESS = -1,
+    LE_EQUAL = 0,
+    LE_GREATER = 1,
+    LE_UNORDERED = 1
+};
+
+COMPILER_RT_ABI enum LE_RESULT __letf2(fp_t a, fp_t b)
+{
+    const srep_t aInt = toRep(a);
+    const srep_t bInt = toRep(b);
+    const rep_t aAbs = aInt & absMask;
+    const rep_t bAbs = bInt & absMask;
+
+    // If either a or b is NaN, they are unordered.
+    if (aAbs > infRep || bAbs > infRep)
+        return LE_UNORDERED;
+
+    // If a and b are both zeros, they are equal.
+    if ((aAbs | bAbs) == 0)
+        return LE_EQUAL;
+
+    // If at least one of a and b is positive, we get the same result comparing
+    // a and b as signed integers as we would with a floating-point compare.
+    if ((aInt & bInt) >= 0)
+    {
+        if (aInt < bInt)
+            return LE_LESS;
+        else if (aInt == bInt)
+            return LE_EQUAL;
+        else
+            return LE_GREATER;
+    }
+    else
+    {
+        // Otherwise, both are negative, so we need to flip the sense of the
+        // comparison to get the correct result.  (This assumes a twos- or ones-
+        // complement integer representation; if integers are represented in a
+        // sign-magnitude representation, then this flip is incorrect).
+        if (aInt > bInt)
+            return LE_LESS;
+        else if (aInt == bInt)
+            return LE_EQUAL;
+        else
+            return LE_GREATER;
+    }
+}
+
+enum GE_RESULT
+{
+    GE_LESS = -1,
+    GE_EQUAL = 0,
+    GE_GREATER = 1,
+    GE_UNORDERED = -1 // Note: different from LE_UNORDERED
+};
+
+COMPILER_RT_ABI enum GE_RESULT __getf2(fp_t a, fp_t b)
+{
+    const srep_t aInt = toRep(a);
+    const srep_t bInt = toRep(b);
+    const rep_t aAbs = aInt & absMask;
+    const rep_t bAbs = bInt & absMask;
+
+    if (aAbs > infRep || bAbs > infRep)
+        return GE_UNORDERED;
+    if ((aAbs | bAbs) == 0)
+        return GE_EQUAL;
+    if ((aInt & bInt) >= 0)
+    {
+        if (aInt < bInt)
+            return GE_LESS;
+        else if (aInt == bInt)
+            return GE_EQUAL;
+        else
+            return GE_GREATER;
+    }
+    else
+    {
+        if (aInt > bInt)
+            return GE_LESS;
+        else if (aInt == bInt)
+            return GE_EQUAL;
+        else
+            return GE_GREATER;
+    }
+}
+
+COMPILER_RT_ABI int __unordtf2(fp_t a, fp_t b)
+{
+    const rep_t aAbs = toRep(a) & absMask;
+    const rep_t bAbs = toRep(b) & absMask;
+    return aAbs > infRep || bAbs > infRep;
+}
+
+// The following are alternative names for the preceding routines.
+
+COMPILER_RT_ABI enum LE_RESULT __eqtf2(fp_t a, fp_t b)
+{
+    return __letf2(a, b);
+}
+
+COMPILER_RT_ABI enum LE_RESULT __lttf2(fp_t a, fp_t b)
+{
+    return __letf2(a, b);
+}
+
+COMPILER_RT_ABI enum LE_RESULT __netf2(fp_t a, fp_t b)
+{
+    return __letf2(a, b);
+}
+
+COMPILER_RT_ABI enum GE_RESULT __gttf2(fp_t a, fp_t b)
+{
+    return __getf2(a, b);
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/ctzdi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/ctzdi2.c
@@ -1,0 +1,28 @@
+/* ===-- ctzdi2.c - Implement __ctzdi2 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ctzdi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: the number of trailing 0-bits  */
+
+/* Precondition: a != 0 */
+
+COMPILER_RT_ABI si_int __ctzdi2(di_int a)
+{
+    dwords x;
+    x.all = a;
+    const si_int f = -(x.s.low == 0);
+    return __builtin_ctz((x.s.high & f) | (x.s.low & ~f)) +
+           (f & ((si_int)(sizeof(si_int) * CHAR_BIT)));
+}

--- a/3rdparty/compiler-rt/compiler-rt/ctzsi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/ctzsi2.c
@@ -1,0 +1,57 @@
+/* ===-- ctzsi2.c - Implement __ctzsi2 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ctzsi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: the number of trailing 0-bits */
+
+/* Precondition: a != 0 */
+
+COMPILER_RT_ABI si_int __ctzsi2(si_int a)
+{
+    su_int x = (su_int)a;
+    si_int t = ((x & 0x0000FFFF) == 0)
+               << 4; /* if (x has no small bits) t = 16 else 0 */
+    x >>= t;         /* x = [0 - 0xFFFF] + higher garbage bits */
+    su_int r = t;    /* r = [0, 16]  */
+    /* return r + ctz(x) */
+    t = ((x & 0x00FF) == 0) << 3;
+    x >>= t; /* x = [0 - 0xFF] + higher garbage bits */
+    r += t;  /* r = [0, 8, 16, 24] */
+    /* return r + ctz(x) */
+    t = ((x & 0x0F) == 0) << 2;
+    x >>= t; /* x = [0 - 0xF] + higher garbage bits */
+    r += t;  /* r = [0, 4, 8, 12, 16, 20, 24, 28] */
+    /* return r + ctz(x) */
+    t = ((x & 0x3) == 0) << 1;
+    x >>= t;
+    x &= 3; /* x = [0 - 3] */
+    r += t; /* r = [0 - 30] and is even */
+    /* return r + ctz(x) */
+
+    /*  The branch-less return statement below is equivalent
+     *  to the following switch statement:
+     *     switch (x)
+     *    {
+     *     case 0:
+     *         return r + 2;
+     *     case 2:
+     *         return r + 1;
+     *     case 1:
+     *     case 3:
+     *         return r;
+     *     }
+     */
+    return r + ((2 - (x >> 1)) & -((x & 1) == 0));
+}

--- a/3rdparty/compiler-rt/compiler-rt/ctzti2.c
+++ b/3rdparty/compiler-rt/compiler-rt/ctzti2.c
@@ -1,0 +1,32 @@
+/* ===-- ctzti2.c - Implement __ctzti2 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ctzti2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: the number of trailing 0-bits */
+
+/* Precondition: a != 0 */
+
+COMPILER_RT_ABI si_int __ctzti2(ti_int a)
+{
+    twords x;
+    x.all = a;
+    const di_int f = -(x.s.low == 0);
+    return __builtin_ctzll((x.s.high & f) | (x.s.low & ~f)) +
+           ((si_int)f & ((si_int)(sizeof(di_int) * CHAR_BIT)));
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/divdi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/divdi3.c
@@ -1,0 +1,29 @@
+/* ===-- divdi3.c - Implement __divdi3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __divdi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: a / b */
+
+COMPILER_RT_ABI di_int __divdi3(di_int a, di_int b)
+{
+    const int bits_in_dword_m1 = (int)(sizeof(di_int) * CHAR_BIT) - 1;
+    di_int s_a = a >> bits_in_dword_m1; /* s_a = a < 0 ? -1 : 0 */
+    di_int s_b = b >> bits_in_dword_m1; /* s_b = b < 0 ? -1 : 0 */
+    a = (a ^ s_a) - s_a;                /* negate if s_a == -1 */
+    b = (b ^ s_b) - s_b;                /* negate if s_b == -1 */
+    s_a ^= s_b;                         /*sign of quotient */
+    return (__udivmoddi4(a, b, (du_int*)0) ^ s_a) -
+           s_a; /* negate if s_a == -1 */
+}

--- a/3rdparty/compiler-rt/compiler-rt/divsi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/divsi3.c
@@ -1,0 +1,36 @@
+/* ===-- divsi3.c - Implement __divsi3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __divsi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: a / b */
+
+ARM_EABI_FNALIAS(idiv, divsi3)
+
+COMPILER_RT_ABI si_int __divsi3(si_int a, si_int b)
+{
+    const int bits_in_word_m1 = (int)(sizeof(si_int) * CHAR_BIT) - 1;
+    si_int s_a = a >> bits_in_word_m1; /* s_a = a < 0 ? -1 : 0 */
+    si_int s_b = b >> bits_in_word_m1; /* s_b = b < 0 ? -1 : 0 */
+    a = (a ^ s_a) - s_a;               /* negate if s_a == -1 */
+    b = (b ^ s_b) - s_b;               /* negate if s_b == -1 */
+    s_a ^= s_b;                        /* sign of quotient */
+    /*
+     * On CPUs without unsigned hardware division support,
+     *  this calls __udivsi3 (notice the cast to su_int).
+     * On CPUs with unsigned hardware division support,
+     *  this uses the unsigned division instruction.
+     */
+    return ((su_int)a / (su_int)b ^ s_a) - s_a; /* negate if s_a == -1 */
+}

--- a/3rdparty/compiler-rt/compiler-rt/divtf3.c
+++ b/3rdparty/compiler-rt/compiler-rt/divtf3.c
@@ -1,0 +1,222 @@
+//===-- lib/divtf3.c - Quad-precision division --------------------*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements quad-precision soft-float division
+// with the IEEE-754 default rounding (to nearest, ties to even).
+//
+// For simplicity, this implementation currently flushes denormals to zero.
+// It should be a fairly straightforward exercise to implement gradual
+// underflow with correct rounding.
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+COMPILER_RT_ABI fp_t __divtf3(fp_t a, fp_t b)
+{
+    const unsigned int aExponent = toRep(a) >> significandBits & maxExponent;
+    const unsigned int bExponent = toRep(b) >> significandBits & maxExponent;
+    const rep_t quotientSign = (toRep(a) ^ toRep(b)) & signBit;
+
+    rep_t aSignificand = toRep(a) & significandMask;
+    rep_t bSignificand = toRep(b) & significandMask;
+    int scale = 0;
+
+    // Detect if a or b is zero, denormal, infinity, or NaN.
+    if (aExponent - 1U >= maxExponent - 1U ||
+        bExponent - 1U >= maxExponent - 1U)
+    {
+        const rep_t aAbs = toRep(a) & absMask;
+        const rep_t bAbs = toRep(b) & absMask;
+
+        // NaN / anything = qNaN
+        if (aAbs > infRep)
+            return fromRep(toRep(a) | quietBit);
+        // anything / NaN = qNaN
+        if (bAbs > infRep)
+            return fromRep(toRep(b) | quietBit);
+
+        if (aAbs == infRep)
+        {
+            // infinity / infinity = NaN
+            if (bAbs == infRep)
+                return fromRep(qnanRep);
+            // infinity / anything else = +/- infinity
+            else
+                return fromRep(aAbs | quotientSign);
+        }
+
+        // anything else / infinity = +/- 0
+        if (bAbs == infRep)
+            return fromRep(quotientSign);
+
+        if (!aAbs)
+        {
+            // zero / zero = NaN
+            if (!bAbs)
+                return fromRep(qnanRep);
+            // zero / anything else = +/- zero
+            else
+                return fromRep(quotientSign);
+        }
+        // anything else / zero = +/- infinity
+        if (!bAbs)
+            return fromRep(infRep | quotientSign);
+
+        // one or both of a or b is denormal, the other (if applicable) is a
+        // normal number.  Renormalize one or both of a and b, and set scale to
+        // include the necessary exponent adjustment.
+        if (aAbs < implicitBit)
+            scale += normalize(&aSignificand);
+        if (bAbs < implicitBit)
+            scale -= normalize(&bSignificand);
+    }
+
+    // Or in the implicit significand bit.  (If we fell through from the
+    // denormal path it was already set by normalize( ), but setting it twice
+    // won't hurt anything.)
+    aSignificand |= implicitBit;
+    bSignificand |= implicitBit;
+    int quotientExponent = aExponent - bExponent + scale;
+
+    // Align the significand of b as a Q63 fixed-point number in the range
+    // [1, 2.0) and get a Q64 approximate reciprocal using a small minimax
+    // polynomial approximation: reciprocal = 3/4 + 1/sqrt(2) - b/2.  This
+    // is accurate to about 3.5 binary digits.
+    const uint64_t q63b = bSignificand >> 49;
+    uint64_t recip64 = UINT64_C(0x7504f333F9DE6484) - q63b;
+    // 0x7504f333F9DE6484 / 2^64 + 1 = 3/4 + 1/sqrt(2)
+
+    // Now refine the reciprocal estimate using a Newton-Raphson iteration:
+    //
+    //     x1 = x0 * (2 - x0 * b)
+    //
+    // This doubles the number of correct binary digits in the approximation
+    // with each iteration.
+    uint64_t correction64;
+    correction64 = -((rep_t)recip64 * q63b >> 64);
+    recip64 = (rep_t)recip64 * correction64 >> 63;
+    correction64 = -((rep_t)recip64 * q63b >> 64);
+    recip64 = (rep_t)recip64 * correction64 >> 63;
+    correction64 = -((rep_t)recip64 * q63b >> 64);
+    recip64 = (rep_t)recip64 * correction64 >> 63;
+    correction64 = -((rep_t)recip64 * q63b >> 64);
+    recip64 = (rep_t)recip64 * correction64 >> 63;
+    correction64 = -((rep_t)recip64 * q63b >> 64);
+    recip64 = (rep_t)recip64 * correction64 >> 63;
+
+    // recip64 might have overflowed to exactly zero in the preceeding
+    // computation if the high word of b is exactly 1.0.  This would sabotage
+    // the full-width final stage of the computation that follows, so we adjust
+    // recip64 downward by one bit.
+    recip64--;
+
+    // We need to perform one more iteration to get us to 112 binary digits;
+    // The last iteration needs to happen with extra precision.
+    const uint64_t q127blo = bSignificand << 15;
+    rep_t correction, reciprocal;
+
+    // NOTE: This operation is equivalent to __multi3, which is not implemented
+    //       in some architechure
+    rep_t r64q63, r64q127, r64cH, r64cL, dummy;
+    wideMultiply((rep_t)recip64, (rep_t)q63b, &dummy, &r64q63);
+    wideMultiply((rep_t)recip64, (rep_t)q127blo, &dummy, &r64q127);
+
+    correction = -(r64q63 + (r64q127 >> 64));
+
+    uint64_t cHi = correction >> 64;
+    uint64_t cLo = correction;
+
+    wideMultiply((rep_t)recip64, (rep_t)cHi, &dummy, &r64cH);
+    wideMultiply((rep_t)recip64, (rep_t)cLo, &dummy, &r64cL);
+
+    reciprocal = r64cH + (r64cL >> 64);
+
+    // We already adjusted the 64-bit estimate, now we need to adjust the final
+    // 128-bit reciprocal estimate downward to ensure that it is strictly
+    // smaller than the infinitely precise exact reciprocal.  Because the
+    // computation of the Newton-Raphson step is truncating at every step, this
+    // adjustment is small; most of the work is already done.
+    reciprocal -= 2;
+
+    // The numerical reciprocal is accurate to within 2^-112, lies in the
+    // interval [0.5, 1.0), and is strictly smaller than the true reciprocal
+    // of b.  Multiplying a by this reciprocal thus gives a numerical q = a/b
+    // in Q127 with the following properties:
+    //
+    //    1. q < a/b
+    //    2. q is in the interval [0.5, 2.0)
+    //    3. the error in q is bounded away from 2^-113 (actually, we have a
+    //       couple of bits to spare, but this is all we need).
+
+    // We need a 128 x 128 multiply high to compute q, which isn't a basic
+    // operation in C, so we need to be a little bit fussy.
+    rep_t quotient, quotientLo;
+    wideMultiply(aSignificand << 2, reciprocal, &quotient, &quotientLo);
+
+    // Two cases: quotient is in [0.5, 1.0) or quotient is in [1.0, 2.0).
+    // In either case, we are going to compute a residual of the form
+    //
+    //     r = a - q*b
+    //
+    // We know from the construction of q that r satisfies:
+    //
+    //     0 <= r < ulp(q)*b
+    //
+    // if r is greater than 1/2 ulp(q)*b, then q rounds up.  Otherwise, we
+    // already have the correct result.  The exact halfway case cannot occur.
+    // We also take this time to right shift quotient if it falls in the [1,2)
+    // range and adjust the exponent accordingly.
+    rep_t residual;
+    rep_t qb;
+
+    if (quotient < (implicitBit << 1))
+    {
+        wideMultiply(quotient, bSignificand, &dummy, &qb);
+        residual = (aSignificand << 113) - qb;
+        quotientExponent--;
+    }
+    else
+    {
+        quotient >>= 1;
+        wideMultiply(quotient, bSignificand, &dummy, &qb);
+        residual = (aSignificand << 112) - qb;
+    }
+
+    const int writtenExponent = quotientExponent + exponentBias;
+
+    if (writtenExponent >= maxExponent)
+    {
+        // If we have overflowed the exponent, return infinity.
+        return fromRep(infRep | quotientSign);
+    }
+    else if (writtenExponent < 1)
+    {
+        // Flush denormals to zero.  In the future, it would be nice to add
+        // code to round them correctly.
+        return fromRep(quotientSign);
+    }
+    else
+    {
+        const bool round = (residual << 1) >= bSignificand;
+        // Clear the implicit bit
+        rep_t absResult = quotient & significandMask;
+        // Insert the exponent
+        absResult |= (rep_t)writtenExponent << significandBits;
+        // Round
+        absResult += round;
+        // Insert the sign and return
+        const long double result = fromRep(absResult | quotientSign);
+        return result;
+    }
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/divti3.c
+++ b/3rdparty/compiler-rt/compiler-rt/divti3.c
@@ -1,0 +1,33 @@
+/* ===-- divti3.c - Implement __divti3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __divti3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: a / b */
+
+COMPILER_RT_ABI ti_int __divti3(ti_int a, ti_int b)
+{
+    const int bits_in_tword_m1 = (int)(sizeof(ti_int) * CHAR_BIT) - 1;
+    ti_int s_a = a >> bits_in_tword_m1; /* s_a = a < 0 ? -1 : 0 */
+    ti_int s_b = b >> bits_in_tword_m1; /* s_b = b < 0 ? -1 : 0 */
+    a = (a ^ s_a) - s_a;                /* negate if s_a == -1 */
+    b = (b ^ s_b) - s_b;                /* negate if s_b == -1 */
+    s_a ^= s_b;                         /* sign of quotient */
+    return (__udivmodti4(a, b, (tu_int*)0) ^ s_a) -
+           s_a; /* negate if s_a == -1 */
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/extenddftf2.c
+++ b/3rdparty/compiler-rt/compiler-rt/extenddftf2.c
@@ -1,0 +1,24 @@
+//===-- lib/extenddftf2.c - double -> quad conversion -------------*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#define SRC_DOUBLE
+#define DST_QUAD
+#include "fp_extend_impl.inc"
+
+COMPILER_RT_ABI long double __extenddftf2(double a)
+{
+    return __extendXfYf2__(a);
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/extendsftf2.c
+++ b/3rdparty/compiler-rt/compiler-rt/extendsftf2.c
@@ -1,0 +1,24 @@
+//===-- lib/extendsftf2.c - single -> quad conversion -------------*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#define SRC_SINGLE
+#define DST_QUAD
+#include "fp_extend_impl.inc"
+
+COMPILER_RT_ABI long double __extendsftf2(float a)
+{
+    return __extendXfYf2__(a);
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/ffsdi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/ffsdi2.c
@@ -1,0 +1,32 @@
+/* ===-- ffsdi2.c - Implement __ffsdi2 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ffsdi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: the index of the least significant 1-bit in a, or
+ * the value zero if a is zero. The least significant bit is index one.
+ */
+
+COMPILER_RT_ABI si_int __ffsdi2(di_int a)
+{
+    dwords x;
+    x.all = a;
+    if (x.s.low == 0)
+    {
+        if (x.s.high == 0)
+            return 0;
+        return __builtin_ctz(x.s.high) + (1 + sizeof(si_int) * CHAR_BIT);
+    }
+    return __builtin_ctz(x.s.low) + 1;
+}

--- a/3rdparty/compiler-rt/compiler-rt/ffsti2.c
+++ b/3rdparty/compiler-rt/compiler-rt/ffsti2.c
@@ -1,0 +1,36 @@
+/* ===-- ffsti2.c - Implement __ffsti2 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ffsti2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: the index of the least significant 1-bit in a, or
+ * the value zero if a is zero. The least significant bit is index one.
+ */
+
+COMPILER_RT_ABI si_int __ffsti2(ti_int a)
+{
+    twords x;
+    x.all = a;
+    if (x.s.low == 0)
+    {
+        if (x.s.high == 0)
+            return 0;
+        return __builtin_ctzll(x.s.high) + (1 + sizeof(di_int) * CHAR_BIT);
+    }
+    return __builtin_ctzll(x.s.low) + 1;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/fixtfsi.c
+++ b/3rdparty/compiler-rt/compiler-rt/fixtfsi.c
@@ -1,0 +1,27 @@
+//===-- lib/fixtfsi.c - Quad-precision -> integer conversion ------*- C -*-===//
+//
+// The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements quad-precision to integer conversion for the
+// compiler-rt library. No range checking is performed; the behavior of this
+// conversion is undefined for out of range values in the C standard.
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#include "fp_fixsi_impl.inc"
+
+COMPILER_RT_ABI int __fixtfsi(fp_t a)
+{
+    return __fixXsi(a);
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/floatsitf.c
+++ b/3rdparty/compiler-rt/compiler-rt/floatsitf.c
@@ -1,0 +1,53 @@
+//===-- lib/floatsitf.c - integer -> quad-precision conversion ----*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements integer to quad-precision conversion for the
+// compiler-rt library in the IEEE-754 default round-to-nearest, ties-to-even
+// mode.
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+COMPILER_RT_ABI fp_t __floatsitf(int a)
+{
+    const int aWidth = sizeof a * CHAR_BIT;
+
+    // Handle zero as a special case to protect clz
+    if (a == 0)
+        return fromRep(0);
+
+    // All other cases begin by extracting the sign and absolute value of a
+    rep_t sign = 0;
+    unsigned aAbs = (unsigned)a;
+    if (a < 0)
+    {
+        sign = signBit;
+        aAbs += 0x80000000;
+    }
+
+    // Exponent of (fp_t)a is the width of abs(a).
+    const int exponent = (aWidth - 1) - __builtin_clz(a);
+    rep_t result;
+
+    // Shift a into the significand field and clear the implicit bit.  Extra
+    // cast to unsigned int is necessary to get the correct behavior for
+    // the input INT_MIN.
+    const int shift = significandBits - exponent;
+    result = (rep_t)aAbs << shift ^ implicitBit;
+
+    // Insert the exponent
+    result += (rep_t)(exponent + exponentBias) << significandBits;
+    // Insert the sign bit and return
+    return fromRep(result | sign);
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/floatunsitf.c
+++ b/3rdparty/compiler-rt/compiler-rt/floatunsitf.c
@@ -1,0 +1,41 @@
+//===-- lib/floatunsitf.c - uint -> quad-precision conversion -----*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements unsigned integer to quad-precision conversion for the
+// compiler-rt library in the IEEE-754 default round-to-nearest, ties-to-even
+// mode.
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+COMPILER_RT_ABI fp_t __floatunsitf(unsigned int a)
+{
+    const int aWidth = sizeof a * CHAR_BIT;
+
+    // Handle zero as a special case to protect clz
+    if (a == 0)
+        return fromRep(0);
+
+    // Exponent of (fp_t)a is the width of abs(a).
+    const int exponent = (aWidth - 1) - __builtin_clz(a);
+    rep_t result;
+
+    // Shift a into the significand field and clear the implicit bit.
+    const int shift = significandBits - exponent;
+    result = (rep_t)a << shift ^ implicitBit;
+
+    // Insert the exponent
+    result += (rep_t)(exponent + exponentBias) << significandBits;
+    return fromRep(result);
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/fp_extend.h
+++ b/3rdparty/compiler-rt/compiler-rt/fp_extend.h
@@ -1,0 +1,88 @@
+//===-lib/fp_extend.h - low precision -> high precision conversion -*- C
+//-*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Set source and destination setting
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FP_EXTEND_HEADER
+#define FP_EXTEND_HEADER
+
+#include "int_lib.h"
+
+#if defined SRC_SINGLE
+typedef float src_t;
+typedef uint32_t src_rep_t;
+#define SRC_REP_C UINT32_C
+static const int srcSigBits = 23;
+#define src_rep_t_clz __builtin_clz
+
+#elif defined SRC_DOUBLE
+typedef double src_t;
+typedef uint64_t src_rep_t;
+#define SRC_REP_C UINT64_C
+static const int srcSigBits = 52;
+static inline int src_rep_t_clz(src_rep_t a)
+{
+#if defined __LP64__
+    return __builtin_clzl(a);
+#else
+    if (a & REP_C(0xffffffff00000000))
+        return __builtin_clz(a >> 32);
+    else
+        return 32 + __builtin_clz(a & REP_C(0xffffffff));
+#endif
+}
+
+#else
+#error Source should be single precision or double precision!
+#endif // end source precision
+
+#if defined DST_DOUBLE
+typedef double dst_t;
+typedef uint64_t dst_rep_t;
+#define DST_REP_C UINT64_C
+static const int dstSigBits = 52;
+
+#elif defined DST_QUAD
+typedef long double dst_t;
+typedef __uint128_t dst_rep_t;
+#define DST_REP_C (__uint128_t)
+static const int dstSigBits = 112;
+
+#else
+#error Destination should be double precision or quad precision!
+#endif // end destination precision
+
+// End of specialization parameters.  Two helper routines for conversion to and
+// from the representation of floating-point data as integer values follow.
+
+static inline src_rep_t srcToRep(src_t x)
+{
+    const union
+    {
+        src_t f;
+        src_rep_t i;
+    } rep = {.f = x};
+    return rep.i;
+}
+
+static inline dst_t dstFromRep(dst_rep_t x)
+{
+    const union
+    {
+        dst_t f;
+        dst_rep_t i;
+    } rep = {.i = x};
+    return rep.f;
+}
+// End helper routines.  Conversion implementation follows.
+
+#endif // FP_EXTEND_HEADER

--- a/3rdparty/compiler-rt/compiler-rt/fp_lib.h
+++ b/3rdparty/compiler-rt/compiler-rt/fp_lib.h
@@ -1,0 +1,292 @@
+//===-- lib/fp_lib.h - Floating-point utilities -------------------*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a configuration header for soft-float routines in compiler-rt.
+// This file does not provide any part of the compiler-rt interface, but defines
+// many useful constants and utility routines that are used in the
+// implementation of the soft-float routines in compiler-rt.
+//
+// Assumes that float, double and long double correspond to the IEEE-754
+// binary32, binary64 and binary 128 types, respectively, and that integer
+// endianness matches floating point endianness on the target platform.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FP_LIB_HEADER
+#define FP_LIB_HEADER
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "int_lib.h"
+
+// x86_64 FreeBSD prior v9.3 define fixed-width types incorrectly in
+// 32-bit mode.
+#if defined(__FreeBSD__) && defined(__i386__)
+#include <sys/param.h>
+#if __FreeBSD_version < 903000 // v9.3
+#define uint64_t unsigned long long
+#define int64_t long long
+#undef UINT64_C
+#define UINT64_C(c) (c##ULL)
+#endif
+#endif
+
+#if defined SINGLE_PRECISION
+
+typedef uint32_t rep_t;
+typedef int32_t srep_t;
+typedef float fp_t;
+#define REP_C UINT32_C
+#define significandBits 23
+
+static inline int rep_clz(rep_t a)
+{
+    return __builtin_clz(a);
+}
+
+// 32x32 --> 64 bit multiply
+static inline void wideMultiply(rep_t a, rep_t b, rep_t* hi, rep_t* lo)
+{
+    const uint64_t product = (uint64_t)a * b;
+    *hi = product >> 32;
+    *lo = product;
+}
+COMPILER_RT_ABI fp_t __addsf3(fp_t a, fp_t b);
+
+#elif defined DOUBLE_PRECISION
+
+typedef uint64_t rep_t;
+typedef int64_t srep_t;
+typedef double fp_t;
+#define REP_C UINT64_C
+#define significandBits 52
+
+static inline int rep_clz(rep_t a)
+{
+#if defined __LP64__
+    return __builtin_clzl(a);
+#else
+    if (a & REP_C(0xffffffff00000000))
+        return __builtin_clz(a >> 32);
+    else
+        return 32 + __builtin_clz(a & REP_C(0xffffffff));
+#endif
+}
+
+#define loWord(a) (a & 0xffffffffU)
+#define hiWord(a) (a >> 32)
+
+// 64x64 -> 128 wide multiply for platforms that don't have such an operation;
+// many 64-bit platforms have this operation, but they tend to have hardware
+// floating-point, so we don't bother with a special case for them here.
+static inline void wideMultiply(rep_t a, rep_t b, rep_t* hi, rep_t* lo)
+{
+    // Each of the component 32x32 -> 64 products
+    const uint64_t plolo = loWord(a) * loWord(b);
+    const uint64_t plohi = loWord(a) * hiWord(b);
+    const uint64_t philo = hiWord(a) * loWord(b);
+    const uint64_t phihi = hiWord(a) * hiWord(b);
+    // Sum terms that contribute to lo in a way that allows us to get the carry
+    const uint64_t r0 = loWord(plolo);
+    const uint64_t r1 = hiWord(plolo) + loWord(plohi) + loWord(philo);
+    *lo = r0 + (r1 << 32);
+    // Sum terms contributing to hi with the carry from lo
+    *hi = hiWord(plohi) + hiWord(philo) + hiWord(r1) + phihi;
+}
+#undef loWord
+#undef hiWord
+
+COMPILER_RT_ABI fp_t __adddf3(fp_t a, fp_t b);
+
+#elif defined QUAD_PRECISION
+#if __LDBL_MANT_DIG__ == 113
+#define CRT_LDBL_128BIT
+typedef __uint128_t rep_t;
+typedef __int128_t srep_t;
+typedef long double fp_t;
+#define REP_C (__uint128_t)
+// Note: Since there is no explicit way to tell compiler the constant is a
+// 128-bit integer, we let the constant be casted to 128-bit integer
+#define significandBits 112
+
+static inline int rep_clz(rep_t a)
+{
+    const union
+    {
+        __uint128_t ll;
+#if _YUGA_BIG_ENDIAN
+        struct
+        {
+            uint64_t high, low;
+        } s;
+#else
+        struct
+        {
+            uint64_t low, high;
+        } s;
+#endif
+    } uu = {.ll = a};
+
+    uint64_t word;
+    uint64_t add;
+
+    if (uu.s.high)
+    {
+        word = uu.s.high;
+        add = 0;
+    }
+    else
+    {
+        word = uu.s.low;
+        add = 64;
+    }
+    return __builtin_clzll(word) + add;
+}
+
+#define Word_LoMask UINT64_C(0x00000000ffffffff)
+#define Word_HiMask UINT64_C(0xffffffff00000000)
+#define Word_FullMask UINT64_C(0xffffffffffffffff)
+#define Word_1(a) (uint64_t)((a >> 96) & Word_LoMask)
+#define Word_2(a) (uint64_t)((a >> 64) & Word_LoMask)
+#define Word_3(a) (uint64_t)((a >> 32) & Word_LoMask)
+#define Word_4(a) (uint64_t)(a & Word_LoMask)
+
+// 128x128 -> 256 wide multiply for platforms that don't have such an operation;
+// many 64-bit platforms have this operation, but they tend to have hardware
+// floating-point, so we don't bother with a special case for them here.
+static inline void wideMultiply(rep_t a, rep_t b, rep_t* hi, rep_t* lo)
+{
+    const uint64_t product11 = Word_1(a) * Word_1(b);
+    const uint64_t product12 = Word_1(a) * Word_2(b);
+    const uint64_t product13 = Word_1(a) * Word_3(b);
+    const uint64_t product14 = Word_1(a) * Word_4(b);
+    const uint64_t product21 = Word_2(a) * Word_1(b);
+    const uint64_t product22 = Word_2(a) * Word_2(b);
+    const uint64_t product23 = Word_2(a) * Word_3(b);
+    const uint64_t product24 = Word_2(a) * Word_4(b);
+    const uint64_t product31 = Word_3(a) * Word_1(b);
+    const uint64_t product32 = Word_3(a) * Word_2(b);
+    const uint64_t product33 = Word_3(a) * Word_3(b);
+    const uint64_t product34 = Word_3(a) * Word_4(b);
+    const uint64_t product41 = Word_4(a) * Word_1(b);
+    const uint64_t product42 = Word_4(a) * Word_2(b);
+    const uint64_t product43 = Word_4(a) * Word_3(b);
+    const uint64_t product44 = Word_4(a) * Word_4(b);
+
+    const __uint128_t sum0 = (__uint128_t)product44;
+    const __uint128_t sum1 = (__uint128_t)product34 + (__uint128_t)product43;
+    const __uint128_t sum2 = (__uint128_t)product24 + (__uint128_t)product33 +
+                             (__uint128_t)product42;
+    const __uint128_t sum3 = (__uint128_t)product14 + (__uint128_t)product23 +
+                             (__uint128_t)product32 + (__uint128_t)product41;
+    const __uint128_t sum4 = (__uint128_t)product13 + (__uint128_t)product22 +
+                             (__uint128_t)product31;
+    const __uint128_t sum5 = (__uint128_t)product12 + (__uint128_t)product21;
+    const __uint128_t sum6 = (__uint128_t)product11;
+
+    const __uint128_t r0 =
+        (sum0 & Word_FullMask) + ((sum1 & Word_LoMask) << 32);
+    const __uint128_t r1 = (sum0 >> 64) + ((sum1 >> 32) & Word_FullMask) +
+                           (sum2 & Word_FullMask) +
+                           ((sum3 << 32) & Word_HiMask);
+
+    *lo = r0 + (r1 << 64);
+    *hi = (r1 >> 64) + (sum1 >> 96) + (sum2 >> 64) + (sum3 >> 32) + sum4 +
+          (sum5 << 32) + (sum6 << 64);
+}
+#undef Word_1
+#undef Word_2
+#undef Word_3
+#undef Word_4
+#undef Word_HiMask
+#undef Word_LoMask
+#undef Word_FullMask
+#endif // __LDBL_MANT_DIG__ == 113
+#else
+#error SINGLE_PRECISION, DOUBLE_PRECISION or QUAD_PRECISION must be defined.
+#endif
+
+#if defined(SINGLE_PRECISION) || defined(DOUBLE_PRECISION) || \
+    defined(CRT_LDBL_128BIT)
+#define typeWidth (sizeof(rep_t) * CHAR_BIT)
+#define exponentBits (typeWidth - significandBits - 1)
+#define maxExponent ((1 << exponentBits) - 1)
+#define exponentBias (maxExponent >> 1)
+
+#define implicitBit (REP_C(1) << significandBits)
+#define significandMask (implicitBit - 1U)
+#define signBit (REP_C(1) << (significandBits + exponentBits))
+#define absMask (signBit - 1U)
+#define exponentMask (absMask ^ significandMask)
+#define oneRep ((rep_t)exponentBias << significandBits)
+#define infRep exponentMask
+#define quietBit (implicitBit >> 1)
+#define qnanRep (exponentMask | quietBit)
+
+static inline rep_t toRep(fp_t x)
+{
+    const union
+    {
+        fp_t f;
+        rep_t i;
+    } rep = {.f = x};
+    return rep.i;
+}
+
+static inline fp_t fromRep(rep_t x)
+{
+    const union
+    {
+        fp_t f;
+        rep_t i;
+    } rep = {.i = x};
+    return rep.f;
+}
+
+static inline int normalize(rep_t* significand)
+{
+    const int shift = rep_clz(*significand) - rep_clz(implicitBit);
+    *significand <<= shift;
+    return 1 - shift;
+}
+
+static inline void wideLeftShift(rep_t* hi, rep_t* lo, int count)
+{
+    *hi = *hi << count | *lo >> (typeWidth - count);
+    *lo = *lo << count;
+}
+
+static inline void wideRightShiftWithSticky(
+    rep_t* hi,
+    rep_t* lo,
+    unsigned int count)
+{
+    if (count < typeWidth)
+    {
+        const bool sticky = *lo << (typeWidth - count);
+        *lo = *hi << (typeWidth - count) | *lo >> count | sticky;
+        *hi = *hi >> count;
+    }
+    else if (count < 2 * typeWidth)
+    {
+        const bool sticky = *hi << (2 * typeWidth - count) | *lo;
+        *lo = *hi >> (count - typeWidth) | sticky;
+        *hi = 0;
+    }
+    else
+    {
+        const bool sticky = *hi | *lo;
+        *lo = sticky;
+        *hi = 0;
+    }
+}
+#endif
+
+#endif // FP_LIB_HEADER

--- a/3rdparty/compiler-rt/compiler-rt/fp_trunc.h
+++ b/3rdparty/compiler-rt/compiler-rt/fp_trunc.h
@@ -1,0 +1,74 @@
+//=== lib/fp_trunc.h - high precision -> low precision conversion *- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// Set source and destination precision setting
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FP_TRUNC_HEADER
+#define FP_TRUNC_HEADER
+
+#include "int_lib.h"
+
+#if defined SRC_DOUBLE
+typedef double src_t;
+typedef uint64_t src_rep_t;
+#define SRC_REP_C UINT64_C
+static const int srcSigBits = 52;
+
+#elif defined SRC_QUAD
+typedef long double src_t;
+typedef __uint128_t src_rep_t;
+#define SRC_REP_C (__uint128_t)
+static const int srcSigBits = 112;
+
+#else
+#error Source should be double precision or quad precision!
+#endif // end source precision
+
+#if defined DST_DOUBLE
+typedef double dst_t;
+typedef uint64_t dst_rep_t;
+#define DST_REP_C UINT64_C
+static const int dstSigBits = 52;
+
+#elif defined DST_SINGLE
+typedef float dst_t;
+typedef uint32_t dst_rep_t;
+#define DST_REP_C UINT32_C
+static const int dstSigBits = 23;
+
+#else
+#error Destination should be single precision or double precision!
+#endif // end destination precision
+
+// End of specialization parameters.  Two helper routines for conversion to and
+// from the representation of floating-point data as integer values follow.
+
+static inline src_rep_t srcToRep(src_t x)
+{
+    const union
+    {
+        src_t f;
+        src_rep_t i;
+    } rep = {.f = x};
+    return rep.i;
+}
+
+static inline dst_t dstFromRep(dst_rep_t x)
+{
+    const union
+    {
+        dst_t f;
+        dst_rep_t i;
+    } rep = {.i = x};
+    return rep.f;
+}
+
+#endif // FP_TRUNC_HEADER

--- a/3rdparty/compiler-rt/compiler-rt/int_endianness.h
+++ b/3rdparty/compiler-rt/compiler-rt/int_endianness.h
@@ -1,0 +1,113 @@
+/* ===-- int_endianness.h - configuration header for compiler-rt ------------===
+ *
+ *		       The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file is a configuration header for compiler-rt.
+ * This file is not part of the interface of this library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#ifndef INT_ENDIANNESS_H
+#define INT_ENDIANNESS_H
+
+#if defined(__SVR4) && defined(__sun)
+#include <sys/byteorder.h>
+
+#if defined(_BIG_ENDIAN)
+#define _YUGA_LITTLE_ENDIAN 0
+#define _YUGA_BIG_ENDIAN 1
+#elif defined(_LITTLE_ENDIAN)
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN 0
+#else /* !_LITTLE_ENDIAN */
+#error "unknown endianness"
+#endif /* !_LITTLE_ENDIAN */
+
+#endif /* Solaris and AuroraUX. */
+
+/* .. */
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || \
+    defined(__minix)
+#include <sys/endian.h>
+
+#if _BYTE_ORDER == _BIG_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 0
+#define _YUGA_BIG_ENDIAN 1
+#elif _BYTE_ORDER == _LITTLE_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN 0
+#endif /* _BYTE_ORDER */
+
+#endif /* *BSD */
+
+#if defined(__OpenBSD__) || defined(__Bitrig__)
+#include <machine/endian.h>
+
+#if _BYTE_ORDER == _BIG_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 0
+#define _YUGA_BIG_ENDIAN 1
+#elif _BYTE_ORDER == _LITTLE_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN 0
+#endif /* _BYTE_ORDER */
+
+#endif /* OpenBSD and Bitrig. */
+
+/* .. */
+
+/* Mac OSX has __BIG_ENDIAN__ or __LITTLE_ENDIAN__ automatically set by the
+ * compiler (at least with GCC) */
+#if defined(__APPLE__) || defined(__ellcc__)
+
+#ifdef __BIG_ENDIAN__
+#if __BIG_ENDIAN__
+#define _YUGA_LITTLE_ENDIAN 0
+#define _YUGA_BIG_ENDIAN 1
+#endif
+#endif /* __BIG_ENDIAN__ */
+
+#ifdef __LITTLE_ENDIAN__
+#if __LITTLE_ENDIAN__
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN 0
+#endif
+#endif /* __LITTLE_ENDIAN__ */
+
+#endif /* Mac OSX */
+
+/* .. */
+
+#if defined(__linux__)
+#include <endian.h>
+
+#if __BYTE_ORDER == __BIG_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 0
+#define _YUGA_BIG_ENDIAN 1
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN 0
+#endif /* __BYTE_ORDER */
+
+#endif /* GNU/Linux */
+
+#if defined(_WIN32)
+
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN 0
+
+#endif /* Windows */
+
+/* . */
+
+#if !defined(_YUGA_LITTLE_ENDIAN) || !defined(_YUGA_BIG_ENDIAN)
+#error Unable to determine endian
+#endif /* Check we found an endianness correctly. */
+
+#endif /* INT_ENDIANNESS_H */

--- a/3rdparty/compiler-rt/compiler-rt/int_lib.h
+++ b/3rdparty/compiler-rt/compiler-rt/int_lib.h
@@ -1,0 +1,70 @@
+/* ===-- int_lib.h - configuration header for compiler-rt  -----------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file is a configuration header for compiler-rt.
+ * This file is not part of the interface of this library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#ifndef INT_LIB_H
+#define INT_LIB_H
+
+/* Assumption: Signed integral is 2's complement. */
+/* Assumption: Right shift of signed negative is arithmetic shift. */
+/* Assumption: Endianness is little or big (not mixed). */
+
+/* ABI macro definitions */
+
+#if __ARM_EABI__
+#define ARM_EABI_FNALIAS(aeabi_name, name) \
+    void __aeabi_##aeabi_name() __attribute__((alias("__" #name)));
+#define COMPILER_RT_ABI __attribute__((pcs("aapcs")))
+#else
+#define ARM_EABI_FNALIAS(aeabi_name, name)
+#define COMPILER_RT_ABI
+#endif
+
+#if defined(__NetBSD__) && (defined(_KERNEL) || defined(_STANDALONE))
+/*
+ * Kernel and boot environment can't use normal headers,
+ * so use the equivalent system headers.
+ */
+#include <machine/limits.h>
+#include <sys/stdint.h>
+#include <sys/types.h>
+#else
+/* Include the standard compiler builtin headers we use functionality from. */
+#include <float.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#endif
+
+/* Include the commonly used internal type definitions. */
+#include "int_types.h"
+
+/* Include internal utility function declarations. */
+#include "int_util.h"
+
+COMPILER_RT_ABI si_int __paritysi2(si_int a);
+COMPILER_RT_ABI si_int __paritydi2(di_int a);
+
+COMPILER_RT_ABI di_int __divdi3(di_int a, di_int b);
+COMPILER_RT_ABI si_int __divsi3(si_int a, si_int b);
+COMPILER_RT_ABI su_int __udivsi3(su_int n, su_int d);
+
+COMPILER_RT_ABI su_int __udivmodsi4(su_int a, su_int b, su_int* rem);
+COMPILER_RT_ABI du_int __udivmoddi4(du_int a, du_int b, du_int* rem);
+#ifdef CRT_HAS_128BIT
+COMPILER_RT_ABI si_int __clzti2(ti_int a);
+COMPILER_RT_ABI tu_int __udivmodti4(tu_int a, tu_int b, tu_int* rem);
+#endif
+
+#endif /* INT_LIB_H */

--- a/3rdparty/compiler-rt/compiler-rt/int_types.h
+++ b/3rdparty/compiler-rt/compiler-rt/int_types.h
@@ -1,0 +1,144 @@
+/* ===-- int_lib.h - configuration header for compiler-rt  -----------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file is not part of the interface of this library.
+ *
+ * This file defines various standard types, most importantly a number of unions
+ * used to access parts of larger types.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#ifndef INT_TYPES_H
+#define INT_TYPES_H
+
+#include "int_endianness.h"
+
+typedef int si_int;
+typedef unsigned su_int;
+
+typedef long long di_int;
+typedef unsigned long long du_int;
+
+typedef union
+{
+    di_int all;
+    struct
+    {
+#if _YUGA_LITTLE_ENDIAN
+        su_int low;
+        si_int high;
+#else
+        si_int high;
+        su_int low;
+#endif /* _YUGA_LITTLE_ENDIAN */
+    } s;
+} dwords;
+
+typedef union
+{
+    du_int all;
+    struct
+    {
+#if _YUGA_LITTLE_ENDIAN
+        su_int low;
+        su_int high;
+#else
+        su_int high;
+        su_int low;
+#endif /* _YUGA_LITTLE_ENDIAN */
+    } s;
+} udwords;
+
+#if __LP64__
+#define CRT_HAS_128BIT
+#endif
+
+#ifdef CRT_HAS_128BIT
+typedef int ti_int __attribute__((mode(TI)));
+typedef unsigned tu_int __attribute__((mode(TI)));
+
+typedef union
+{
+    ti_int all;
+    struct
+    {
+#if _YUGA_LITTLE_ENDIAN
+        du_int low;
+        di_int high;
+#else
+        di_int high;
+        du_int low;
+#endif /* _YUGA_LITTLE_ENDIAN */
+    } s;
+} twords;
+
+typedef union
+{
+    tu_int all;
+    struct
+    {
+#if _YUGA_LITTLE_ENDIAN
+        du_int low;
+        du_int high;
+#else
+        du_int high;
+        du_int low;
+#endif /* _YUGA_LITTLE_ENDIAN */
+    } s;
+} utwords;
+
+static inline ti_int make_ti(di_int h, di_int l)
+{
+    twords r;
+    r.s.high = h;
+    r.s.low = l;
+    return r.all;
+}
+
+static inline tu_int make_tu(du_int h, du_int l)
+{
+    utwords r;
+    r.s.high = h;
+    r.s.low = l;
+    return r.all;
+}
+
+#endif /* CRT_HAS_128BIT */
+
+typedef union
+{
+    su_int u;
+    float f;
+} float_bits;
+
+typedef union
+{
+    udwords u;
+    double f;
+} double_bits;
+
+typedef struct
+{
+#if _YUGA_LITTLE_ENDIAN
+    udwords low;
+    udwords high;
+#else
+    udwords high;
+    udwords low;
+#endif /* _YUGA_LITTLE_ENDIAN */
+} uqwords;
+
+typedef union
+{
+    uqwords u;
+    long double f;
+} long_double_bits;
+
+#endif /* INT_TYPES_H */

--- a/3rdparty/compiler-rt/compiler-rt/int_util.h
+++ b/3rdparty/compiler-rt/compiler-rt/int_util.h
@@ -1,0 +1,28 @@
+/* ===-- int_util.h - internal utility functions ----------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===-----------------------------------------------------------------------===
+ *
+ * This file is not part of the interface of this library.
+ *
+ * This file defines non-inline utilities which are available for use in the
+ * library. The function definitions themselves are all contained in int_util.c
+ * which will always be compiled into any compiler-rt library.
+ *
+ * ===-----------------------------------------------------------------------===
+ */
+
+#ifndef INT_UTIL_H
+#define INT_UTIL_H
+
+/** \brief Trigger a program abort (or panic for kernel code). */
+#define compilerrt_abort() compilerrt_abort_impl(__FILE__, __LINE__, __func__)
+
+void compilerrt_abort_impl(const char* file, int line, const char* function)
+    __attribute__((noreturn));
+
+#endif /* INT_UTIL_H */

--- a/3rdparty/compiler-rt/compiler-rt/lshrdi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/lshrdi3.c
@@ -1,0 +1,43 @@
+/* ===-- lshrdi3.c - Implement __lshrdi3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __lshrdi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: logical a >> b */
+
+/* Precondition:  0 <= b < bits_in_dword */
+
+ARM_EABI_FNALIAS(llsr, lshrdi3)
+
+COMPILER_RT_ABI di_int __lshrdi3(di_int a, si_int b)
+{
+    const int bits_in_word = (int)(sizeof(si_int) * CHAR_BIT);
+    udwords input;
+    udwords result;
+    input.all = a;
+    if (b & bits_in_word) /* bits_in_word <= b < bits_in_dword */
+    {
+        result.s.high = 0;
+        result.s.low = input.s.high >> (b - bits_in_word);
+    }
+    else /* 0 <= b < bits_in_word */
+    {
+        if (b == 0)
+            return a;
+        result.s.high = input.s.high >> b;
+        result.s.low =
+            (input.s.high << (bits_in_word - b)) | (input.s.low >> b);
+    }
+    return result.all;
+}

--- a/3rdparty/compiler-rt/compiler-rt/lshrti3.c
+++ b/3rdparty/compiler-rt/compiler-rt/lshrti3.c
@@ -1,0 +1,45 @@
+/* ===-- lshrti3.c - Implement __lshrti3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __lshrti3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: logical a >> b */
+
+/* Precondition:  0 <= b < bits_in_tword */
+
+COMPILER_RT_ABI ti_int __lshrti3(ti_int a, si_int b)
+{
+    const int bits_in_dword = (int)(sizeof(di_int) * CHAR_BIT);
+    utwords input;
+    utwords result;
+    input.all = a;
+    if (b & bits_in_dword) /* bits_in_dword <= b < bits_in_tword */
+    {
+        result.s.high = 0;
+        result.s.low = input.s.high >> (b - bits_in_dword);
+    }
+    else /* 0 <= b < bits_in_dword */
+    {
+        if (b == 0)
+            return a;
+        result.s.high = input.s.high >> b;
+        result.s.low =
+            (input.s.high << (bits_in_dword - b)) | (input.s.low >> b);
+    }
+    return result.all;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/moddi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/moddi3.c
@@ -1,0 +1,29 @@
+/*===-- moddi3.c - Implement __moddi3 -------------------------------------===
+ *
+ *                    The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __moddi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: a % b */
+
+COMPILER_RT_ABI di_int __moddi3(di_int a, di_int b)
+{
+    const int bits_in_dword_m1 = (int)(sizeof(di_int) * CHAR_BIT) - 1;
+    di_int s = b >> bits_in_dword_m1; /* s = b < 0 ? -1 : 0 */
+    b = (b ^ s) - s;                  /* negate if s == -1 */
+    s = a >> bits_in_dword_m1;        /* s = a < 0 ? -1 : 0 */
+    a = (a ^ s) - s;                  /* negate if s == -1 */
+    du_int r;
+    __udivmoddi4(a, b, &r);
+    return ((di_int)r ^ s) - s; /* negate if s == -1 */
+}

--- a/3rdparty/compiler-rt/compiler-rt/modsi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/modsi3.c
@@ -1,0 +1,22 @@
+/* ===-- modsi3.c - Implement __modsi3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __modsi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: a % b */
+
+COMPILER_RT_ABI si_int __modsi3(si_int a, si_int b)
+{
+    return a - __divsi3(a, b) * b;
+}

--- a/3rdparty/compiler-rt/compiler-rt/modti3.c
+++ b/3rdparty/compiler-rt/compiler-rt/modti3.c
@@ -1,0 +1,33 @@
+/* ===-- modti3.c - Implement __modti3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __modti3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/*Returns: a % b */
+
+COMPILER_RT_ABI ti_int __modti3(ti_int a, ti_int b)
+{
+    const int bits_in_tword_m1 = (int)(sizeof(ti_int) * CHAR_BIT) - 1;
+    ti_int s = b >> bits_in_tword_m1; /* s = b < 0 ? -1 : 0 */
+    b = (b ^ s) - s;                  /* negate if s == -1 */
+    s = a >> bits_in_tword_m1;        /* s = a < 0 ? -1 : 0 */
+    a = (a ^ s) - s;                  /* negate if s == -1 */
+    tu_int r;
+    __udivmodti4(a, b, &r);
+    return ((ti_int)r ^ s) - s; /* negate if s == -1 */
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/muldi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/muldi3.c
@@ -1,0 +1,53 @@
+/* ===-- muldi3.c - Implement __muldi3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __muldi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: a * b */
+
+static di_int __muldsi3(su_int a, su_int b)
+{
+    dwords r;
+    const int bits_in_word_2 = (int)(sizeof(si_int) * CHAR_BIT) / 2;
+    const su_int lower_mask = (su_int)~0 >> bits_in_word_2;
+    r.s.low = (a & lower_mask) * (b & lower_mask);
+    su_int t = r.s.low >> bits_in_word_2;
+    r.s.low &= lower_mask;
+    t += (a >> bits_in_word_2) * (b & lower_mask);
+    r.s.low += (t & lower_mask) << bits_in_word_2;
+    r.s.high = t >> bits_in_word_2;
+    t = r.s.low >> bits_in_word_2;
+    r.s.low &= lower_mask;
+    t += (b >> bits_in_word_2) * (a & lower_mask);
+    r.s.low += (t & lower_mask) << bits_in_word_2;
+    r.s.high += t >> bits_in_word_2;
+    r.s.high += (a >> bits_in_word_2) * (b >> bits_in_word_2);
+    return r.all;
+}
+
+/* Returns: a * b */
+
+ARM_EABI_FNALIAS(lmul, muldi3)
+
+COMPILER_RT_ABI di_int __muldi3(di_int a, di_int b)
+{
+    dwords x;
+    x.all = a;
+    dwords y;
+    y.all = b;
+    dwords r;
+    r.all = __muldsi3(x.s.low, y.s.low);
+    r.s.high += x.s.high * y.s.low + x.s.low * y.s.high;
+    return r.all;
+}

--- a/3rdparty/compiler-rt/compiler-rt/multf3.c
+++ b/3rdparty/compiler-rt/compiler-rt/multf3.c
@@ -1,0 +1,26 @@
+//===-- lib/multf3.c - Quad-precision multiplication --------------*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements quad-precision soft-float multiplication
+// with the IEEE-754 default rounding (to nearest, ties to even).
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#include "fp_mul_impl.inc"
+
+COMPILER_RT_ABI fp_t __multf3(fp_t a, fp_t b)
+{
+    return __mulXf3__(a, b);
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/multi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/multi3.c
@@ -1,0 +1,55 @@
+/* ===-- multi3.c - Implement __multi3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+
+ * This file implements __multi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: a * b */
+
+static ti_int __mulddi3(du_int a, du_int b)
+{
+    twords r;
+    const int bits_in_dword_2 = (int)(sizeof(di_int) * CHAR_BIT) / 2;
+    const du_int lower_mask = (du_int)~0 >> bits_in_dword_2;
+    r.s.low = (a & lower_mask) * (b & lower_mask);
+    du_int t = r.s.low >> bits_in_dword_2;
+    r.s.low &= lower_mask;
+    t += (a >> bits_in_dword_2) * (b & lower_mask);
+    r.s.low += (t & lower_mask) << bits_in_dword_2;
+    r.s.high = t >> bits_in_dword_2;
+    t = r.s.low >> bits_in_dword_2;
+    r.s.low &= lower_mask;
+    t += (b >> bits_in_dword_2) * (a & lower_mask);
+    r.s.low += (t & lower_mask) << bits_in_dword_2;
+    r.s.high += t >> bits_in_dword_2;
+    r.s.high += (a >> bits_in_dword_2) * (b >> bits_in_dword_2);
+    return r.all;
+}
+
+/* Returns: a * b */
+
+COMPILER_RT_ABI ti_int __multi3(ti_int a, ti_int b)
+{
+    twords x;
+    x.all = a;
+    twords y;
+    y.all = b;
+    twords r;
+    r.all = __mulddi3(x.s.low, y.s.low);
+    r.s.high += x.s.high * y.s.low + x.s.low * y.s.high;
+    return r.all;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/negdi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/negdi2.c
@@ -1,0 +1,25 @@
+/* ===-- negdi2.c - Implement __negdi2 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __negdi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: -a */
+
+COMPILER_RT_ABI di_int __negdi2(di_int a)
+{
+    /* Note: this routine is here for API compatibility; any sane compiler
+     * should expand it inline.
+     */
+    return -a;
+}

--- a/3rdparty/compiler-rt/compiler-rt/negti2.c
+++ b/3rdparty/compiler-rt/compiler-rt/negti2.c
@@ -1,0 +1,29 @@
+/* ===-- negti2.c - Implement __negti2 -------------------------------------===
+ *
+ *      	       The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __negti2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: -a */
+
+COMPILER_RT_ABI ti_int __negti2(ti_int a)
+{
+    /* Note: this routine is here for API compatibility; any sane compiler
+     * should expand it inline.
+     */
+    return -a;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/paritydi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/paritydi2.c
@@ -1,0 +1,24 @@
+/* ===-- paritydi2.c - Implement __paritydi2 -------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __paritydi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: 1 if number of bits is odd else returns 0 */
+
+COMPILER_RT_ABI si_int __paritydi2(di_int a)
+{
+    dwords x;
+    x.all = a;
+    return __paritysi2(x.s.high ^ x.s.low);
+}

--- a/3rdparty/compiler-rt/compiler-rt/paritysi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/paritysi2.c
@@ -1,0 +1,26 @@
+/* ===-- paritysi2.c - Implement __paritysi2 -------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __paritysi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: 1 if number of bits is odd else returns 0 */
+
+COMPILER_RT_ABI si_int __paritysi2(si_int a)
+{
+    su_int x = (su_int)a;
+    x ^= x >> 16;
+    x ^= x >> 8;
+    x ^= x >> 4;
+    return (0x6996 >> (x & 0xF)) & 1;
+}

--- a/3rdparty/compiler-rt/compiler-rt/parityti2.c
+++ b/3rdparty/compiler-rt/compiler-rt/parityti2.c
@@ -1,0 +1,28 @@
+/* ===-- parityti2.c - Implement __parityti2 -------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __parityti2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: 1 if number of bits is odd else returns 0 */
+
+COMPILER_RT_ABI si_int __parityti2(ti_int a)
+{
+    twords x;
+    x.all = a;
+    return __paritydi2(x.s.high ^ x.s.low);
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/popcountdi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/popcountdi2.c
@@ -1,0 +1,37 @@
+/* ===-- popcountdi2.c - Implement __popcountdi2 ----------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __popcountdi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: count of 1 bits */
+
+COMPILER_RT_ABI si_int __popcountdi2(di_int a)
+{
+    du_int x2 = (du_int)a;
+    x2 = x2 - ((x2 >> 1) & 0x5555555555555555uLL);
+    /* Every 2 bits holds the sum of every pair of bits (32) */
+    x2 = ((x2 >> 2) & 0x3333333333333333uLL) + (x2 & 0x3333333333333333uLL);
+    /* Every 4 bits holds the sum of every 4-set of bits (3 significant bits)
+     * (16) */
+    x2 = (x2 + (x2 >> 4)) & 0x0F0F0F0F0F0F0F0FuLL;
+    /* Every 8 bits holds the sum of every 8-set of bits (4 significant bits)
+     * (8) */
+    su_int x = (su_int)(x2 + (x2 >> 32));
+    /* The lower 32 bits hold four 16 bit sums (5 significant bits). */
+    /*   Upper 32 bits are garbage */
+    x = x + (x >> 16);
+    /* The lower 16 bits hold two 32 bit sums (6 significant bits). */
+    /*   Upper 16 bits are garbage */
+    return (x + (x >> 8)) & 0x0000007F; /* (7 significant bits) */
+}

--- a/3rdparty/compiler-rt/compiler-rt/popcountsi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/popcountsi2.c
@@ -1,0 +1,32 @@
+/* ===-- popcountsi2.c - Implement __popcountsi2 ---------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __popcountsi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: count of 1 bits */
+
+COMPILER_RT_ABI si_int __popcountsi2(si_int a)
+{
+    su_int x = (su_int)a;
+    x = x - ((x >> 1) & 0x55555555);
+    /* Every 2 bits holds the sum of every pair of bits */
+    x = ((x >> 2) & 0x33333333) + (x & 0x33333333);
+    /* Every 4 bits holds the sum of every 4-set of bits (3 significant bits) */
+    x = (x + (x >> 4)) & 0x0F0F0F0F;
+    /* Every 8 bits holds the sum of every 8-set of bits (4 significant bits) */
+    x = (x + (x >> 16));
+    /* The lower 16 bits hold two 8 bit sums (5 significant bits).*/
+    /*    Upper 16 bits are garbage */
+    return (x + (x >> 8)) & 0x0000003F; /* (6 significant bits) */
+}

--- a/3rdparty/compiler-rt/compiler-rt/popcountti2.c
+++ b/3rdparty/compiler-rt/compiler-rt/popcountti2.c
@@ -1,0 +1,49 @@
+/* ===-- popcountti2.c - Implement __popcountti2 ----------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __popcountti2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: count of 1 bits */
+
+COMPILER_RT_ABI si_int __popcountti2(ti_int a)
+{
+    tu_int x3 = (tu_int)a;
+    x3 = x3 - ((x3 >> 1) &
+               (((tu_int)0x5555555555555555uLL << 64) | 0x5555555555555555uLL));
+    /* Every 2 bits holds the sum of every pair of bits (64) */
+    x3 = ((x3 >> 2) &
+          (((tu_int)0x3333333333333333uLL << 64) | 0x3333333333333333uLL)) +
+         (x3 & (((tu_int)0x3333333333333333uLL << 64) | 0x3333333333333333uLL));
+    /* Every 4 bits holds the sum of every 4-set of bits (3 significant bits)
+     * (32) */
+    x3 = (x3 + (x3 >> 4)) &
+         (((tu_int)0x0F0F0F0F0F0F0F0FuLL << 64) | 0x0F0F0F0F0F0F0F0FuLL);
+    /* Every 8 bits holds the sum of every 8-set of bits (4 significant bits)
+     * (16) */
+    du_int x2 = (du_int)(x3 + (x3 >> 64));
+    /* Every 8 bits holds the sum of every 8-set of bits (5 significant bits)
+     * (8) */
+    su_int x = (su_int)(x2 + (x2 >> 32));
+    /* Every 8 bits holds the sum of every 8-set of bits (6 significant bits)
+     * (4) */
+    x = x + (x >> 16);
+    /* Every 8 bits holds the sum of every 8-set of bits (7 significant bits)
+     * (2) */
+    /* Upper 16 bits are garbage */
+    return (x + (x >> 8)) & 0xFF; /* (8 significant bits) */
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/stack_chk.c
+++ b/3rdparty/compiler-rt/compiler-rt/stack_chk.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "stdlib.h"
+
+void __attribute__((noreturn)) __stack_chk_fail(void)
+{
+    abort();
+}
+
+void __attribute__((noreturn)) __attribute__((visibility("hidden")))
+__stack_chk_fail_local(void)
+{
+    __stack_chk_fail();
+}
+
+extern void* __intel_security_cookie;
+
+#ifdef __x86_64__
+void __intel_security_check_cookie(void* cookie)
+#else
+void __attribute__((regparm(1))) __intel_security_check_cookie(void* cookie)
+#endif /* __x86_64__ */
+{
+    if (cookie == __intel_security_cookie)
+        return;
+    abort();
+}

--- a/3rdparty/compiler-rt/compiler-rt/subtf3.c
+++ b/3rdparty/compiler-rt/compiler-rt/subtf3.c
@@ -1,0 +1,27 @@
+//===-- lib/subtf3.c - Quad-precision subtraction -----------------*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements quad-precision soft-float subtraction with the
+// IEEE-754 default rounding (to nearest, ties to even).
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+COMPILER_RT_ABI fp_t __addtf3(fp_t a, fp_t b);
+
+// Subtraction; flip the sign bit of b and add.
+COMPILER_RT_ABI fp_t __subtf3(fp_t a, fp_t b)
+{
+    return __addtf3(a, fromRep(toRep(b) ^ signBit));
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/trunctfdf2.c
+++ b/3rdparty/compiler-rt/compiler-rt/trunctfdf2.c
@@ -1,0 +1,23 @@
+//===-- lib/truncdfsf2.c - quad -> double conversion --------------*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#define SRC_QUAD
+#define DST_DOUBLE
+#include "fp_trunc_impl.inc"
+
+COMPILER_RT_ABI double __trunctfdf2(long double a)
+{
+    return __truncXfYf2__(a);
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/trunctfsf2.c
+++ b/3rdparty/compiler-rt/compiler-rt/trunctfsf2.c
@@ -1,0 +1,23 @@
+//===-- lib/trunctfsf2.c - quad -> single conversion --------------*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#define SRC_QUAD
+#define DST_SINGLE
+#include "fp_trunc_impl.inc"
+
+COMPILER_RT_ABI float __trunctfsf2(long double a)
+{
+    return __truncXfYf2__(a);
+}
+
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/ucmpdi2.c
+++ b/3rdparty/compiler-rt/compiler-rt/ucmpdi2.c
@@ -1,0 +1,48 @@
+/* ===-- ucmpdi2.c - Implement __ucmpdi2 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ucmpdi2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns:  if (a <  b) returns 0
+ *           if (a == b) returns 1
+ *           if (a >  b) returns 2
+ */
+
+COMPILER_RT_ABI si_int __ucmpdi2(du_int a, du_int b)
+{
+    udwords x;
+    x.all = a;
+    udwords y;
+    y.all = b;
+    if (x.s.high < y.s.high)
+        return 0;
+    if (x.s.high > y.s.high)
+        return 2;
+    if (x.s.low < y.s.low)
+        return 0;
+    if (x.s.low > y.s.low)
+        return 2;
+    return 1;
+}
+
+#ifdef __ARM_EABI__
+/* Returns: if (a <  b) returns -1
+ *           if (a == b) returns  0
+ *           if (a >  b) returns  1
+ */
+COMPILER_RT_ABI si_int __aeabi_ulcmp(di_int a, di_int b)
+{
+    return __ucmpdi2(a, b) - 1;
+}
+#endif

--- a/3rdparty/compiler-rt/compiler-rt/ucmpti2.c
+++ b/3rdparty/compiler-rt/compiler-rt/ucmpti2.c
@@ -1,0 +1,41 @@
+/* ===-- ucmpti2.c - Implement __ucmpti2 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ucmpti2 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns:  if (a <  b) returns 0
+ *           if (a == b) returns 1
+ *           if (a >  b) returns 2
+ */
+
+COMPILER_RT_ABI si_int __ucmpti2(tu_int a, tu_int b)
+{
+    utwords x;
+    x.all = a;
+    utwords y;
+    y.all = b;
+    if (x.s.high < y.s.high)
+        return 0;
+    if (x.s.high > y.s.high)
+        return 2;
+    if (x.s.low < y.s.low)
+        return 0;
+    if (x.s.low > y.s.low)
+        return 2;
+    return 1;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/udivdi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/udivdi3.c
@@ -1,0 +1,22 @@
+/* ===-- udivdi3.c - Implement __udivdi3 -----------------------------------===
+ *
+ *                    The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __udivdi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: a / b */
+
+COMPILER_RT_ABI du_int __udivdi3(du_int a, du_int b)
+{
+    return __udivmoddi4(a, b, 0);
+}

--- a/3rdparty/compiler-rt/compiler-rt/udivmoddi4.c
+++ b/3rdparty/compiler-rt/compiler-rt/udivmoddi4.c
@@ -1,0 +1,231 @@
+/* ===-- udivmoddi4.c - Implement __udivmoddi4 -----------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __udivmoddi4 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Effects: if rem != 0, *rem = a % b
+ * Returns: a / b
+ */
+
+/* Translated from Figure 3-40 of The PowerPC Compiler Writer's Guide */
+
+COMPILER_RT_ABI du_int __udivmoddi4(du_int a, du_int b, du_int* rem)
+{
+    const unsigned n_uword_bits = sizeof(su_int) * CHAR_BIT;
+    const unsigned n_udword_bits = sizeof(du_int) * CHAR_BIT;
+    udwords n;
+    n.all = a;
+    udwords d;
+    d.all = b;
+    udwords q;
+    udwords r;
+    unsigned sr;
+    /* special cases, X is unknown, K != 0 */
+    if (n.s.high == 0)
+    {
+        if (d.s.high == 0)
+        {
+            /* 0 X
+             * ---
+             * 0 X
+             */
+            if (rem)
+                *rem = n.s.low % d.s.low;
+            return n.s.low / d.s.low;
+        }
+        /* 0 X
+         * ---
+         * K X
+         */
+        if (rem)
+            *rem = n.s.low;
+        return 0;
+    }
+    /* n.s.high != 0 */
+    if (d.s.low == 0)
+    {
+        if (d.s.high == 0)
+        {
+            /* K X
+             * ---
+             * 0 0
+             */
+            if (rem)
+                *rem = n.s.high % d.s.low;
+            return n.s.high / d.s.low;
+        }
+        /* d.s.high != 0 */
+        if (n.s.low == 0)
+        {
+            /* K 0
+             * ---
+             * K 0
+             */
+            if (rem)
+            {
+                r.s.high = n.s.high % d.s.high;
+                r.s.low = 0;
+                *rem = r.all;
+            }
+            return n.s.high / d.s.high;
+        }
+        /* K K
+         * ---
+         * K 0
+         */
+        if ((d.s.high & (d.s.high - 1)) == 0) /* if d is a power of 2 */
+        {
+            if (rem)
+            {
+                r.s.low = n.s.low;
+                r.s.high = n.s.high & (d.s.high - 1);
+                *rem = r.all;
+            }
+            return n.s.high >> __builtin_ctz(d.s.high);
+        }
+        /* K K
+         * ---
+         * K 0
+         */
+        sr = __builtin_clz(d.s.high) - __builtin_clz(n.s.high);
+        /* 0 <= sr <= n_uword_bits - 2 or sr large */
+        if (sr > n_uword_bits - 2)
+        {
+            if (rem)
+                *rem = n.all;
+            return 0;
+        }
+        ++sr;
+        /* 1 <= sr <= n_uword_bits - 1 */
+        /* q.all = n.all << (n_udword_bits - sr); */
+        q.s.low = 0;
+        q.s.high = n.s.low << (n_uword_bits - sr);
+        /* r.all = n.all >> sr; */
+        r.s.high = n.s.high >> sr;
+        r.s.low = (n.s.high << (n_uword_bits - sr)) | (n.s.low >> sr);
+    }
+    else /* d.s.low != 0 */
+    {
+        if (d.s.high == 0)
+        {
+            /* K X
+             * ---
+             * 0 K
+             */
+            if ((d.s.low & (d.s.low - 1)) == 0) /* if d is a power of 2 */
+            {
+                if (rem)
+                    *rem = n.s.low & (d.s.low - 1);
+                if (d.s.low == 1)
+                    return n.all;
+                sr = __builtin_ctz(d.s.low);
+                q.s.high = n.s.high >> sr;
+                q.s.low = (n.s.high << (n_uword_bits - sr)) | (n.s.low >> sr);
+                return q.all;
+            }
+            /* K X
+             * ---
+             * 0 K
+             */
+            sr = 1 + n_uword_bits + __builtin_clz(d.s.low) -
+                 __builtin_clz(n.s.high);
+            /* 2 <= sr <= n_udword_bits - 1
+             * q.all = n.all << (n_udword_bits - sr);
+             * r.all = n.all >> sr;
+             */
+            if (sr == n_uword_bits)
+            {
+                q.s.low = 0;
+                q.s.high = n.s.low;
+                r.s.high = 0;
+                r.s.low = n.s.high;
+            }
+            else if (sr < n_uword_bits) // 2 <= sr <= n_uword_bits - 1
+            {
+                q.s.low = 0;
+                q.s.high = n.s.low << (n_uword_bits - sr);
+                r.s.high = n.s.high >> sr;
+                r.s.low = (n.s.high << (n_uword_bits - sr)) | (n.s.low >> sr);
+            }
+            else // n_uword_bits + 1 <= sr <= n_udword_bits - 1
+            {
+                q.s.low = n.s.low << (n_udword_bits - sr);
+                q.s.high = (n.s.high << (n_udword_bits - sr)) |
+                           (n.s.low >> (sr - n_uword_bits));
+                r.s.high = 0;
+                r.s.low = n.s.high >> (sr - n_uword_bits);
+            }
+        }
+        else
+        {
+            /* K X
+             * ---
+             * K K
+             */
+            sr = __builtin_clz(d.s.high) - __builtin_clz(n.s.high);
+            /* 0 <= sr <= n_uword_bits - 1 or sr large */
+            if (sr > n_uword_bits - 1)
+            {
+                if (rem)
+                    *rem = n.all;
+                return 0;
+            }
+            ++sr;
+            /* 1 <= sr <= n_uword_bits */
+            /*  q.all = n.all << (n_udword_bits - sr); */
+            q.s.low = 0;
+            if (sr == n_uword_bits)
+            {
+                q.s.high = n.s.low;
+                r.s.high = 0;
+                r.s.low = n.s.high;
+            }
+            else
+            {
+                q.s.high = n.s.low << (n_uword_bits - sr);
+                r.s.high = n.s.high >> sr;
+                r.s.low = (n.s.high << (n_uword_bits - sr)) | (n.s.low >> sr);
+            }
+        }
+    }
+    /* Not a special case
+     * q and r are initialized with:
+     * q.all = n.all << (n_udword_bits - sr);
+     * r.all = n.all >> sr;
+     * 1 <= sr <= n_udword_bits - 1
+     */
+    su_int carry = 0;
+    for (; sr > 0; --sr)
+    {
+        /* r:q = ((r:q)  << 1) | carry */
+        r.s.high = (r.s.high << 1) | (r.s.low >> (n_uword_bits - 1));
+        r.s.low = (r.s.low << 1) | (q.s.high >> (n_uword_bits - 1));
+        q.s.high = (q.s.high << 1) | (q.s.low >> (n_uword_bits - 1));
+        q.s.low = (q.s.low << 1) | carry;
+        /* carry = 0;
+         * if (r.all >= d.all)
+         * {
+         *      r.all -= d.all;
+         *      carry = 1;
+         * }
+         */
+        const di_int s = (di_int)(d.all - r.all - 1) >> (n_udword_bits - 1);
+        carry = s & 1;
+        r.all -= d.all & s;
+    }
+    q.all = (q.all << 1) | carry;
+    if (rem)
+        *rem = r.all;
+    return q.all;
+}

--- a/3rdparty/compiler-rt/compiler-rt/udivmodti4.c
+++ b/3rdparty/compiler-rt/compiler-rt/udivmodti4.c
@@ -1,0 +1,237 @@
+/* ===-- udivmodti4.c - Implement __udivmodti4 -----------------------------===
+ *
+ *                    The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __udivmodti4 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Effects: if rem != 0, *rem = a % b
+ * Returns: a / b
+ */
+
+/* Translated from Figure 3-40 of The PowerPC Compiler Writer's Guide */
+
+COMPILER_RT_ABI tu_int __udivmodti4(tu_int a, tu_int b, tu_int* rem)
+{
+    const unsigned n_udword_bits = sizeof(du_int) * CHAR_BIT;
+    const unsigned n_utword_bits = sizeof(tu_int) * CHAR_BIT;
+    utwords n;
+    n.all = a;
+    utwords d;
+    d.all = b;
+    utwords q;
+    utwords r;
+    unsigned sr;
+    /* special cases, X is unknown, K != 0 */
+    if (n.s.high == 0)
+    {
+        if (d.s.high == 0)
+        {
+            /* 0 X
+             * ---
+             * 0 X
+             */
+            if (rem)
+                *rem = n.s.low % d.s.low;
+            return n.s.low / d.s.low;
+        }
+        /* 0 X
+         * ---
+         * K X
+         */
+        if (rem)
+            *rem = n.s.low;
+        return 0;
+    }
+    /* n.s.high != 0 */
+    if (d.s.low == 0)
+    {
+        if (d.s.high == 0)
+        {
+            /* K X
+             * ---
+             * 0 0
+             */
+            if (rem)
+                *rem = n.s.high % d.s.low;
+            return n.s.high / d.s.low;
+        }
+        /* d.s.high != 0 */
+        if (n.s.low == 0)
+        {
+            /* K 0
+             * ---
+             * K 0
+             */
+            if (rem)
+            {
+                r.s.high = n.s.high % d.s.high;
+                r.s.low = 0;
+                *rem = r.all;
+            }
+            return n.s.high / d.s.high;
+        }
+        /* K K
+         * ---
+         * K 0
+         */
+        if ((d.s.high & (d.s.high - 1)) == 0) /* if d is a power of 2 */
+        {
+            if (rem)
+            {
+                r.s.low = n.s.low;
+                r.s.high = n.s.high & (d.s.high - 1);
+                *rem = r.all;
+            }
+            return n.s.high >> __builtin_ctzll(d.s.high);
+        }
+        /* K K
+         * ---
+         * K 0
+         */
+        sr = __builtin_clzll(d.s.high) - __builtin_clzll(n.s.high);
+        /* 0 <= sr <= n_udword_bits - 2 or sr large */
+        if (sr > n_udword_bits - 2)
+        {
+            if (rem)
+                *rem = n.all;
+            return 0;
+        }
+        ++sr;
+        /* 1 <= sr <= n_udword_bits - 1 */
+        /* q.all = n.all << (n_utword_bits - sr); */
+        q.s.low = 0;
+        q.s.high = n.s.low << (n_udword_bits - sr);
+        /* r.all = n.all >> sr; */
+        r.s.high = n.s.high >> sr;
+        r.s.low = (n.s.high << (n_udword_bits - sr)) | (n.s.low >> sr);
+    }
+    else /* d.s.low != 0 */
+    {
+        if (d.s.high == 0)
+        {
+            /* K X
+             * ---
+             * 0 K
+             */
+            if ((d.s.low & (d.s.low - 1)) == 0) /* if d is a power of 2 */
+            {
+                if (rem)
+                    *rem = n.s.low & (d.s.low - 1);
+                if (d.s.low == 1)
+                    return n.all;
+                sr = __builtin_ctzll(d.s.low);
+                q.s.high = n.s.high >> sr;
+                q.s.low = (n.s.high << (n_udword_bits - sr)) | (n.s.low >> sr);
+                return q.all;
+            }
+            /* K X
+             * ---
+             * 0 K
+             */
+            sr = 1 + n_udword_bits + __builtin_clzll(d.s.low) -
+                 __builtin_clzll(n.s.high);
+            /* 2 <= sr <= n_utword_bits - 1
+             * q.all = n.all << (n_utword_bits - sr);
+             * r.all = n.all >> sr;
+             */
+            if (sr == n_udword_bits)
+            {
+                q.s.low = 0;
+                q.s.high = n.s.low;
+                r.s.high = 0;
+                r.s.low = n.s.high;
+            }
+            else if (sr < n_udword_bits) // 2 <= sr <= n_udword_bits - 1
+            {
+                q.s.low = 0;
+                q.s.high = n.s.low << (n_udword_bits - sr);
+                r.s.high = n.s.high >> sr;
+                r.s.low = (n.s.high << (n_udword_bits - sr)) | (n.s.low >> sr);
+            }
+            else // n_udword_bits + 1 <= sr <= n_utword_bits - 1
+            {
+                q.s.low = n.s.low << (n_utword_bits - sr);
+                q.s.high = (n.s.high << (n_utword_bits - sr)) |
+                           (n.s.low >> (sr - n_udword_bits));
+                r.s.high = 0;
+                r.s.low = n.s.high >> (sr - n_udword_bits);
+            }
+        }
+        else
+        {
+            /* K X
+             * ---
+             * K K
+             */
+            sr = __builtin_clzll(d.s.high) - __builtin_clzll(n.s.high);
+            /*0 <= sr <= n_udword_bits - 1 or sr large */
+            if (sr > n_udword_bits - 1)
+            {
+                if (rem)
+                    *rem = n.all;
+                return 0;
+            }
+            ++sr;
+            /* 1 <= sr <= n_udword_bits
+             * q.all = n.all << (n_utword_bits - sr);
+             * r.all = n.all >> sr;
+             */
+            q.s.low = 0;
+            if (sr == n_udword_bits)
+            {
+                q.s.high = n.s.low;
+                r.s.high = 0;
+                r.s.low = n.s.high;
+            }
+            else
+            {
+                r.s.high = n.s.high >> sr;
+                r.s.low = (n.s.high << (n_udword_bits - sr)) | (n.s.low >> sr);
+                q.s.high = n.s.low << (n_udword_bits - sr);
+            }
+        }
+    }
+    /* Not a special case
+     * q and r are initialized with:
+     * q.all = n.all << (n_utword_bits - sr);
+     * r.all = n.all >> sr;
+     * 1 <= sr <= n_utword_bits - 1
+     */
+    su_int carry = 0;
+    for (; sr > 0; --sr)
+    {
+        /* r:q = ((r:q)  << 1) | carry */
+        r.s.high = (r.s.high << 1) | (r.s.low >> (n_udword_bits - 1));
+        r.s.low = (r.s.low << 1) | (q.s.high >> (n_udword_bits - 1));
+        q.s.high = (q.s.high << 1) | (q.s.low >> (n_udword_bits - 1));
+        q.s.low = (q.s.low << 1) | carry;
+        /* carry = 0;
+         * if (r.all >= d.all)
+         * {
+         *     r.all -= d.all;
+         *      carry = 1;
+         * }
+         */
+        const ti_int s = (ti_int)(d.all - r.all - 1) >> (n_utword_bits - 1);
+        carry = s & 1;
+        r.all -= d.all & s;
+    }
+    q.all = (q.all << 1) | carry;
+    if (rem)
+        *rem = r.all;
+    return q.all;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/udivsi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/udivsi3.c
@@ -1,0 +1,65 @@
+/* ===-- udivsi3.c - Implement __udivsi3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __udivsi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: a / b */
+
+/* Translated from Figure 3-40 of The PowerPC Compiler Writer's Guide */
+
+ARM_EABI_FNALIAS(uidiv, udivsi3)
+
+/* This function should not call __divsi3! */
+COMPILER_RT_ABI su_int __udivsi3(su_int n, su_int d)
+{
+    const unsigned n_uword_bits = sizeof(su_int) * CHAR_BIT;
+    su_int q;
+    su_int r;
+    unsigned sr;
+    /* special cases */
+    if (d == 0)
+        return 0; /* ?! */
+    if (n == 0)
+        return 0;
+    sr = __builtin_clz(d) - __builtin_clz(n);
+    /* 0 <= sr <= n_uword_bits - 1 or sr large */
+    if (sr > n_uword_bits - 1) /* d > r */
+        return 0;
+    if (sr == n_uword_bits - 1) /* d == 1 */
+        return n;
+    ++sr;
+    /* 1 <= sr <= n_uword_bits - 1 */
+    /* Not a special case */
+    q = n << (n_uword_bits - sr);
+    r = n >> sr;
+    su_int carry = 0;
+    for (; sr > 0; --sr)
+    {
+        /* r:q = ((r:q)  << 1) | carry */
+        r = (r << 1) | (q >> (n_uword_bits - 1));
+        q = (q << 1) | carry;
+        /* carry = 0;
+         * if (r.all >= d.all)
+         * {
+         *      r.all -= d.all;
+         *      carry = 1;
+         * }
+         */
+        const si_int s = (si_int)(d - r - 1) >> (n_uword_bits - 1);
+        carry = s & 1;
+        r -= d & s;
+    }
+    q = (q << 1) | carry;
+    return q;
+}

--- a/3rdparty/compiler-rt/compiler-rt/udivti3.c
+++ b/3rdparty/compiler-rt/compiler-rt/udivti3.c
@@ -1,0 +1,26 @@
+/* ===-- udivti3.c - Implement __udivti3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __udivti3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: a / b */
+
+COMPILER_RT_ABI tu_int __udivti3(tu_int a, tu_int b)
+{
+    return __udivmodti4(a, b, 0);
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/3rdparty/compiler-rt/compiler-rt/umoddi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/umoddi3.c
@@ -1,0 +1,24 @@
+/* ===-- umoddi3.c - Implement __umoddi3 -----------------------------------===
+ *
+ *                    The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __umoddi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: a % b */
+
+COMPILER_RT_ABI du_int __umoddi3(du_int a, du_int b)
+{
+    du_int r;
+    __udivmoddi4(a, b, &r);
+    return r;
+}

--- a/3rdparty/compiler-rt/compiler-rt/umodsi3.c
+++ b/3rdparty/compiler-rt/compiler-rt/umodsi3.c
@@ -1,0 +1,22 @@
+/* ===-- umodsi3.c - Implement __umodsi3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __umodsi3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: a % b */
+
+COMPILER_RT_ABI su_int __umodsi3(su_int a, su_int b)
+{
+    return a - __udivsi3(a, b) * b;
+}

--- a/3rdparty/compiler-rt/compiler-rt/umodti3.c
+++ b/3rdparty/compiler-rt/compiler-rt/umodti3.c
@@ -1,0 +1,28 @@
+/* ===-- umodti3.c - Implement __umodti3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __umodti3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: a % b */
+
+COMPILER_RT_ABI tu_int __umodti3(tu_int a, tu_int b)
+{
+    tu_int r;
+    __udivmodti4(a, b, &r);
+    return r;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -192,13 +192,19 @@ list(APPEND NEEDS_STDC_NAMES ${MUSL_SRC_DIR}/prng/rand.c
 
 list(APPEND W_NO_CONVERSION ${MUSL_SRC_DIR}/prng/rand.c)
 
-set_property(SOURCE ${W_NO_CONVERSION} APPEND_STRING PROPERTY COMPILE_FLAGS
-                                                              "-Wno-conversion")
+set_property(
+  SOURCE ${W_NO_CONVERSION}
+  APPEND_STRING
+  PROPERTY COMPILE_FLAGS "-Wno-conversion")
 
-set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND_STRING
-             PROPERTY COMPILE_FLAGS " -I${CORELIBC_INCLUDES}")
-set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND PROPERTY COMPILE_DEFINITIONS
-                                                        OE_NEED_STDC_NAMES)
+set_property(
+  SOURCE ${NEEDS_STDC_NAMES}
+  APPEND_STRING
+  PROPERTY COMPILE_FLAGS " -I${CORELIBC_INCLUDES}")
+set_property(
+  SOURCE ${NEEDS_STDC_NAMES}
+  APPEND
+  PROPERTY COMPILE_DEFINITIONS OE_NEED_STDC_NAMES)
 
 maybe_build_using_clangw(oecore)
 
@@ -220,7 +226,8 @@ if (OE_TRUSTZONE)
     oecore PRIVATE ${PROJECT_SOURCE_DIR}/include/openenclave/corelibc)
 endif ()
 
-enclave_link_libraries(oecore PUBLIC oe_includes ${DEFAULT_ALLOCATOR_LIB})
+enclave_link_libraries(oecore PUBLIC oe_includes ${DEFAULT_ALLOCATOR_LIB}
+                       oecompilerrt_obj)
 
 if (CMAKE_C_COMPILER_ID MATCHES GNU)
   enclave_compile_options(oecore PRIVATE -Wjump-misses-init)

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -30,6 +30,7 @@ tests/mbed/tests\..*$
 tests/openssl/tests\..*$
 
 # Directories
+3rdparty/compiler-rt/compiler-rt
 3rdparty/dlmalloc/dlmalloc/.*
 3rdparty/libcxx/libcxx/.*
 3rdparty/libcxxrt/libcxxrt/.*


### PR DESCRIPTION
GCC/clang generate calls to functions defined in "compiler-rt" when they encounter certain constructs
that don't have a direct mapping to a processor instruction.
See https://gcc.gnu.org/onlinedocs/gcc-4.9.4/gccint/Integer-library-routines.html
These functions are normally available in libgcc.a library.

Clang implements these functions in a "compiler-rt" library.
See: https://compiler-rt.llvm.org/
The files in this PR provide the builtins as described in the link above.

The code has been borrowed from Intel SDK.
https://github.com/intel/linux-sgx/tree/master/sdk/compiler-rt

Compiler-rt is one of the core libraries and when compiling a program normally,
the compiler would automatically add this library to the linker line.

The mirror the same behavior, compiler-rt is built as an object library which
is then added to oecore. This ensures that compiler-rt routines appear at the
appropriate position in the linker line - the last library. By adding the objects
to oecore, there is no change to the user experience, and thus this is not a
breaking change.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>