### PR TITLE
Add new sgx quote fields to oecertdump output

### DIFF
--- a/tests/tools/oecertdump/host/sgx_quote.cpp
+++ b/tests/tools/oecertdump/host/sgx_quote.cpp
@@ -305,14 +305,22 @@ oe_result_t output_sgx_report(const uint8_t* report, size_t report_size)
     printf("            cpusvn (hex): ");
     oe_hex_dump(report_body->cpusvn, OE_COUNTOF(report_body->cpusvn));
     printf("            miscselect: 0x%x\n", report_body->miscselect);
+    printf("            isvextprodid (hex): ");
+    oe_hex_dump(
+        report_body->isvextprodid, OE_COUNTOF(report_body->isvextprodid));
     printf("            attributes (hex): ");
     oe_hex_dump(&report_body->attributes, sizeof(report_body->attributes));
     printf("            mrenclave (hex): ");
-    oe_hex_dump(report_body->mrenclave, sizeof(report_body->mrenclave));
+    oe_hex_dump(report_body->mrenclave, OE_COUNTOF(report_body->mrenclave));
     printf("            mrsigner (hex): ");
-    oe_hex_dump(report_body->mrsigner, sizeof(report_body->mrsigner));
+    oe_hex_dump(report_body->mrsigner, OE_COUNTOF(report_body->mrsigner));
+    printf("            configid (hex): ");
+    oe_hex_dump(report_body->configid, OE_COUNTOF(report_body->configid));
     printf("            isvprodid: 0x%x\n", report_body->isvprodid);
     printf("            isvsvn: 0x%x\n", report_body->isvsvn);
+    printf("            configsvn: 0x%x\n", report_body->configsvn);
+    printf("            isvfamilyid (hex): ");
+    oe_hex_dump(report_body->isvfamilyid, OE_COUNTOF(report_body->isvfamilyid));
     printf("            report_data (hex): ");
     oe_hex_dump(&report_body->report_data, sizeof(report_body->report_data));
     printf("        } report_body\n");
@@ -337,9 +345,10 @@ oe_result_t output_sgx_report(const uint8_t* report, size_t report_size)
     oe_hex_dump(
         &qe_report_body->attributes, sizeof(qe_report_body->attributes));
     printf("                    mrenclave (hex): ");
-    oe_hex_dump(qe_report_body->mrenclave, sizeof(qe_report_body->mrenclave));
+    oe_hex_dump(
+        qe_report_body->mrenclave, OE_COUNTOF(qe_report_body->mrenclave));
     printf("                    mrsigner (hex): ");
-    oe_hex_dump(qe_report_body->mrsigner, sizeof(qe_report_body->mrsigner));
+    oe_hex_dump(qe_report_body->mrsigner, OE_COUNTOF(qe_report_body->mrsigner));
     printf("                    isvprodid: 0x%x\n", qe_report_body->isvprodid);
     printf("                    isvsvn: 0x%x\n", qe_report_body->isvsvn);
     printf("                    report_data (hex): ");


### PR DESCRIPTION
New fields as `isvextprodid `, `configid `, `configsvn` and `isvfamilyid` were added in sgx quote report body.
Added those fields to `oecertdump` as well. 
```
report_body {
    cpusvn (hex): 11110305ff8006000000000000000000
    miscselect: 0x0
    isvextprodid (hex): 00000000000000000000000000000000
    attributes (hex): 07000000000000000700000000000000
    mrenclave (hex): c0137edc76e473bad134ad7ddc0279ba77221a39e6c74ce2e8a1d29392f02f43
    mrsigner (hex): ca9ad7331448980aa28890ce73e433638377f179ab4456b2fe237193193a8d0a
    configid (hex): 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
    isvprodid: 0x1
    isvsvn: 0x1
    configsvn: 0x0
    isvfamilyid (hex): 00000000000000000000000000000000
    report_data (hex): 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
} report_body
```

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>