### PR TITLE
Update OpenSSL version to 1.1.1j

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,6 @@
 [submodule "3rdparty/openssl/openssl"]
 	path = 3rdparty/openssl/openssl
 	url = https://github.com/openssl/openssl
-	branch = OpenSSL_1_1_1-stable
 [submodule "3rdparty/mbedtls/mbedtls"]
 	path = 3rdparty/mbedtls/mbedtls
 	url = https://github.com/openenclave/openenclave-mbedtls.git

--- a/3rdparty/openssl/README.md
+++ b/3rdparty/openssl/README.md
@@ -5,7 +5,18 @@ This directory includes the necessary files to build the OpenSSL libraries, incl
 that work with Open Enclave. The structure of the directory is as follows.
 
 - openssl/
-  The clone of official OpenSSL repository that is included as a git submodule.
+  The clone of official OpenSSL repository that is included as a git submodule, which points to
+  a recent release tag. To update the submodule, we use the following procedure:
+  - Checkout the tag that we want to update to.
+    ```
+    cd openssl
+    git checkout <tag>
+    ```
+  - Check the diff between the tag and the previous tag and update the tests in test/openssl.
+    ```
+    git diff <previous tag> <tag> --stat
+    ```
+  - Ensure the OE SDK builds and tests run successfully.
 
 - intel-sgx-ssl/
   The clone of Intel SGX SSL that includes the necessary changes to support full LVI mitigation.

--- a/tests/openssl/CMakeLists.txt
+++ b/tests/openssl/CMakeLists.txt
@@ -437,7 +437,8 @@ foreach (testcase ${openssltests})
   if ("${name}" STREQUAL verify_extra_test)
     add_openssl_test(
       "${name}" "${name}" ${OPENSSL_TEST_DIR}/certs/roots.pem
-      ${OPENSSL_TEST_DIR}/certs/untrusted.pem ${OPENSSL_TEST_DIR}/certs/bad.pem)
+      ${OPENSSL_TEST_DIR}/certs/untrusted.pem ${OPENSSL_TEST_DIR}/certs/bad.pem
+      ${OPENSSL_TEST_DIR}/certs/rootCA.pem)
     continue()
   endif ()
 
@@ -480,7 +481,8 @@ foreach (testcase ${openssltests})
       ${OPENSSL_TEST_DIR}/certs/roots.pem
       ${OPENSSL_TEST_DIR}/certs/root+anyEKU.pem
       ${OPENSSL_TEST_DIR}/certs/root-anyEKU.pem
-      ${OPENSSL_TEST_DIR}/certs/root-cert.pem)
+      ${OPENSSL_TEST_DIR}/certs/root-cert.pem
+      ${OPENSSL_TEST_DIR}/certs/invalid-cert.pem)
     continue()
   endif ()
 


### PR DESCRIPTION
Update the OpenSSL version from 1.1.1h-dev to 1.1.1j (release tag: https://github.com/openssl/openssl/releases/tag/OpenSSL_1_1_1j). Note that we no longer point to the OpenSSL_1_1_1-stable branch.
This includes several security fixes as follows.
- CVE-2021-23841
- CVE-2021-23840
- CVE-2021-23839
- CVE-2020-1971

Refer to the CHANGES log in the OpenSSL repo for more detail.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>