### PR TITLE
Update VS Extension

### DIFF
--- a/devex/vsextension/ItemTemplates/oehost/host.vstemplate
+++ b/devex/vsextension/ItemTemplates/oehost/host.vstemplate
@@ -17,7 +17,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.12.0.2" />
+      <package id="open-enclave-cross" version="0.14.0" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
@@ -169,12 +169,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\open-enclave-cross.0.12.0.2\build\native\open-enclave-cross.targets" Condition="Exists('..\packages\open-enclave-cross.0.12.0.2\build\native\open-enclave-cross.targets')" />
+    <Import Project="..\packages\open-enclave-cross.0.14.0\build\native\open-enclave-cross.targets" Condition="Exists('..\packages\open-enclave-cross.0.14.0\build\native\open-enclave-cross.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\open-enclave-cross.0.12.0.2\build\native\open-enclave-cross.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\open-enclave-cross.0.12.0.2\build\native\open-enclave-cross.targets'))" />
+    <Error Condition="!Exists('..\packages\open-enclave-cross.0.14.0\build\native\open-enclave-cross.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\open-enclave-cross.0.14.0\build\native\open-enclave-cross.targets'))" />
   </Target>
 </Project>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
@@ -32,7 +32,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.12.0.2" />
+      <package id="open-enclave-cross" version="0.14.0" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectTemplates/oeenclave-linux/packages.config
+++ b/devex/vsextension/ProjectTemplates/oeenclave-linux/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="open-enclave-cross" version="0.12.0.2" targetFramework="native" />
+  <package id="open-enclave-cross" version="0.14.0" targetFramework="native" />
 </packages>

--- a/devex/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
+++ b/devex/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
@@ -33,7 +33,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="open-enclave-cross" version="0.12.0.2" />
+      <package id="open-enclave-cross" version="0.14.0" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/devex/vsextension/ProjectWizard/ImportEnclaveCommand.cs
+++ b/devex/vsextension/ProjectWizard/ImportEnclaveCommand.cs
@@ -345,7 +345,7 @@ namespace OpenEnclaveSDK
                     // Add nuget package to project.
                     // See https://stackoverflow.com/questions/41803738/how-to-programmatically-install-a-nuget-package/41895490#41895490
                     // and more particularly https://docs.microsoft.com/en-us/nuget/visual-studio-extensibility/nuget-api-in-visual-studio
