### PR TITLE
Remove unused parameters from internal loadelf.c functions

### DIFF
--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -921,7 +921,7 @@ oe_result_t oe_sgx_build_enclave(
     enclave->size = enclave_size;
 
     /* Patch image */
-    OE_CHECK(oeimage.sgx_patch(&oeimage, context, enclave_size));
+    OE_CHECK(oeimage.sgx_patch(&oeimage, enclave_size));
 
     /* Add image to enclave */
     OE_CHECK(oeimage.add_pages(&oeimage, context, enclave, &vaddr));

--- a/host/sgx/load.c
+++ b/host/sgx/load.c
@@ -76,24 +76,20 @@ oe_result_t oe_unload_enclave_image(oe_enclave_image_t* oeimage)
 
 oe_result_t oe_sgx_load_enclave_properties(
     const oe_enclave_image_t* oeimage,
-    const char* section_name,
     oe_sgx_enclave_properties_t* properties)
 {
     if (!oeimage || !oeimage->sgx_load_enclave_properties)
         return OE_INVALID_PARAMETER;
 
-    return oeimage->sgx_load_enclave_properties(
-        oeimage, section_name, properties);
+    return oeimage->sgx_load_enclave_properties(oeimage, properties);
 }
 
 oe_result_t oe_sgx_update_enclave_properties(
     const oe_enclave_image_t* oeimage,
-    const char* section_name,
     const oe_sgx_enclave_properties_t* properties)
 {
     if (!oeimage || !oeimage->sgx_update_enclave_properties)
         return OE_INVALID_PARAMETER;
 
-    return oeimage->sgx_update_enclave_properties(
-        oeimage, section_name, properties);
+    return oeimage->sgx_update_enclave_properties(oeimage, properties);
 }

--- a/host/sgx/loadelf.c
+++ b/host/sgx/loadelf.c
@@ -535,9 +535,8 @@ static uint64_t _make_secinfo_flags(uint32_t flags)
 
 static oe_result_t _add_relocation_pages(
     oe_sgx_load_context_t* context,
-    uint64_t enclave_addr,
-    const void* reloc_data,
-    const size_t reloc_size,
+    uint64_t enclave_base,
+    const oe_enclave_elf_image_t* image,
     uint64_t* vaddr)
 {
     oe_result_t result = OE_UNEXPECTED;
@@ -545,20 +544,20 @@ static oe_result_t _add_relocation_pages(
     if (!context || !vaddr)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    if (reloc_data && reloc_size)
+    if (image->reloc_data && image->reloc_size)
     {
-        const oe_page_t* pages = (const oe_page_t*)reloc_data;
-        size_t npages = reloc_size / sizeof(oe_page_t);
+        const oe_page_t* pages = (const oe_page_t*)image->reloc_data;
+        size_t npages = image->reloc_size / sizeof(oe_page_t);
 
         for (size_t i = 0; i < npages; i++)
         {
-            uint64_t addr = enclave_addr + *vaddr;
+            uint64_t addr = enclave_base + *vaddr;
             uint64_t src = (uint64_t)&pages[i];
             uint64_t flags = SGX_SECINFO_REG | SGX_SECINFO_R;
             bool extend = true;
 
             OE_CHECK(oe_sgx_load_enclave_data(
-                context, enclave_addr, addr, src, flags, extend));
+                context, enclave_base, addr, src, flags, extend));
             (*vaddr) += sizeof(oe_page_t);
         }
     }
@@ -571,43 +570,46 @@ done:
 
 static oe_result_t _add_segment_pages(
     oe_sgx_load_context_t* context,
-    uint64_t enclave_addr,
-    const oe_elf_segment_t* segment,
-    void* image)
+    uint64_t enclave_base,
+    const oe_enclave_elf_image_t* image,
+    uint64_t* vaddr)
 {
     oe_result_t result = OE_UNEXPECTED;
-    uint64_t flags;
-    uint64_t page_rva;
-    uint64_t segment_end;
 
     assert(context);
-    assert(segment);
     assert(image);
+    assert(vaddr);
 
-    /* Take into account that segment base address may not be page aligned */
-    page_rva = oe_round_down_to_page_size(segment->vaddr);
-    segment_end = segment->vaddr + segment->memsz;
-    flags = _make_secinfo_flags(segment->flags);
-
-    if (flags == 0)
+    for (size_t i = 0; i < image->num_segments; i++)
     {
-        OE_RAISE_MSG(
-            OE_UNEXPECTED, "Segment with no page protections found.", NULL);
+        oe_elf_segment_t* segment = &image->segments[i];
+
+        /* Align if segment base address is not page aligned */
+        uint64_t page_rva = oe_round_down_to_page_size(segment->vaddr);
+        uint64_t segment_end = segment->vaddr + segment->memsz;
+        uint64_t flags = _make_secinfo_flags(segment->flags);
+
+        if (flags == 0)
+        {
+            OE_RAISE_MSG(
+                OE_UNEXPECTED, "Segment with no page protections found.", NULL);
+        }
+
+        flags |= SGX_SECINFO_REG;
+
+        for (; page_rva < segment_end; page_rva += OE_PAGE_SIZE)
+        {
+            OE_CHECK(oe_sgx_load_enclave_data(
+                context,
+                enclave_base,
+                enclave_base + *vaddr + page_rva,
+                (uint64_t)image->image_base + page_rva,
+                flags,
+                true));
+        }
     }
 
-    flags |= SGX_SECINFO_REG;
-
-    for (; page_rva < segment_end; page_rva += OE_PAGE_SIZE)
-    {
-        OE_CHECK(oe_sgx_load_enclave_data(
-            context,
-            enclave_addr,
-            enclave_addr + page_rva,
-            (uint64_t)image + page_rva,
-            flags,
-            true));
-    }
-
+    *vaddr = *vaddr + image->image_size;
     result = OE_OK;
 
 done:
@@ -615,7 +617,7 @@ done:
 }
 
 static oe_result_t _add_elf_image_pages(
-    oe_enclave_elf_image_t* image,
+    const oe_enclave_elf_image_t* image,
     oe_sgx_load_context_t* context,
     oe_enclave_t* enclave,
     uint64_t* vaddr)
