### PR TITLE
Added CodeQL Scans

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,7 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+name: "CodeQL config"
+disable-default-queries: true
+queries:
+  - uses: "openenclave/openenclave-security/src/static/codeql/queries/cpp/suites/oe-codeql-security-queries.qls@main"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,46 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+name: "CodeQL"
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        config-file: .github/codeql/codeql-config.yml
+
+    - name: Install Dependencies
+      run: |
+        sudo apt install -y doxygen
+        git submodule update --init --recursive
+
+    - name: Build
+      run: |
+       mkdir build
+       cd build
+       cmake .. -DBUILD_TESTS=OFF
+       make -j8
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
The scan is configured by a [config file](https://github.com/openenclave/openenclave-security/blob/main/src/static/codeql/queries/cpp/suites/oe-codeql-security-queries.qls) on the [openenclave-security repo](https://github.com/openenclave/openenclave-security).

The CodeQL scan is triggered:
- nightly on master
- PRs to master

To minimize the runtime of the Github Action, the Open Enclave SDK is built with the `-DBUILD_TESTS=OFF` flag.