-                    var packageVersions = new Dictionary<string, string>() { { "open-enclave-cross", "0.12.0.2" } };
+                    var packageVersions = new Dictionary<string, string>() { { "open-enclave-cross", "0.14.0" } };
                     var componentModel = (IComponentModel)(await this.ServiceProvider.GetServiceAsync(typeof(SComponentModel)));
                     var packageInstaller = componentModel.GetService<IVsPackageInstaller2>();
                     packageInstaller.InstallPackagesFromVSExtensionRepository(

--- a/devex/vsextension/ProjectWizard/VCTargets/OpenEnclave.Cpp.Clang.targets
+++ b/devex/vsextension/ProjectWizard/VCTargets/OpenEnclave.Cpp.Clang.targets
@@ -273,7 +273,7 @@ that use Clang Front-End.
       <OutDirTrimmed>$(OutDir.TrimEnd({'\\'))</OutDirTrimmed>
     </PropertyGroup>
 
-    <Exec Command='"$(ClangToolExe)" -target x86_64-pc-linux $(ObjectsListSpaced) -o "$(OutDir)$(TargetName).elf" -nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,-pie,--build-id -Wl,-z,noexecstack -Wl,-z,now -Wl,-gc-sections -fuse-ld=lld %(Link.AdditionalOptions) "-L$(OutDirTrimmed)" $(LibsListSpaced) -loeenclave -loelibcxx -loelibc -loecryptombed -lmbedtls -lmbedx509 -lmbedcrypto -loelibc -loesyscall -loecore'>
+    <Exec Command='"$(ClangToolExe)" -target x86_64-pc-linux $(ObjectsListSpaced) -o "$(OutDir)$(TargetName).elf" -nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,-pie,--build-id -Wl,-z,noexecstack -Wl,-z,now -Wl,-gc-sections -fuse-ld=lld %(Link.AdditionalOptions) "-L$(OutDirTrimmed)" $(LibsListSpaced) -loeenclave -loelibcxx -loelibc -loecryptombedtls -lmbedtls -lmbedx509 -lmbedcrypto -loelibc -loesyscall -loecore'>
     </Exec>
   </Target>
 

--- a/devex/vsextension/ProjectWizard/VCTargets/OpenEnclave.Cpp.Common.props
+++ b/devex/vsextension/ProjectWizard/VCTargets/OpenEnclave.Cpp.Common.props
@@ -41,7 +41,7 @@
   <!-- Open Enclave settings -->
   <PropertyGroup>
     <ClangToolExe>clang.exe</ClangToolExe>
-    <ClangVersion>7.0</ClangVersion>
+    <ClangVersion>8.0.1</ClangVersion>
     <ClangTarget>x86_64-pc-linux</ClangTarget>
     <GNUMode>true</GNUMode>
     <ToolchainFriendlyName>Clang</ToolchainFriendlyName>

--- a/devex/vsextension/ProjectWizard/VSExtension.csproj
+++ b/devex/vsextension/ProjectWizard/VSExtension.csproj
@@ -3,8 +3,8 @@
      Licensed under the MIT License.
   -->
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.props')" />
   <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -154,7 +154,7 @@
       <ResourceName>Menus.ctmenu</ResourceName>
       <SubType>Designer</SubType>
     </VSCTCompile>
-    <Content Include="Packages\open-enclave-cross.0.12.0.2.nupkg">
+    <Content Include="Packages\open-enclave-cross.0.14.0.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="VCTargets\OpenEnclave.Cpp.Common.props">
@@ -278,7 +278,10 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.9.0.16.7.30328.74\lib\net45\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.TemplateWizardInterface.12.0.4\lib\net20\Microsoft.VisualStudio.TemplateWizardInterface.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.16.7.30328.74\lib\net45\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
     </Reference>
@@ -396,7 +399,7 @@
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
@@ -419,8 +422,6 @@
     <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.CSharp.dll" />
     <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.VisualBasic.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -476,23 +477,23 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.7.9\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.7.9\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets'))" />
-    <Error Condition="!Exists('..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets'))" />
+    <Error Condition="!Exists('..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
   <PropertyGroup>
-    <PreBuildEvent>curl --proto "=https" --tlsv1.2 -sSfL https://www.nuget.org/api/v2/package/open-enclave-cross/0.12.0.2 --output $(ProjectDir)\packages\open-enclave-cross.0.12.0.2.nupkg -z $(ProjectDir)\packages\open-enclave-cross.0.12.0.2.nupkg</PreBuildEvent>
+    <PreBuildEvent>curl --proto "=https" --tlsv1.2 -sSfL https://www.nuget.org/api/v2/package/open-enclave-cross/0.14.0 --output $(ProjectDir)\packages\open-enclave-cross.0.14.0.nupkg -z $(ProjectDir)\packages\open-enclave-cross.0.14.0.nupkg</PreBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.7.9\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.7.9\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
-  <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets')" />
-  <Import Project="..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets" Condition="Exists('..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.16.7.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
   <Import Project="..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.16.7.3069\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.34\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
+  <Import Project="..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets" Condition="Exists('..\packages\NuGet.VisualStudio.5.7.0\build\NuGet.VisualStudio.targets')" />
 </Project>

--- a/devex/vsextension/ProjectWizard/WizardImplementation.cs
+++ b/devex/vsextension/ProjectWizard/WizardImplementation.cs
@@ -135,7 +135,7 @@ namespace OpenEnclaveSDK
                 // User picked a specific board for which we have binaries in the nuget package.
                 string solutionDirectory;
                 replacementsDictionary.TryGetValue("$solutiondirectory$", out solutionDirectory);
-                oeFolder = Path.Combine(solutionDirectory, "packages\\open-enclave-cross.0.12.0.2\\lib\\native\\linux\\optee\\v3.6.0\\" + board);
+                oeFolder = Path.Combine(solutionDirectory, "packages\\open-enclave-cross.0.14.0\\lib\\native\\linux\\optee\\v3.6.0\\" + board);
             }
             else
             {

--- a/devex/vsextension/ProjectWizard/packages.config
+++ b/devex/vsextension/ProjectWizard/packages.config
@@ -62,7 +62,7 @@
   <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Dataflow" version="4.11.1" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" requireReinstallation="true" />
   <package id="VSSDK.DTE" version="7.0.4" targetFramework="net461" />
   <package id="VSSDK.IDE" version="7.0.4" targetFramework="net461" />
   <package id="VSSDK.IDE.12" version="12.0.4" targetFramework="net461" />

--- a/devex/vsextension/ProjectWizard/source.extension.vsixmanifest
+++ b/devex/vsextension/ProjectWizard/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
   -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="OpenEnclaveVisualStudioExtension-1" Version="0.12.33" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="OpenEnclaveVisualStudioExtension-1" Version="0.14.34" Language="en-US" Publisher="Microsoft" />
         <DisplayName>Open Enclave - Preview</DisplayName>
         <Description xml:space="preserve">Support for developing and debugging Trusted Execution Environment enclaves that can run on both SGX and TrustZone, and using them from your own applications.</Description>
         <MoreInfo>https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/visualstudio_dev.md</MoreInfo>
@@ -19,7 +19,7 @@
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveWindowsProject.zip" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveLinuxProject.zip" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
-        <Asset Type="open-enclave-cross.0.12.0.2.nupkg" d:Source="File" Path="Packages\open-enclave-cross.0.12.0.2.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="open-enclave-cross.0.14.0.nupkg" d:Source="File" Path="Packages\open-enclave-cross.0.14.0.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="ItemTemplates\Built\OEHostItem.zip" />
     </Assets>


### PR DESCRIPTION
Updated project files for VS Extension release version 0.14.34
- Upgrade from Clang-7 to Clang-8
- Updated library reference to `oecryptombedtls`
- Updated packages