### PR TITLE
Wait for other apt processes first

### DIFF
--- a/scripts/ansible/install-ansible.sh
+++ b/scripts/ansible/install-ansible.sh
@@ -7,11 +7,30 @@ set -o errexit
 
 DIR=$(dirname "$0")
 
+function wait-apt-get {
+    i=0
+    echo "Checking for locks..."
+    # Check for locks
+    while fuser /var/lib/dpkg/lock > /dev/null 2>&1 ||
+          fuser /var/lib/dpkg/lock-frontend > /dev/null 2>&1 ||
+          fuser /var/lib/apt/lists/lock > /dev/null 2>&1; do
+        # Wait up to 600 seconds to lock to be released
+        if (( i > 600 )); then
+            echo "Timeout waiting for lock."
+            exit 1
+        fi
+        echo "Waiting for apt/dpkg locks..."
+        i=$((i++))
+        sleep 1
+    done
+    apt-get "${@}"
+}
+
 if which yum > /dev/null; then
     yum install git python3-pip -y
 elif which apt-get > /dev/null; then
-    apt-get update
-    apt-get install libssl-dev libffi-dev python3-pip -y
+    wait-apt-get update
+    wait-apt-get install libssl-dev libffi-dev python3-pip -y
 else
     echo "ERROR: Only these package managers are supported: yum, apt-get"
     exit 1


### PR DESCRIPTION
install-ansible.sh can fail when there is an existing process using apt. This has been happening for a number of E2E tests.

E.g.
```
+ sudo bash scripts/ansible/install-ansible.sh
Hit:1 http://azure.archive.ubuntu.com/ubuntu bionic InRelease
Hit:2 http://azure.archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:3 http://azure.archive.ubuntu.com/ubuntu bionic-backports InRelease
Get:4 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
Fetched 88.7 kB in 0s (257 kB/s)
Reading package lists...
E: Could not get lock /var/lib/dpkg/lock-frontend - open (11: Resource temporarily unavailable)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
script returned exit code 100
```

Signed-off-by: Chris Yan <chrisyan@microsoft.com>