### PR TITLE
Add oe_verify_attestation_certificate_with_evidence_v2()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The OpenEnclave CMake configuration now explicitly sets CMAKE_SKIP_RPATH to TRUE. This change should not affect fully static-linked enclaves.
+- oe_verify_attestation_certificate_with_evidence() has been deprecated because it has been deemed insufficient for security. Use the new, experimental oe_verify_attestation_certificate_with_evidence_v2() instead to generate a self-signed certificate for use in the TLS handshaking process.
 
 [v0.15.0][v0.15.0_log]
 --------------

--- a/common/attest_plugin.c
+++ b/common/attest_plugin.c
@@ -413,10 +413,63 @@ done:
 }
 
 oe_result_t oe_verify_attestation_certificate_with_evidence(
-    uint8_t* cert_in_der,
-    size_t cert_in_der_len,
+    uint8_t* certificate_in_der,
+    size_t certificate_in_der_size,
     oe_verify_claims_callback_t claim_verify_callback,
     void* arg)
+{
+    oe_result_t result = OE_FAILURE;
+    oe_claim_t* claims = NULL;
+    size_t claims_length = 0;
+
+    result = oe_verify_attestation_certificate_with_evidence_v2(
+        certificate_in_der,
+        certificate_in_der_size,
+        NULL,
+        0,
+        NULL,
+        0,
+        &claims,
+        &claims_length);
+
+    if (result != OE_OK)
+        OE_RAISE_MSG(
+            result,
+            "oe_verify_attestation_certificate_with_evidence() failed with "
+            "error = %s\n",
+            oe_result_str(result));
+
+    //---------------------------------------
+    // call client to further check claims
+    // --------------------------------------
+    if (claim_verify_callback)
+    {
+        result = claim_verify_callback(claims, claims_length, arg);
+        OE_CHECK(result);
+        OE_TRACE_VERBOSE("claim_verify_callback() succeeded");
+    }
+    else
+    {
+        OE_TRACE_WARNING(
+            "No claim_verify_callback provided in "
+            "oe_verify_attestation_certificate_with_evidence call",
+            NULL);
+    }
+
+done:
+    oe_free_claims(claims, claims_length);
+    return result;
+}
+
+oe_result_t oe_verify_attestation_certificate_with_evidence_v2(
+    uint8_t* certificate_in_der,
+    size_t certificate_in_der_size,
+    uint8_t* endorsements_buffer,
+    size_t endorsements_buffer_size,
+    oe_policy_t* policies,
+    size_t policies_size,
+    oe_claim_t** claims,
+    size_t* claims_length)
 {
     oe_result_t result = OE_FAILURE;
     oe_cert_t cert = {0};
@@ -425,8 +478,6 @@ oe_result_t oe_verify_attestation_certificate_with_evidence(
     oe_attestation_header_t* header = NULL;
     uint8_t* pub_key_buff = NULL;
     size_t pub_key_buff_size = KEY_BUFF_SIZE;
-    oe_claim_t* claims = NULL;
-    size_t claims_length = 0;
 
     const char* oid_array[] = {
         oid_oe_report, oid_new_oe_report, oid_oe_evidence, oid_new_oe_evidence};
@@ -437,8 +488,9 @@ oe_result_t oe_verify_attestation_certificate_with_evidence(
     if (!pub_key_buff)
         OE_RAISE(OE_OUT_OF_MEMORY);
 
-    result = oe_cert_read_der(&cert, cert_in_der, cert_in_der_len);
-    OE_CHECK_MSG(result, "cert_in_der_len=%d", cert_in_der_len);
+    result =
+        oe_cert_read_der(&cert, certificate_in_der, certificate_in_der_size);
+    OE_CHECK_MSG(result, "certificate_in_der_size=%d", certificate_in_der_size);
 
     // validate the certificate signature
     result = oe_cert_verify(&cert, NULL, NULL, 0);
@@ -504,12 +556,12 @@ oe_result_t oe_verify_attestation_certificate_with_evidence(
             NULL,
             report,
             report_size,
-            NULL,
-            0,
-            NULL,
-            0,
-            &claims,
-            &claims_length);
+            endorsements_buffer,
+            endorsements_buffer_size,
+            policies,
+            policies_size,
+            claims,
+            claims_length);
     }
     else // oid_oe_report or oid_new_oe_report
     {
@@ -519,12 +571,12 @@ oe_result_t oe_verify_attestation_certificate_with_evidence(
             &_uuid_legacy_report_remote,
             report,
             report_size,
-            NULL,
-            0,
-            NULL,
-            0,
-            &claims,
-            &claims_length);
+            endorsements_buffer,
+            endorsements_buffer_size,
+            policies,
+            policies_size,
+            claims,
+            claims_length);
     }
 
     OE_CHECK(result);
