### PR TITLE
change tabs to spaces in log_callback makefile

### DIFF
--- a/samples/debugmalloc/enclave/Makefile
+++ b/samples/debugmalloc/enclave/Makefile
@@ -6,15 +6,15 @@ include ../../config.mk
 CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libs)
 
 ifeq ($(LVI_MITIGATION), ControlFlow)
-	ifeq ($(LVI_MITIGATION_BINDIR),)
-		$(error LVI_MITIGATION_BINDIR is not set)
-	endif
-	# Only run once.
-	ifeq (,$(findstring $(LVI_MITIGATION_BINDIR),$(CC)))
-		CC := $(LVI_MITIGATION_BINDIR)/$(CC)
-	endif
-	COMPILER := $(COMPILER)-lvi-cfg
-	CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libslvicfg)
+    ifeq ($(LVI_MITIGATION_BINDIR),)
+        $(error LVI_MITIGATION_BINDIR is not set)
+    endif
+    # Only run once.
+    ifeq (,$(findstring $(LVI_MITIGATION_BINDIR),$(CC)))
+        CC := $(LVI_MITIGATION_BINDIR)/$(CC)
+    endif
+    COMPILER := $(COMPILER)-lvi-cfg
+    CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libslvicfg)
 endif
 
 CFLAGS=$(shell pkg-config oeenclave-$(COMPILER) --cflags)

--- a/samples/helloworld/enclave/Makefile
+++ b/samples/helloworld/enclave/Makefile
@@ -6,15 +6,15 @@ include ../../config.mk
 CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libs)
 
 ifeq ($(LVI_MITIGATION), ControlFlow)
-	ifeq ($(LVI_MITIGATION_BINDIR),)
-		$(error LVI_MITIGATION_BINDIR is not set)
-	endif
-	# Only run once.
-	ifeq (,$(findstring $(LVI_MITIGATION_BINDIR),$(CC)))
-		CC := $(LVI_MITIGATION_BINDIR)/$(CC)
-	endif
-	COMPILER := $(COMPILER)-lvi-cfg
-	CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libslvicfg)
+    ifeq ($(LVI_MITIGATION_BINDIR),)
+        $(error LVI_MITIGATION_BINDIR is not set)
+    endif
+    # Only run once.
+    ifeq (,$(findstring $(LVI_MITIGATION_BINDIR),$(CC)))
+        CC := $(LVI_MITIGATION_BINDIR)/$(CC)
+    endif
+    COMPILER := $(COMPILER)-lvi-cfg
+    CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libslvicfg)
 endif
 
 CFLAGS=$(shell pkg-config oeenclave-$(COMPILER) --cflags)

--- a/samples/log_callback/enclave/Makefile
+++ b/samples/log_callback/enclave/Makefile
@@ -7,7 +7,7 @@ CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPT
 
 ifeq ($(LVI_MITIGATION), ControlFlow)
     ifeq ($(LVI_MITIGATION_BINDIR),)
-    $(error LVI_MITIGATION_BINDIR is not set)
+        $(error LVI_MITIGATION_BINDIR is not set)
     endif
     # Only run once.
     ifeq (,$(findstring $(LVI_MITIGATION_BINDIR),$(CC)))

--- a/samples/log_callback/enclave/Makefile
+++ b/samples/log_callback/enclave/Makefile
@@ -6,15 +6,15 @@ include ../../config.mk
 CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libs)
 
 ifeq ($(LVI_MITIGATION), ControlFlow)
-	ifeq ($(LVI_MITIGATION_BINDIR),)
-		$(error LVI_MITIGATION_BINDIR is not set)
-	endif
-	# Only run once.
-	ifeq (,$(findstring $(LVI_MITIGATION_BINDIR),$(CC)))
-		CC := $(LVI_MITIGATION_BINDIR)/$(CC)
-	endif
-	COMPILER := $(COMPILER)-lvi-cfg
-	CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libslvicfg)
+    ifeq ($(LVI_MITIGATION_BINDIR),)
+    $(error LVI_MITIGATION_BINDIR is not set)
+    endif
+    # Only run once.
+    ifeq (,$(findstring $(LVI_MITIGATION_BINDIR),$(CC)))
+        CC := $(LVI_MITIGATION_BINDIR)/$(CC)
+    endif
+    COMPILER := $(COMPILER)-lvi-cfg
+    CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libslvicfg)
 endif
 
 CFLAGS=$(shell pkg-config oeenclave-$(COMPILER) --cflags)


### PR DESCRIPTION
This PR addresses an issue in the log_callback make file where tabs instead of spaces are used. This was not caught before because it depends on an environment variable that is never set in CI and is not the general use case.

Signed-off-by: brmclare <brmclare@microsoft.com>