### PR TITLE
Separate image builds into stages

### DIFF
--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -23,7 +23,6 @@ AZURE_IMAGES_MAP = [
     ]
 ]
 
-
 def get_image_version() {
     def now = LocalDateTime.now()
     return (now.format(DateTimeFormatter.ofPattern("yyyy")) + "." + \
@@ -35,18 +34,21 @@ def get_image_id() {
     if (params.IMAGE_ID) {
         return params.IMAGE_ID
     }
+    checkout scm
     def last_commit_id = sh(script: "git rev-parse --short HEAD", returnStdout: true).tokenize().last()
     return (get_image_version() + "-" + last_commit_id)
 }
 
+
+
 def buildLinuxManagedImage(String os_type, String version) {
     node(params.AGENTS_LABEL) {
-        stage("${os_type}-${version}") {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def managed_image_name_id = get_image_id()
-                def gallery_image_version = get_image_version()
+        def managed_image_name_id = get_image_id()
+        def gallery_image_version = get_image_version()
+        withEnv(["DOCKER_REGISTRY=${OETOOLS_REPO}",
+            "MANAGED_IMAGE_NAME_ID=${managed_image_name_id}",
+            "GALLERY_IMAGE_VERSION=${gallery_image_version}"]) {
+            stage("${os_type}-${version}-cleanup") {
                 def az_cleanup_existing_image_version_script = """
                     az login --service-principal -u \$SERVICE_PRINCIPAL_ID -p \$SERVICE_PRINCIPAL_PASSWORD --tenant \$TENANT_ID
                     az account set -s \$SUBSCRIPTION_ID
@@ -60,19 +62,19 @@ def buildLinuxManagedImage(String os_type, String version) {
                         --gallery-image-version ${gallery_image_version}
                 """
                 oe.azureEnvironment(az_cleanup_existing_image_version_script, params.OE_DEPLOY_IMAGE)
-                withCredentials([usernamePassword(credentialsId: OETOOLS_REPO_CREDENTIALS_ID,
-                                                  usernameVariable: "DOCKER_USER_NAME",
-                                                  passwordVariable: "DOCKER_USER_PASSWORD"),
-                                usernamePassword(credentialsId: JENKINS_USER_CREDS_ID,
-                                                  usernameVariable: "SSH_USERNAME",
-                                                  passwordVariable: "SSH_PASSWORD")]) {
-                    withEnv(["DOCKER_REGISTRY=${OETOOLS_REPO}",
-                             "MANAGED_IMAGE_NAME_ID=${managed_image_name_id}",
-                             "GALLERY_IMAGE_VERSION=${gallery_image_version}"]) {
+            }
+            stage("${os_type}-${version}-build") {
+                timeout(GLOBAL_TIMEOUT_MINUTES) {
+                    withCredentials([usernamePassword(credentialsId: OETOOLS_REPO_CREDENTIALS_ID,
+                                                    usernameVariable: "DOCKER_USER_NAME",
+                                                    passwordVariable: "DOCKER_USER_PASSWORD"),
+                                    usernamePassword(credentialsId: JENKINS_USER_CREDS_ID,
+                                                    usernameVariable: "SSH_USERNAME",
+                                                    passwordVariable: "SSH_PASSWORD")]) {
                         def cmd = ("packer build -force " +
                                     "-var-file=${WORKSPACE}/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/${os_type}-${version}-variables.json " +
                                     "${WORKSPACE}/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/packer-${os_type}.json")
-                        oe.exec_with_retry(10, 300) {
+                        oe.exec_with_retry(10, 60) {
                             oe.azureEnvironment(cmd, params.OE_DEPLOY_IMAGE)
                         }
                     }
@@ -84,36 +86,42 @@ def buildLinuxManagedImage(String os_type, String version) {
 
 def buildWindowsManagedImage(String os_series, String img_name_suffix, String launch_configuration) {
     node(params.AGENTS_LABEL) {
-        stage(img_name_suffix) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def managed_image_name_id = get_image_id()
-                def gallery_image_version = get_image_version()
-                def vm_rg_name = "build-${managed_image_name_id}-${img_name_suffix}-${BUILD_NUMBER}"
-                def vm_name = "${os_series}-vm"
-                def jenkins_rg_name = params.JENKINS_RESOURCE_GROUP
-                def jenkins_vnet_name = params.JENKINS_VNET_NAME
-                def jenkins_subnet_name = params.JENKINS_SUBNET_NAME
-                def azure_image_id = AZURE_IMAGES_MAP[os_series]["image"]
-                withCredentials([usernamePassword(credentialsId: JENKINS_USER_CREDS_ID,
-                                                  usernameVariable: "JENKINS_USER_NAME",
-                                                  passwordVariable: "JENKINS_USER_PASSWORD")]) {
-                    def az_login_script = """
-                        az login --service-principal -u \$SERVICE_PRINCIPAL_ID -p \$SERVICE_PRINCIPAL_PASSWORD --tenant \$TENANT_ID
-                        az account set -s \$SUBSCRIPTION_ID
-                    """
-                    def az_build_managed_img_script = """
-                        source ${WORKSPACE}/.jenkins/infrastructure/provision/utils.sh
+        withCredentials([usernamePassword(credentialsId: JENKINS_USER_CREDS_ID,
+                                    usernameVariable: "JENKINS_USER_NAME",
+                                    passwordVariable: "JENKINS_USER_PASSWORD")]) {
+            def az_login_script = """
+                az login --service-principal -u \$SERVICE_PRINCIPAL_ID -p \$SERVICE_PRINCIPAL_PASSWORD --tenant \$TENANT_ID
+                az account set -s \$SUBSCRIPTION_ID
+            """
+            def managed_image_name_id = get_image_id()
+            def gallery_image_version = get_image_version()
+            def vm_rg_name = "build-${managed_image_name_id}-${img_name_suffix}-${BUILD_NUMBER}"
+            def vm_name = "${os_series}-vm"
+            def jenkins_rg_name = params.JENKINS_RESOURCE_GROUP
+            def jenkins_vnet_name = params.JENKINS_VNET_NAME
+            def jenkins_subnet_name = params.JENKINS_SUBNET_NAME
+            def azure_image_id = AZURE_IMAGES_MAP[os_series]["image"]
 
+            stage("${img_name_suffix}-prepare") {
+                def az_rg_create_script = """
+                    ${az_login_script}
+                    az group create --name ${vm_rg_name} --location ${REGION}
+                """
+                cleanWs()
+                oe.azureEnvironment(az_rg_create_script, params.OE_DEPLOY_IMAGE)
+            }
+
+            try {
+                stage("${img_name_suffix}-provisioning") {
+                    def provision_script = """
                         ${az_login_script}
 
-                        SUBNET_ID=`az network vnet subnet show \
+                        SUBNET_ID=\$(az network vnet subnet show \
                             --resource-group ${jenkins_rg_name} \
                             --name ${jenkins_subnet_name} \
-                            --vnet-name ${jenkins_vnet_name} --query id -o tsv`
+                            --vnet-name ${jenkins_vnet_name} --query id -o tsv)
 
-                        VM_ID=`az vm create \
+                        az vm create \
                             --resource-group ${vm_rg_name} \
                             --location ${REGION} \
                             --name ${vm_name} \
@@ -122,81 +130,133 @@ def buildWindowsManagedImage(String os_series, String img_name_suffix, String la
                             --subnet \$SUBNET_ID \
                             --admin-username ${JENKINS_USER_NAME} \
                             --admin-password ${JENKINS_USER_PASSWORD} \
-                            --image ${azure_image_id} | jq -r '.id'`
+                            --image ${azure_image_id}
+                    """
+                    oe.azureEnvironment(provision_script, params.OE_DEPLOY_IMAGE)
+                }
 
-                        VM_DETAILS=`az vm show --ids \$VM_ID --show-details`
+                stage("${img_name_suffix}-deploy") {
+                    def deploy_script = """
+                        ${az_login_script}
+
+                        VM_DETAILS=\$(az vm show --resource-group ${vm_rg_name} \
+                                                --name ${vm_name} \
+                                                --show-details)
 
                         az vm run-command invoke \
                             --resource-group ${vm_rg_name} \
                             --name ${vm_name} \
                             --command-id EnableRemotePS
+                        
+                        PRIVATE_IP=\$(echo \$VM_DETAILS | jq -r '.privateIps')
+                        rm -f ${WORKSPACE}/scripts/ansible/inventory/hosts
+                        echo "[windows-agents]" >> ${WORKSPACE}/scripts/ansible/inventory/hosts
+                        echo "\$PRIVATE_IP" >> ${WORKSPACE}/scripts/ansible/inventory/hosts
+                        echo "ansible_user: ${JENKINS_USER_NAME}" >> ${WORKSPACE}/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
+                        echo "ansible_password: ${JENKINS_USER_PASSWORD}" >> ${WORKSPACE}/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
+                        echo "ansible_winrm_transport: ntlm" >> ${WORKSPACE}/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
+                        echo "launch_configuration: ${launch_configuration}" >> ${WORKSPACE}/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
 
-                        PRIVATE_IP=`echo \$VM_DETAILS | jq -r '.privateIps'`
-                        echo "[windows-agents]" > $WORKSPACE/scripts/ansible/inventory/hosts
-                        echo "\$PRIVATE_IP" >> $WORKSPACE/scripts/ansible/inventory/hosts
-                        echo "ansible_user: ${JENKINS_USER_NAME}" > $WORKSPACE/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
-                        echo "ansible_password: ${JENKINS_USER_PASSWORD}" >> $WORKSPACE/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
-                        echo "ansible_winrm_transport: ntlm" >> $WORKSPACE/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
-                        echo "launch_configuration: ${launch_configuration}" >> $WORKSPACE/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
-
-                        cd $WORKSPACE/scripts/ansible
-                        retrycmd_if_failure 5 10 2h ansible-playbook oe-windows-acc-setup.yml
-                        retrycmd_if_failure 5 10 30m ansible-playbook jenkins-packer.yml
+                        cd ${WORKSPACE}/scripts/ansible
+                        source ${WORKSPACE}/.jenkins/infrastructure/provision/utils.sh
+                        ansible-playbook oe-windows-acc-setup.yml
+                        ansible-playbook jenkins-packer.yml
 
                         az vm run-command invoke \
                             --resource-group ${vm_rg_name} \
                             --name ${vm_name} \
                             --command-id RunPowerShellScript \
-                            --scripts @$WORKSPACE/.jenkins/infrastructure/provision/run-sysprep.ps1
-
-                        az vm deallocate --ids \$VM_ID
-                        az vm generalize --ids \$VM_ID
-
-                        # If the target image doesn't exist, the below command
-                        # will not fail because it is idempotent.
-                        az image delete \
-                            --resource-group ${RESOURCE_GROUP} \
-                            --name ${managed_image_name_id}-${img_name_suffix}
-
-                        MANAGED_IMG_ID=`az image create \
-                            --resource-group ${RESOURCE_GROUP} \
-                            --name ${managed_image_name_id}-${img_name_suffix} \
-                            --hyper-v-generation ${AZURE_IMAGES_MAP[os_series]["generation"]} \
-                            --source \$VM_ID | jq -r '.id'`
-
-                        # If the target image version doesn't exist, the below
-                        # command will not fail because it is idempotent.
-                        az sig image-version delete \
-                            --resource-group ${RESOURCE_GROUP} \
-                            --gallery-name ${GALLERY_NAME} \
-                            --gallery-image-definition ${img_name_suffix} \
-                            --gallery-image-version ${gallery_image_version}
-
-                        az sig image-version create \
-                            --resource-group ${RESOURCE_GROUP} \
-                            --gallery-name ${GALLERY_NAME} \
-                            --gallery-image-definition ${img_name_suffix} \
-                            --gallery-image-version ${gallery_image_version} \
-                            --managed-image \$MANAGED_IMG_ID \
-                            --target-regions ${env.REPLICATION_REGIONS.split(',').join(' ')} \
-                            --replica-count 1
+                            --scripts @${WORKSPACE}/.jenkins/infrastructure/provision/run-sysprep.ps1
                     """
-                    def az_rg_create_script = """
-                        ${az_login_script}
-                        az group create --name ${vm_rg_name} --location ${REGION}
-                    """
+                    cleanWs()
+                    checkout scm
+                    oe.exec_with_retry(10, 30) {
+                        oe.azureEnvironment(deploy_script, params.OE_DEPLOY_IMAGE)
+                    }
+                }
+
+
+                stage("${img_name_suffix}-generalize") {
+                    timeout(GLOBAL_TIMEOUT_MINUTES) {
+                        def generalize_script = """
+                            ${az_login_script}
+
+                            az vm deallocate --resource-group ${vm_rg_name} --name ${vm_name}
+                            az vm generalize --resource-group ${vm_rg_name} --name ${vm_name}
+                        """
+                        oe.exec_with_retry(10, 30) {                           
+                            oe.azureEnvironment(generalize_script, params.OE_DEPLOY_IMAGE)
+                        }
+                    }
+                }
+
+                stage("${img_name_suffix}-capture") {
+                    timeout(GLOBAL_TIMEOUT_MINUTES) {
+                        def capture_script = """
+                            ${az_login_script}
+
+                            VM_ID=\$(az vm show \
+                                --resource-group ${vm_rg_name} \
+                                --name ${vm_name} | jq -r '.id' )
+
+                            # If the target image doesn't exist, the below command
+                            # will not fail because it is idempotent.
+                            az image delete \
+                                --resource-group ${RESOURCE_GROUP} \
+                                --name ${managed_image_name_id}-${img_name_suffix}
+
+                            az image create \
+                                --resource-group ${RESOURCE_GROUP} \
+                                --name ${managed_image_name_id}-${img_name_suffix} \
+                                --hyper-v-generation ${AZURE_IMAGES_MAP[os_series]["generation"]} \
+                                --source \$VM_ID
+                            """
+                        oe.exec_with_retry(10, 30) {
+                            oe.azureEnvironment(capture_script, params.OE_DEPLOY_IMAGE)
+                        }
+                    }
+                }
+
+                stage("${img_name_suffix}-upload") {
+                    timeout(GLOBAL_TIMEOUT_MINUTES) {
+                        def upload_script = """
+                            ${az_login_script}
+
+                            MANAGED_IMG_ID=\$(az image show \
+                                --resource-group ${RESOURCE_GROUP} \
+                                --name ${managed_image_name_id}-${img_name_suffix} \
+                                | jq -r '.id' )
+
+                            # If the target image version doesn't exist, the below
+                            # command will not fail because it is idempotent.
+                            az sig image-version delete \
+                                --resource-group ${RESOURCE_GROUP} \
+                                --gallery-name ${GALLERY_NAME} \
+                                --gallery-image-definition ${img_name_suffix} \
+                                --gallery-image-version ${gallery_image_version}
+
+                            az sig image-version create \
+                                --resource-group ${RESOURCE_GROUP} \
+                                --gallery-name ${GALLERY_NAME} \
+                                --gallery-image-definition ${img_name_suffix} \
+                                --gallery-image-version ${gallery_image_version} \
+                                --managed-image \$MANAGED_IMG_ID \
+                                --target-regions ${env.REPLICATION_REGIONS.split(',').join(' ')} \
+                                --replica-count 1
+                        """
+                        oe.exec_with_retry(10, 30) {                           
+                            oe.azureEnvironment(upload_script, params.OE_DEPLOY_IMAGE)
+                        }
+                    }
+                }
+
+            } finally {
+                stage("${img_name_suffix}-cleanup") {
                     def az_rg_cleanup_script = """
                         ${az_login_script}
                         az group delete --name ${vm_rg_name} --yes
                     """
-                    oe.exec_with_retry(10, 300) {
-                        try {
-                            oe.azureEnvironment(az_rg_create_script, params.OE_DEPLOY_IMAGE)
-                            oe.azureEnvironment(az_build_managed_img_script, params.OE_DEPLOY_IMAGE)
-                        } finally {
-                            oe.azureEnvironment(az_rg_cleanup_script, params.OE_DEPLOY_IMAGE)
-                        }
-                    }
+                    oe.azureEnvironment(az_rg_cleanup_script, params.OE_DEPLOY_IMAGE)
                 }
             }
         }

--- a/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
+++ b/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
@@ -2,11 +2,12 @@
 # Licensed under the MIT License.
 
 ---
+
 - name: Install apt-transport-https APT package
   apt:
     name: apt-transport-https
     state: latest
-  retries: 10
+  retries: 100
   register: add_transport
   until: add_transport is success
 

--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
@@ -22,6 +22,6 @@
     state: latest
     update_cache: yes
     install_recommends: no
-  retries: 10
+  retries: 100
   register: install
   until: install is success


### PR DESCRIPTION
This separates out the Azure Managed Instance image builds into individual stages so that retries can occur at the stage level rather than repeating the entire process.

Minor changes:
* The retry sleep period has been decreased from 5 minutes to 1 minute each try.
* Ansible runs often fail waiting for apt lock from cache updates. The retry limit has been increased to 100 which almost guarantees the lock will be released sometime during the task.

This also sets the stage for some additional work for addition of Ubuntu 20.04 and deprecation of Windows Server 2016.