@@ -630,17 +632,10 @@ static oe_result_t _add_elf_image_pages(
     assert(enclave->size > image->image_size);
 
     /* Add the program segments first */
-    for (size_t i = 0; i < image->num_segments; i++)
-    {
-        OE_CHECK(_add_segment_pages(
-            context, enclave->addr, &image->segments[i], image->image_base));
-    }
-
-    *vaddr = image->image_size;
+    OE_CHECK(_add_segment_pages(context, enclave->addr, image, vaddr));
 
     /* Add the relocation pages (contain relocation entries) */
-    OE_CHECK(_add_relocation_pages(
-        context, enclave->addr, image->reloc_data, image->reloc_size, vaddr));
+    OE_CHECK(_add_relocation_pages(context, enclave->addr, image, vaddr));
 
     result = OE_OK;
 
@@ -650,7 +645,7 @@ done:
 
 /* Add image to enclave */
 static oe_result_t _add_pages(
-    oe_enclave_image_t* image,
+    const oe_enclave_image_t* image,
     oe_sgx_load_context_t* context,
     oe_enclave_t* enclave,
     uint64_t* vaddr)
@@ -700,15 +695,12 @@ done:
 
 static oe_result_t _patch_elf_image(
     oe_enclave_elf_image_t* image,
-    oe_sgx_load_context_t* context,
     size_t enclave_size,
     size_t tls_page_count)
 {
     oe_result_t result = OE_UNEXPECTED;
     oe_sgx_enclave_properties_t* oeprops;
     uint64_t enclave_rva = 0;
-
-    OE_UNUSED(context);
 
     oeprops =
         (oe_sgx_enclave_properties_t*)(image->image_base + image->oeinfo_rva);
@@ -745,12 +737,13 @@ static oe_result_t _patch_elf_image(
     oeprops->image_info.reloc_rva = image->image_size;
     oeprops->image_info.reloc_size = image->reloc_size;
     OE_CHECK(_set_uint64_t_dynamic_symbol_value(
-        image, "_reloc_rva", image->image_size));
+        image, "_reloc_rva", oeprops->image_info.reloc_rva));
     OE_CHECK(_set_uint64_t_dynamic_symbol_value(
-        image, "_reloc_size", image->reloc_size));
+        image, "_reloc_size", oeprops->image_info.reloc_size));
 
