### PR TITLE
Use clang by default with cmake in samples

### DIFF
--- a/samples/attestation/CMakeLists.txt
+++ b/samples/attestation/CMakeLists.txt
@@ -3,6 +3,19 @@
 
 cmake_minimum_required(VERSION 3.11)
 
+# If the CC environment variable has been specified or if the CMAKE_C_COMPILER
+# cmake variable has been passed to cmake, use the C compiler that has been
+# specified. Otherwise, prefer clang. Same for C++ compiler.
+# This must be done before the `project` command.
+if (UNIX)
+  if (NOT DEFINED ENV{CC} AND NOT DEFINED CMAKE_C_COMPILER)
+    find_program(CMAKE_C_COMPILER clang-8 clang)
+  endif ()
+  if (NOT DEFINED ENV{CXX} AND NOT DEFINED CMAKE_CXX_COMPILER)
+    find_program(CMAKE_CXX_COMPILER clang++-8 clang++)
+  endif ()
+endif ()
+
 project("Attestation Sample" LANGUAGES C CXX)
 
 find_package(OpenEnclave CONFIG REQUIRED)

--- a/samples/attested_tls/CMakeLists.txt
+++ b/samples/attested_tls/CMakeLists.txt
@@ -3,6 +3,19 @@
 
 cmake_minimum_required(VERSION 3.11)
 
+# If the CC environment variable has been specified or if the CMAKE_C_COMPILER
+# cmake variable has been passed to cmake, use the C compiler that has been
+# specified. Otherwise, prefer clang. Same for C++ compiler.
+# This must be done before the `project` command.
+if (UNIX)
+  if (NOT DEFINED ENV{CC} AND NOT DEFINED CMAKE_C_COMPILER)
+    find_program(CMAKE_C_COMPILER clang-8 clang)
+  endif ()
+  if (NOT DEFINED ENV{CXX} AND NOT DEFINED CMAKE_CXX_COMPILER)
+    find_program(CMAKE_CXX_COMPILER clang++-8 clang++)
+  endif ()
+endif ()
+
 project("Attested TLS sample" LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 11)
 # set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.

--- a/samples/data-sealing/CMakeLists.txt
+++ b/samples/data-sealing/CMakeLists.txt
@@ -3,6 +3,19 @@
 
 cmake_minimum_required(VERSION 3.11)
 
+# If the CC environment variable has been specified or if the CMAKE_C_COMPILER
+# cmake variable has been passed to cmake, use the C compiler that has been
+# specified. Otherwise, prefer clang. Same for C++ compiler.
+# This must be done before the `project` command.
+if (UNIX)
+  if (NOT DEFINED ENV{CC} AND NOT DEFINED CMAKE_C_COMPILER)
+    find_program(CMAKE_C_COMPILER clang-8 clang)
+  endif ()
+  if (NOT DEFINED ENV{CXX} AND NOT DEFINED CMAKE_CXX_COMPILER)
+    find_program(CMAKE_CXX_COMPILER clang++-8 clang++)
+  endif ()
+endif ()
+
 project("Data Sealing Sample" LANGUAGES C CXX)
 
 find_package(OpenEnclave CONFIG REQUIRED)

--- a/samples/debugmalloc/CMakeLists.txt
+++ b/samples/debugmalloc/CMakeLists.txt
@@ -7,6 +7,20 @@ if (LVI_MITIGATION MATCHES ControlFlow)
   # Configure the cmake to use customized compilation toolchain.
   # This package has to be added before `project()`.
   find_package(OpenEnclave-LVI-Mitigation CONFIG REQUIRED)
+else ()
+  # Setting the cmake compiler when LVI mitigation is not enabled. If the CC
+  # environment variable has been specified or the if CMAKE_C_COMPILER cmake
+  # variable has been passed to cmake, use the C compiler that has been specified.
+  # Otherwise, prefer clang. Same for C++ compiler. This must be done before
+  # the `project` command.
+  if (UNIX)
+    if (NOT DEFINED ENV{CC} AND NOT DEFINED CMAKE_C_COMPILER)
+      find_program(CMAKE_C_COMPILER clang-8 clang)
+    endif ()
+    if (NOT DEFINED ENV{CXX} AND NOT DEFINED CMAKE_CXX_COMPILER)
+      find_program(CMAKE_CXX_COMPILER clang++-8 clang++)
+    endif ()
+  endif ()
 endif ()
 
 project("Debug Malloc Sample" LANGUAGES C CXX)

--- a/samples/file-encryptor/CMakeLists.txt
+++ b/samples/file-encryptor/CMakeLists.txt
@@ -3,6 +3,19 @@
 
 cmake_minimum_required(VERSION 3.11)
 
+# If the CC environment variable has been specified or if the CMAKE_C_COMPILER
+# cmake variable has been passed to cmake, use the C compiler that has been
+# specified. Otherwise, prefer clang. Same for C++ compiler.
+# This must be done before the `project` command.
+if (UNIX)
+  if (NOT DEFINED ENV{CC} AND NOT DEFINED CMAKE_C_COMPILER)
+    find_program(CMAKE_C_COMPILER clang-8 clang)
+  endif ()
+  if (NOT DEFINED ENV{CXX} AND NOT DEFINED CMAKE_CXX_COMPILER)
+    find_program(CMAKE_CXX_COMPILER clang++-8 clang++)
+  endif ()
+endif ()
+
 project("File Encryptor Sample" LANGUAGES C CXX)
 
 find_package(OpenEnclave CONFIG REQUIRED)

