### PR TITLE
Added Ubuntu 20.04 CI files

### DIFF
--- a/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
+++ b/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
@@ -2,6 +2,10 @@
 # Licensed under the MIT License.
 
 ---
+- name: Include distribution vars
+  include_vars:
+    file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
+
 - name: Install apt-transport-https APT package
   apt:
     name: apt-transport-https

--- a/scripts/ansible/roles/linux/common/vars/ubuntu/bionic.yml
+++ b/scripts/ansible/roles/linux/common/vars/ubuntu/bionic.yml
@@ -1,0 +1,5 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+llvm_apt_repository: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-7 main"

--- a/scripts/ansible/roles/linux/common/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/common/vars/ubuntu/focal.yml
@@ -1,0 +1,5 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+llvm_apt_repository: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-12 main"

--- a/scripts/ansible/roles/linux/common/vars/ubuntu/xenial.yml
+++ b/scripts/ansible/roles/linux/common/vars/ubuntu/xenial.yml
@@ -1,0 +1,5 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+llvm_apt_repository: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-7 main"

--- a/scripts/ansible/roles/linux/docker/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/docker/vars/ubuntu/focal.yml
@@ -1,0 +1,14 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+ci_apt_packages:
+  - "automake"
+  - "dh-exec"
+  - "dpkg-dev"
+  - "gawk"
+  - "git"
+  - "libmbedtls12"
+  - "sudo"
+  - "libcurl4"
+  - "libprotobuf17"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/focal.yml
@@ -1,0 +1,8 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.9/linux/distro/ubuntu20.04-server/sgx_linux_x64_driver_1.36.2.bin"
+intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.13/distro/ubuntu20.04-server/sgx_linux_x64_driver_2.11.0_0373e2e.bin"
+intel_sgx_package_dependencies:
+  - "libprotobuf17"

--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
@@ -14,7 +14,7 @@
     tasks_from: apt-repo.yml
   vars:
     apt_key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
-    apt_repository: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-7 main"
+    apt_repository: "{{ llvm_apt_repository }}"
 
 - name: Install all the Open Enclave prerequisites APT packages for development
   apt:

--- a/scripts/ansible/roles/linux/openenclave/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/ubuntu/focal.yml
@@ -1,6 +1,6 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
-cryptography==3.3.2
-ansible==2.9.18
-cmake_format==0.6.9
-pywinrm==0.2.1
+
+---
+gcc_target_version: "9.3.0"
+clang_target_version: "8.0.1"


### PR DESCRIPTION
Added Ansible files for Ubuntu 20.04 (focal)
- Different LLVM repository for each Ubuntu release

Updated the following packages:
- Ansible from 2.8.8 to 2.9.9 (addresses a bug on 20.04, and is still compatible with 16.04 and 18.04)
- `libprotobuf10` to `libprotobuf17` (default version on 20.04)
-  Expected clang version from `8.0.0` to `8.0.1` (default version on 20.04)