### PR TITLE
oeverify tool prints custom claims

### DIFF
--- a/tools/oeverify/README.md
+++ b/tools/oeverify/README.md
@@ -1,12 +1,13 @@
-oeverify
-========
+# oeverify
 
 This directory contains the oeverify tool, which can verify remote attestation evidence and attestation certificates.
 
 For example:
 
-$ /opt/openenclave/bin/oeverify -r <path/to/evidence> -e </path/to/endorsement> -f <evidence_format>
+```bash
+$ /opt/openenclave/bin/oeverify -r <path/to/evidence> -e </path/to/endorsement> [-f <evidence_format>]
 Verifying evidence ...
 Claims:
 ...
 Evidence verification succeeded (0).
+```


### PR DESCRIPTION
The `oeverify` tool now also prints the list of custom claims embedded in a report. This is useful when verifying evidences generated with the new format (`OE_FORMAT_UUID_SGX_ECDSA`). 

Feedback welcome! 