--- a/samples/helloworld/CMakeLists.txt
+++ b/samples/helloworld/CMakeLists.txt
@@ -7,6 +7,20 @@ if (LVI_MITIGATION MATCHES ControlFlow)
   # Configure the cmake to use customized compilation toolchain.
   # This package has to be added before `project()`.
   find_package(OpenEnclave-LVI-Mitigation CONFIG REQUIRED)
+else ()
+  # Setting the cmake compiler when LVI mitigation is not enabled. If the CC
+  # environment variable has been specified or the if CMAKE_C_COMPILER cmake
+  # variable has been passed to cmake, use the C compiler that has been specified.
+  # Otherwise, prefer clang. Same for C++ compiler. This must be done before
+  # the `project` command.
+  if (UNIX)
+    if (NOT DEFINED ENV{CC} AND NOT DEFINED CMAKE_C_COMPILER)
+      find_program(CMAKE_C_COMPILER clang-8 clang)
+    endif ()
+    if (NOT DEFINED ENV{CXX} AND NOT DEFINED CMAKE_CXX_COMPILER)
+      find_program(CMAKE_CXX_COMPILER clang++-8 clang++)
+    endif ()
+  endif ()
 endif ()
 
 project("Hello World Sample" LANGUAGES C CXX)

--- a/samples/log_callback/CMakeLists.txt
+++ b/samples/log_callback/CMakeLists.txt
@@ -9,6 +9,19 @@ if (LVI_MITIGATION MATCHES ControlFlow)
   find_package(OpenEnclave-LVI-Mitigation CONFIG REQUIRED)
 endif ()
 
+# If the CC environment variable has been specified or if the CMAKE_C_COMPILER
+# cmake variable has been passed to cmake, use the C compiler that has been
+# specified. Otherwise, prefer clang. Same for C++ compiler.
+# This must be done before the `project` command.
+if (UNIX)
+  if (NOT DEFINED ENV{CC} AND NOT DEFINED CMAKE_C_COMPILER)
+    find_program(CMAKE_C_COMPILER clang-8 clang)
+  endif ()
+  if (NOT DEFINED ENV{CXX} AND NOT DEFINED CMAKE_CXX_COMPILER)
+    find_program(CMAKE_CXX_COMPILER clang++-8 clang++)
+  endif ()
+endif ()
+
 project("log_callback Sample" LANGUAGES C CXX)
 
 # Currently the `OpenEnclave` package depends on `project()`.

--- a/samples/pluggable_allocator/CMakeLists.txt
+++ b/samples/pluggable_allocator/CMakeLists.txt
@@ -7,6 +7,20 @@ if (LVI_MITIGATION MATCHES ControlFlow)
   # Configure the cmake to use customized compilation toolchain.
   # This package has to be added before `project()`.
   find_package(OpenEnclave-LVI-Mitigation CONFIG REQUIRED)
+else ()
+  # Setting the cmake compiler when LVI mitigation is not enabled. If the CC
+  # environment variable has been specified or the if CMAKE_C_COMPILER cmake
+  # variable has been passed to cmake, use the C compiler that has been specified.
+  # Otherwise, prefer clang. Same for C++ compiler. This must be done before
+  # the `project` command.
+  if (UNIX)
+    if (NOT DEFINED ENV{CC} AND NOT DEFINED CMAKE_C_COMPILER)
+      find_program(CMAKE_C_COMPILER clang-8 clang)
+    endif ()
+    if (NOT DEFINED ENV{CXX} AND NOT DEFINED CMAKE_CXX_COMPILER)
+      find_program(CMAKE_CXX_COMPILER clang++-8 clang++)
+    endif ()
+  endif ()
 endif ()
 
 project("Pluggable Allocator Sample" LANGUAGES C CXX)

--- a/samples/switchless/CMakeLists.txt
+++ b/samples/switchless/CMakeLists.txt
@@ -3,6 +3,19 @@
 
 cmake_minimum_required(VERSION 3.11)
 
+# If the CC environment variable has been specified or if the CMAKE_C_COMPILER
+# cmake variable has been passed to cmake, use the C compiler that has been
+# specified. Otherwise, prefer clang. Same for C++ compiler.
+# This must be done before the `project` command.
+if (UNIX)
+  if (NOT DEFINED ENV{CC} AND NOT DEFINED CMAKE_C_COMPILER)
+    find_program(CMAKE_C_COMPILER clang-8 clang)
+  endif ()
+  if (NOT DEFINED ENV{CXX} AND NOT DEFINED CMAKE_CXX_COMPILER)
+    find_program(CMAKE_CXX_COMPILER clang++-8 clang++)
+  endif ()
+endif ()
+
 project("Switchless Call Sample" LANGUAGES C CXX)
 
 find_package(OpenEnclave CONFIG REQUIRED)


### PR DESCRIPTION
This PR addresses the inconsistency between the behavior of building samples with make and cmake. Now the cmake will use clang by default unless the `CC` and `CXX` environment variables are specified to other compilers.

Fixes #3179.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>