-    /* heap right after image */
-    oeprops->image_info.heap_rva = image->image_size + image->reloc_size;
+    /* heap is right after all the relocs */
+    oeprops->image_info.heap_rva =
+        oeprops->image_info.reloc_rva + oeprops->image_info.reloc_size;
 
     if (image->tdata_size)
     {
@@ -782,17 +775,13 @@ done:
     return result;
 }
 
-static oe_result_t _patch(
-    oe_enclave_image_t* image,
-    oe_sgx_load_context_t* context,
-    size_t enclave_size)
+static oe_result_t _patch(oe_enclave_image_t* image, size_t enclave_size)
 {
     oe_result_t result = OE_UNEXPECTED;
     size_t tls_page_count;
 
     OE_CHECK(image->get_tls_page_count(image, &tls_page_count));
-    OE_CHECK(
-        _patch_elf_image(&image->elf, context, enclave_size, tls_page_count));
+    OE_CHECK(_patch_elf_image(&image->elf, enclave_size, tls_page_count));
 
     result = OE_OK;
 done:
@@ -801,11 +790,9 @@ done:
 
 static oe_result_t _sgx_load_enclave_properties(
     const oe_enclave_image_t* image,
-    const char* section_name,
     oe_sgx_enclave_properties_t* properties)
 {
     oe_result_t result = OE_UNEXPECTED;
-    OE_UNUSED(section_name);
 
     /* Copy from the image at oeinfo_rva. */
     OE_CHECK(oe_memcpy_s(
@@ -822,11 +809,9 @@ done:
 
 static oe_result_t _sgx_update_enclave_properties(
     const oe_enclave_image_t* image,
-    const char* section_name,
     const oe_sgx_enclave_properties_t* properties)
 {
     oe_result_t result = OE_UNEXPECTED;
-    OE_UNUSED(section_name);
 
     /* Copy to both the image and ELF file*/
     OE_CHECK(oe_memcpy_s(

--- a/include/openenclave/internal/load.h
+++ b/include/openenclave/internal/load.h
@@ -12,6 +12,8 @@
 
 OE_EXTERNC_BEGIN
 
+typedef struct _oe_enclave_elf_image oe_enclave_elf_image_t;
+
 typedef struct _oe_enclave_image oe_enclave_image_t;
 
 typedef struct _oe_sgx_load_context oe_sgx_load_context_t;
@@ -33,7 +35,7 @@ typedef struct _oe_elf_segment
     uint32_t flags;
 } oe_elf_segment_t;
 
-typedef struct _oe_enclave_elf_image
+struct _oe_enclave_elf_image
 {
     elf64_t elf;
 
@@ -71,8 +73,7 @@ typedef struct _oe_enclave_elf_image
     /* Offset to write back to the file oe_sgx_enclave_properties_t
      * during signing */
     uint64_t oeinfo_file_pos;
-
-} oe_enclave_elf_image_t;
+};
 
 typedef enum _oe_image_type
 {
@@ -97,24 +98,19 @@ struct _oe_enclave_image
         size_t* tls_page_count);
 
     oe_result_t (*add_pages)(
-        oe_enclave_image_t* image,
+        const oe_enclave_image_t* image,
         oe_sgx_load_context_t* context,
         oe_enclave_t* enclave,
         uint64_t* vaddr);
 
-    oe_result_t (*sgx_patch)(
-        oe_enclave_image_t* image,
-        oe_sgx_load_context_t* context,
-        size_t enclave_size);
+    oe_result_t (*sgx_patch)(oe_enclave_image_t* image, size_t enclave_size);
 
     oe_result_t (*sgx_load_enclave_properties)(
         const oe_enclave_image_t* image,
-        const char* section_name,
         oe_sgx_enclave_properties_t* properties);
 
     oe_result_t (*sgx_update_enclave_properties)(
         const oe_enclave_image_t* image,
-        const char* section_name,
         const oe_sgx_enclave_properties_t* properties);
 
     oe_result_t (*unload)(oe_enclave_image_t* image);
@@ -132,11 +128,9 @@ oe_result_t oe_unload_enclave_image(oe_enclave_image_t* oeimage);
  * Find the oe_sgx_enclave_properties_t struct within the given section
  *
  * This function attempts to find the **oe_sgx_enclave_properties_t** struct
- * within
- * the specified section of the ELF binary.
+ * within the ELF binary.
  *
  * @param oeimage OE Enclave image
- * @param section_name name of section to search for enclave properties
  * @param properties pointer where enclave properties are copied
  *
  * @returns OE_OK
@@ -147,18 +141,16 @@ oe_result_t oe_unload_enclave_image(oe_enclave_image_t* oeimage);
  */
 oe_result_t oe_sgx_load_enclave_properties(
     const oe_enclave_image_t* oeimage,
-    const char* section_name,
     oe_sgx_enclave_properties_t* properties);
 
 /**
  * Update the oe_sgx_enclave_properties_t struct within the given section
  *
  * This function attempts to update the **oe_sgx_enclave_properties_t** struct
- * within the specified section of the ELF binary. If found, the section is
- * updated with the value of the **properties** parameter.
+ * within the ELF binary. If found, the section is updated with the value of
+ * the **properties** parameter.
  *
  * @param oeimage OE Enclave image
- * @param section_name name of section to search for enclave properties
  * @param properties new value of enclave properties
  *
  * @returns OE_OK
@@ -169,7 +161,6 @@ oe_result_t oe_sgx_load_enclave_properties(
  */
 oe_result_t oe_sgx_update_enclave_properties(
     const oe_enclave_image_t* oeimage,
-    const char* section_name,
     const oe_sgx_enclave_properties_t* properties);
 
 OE_EXTERNC_END

--- a/tests/props/host/host.c
+++ b/tests/props/host/host.c
@@ -65,8 +65,7 @@ static oe_result_t _sgx_load_enclave_properties(
         OE_RAISE(OE_FAILURE);
 
     /* Load the SGX enclave properties */
-    if (oe_sgx_load_enclave_properties(
-            &oeimage, OE_INFO_SECTION_NAME, properties) != OE_OK)
+    if (oe_sgx_load_enclave_properties(&oeimage, properties) != OE_OK)
         OE_RAISE(OE_NOT_FOUND);
 
     result = OE_OK;

--- a/tests/tools/oesign/test-enclave/host/host.c
+++ b/tests/tools/oesign/test-enclave/host/host.c
@@ -50,8 +50,8 @@ int main(int argc, const char* argv[])
     }
 
     /* Load the SGX enclave properties */
-    if ((result = oe_sgx_load_enclave_properties(
-             &oeimage, OE_INFO_SECTION_NAME, &properties)) != OE_OK)
+    if ((result = oe_sgx_load_enclave_properties(&oeimage, &properties)) !=
+        OE_OK)
     {
         oe_put_err("oe_sgx_load_enclave_properties(): result=%u", result);
     }

--- a/tools/oesign/oeinfo.c
+++ b/tools/oesign/oeinfo.c
@@ -27,8 +27,7 @@ oe_result_t oe_read_oeinfo_sgx(
     OE_CHECK(oe_load_enclave_image(path, &oeimage));
 
     /* Load the SGX enclave properties */
-    OE_CHECK(oe_sgx_load_enclave_properties(
-        &oeimage, OE_INFO_SECTION_NAME, properties));
+    OE_CHECK(oe_sgx_load_enclave_properties(&oeimage, properties));
 
     result = OE_OK;
 
@@ -67,8 +66,7 @@ oe_result_t oe_write_oeinfo_sgx(
 
     /* Write the .oeinfo section. */
     OE_CHECK_ERR(
-        oe_sgx_update_enclave_properties(
-            &oeimage, OE_INFO_SECTION_NAME, properties),
+        oe_sgx_update_enclave_properties(&oeimage, properties),
         "Cannot write section: %s",
         OE_INFO_SECTION_NAME);
 


### PR DESCRIPTION
This PR carries the changes from @CodeMonkeyLeet, which cleans up the internal code as follows.
- Remove unused `context` parameter from `sgx_patch()` function definiton.
- Remove unused `section_name` parameter from `sgx_load_enclave_properties()`
  and `sgx_update_enclave_properties()` function definitiions.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>