@@ -540,30 +592,12 @@ oe_result_t oe_verify_attestation_certificate_with_evidence(
         "oe_cert_write_public_key_pem pub_key_buf_size=%d", pub_key_buff_size);
 
     result = _verify_public_key_claim(
-        claims, claims_length, pub_key_buff, pub_key_buff_size);
+        *claims, *claims_length, pub_key_buff, pub_key_buff_size);
     OE_CHECK(result);
     OE_TRACE_VERBOSE("user data: hash(public key) validation passed", NULL);
 
-    //---------------------------------------
-    // call client to further check claims
-    // --------------------------------------
-    if (claim_verify_callback)
-    {
-        result = claim_verify_callback(claims, claims_length, arg);
-        OE_CHECK(result);
-        OE_TRACE_VERBOSE("claim_verify_callback() succeeded");
-    }
-    else
-    {
-        OE_TRACE_WARNING(
-            "No claim_verify_callback provided in "
-            "oe_verify_attestation_certificate_with_evidence call",
-            NULL);
-    }
-
 done:
     oe_free(pub_key_buff);
-    oe_free_claims(claims, claims_length);
     oe_cert_free(&cert);
     oe_free(report);
     return result;

--- a/include/openenclave/attestation/verifier.h
+++ b/include/openenclave/attestation/verifier.h
@@ -191,23 +191,64 @@ typedef oe_result_t (*oe_verify_claims_callback_t)(
  * validate the claims of the enclave creating the certificate.
  * OE_FAILURE is returned if the expected certificate extension OID is not
  * found.
- * @param[in] cert_in_der a pointer to buffer holding certificate contents
- *  in DER format
- * @param[in] cert_in_der_len size of certificate buffer above
- * @param[in] claim_verify_callback callback routine for custom claim checking
- * @param[in] arg an optional context pointer argument specified by the caller
- * when setting callback
- * @retval OE_OK on a successful validation
- * @retval OE_VERIFY_FAILED on quote failure
- * @retval OE_INVALID_PARAMETER At least one parameter is invalid
- * @retval OE_FAILURE general failure
- * @retval other appropriate error code
+ *
+ * @deprecated
+ *
+ * @param[in] certificate_in_der A pointer to buffer holding certificate
+ * contents in DER format.
+ * @param[in] certificate_in_der_size Size of certificate buffer above.
+ * @param[in] claim_verify_callback Callback routine for custom claim checking.
+ * @param[in] arg An optional context pointer argument specified by the caller
+ * when setting callback.
+ * @retval OE_OK Successful validation.
+ * @retval OE_VERIFY_FAILED Quote failure.
+ * @retval OE_INVALID_PARAMETER One or more invalid parameters.
+ * @retval OE_FAILURE General failure.
+ * @retval Other appropriate error code.
  */
 oe_result_t oe_verify_attestation_certificate_with_evidence(
-    uint8_t* cert_in_der,
-    size_t cert_in_der_len,
+    uint8_t* certificate_in_der,
+    size_t certificate_in_der_size,
     oe_verify_claims_callback_t claim_verify_callback,
     void* arg);
+
+/**
+ * oe_verify_attestation_certificate_with_evidence_v2
+ *
+ * This function performs a custom validation on the input certificate. This
+ * validation includes extracting an attestation evidence extension from the
+ * certificate before validating this evidence. An optional
+ * claim_verify_callback could be passed in for a calling client to further
+ * validate the claims of the enclave creating the certificate.
+ * OE_FAILURE is returned if the expected certificate extension OID is not
+ * found.
+ *
+ * @experimental
+ *
+ * @param[in] certificate_in_der A pointer to buffer holding certificate
+ * contents in DER format.
+ * @param[in] certificate_in_der_size Size of certificate buffer above.
+ * @param[in] endorsements_buffer A pointer to buffer holding endorsements.
+ * @param[in] endorsements_buffer_size Size of the endorsements buffer.
+ * @param[in] policies A pointer to buffer holding policies.
+ * @param[in] policies_size Size of the policies buffer.
+ * @param[out] claims A double-pointer to buffer holding claims.
+ * @param[out] claims_length Size of the claims buffer if not NULL.
+ * @retval OE_OK Successful validation.
+ * @retval OE_VERIFY_FAILED Quote failure.
+ * @retval OE_INVALID_PARAMETER One or more invalid parameters.
+ * @retval OE_FAILURE General failure.
+ * @retval Other appropriate error code.
+ */
+oe_result_t oe_verify_attestation_certificate_with_evidence_v2(
+    uint8_t* certificate_in_der,
+    size_t certificate_in_der_size,
+    uint8_t* endorsements_buffer,
+    size_t endorsements_buffer_size,
+    oe_policy_t* policies,
+    size_t policies_size,
+    oe_claim_t** claims,
+    size_t* claims_length);
 
 /**
  * oe_free_claims

--- a/samples/attested_tls/AttestedTLSREADME.md
+++ b/samples/attested_tls/AttestedTLSREADME.md
@@ -86,7 +86,7 @@ oe_result_t oe_get_attestation_certificate_with_evidence_v2(
 
 Upon receiving a certificate from the peer endpoint, a connecting party needs to perform peer certificate validation.
 
-In this feature, instead of using the TLS API's default authentication routine, which validates the certificate against a pre-determined CAs for authentication, an application needs to conduct "Extended custom certificate validation" inside the peer custom certificate verification callback (cert_verify_callback), which is supported by all the popular TLS APIs.
+In this feature, instead of using the TLS API's default authentication routine, which validates the certificate against a pre-determined CAs for authentication, an application needs to conduct "Extended custom certificate validation" inside the peer custom certificate verification callback (`cert_verify_callback`), which is supported by all the popular TLS APIs.
 
 ```
 For example:
@@ -104,18 +104,17 @@ For example:
 ```
 ##### Custom extended certificate validation
 
-The following four validation steps are performed inside the cert_verify_callback
-  1. Validate certificate
+The following three validation steps are performed inside `cert_verify_callback`:
+  1. Validate certificate.
      - Verify the signature of the self-signed certificate to ascertain that the attestation evidence is genuine and unmodified.
-  2. Validate the evidence
-     - Extract this evidence extension from the certificate
-     - Perform evidence validation
-  3. Validate peer enclave's identity
+  2. Validate the evidence.
+     - Extract this evidence extension from the certificate and perform evidence validation.
+  3. Validate peer enclave's identity.
      - Validate the enclave’s identity (e.g., MRENCLAVE in SGX) against the expected list. This check ensures only the intended party is allowed to connect to.
 
-  A new OE API, oe_verify_attestation_certificate_with_evidence(), was added to perform step 1-2 and leaving step 3 to application for business logic, which can be done inside a caller-registered callback, enclave_identity_callback, a callback parameter to oe_verify_attestation_certificate_with_evidence() call.
+  An OE API, `oe_verify_attestation_certificate_with_evidence()`, was added to perform step 1-2 and leaving step 3 to application for business logic, which can be done inside a caller-registered callback, `enclave_identity_callback`, a callback parameter to `oe_verify_attestation_certificate_with_evidence()` call. The API then calls another OE API, `oe_verify_attestation_certificate_with_evidence_v2()`, which was added in order to take endorsements and policies as input.
 
-  A caller wants to fail cert_verify_callback with non-zero code if either certificate signature validation failed or unexpected TEE identity was found. This failure return will cause the TLS handshaking process to terminate immediately, thus preventing establishing connection with an unqualified connecting party.
+  A caller wants to fail `cert_verify_callback` with non-zero code if either certificate signature validation failed or unexpected TEE identity was found. This failure return will cause the TLS handshaking process to terminate immediately, thus preventing establishing connection with an unqualified connecting party.
 
 ```
 /**

--- a/samples/attested_tls/common/cert_verifier.cpp
+++ b/samples/attested_tls/common/cert_verifier.cpp
@@ -14,7 +14,7 @@
 #include "cert_verify_config.h"
 #include "utility.h"
 
-oe_result_t enclave_claims_verifier_callback(
+oe_result_t claims_verifier_callback(
     oe_claim_t* claims,
     size_t claims_length,
     void* arg);
@@ -50,7 +50,7 @@ int cert_verify_callback(
         goto exit;
 
     result = oe_verify_attestation_certificate_with_evidence(
-        cert_buf, cert_size, enclave_claims_verifier_callback, NULL);
+        cert_buf, cert_size, claims_verifier_callback, NULL);
     if (result != OE_OK)
     {
         printf(

--- a/samples/attested_tls/common/identity_verifier.cpp
+++ b/samples/attested_tls/common/identity_verifier.cpp
@@ -7,7 +7,7 @@
 #include "cert_verify_config.h"
 #include "utility.h"
 
-oe_result_t enclave_claims_verifier_callback(
+oe_result_t claims_verifier_callback(
     oe_claim_t* claims,
     size_t claims_length,
     void* arg)
@@ -18,7 +18,7 @@ oe_result_t enclave_claims_verifier_callback(
     const oe_claim_t* claim;
 
     printf(TLS_ENCLAVE
-           "enclave_claims_verifier_callback is called with enclave "
+           "claims_verifier_callback is called with enclave "
            "identity information extracted from the evidence claims:\n");
 
     // Enclave's security version

--- a/samples/host_verify/README.md
+++ b/samples/host_verify/README.md
@@ -22,7 +22,7 @@ A user can generate a report, an endorsement file or a certificate with `oecert`
 In the main function, if it sees the attribute `-r`, then it will continue to read the next argument to get the report and call `verify_report()` to verify the report.
 Likewise, if it sees the attribute `-c`, then it will continue to read the next argument to get the certificate and call `verify_cert()` to verify the certificate.
 If it sees the attribute `-h`, it will show the usage of this program.
-There is also an `sgx_enclave_claims_verifier()` function, which is called by `verify_cert()` and shows the information of a certificate if you feed it to the program.
+There is also an `enclave_claims_verifier()` function, which is called by `verify_cert()` and shows the information of a certificate if you feed it to the program.
 
 ## Build and run
 

--- a/samples/host_verify/host.c
+++ b/samples/host_verify/host.c
@@ -189,7 +189,7 @@ oe_result_t verify_evidence(
     return result;
 }
 
-oe_result_t sgx_enclave_claims_verifier(
+oe_result_t enclave_claims_verifier(
     oe_claim_t* claims,
     size_t claims_length,
     void* arg)
@@ -197,7 +197,7 @@ oe_result_t sgx_enclave_claims_verifier(
     oe_result_t result = OE_VERIFY_FAILED;
 
     (void)arg;
-    printf("sgx_enclave_claims_verifier is called with claims:\n");
+    printf("enclave_claims_verifier is called with claims:\n");
 
     for (size_t i = 0; i < claims_length; i++)
     {
@@ -240,11 +240,15 @@ oe_result_t verify_cert(const char* filename)
     oe_result_t result = OE_FAILURE;
     size_t cert_file_size = 0;
     uint8_t* cert_data = NULL;
+    uint8_t* endorsements_buffer = NULL;
+    size_t endorsements_buffer_size = 0;
+    oe_policy_t* policies = NULL;
+    size_t policies_size = 0;
 
     if (read_binary_file(filename, &cert_data, &cert_file_size))
     {
         result = oe_verify_attestation_certificate_with_evidence(
-            cert_data, cert_file_size, sgx_enclave_claims_verifier, NULL);
+            cert_data, cert_file_size, enclave_claims_verifier, NULL);
     }
 
     if (cert_data != NULL)

--- a/tests/attestation_cert_apis/enc/enc.cpp
+++ b/tests/attestation_cert_apis/enc/enc.cpp
@@ -66,7 +66,7 @@ done:
 // This is the claims validation callback. A TLS connecting party (client or
 // server) can verify the passed in claims to decide whether to
 // accept a connection request
-oe_result_t sgx_enclave_claims_verifier(
+oe_result_t enclave_claims_verifier(
     oe_claim_t* claims,
     size_t claims_length,
     void* arg)
@@ -74,7 +74,7 @@ oe_result_t sgx_enclave_claims_verifier(
     oe_result_t result = OE_VERIFY_FAILED;
 
     (void)arg;
-    OE_TRACE_INFO("sgx_enclave_claims_verifier is called with claims:\n");
+    OE_TRACE_INFO("enclave_claims_verifier is called with claims:\n");
 
     for (size_t i = 0; i < claims_length; i++)
     {
@@ -236,10 +236,10 @@ oe_result_t get_tls_cert_signed_with_key(
         goto done;
     }
 
-    // validate cert with oe_verify_attestation_certificate_with_evidence() to
-    // ensure that the added report verifier part of the function works well
+    // validate cert with oe_verify_attestation_certificate_with_evidence()
+    // to ensure that the added report verifier part of the function works well
     result = oe_verify_attestation_certificate_with_evidence(
-        output_cert, output_cert_size, sgx_enclave_claims_verifier, nullptr);
+        output_cert, output_cert_size, enclave_claims_verifier, nullptr);
     OE_TRACE_INFO(
         "\nFrom inside enclave: verifying the certificate with "
         "oe_verify_attestation_certificate_with_evidence()... %s\n",

--- a/tests/attestation_plugin_cert/README.md
+++ b/tests/attestation_plugin_cert/README.md
@@ -3,9 +3,9 @@ Certificate based attestation: with evidences
 
 This test validates the following OE public APIs:
 
-* oe_get_attestation_certificate_with_evidence
+* oe_get_attestation_certificate_with_evidence_v2
 * oe_free_attestation_certificate, and
-* oe_verify_attestation_certificate_with_evidence
+* oe_verify_attestation_certificate_with_evidence_v2
 
 Test scenario:
 
@@ -15,6 +15,6 @@ Test scenario:
   3. Once the certificate is received, call oe_verify_attestation_certificate_with_evidence to verify the certificate.
 
 - **Enclave side**
-  1. Implement get_tls_cert(), which calls oe_get_attestation_certificate_with_evidence API to generate a requested certificate
+  1. Implement get_tls_cert(), which calls oe_get_attestation_certificate_with_evidence_v2() API to generate a requested certificate
       based on a given format UUID
-  2. Call oe_verify_attestation_certificate_with_evidence on the generated certificate before returning from get_tls_cert call
+  2. Call oe_verify_attestation_certificate_with_evidence_v2() on the generated certificate before returning from get_tls_cert call

--- a/tests/attestation_plugin_cert/enc/enc.cpp
+++ b/tests/attestation_plugin_cert/enc/enc.cpp
@@ -29,7 +29,7 @@
 // This is the claims validation callback. A TLS connecting party (client or
 // server) can verify the passed in claims to decide whether to
 // accept a connection request
-oe_result_t sgx_enclave_claims_verifier(
+oe_result_t enclave_claims_verifier(
     oe_claim_t* claims,
     size_t claims_length,
     void* arg)
@@ -37,7 +37,7 @@ oe_result_t sgx_enclave_claims_verifier(
     oe_result_t result = OE_VERIFY_FAILED;
 
     (void)arg;
-    OE_TRACE_INFO("sgx_enclave_claims_verifier is called with claims:\n");
+    OE_TRACE_INFO("enclave_claims_verifier is called with claims:\n");
 
     for (size_t i = 0; i < claims_length; i++)
     {
@@ -199,7 +199,7 @@ oe_result_t get_tls_cert_signed_with_key(
     oe_verifier_initialize();
     // validate cert inside the enclave
     result = oe_verify_attestation_certificate_with_evidence(
-        output_cert, output_cert_size, sgx_enclave_claims_verifier, nullptr);
+        output_cert, output_cert_size, enclave_claims_verifier, nullptr);
     OE_TRACE_INFO(
         "\nFrom inside enclave: verifying the certificate... %s\n",
         result == OE_OK ? "Success" : "Fail");

--- a/tests/attestation_plugin_cert/host/host.cpp
+++ b/tests/attestation_plugin_cert/host/host.cpp
@@ -27,7 +27,7 @@
 // This is the claims validation callback. A TLS connecting party (client or
 // server) can verify the passed in claims to decide whether to
 // accept a connection request
-oe_result_t sgx_enclave_claims_verifier(
+oe_result_t enclave_claims_verifier(
     oe_claim_t* claims,
     size_t claims_length,
     void* arg)
@@ -35,7 +35,7 @@ oe_result_t sgx_enclave_claims_verifier(
     oe_result_t result = OE_VERIFY_FAILED;
 
     (void)arg;
-    OE_TRACE_INFO("sgx_enclave_claims_verifier is called with claims:\n");
+    OE_TRACE_INFO("enclave_claims_verifier is called with claims:\n");
 
     for (size_t i = 0; i < claims_length; i++)
     {
@@ -127,7 +127,7 @@ void run_test(oe_enclave_t* enclave, int test_type)
     OE_TRACE_INFO("Host: Verifying tls certificate\n");
     OE_TRACE_INFO("Host: cert = %p cert_size = %d\n", cert, cert_size);
     result = oe_verify_attestation_certificate_with_evidence(
-        cert, cert_size, sgx_enclave_claims_verifier, nullptr);
+        cert, cert_size, enclave_claims_verifier, nullptr);
     OE_TRACE_INFO(
         "Host: Verifying the certificate from a host ... %s\n",
         result == OE_OK ? "Success" : "Fail");

--- a/tools/oeverify/oeverify.c
+++ b/tools/oeverify/oeverify.c
@@ -247,13 +247,13 @@ oe_result_t verify_evidence(
     return result;
 }
 
-oe_result_t sgx_enclave_claims_verifier(
+oe_result_t enclave_claims_verifier(
     oe_claim_t* claims,
     size_t claims_length,
     void* arg)
 {
     (void)arg;
-    fprintf(stdout, "sgx_enclave_claims_verifier is called with claims:\n");
+    fprintf(stdout, "enclave_claims_verifier is called with claims:\n");
     return print_and_verify_claims(claims, claims_length);
 }
 
@@ -266,7 +266,7 @@ oe_result_t verify_cert(const char* filename)
     if (read_binary_file(filename, &cert_data, &cert_file_size))
     {
         result = oe_verify_attestation_certificate_with_evidence(
-            cert_data, cert_file_size, sgx_enclave_claims_verifier, NULL);
+            cert_data, cert_file_size, enclave_claims_verifier, NULL);
     }
 
     if (cert_data != NULL)


### PR DESCRIPTION
Add a new function `oe_verify_attestation_certificate_with_evidence_v2()`, which takes all the parameters of the original `oe_verify_attestation_certificate_with_evidence()` as well as the following additional ones as input:

* `endorsements_buffer`
* `endorsements_buffer_size`
* `policies`
* `policies_size`

Resolve #3856.