### PR TITLE
Use OBJECT library in data-sealling and attestation samples

### DIFF
--- a/samples/attestation/common/CMakeLists.txt
+++ b/samples/attestation/common/CMakeLists.txt
@@ -11,7 +11,7 @@ add_custom_command(
     ${OE_INCLUDEDIR}/openenclave/edl/sgx)
 
 # Create a library common to each of our two enclaves.
-add_library(common STATIC attestation.cpp crypto.cpp dispatcher.cpp
+add_library(common OBJECT attestation.cpp crypto.cpp dispatcher.cpp
                           ${CMAKE_CURRENT_BINARY_DIR}/attestation_t.c)
 
 if (WIN32)
@@ -20,16 +20,7 @@ endif ()
 
 target_compile_definitions(common PUBLIC OE_API_VERSION=2)
 target_link_libraries(
-  common
-  PUBLIC # `liboecore`, a dependency of `liboeenclave`, requires the ecalls
-         # function table. Because the libraries linking `libcommon` do not
-         # directly require this symbol, the linker skips the object in
-         # `libcommon` which defines them. So we manually require it.
-         #
-         # Alternatively we could use a CMake OBJECT library, but that
-         # requires a newish version of CMake.
-         $<$<PLATFORM_ID:Linux>:-Wl,--require-defined=__oe_ecalls_table>
-         openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB}
-         openenclave::oelibcxx)
+  common PUBLIC openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB}
+                openenclave::oelibcxx)
 target_include_directories(common PUBLIC ${CMAKE_SOURCE_DIR}
                                          ${CMAKE_BINARY_DIR})

--- a/samples/data-sealing/common/CMakeLists.txt
+++ b/samples/data-sealing/common/CMakeLists.txt
@@ -11,22 +11,13 @@ add_custom_command(
     ${OE_INCLUDEDIR}/openenclave/edl/sgx)
 
 # Create a library common to each of our three enclaves.
-add_library(common STATIC dispatcher.cpp keys.cpp
+add_library(common OBJECT dispatcher.cpp keys.cpp
                           ${CMAKE_CURRENT_BINARY_DIR}/datasealing_t.c)
 target_compile_definitions(common PUBLIC OE_API_VERSION=2)
 
 target_link_libraries(
-  common
-  PUBLIC # `liboecore`, a dependency of `liboeenclave`, requires the ecalls
-         # function table. Because the libraries linking `libcommon` do not
-         # directly require this symbol, the linker skips the object in
-         # `libcommon` which defines them. So we manually require it.
-         #
-         # Alternatively we could use a CMake OBJECT library, but that
-         # requires a newish version of CMake.
-         $<$<PLATFORM_ID:Linux>:-Wl,--require-defined=__oe_ecalls_table>
-         openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB}
-         openenclave::oelibcxx)
+  common PUBLIC openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB}
+                openenclave::oelibcxx)
 if (WIN32)
   maybe_build_using_clangw(common)
 endif ()


### PR DESCRIPTION
OE has used CMake 3.12 for a while and the OBJECT library was introduced by CMake 2.8.8. Update the data-sealing and attestation samples to use the OBJECT library instead, which addresses the previous comments in the CMakeList.txt files.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>