### PR TITLE
[WIP] Deprecate Windows Server 2016

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -17,11 +17,9 @@ AGENTS_LABELS = [
     "acc-ubuntu-18.04": env.UBUNTU_1804_CUSTOM_LABEL ?: "ACC-1804",
     "ubuntu-nonsgx":    env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX",
     "acc-rhel-8":       env.RHEL_8_CUSTOM_LABEL ?: "ACC-RHEL-8",
-    "acc-win2016":      env.WINDOWS_2016_CUSTOM_LABEL ?: "SGX-Windows-2016",
-    "acc-win2016-dcap": env.WINDOWS_2016_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2016-DCAP",
     "acc-win2019":      env.WINDOWS_2019_CUSTOM_LABEL ?: "SGX-Windows-2019",
     "acc-win2019-dcap": env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP",
-    "windows-nonsgx":   env.WINDOWS_NONSGX_CUSTOM_LABEL ?: "nonSGX-Windows"
+    "windows-nonsgx":   env.WINDOWS_NONSGX_CUSTOM_LABEL ?: "nonSGX-Windows-2019"
 ]
 
 properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',

--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -264,6 +264,7 @@ def buildWindowsManagedImage(String os_series, String img_name_suffix, String la
 }
 
 parallel "Build Ubuntu 18.04"              : { buildLinuxManagedImage("ubuntu", "18.04") },
+         "Build Ubuntu 20.04"              : { buildLinuxManagedImage("ubuntu", "20.04") },
          "Build RHEL 8"                    : { buildLinuxManagedImage("rhel", "8") },
          "Build Windows 2016 SGX1"         : { buildWindowsManagedImage("win2016", "ws2016-SGX", "SGX1") },
          "Build Windows 2016 SGX1FLC DCAP" : { buildWindowsManagedImage("win2016", "ws2016-SGX-DCAP", "SGX1FLC") },

--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -266,8 +266,6 @@ def buildWindowsManagedImage(String os_series, String img_name_suffix, String la
 parallel "Build Ubuntu 18.04"              : { buildLinuxManagedImage("ubuntu", "18.04") },
          "Build Ubuntu 20.04"              : { buildLinuxManagedImage("ubuntu", "20.04") },
          "Build RHEL 8"                    : { buildLinuxManagedImage("rhel", "8") },
-         "Build Windows 2016 SGX1"         : { buildWindowsManagedImage("win2016", "ws2016-SGX", "SGX1") },
-         "Build Windows 2016 SGX1FLC DCAP" : { buildWindowsManagedImage("win2016", "ws2016-SGX-DCAP", "SGX1FLC") },
-         "Build Windows 2016 nonSGX"       : { buildWindowsManagedImage("win2016", "ws2016-nonSGX", "SGX1FLC-NoIntelDrivers") },
+         "Build Windows 2019 nonSGX"       : { buildWindowsManagedImage("win2019", "ws2019-nonSGX", "SGX1FLC-NoIntelDrivers") },
          "Build Windows 2019 SGX1"         : { buildWindowsManagedImage("win2019", "ws2019-SGX", "SGX1") },
          "Build Windows 2019 SGX1FLC DCAP" : { buildWindowsManagedImage("win2019", "ws2019-SGX-DCAP", "SGX1FLC") }

--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -23,7 +23,6 @@ AZURE_IMAGES_MAP = [
     ]
 ]
 
-
 def get_image_version() {
     def now = LocalDateTime.now()
     return (now.format(DateTimeFormatter.ofPattern("yyyy")) + "." + \
@@ -35,18 +34,21 @@ def get_image_id() {
     if (params.IMAGE_ID) {
         return params.IMAGE_ID
     }
+    checkout scm
     def last_commit_id = sh(script: "git rev-parse --short HEAD", returnStdout: true).tokenize().last()
     return (get_image_version() + "-" + last_commit_id)
 }
 
+
+
 def buildLinuxManagedImage(String os_type, String version) {
     node(params.AGENTS_LABEL) {
-        stage("${os_type}-${version}") {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def managed_image_name_id = get_image_id()
-                def gallery_image_version = get_image_version()
+        def managed_image_name_id = get_image_id()
+        def gallery_image_version = get_image_version()
+        withEnv(["DOCKER_REGISTRY=${OETOOLS_REPO}",
+            "MANAGED_IMAGE_NAME_ID=${managed_image_name_id}",
+            "GALLERY_IMAGE_VERSION=${gallery_image_version}"]) {
+            stage("${os_type}-${version}-cleanup") {
                 def az_cleanup_existing_image_version_script = """
                     az login --service-principal -u \$SERVICE_PRINCIPAL_ID -p \$SERVICE_PRINCIPAL_PASSWORD --tenant \$TENANT_ID
                     az account set -s \$SUBSCRIPTION_ID
@@ -60,19 +62,19 @@ def buildLinuxManagedImage(String os_type, String version) {
                         --gallery-image-version ${gallery_image_version}
                 """
                 oe.azureEnvironment(az_cleanup_existing_image_version_script, params.OE_DEPLOY_IMAGE)
-                withCredentials([usernamePassword(credentialsId: OETOOLS_REPO_CREDENTIALS_ID,
-                                                  usernameVariable: "DOCKER_USER_NAME",
-                                                  passwordVariable: "DOCKER_USER_PASSWORD"),
-                                usernamePassword(credentialsId: JENKINS_USER_CREDS_ID,
-                                                  usernameVariable: "SSH_USERNAME",
-                                                  passwordVariable: "SSH_PASSWORD")]) {
-                    withEnv(["DOCKER_REGISTRY=${OETOOLS_REPO}",
-                             "MANAGED_IMAGE_NAME_ID=${managed_image_name_id}",
-                             "GALLERY_IMAGE_VERSION=${gallery_image_version}"]) {
+            }
+            stage("${os_type}-${version}-build") {
+                timeout(GLOBAL_TIMEOUT_MINUTES) {
+                    withCredentials([usernamePassword(credentialsId: OETOOLS_REPO_CREDENTIALS_ID,
+                                                    usernameVariable: "DOCKER_USER_NAME",
+                                                    passwordVariable: "DOCKER_USER_PASSWORD"),
+                                    usernamePassword(credentialsId: JENKINS_USER_CREDS_ID,
+                                                    usernameVariable: "SSH_USERNAME",
+                                                    passwordVariable: "SSH_PASSWORD")]) {
                         def cmd = ("packer build -force " +
                                     "-var-file=${WORKSPACE}/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/${os_type}-${version}-variables.json " +
                                     "${WORKSPACE}/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/packer-${os_type}.json")
-                        oe.exec_with_retry(10, 300) {
+                        oe.exec_with_retry(10, 60) {
                             oe.azureEnvironment(cmd, params.OE_DEPLOY_IMAGE)
                         }
                     }
@@ -84,36 +86,42 @@ def buildLinuxManagedImage(String os_type, String version) {
 
 def buildWindowsManagedImage(String os_series, String img_name_suffix, String launch_configuration) {
     node(params.AGENTS_LABEL) {
-        stage(img_name_suffix) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def managed_image_name_id = get_image_id()
-                def gallery_image_version = get_image_version()
-                def vm_rg_name = "build-${managed_image_name_id}-${img_name_suffix}-${BUILD_NUMBER}"
-                def vm_name = "${os_series}-vm"
-                def jenkins_rg_name = params.JENKINS_RESOURCE_GROUP
-                def jenkins_vnet_name = params.JENKINS_VNET_NAME
-                def jenkins_subnet_name = params.JENKINS_SUBNET_NAME
-                def azure_image_id = AZURE_IMAGES_MAP[os_series]["image"]
-                withCredentials([usernamePassword(credentialsId: JENKINS_USER_CREDS_ID,
-                                                  usernameVariable: "JENKINS_USER_NAME",
-                                                  passwordVariable: "JENKINS_USER_PASSWORD")]) {
-                    def az_login_script = """
-                        az login --service-principal -u \$SERVICE_PRINCIPAL_ID -p \$SERVICE_PRINCIPAL_PASSWORD --tenant \$TENANT_ID
-                        az account set -s \$SUBSCRIPTION_ID
-                    """
-                    def az_build_managed_img_script = """
-                        source ${WORKSPACE}/.jenkins/infrastructure/provision/utils.sh
+        withCredentials([usernamePassword(credentialsId: JENKINS_USER_CREDS_ID,
+                                    usernameVariable: "JENKINS_USER_NAME",
+                                    passwordVariable: "JENKINS_USER_PASSWORD")]) {
+            def az_login_script = """
+                az login --service-principal -u \$SERVICE_PRINCIPAL_ID -p \$SERVICE_PRINCIPAL_PASSWORD --tenant \$TENANT_ID
+                az account set -s \$SUBSCRIPTION_ID
+            """
+            def managed_image_name_id = get_image_id()
+            def gallery_image_version = get_image_version()
+            def vm_rg_name = "build-${managed_image_name_id}-${img_name_suffix}-${BUILD_NUMBER}"
+            def vm_name = "${os_series}-vm"
+            def jenkins_rg_name = params.JENKINS_RESOURCE_GROUP
+            def jenkins_vnet_name = params.JENKINS_VNET_NAME
+            def jenkins_subnet_name = params.JENKINS_SUBNET_NAME
+            def azure_image_id = AZURE_IMAGES_MAP[os_series]["image"]
 
+            stage("${img_name_suffix}-prepare") {
+                def az_rg_create_script = """
+                    ${az_login_script}
+                    az group create --name ${vm_rg_name} --location ${REGION}
+                """
+                cleanWs()
+                oe.azureEnvironment(az_rg_create_script, params.OE_DEPLOY_IMAGE)
+            }
+
+            try {
+                stage("${img_name_suffix}-provisioning") {
+                    def provision_script = """
                         ${az_login_script}
 
-                        SUBNET_ID=`az network vnet subnet show \
+                        SUBNET_ID=\$(az network vnet subnet show \
                             --resource-group ${jenkins_rg_name} \
                             --name ${jenkins_subnet_name} \
-                            --vnet-name ${jenkins_vnet_name} --query id -o tsv`
+                            --vnet-name ${jenkins_vnet_name} --query id -o tsv)
 
-                        VM_ID=`az vm create \
+                        az vm create \
                             --resource-group ${vm_rg_name} \
                             --location ${REGION} \
                             --name ${vm_name} \
@@ -122,81 +130,133 @@ def buildWindowsManagedImage(String os_series, String img_name_suffix, String la
                             --subnet \$SUBNET_ID \
                             --admin-username ${JENKINS_USER_NAME} \
                             --admin-password ${JENKINS_USER_PASSWORD} \
-                            --image ${azure_image_id} | jq -r '.id'`
+                            --image ${azure_image_id}
+                    """
+                    oe.azureEnvironment(provision_script, params.OE_DEPLOY_IMAGE)
+                }
 
-                        VM_DETAILS=`az vm show --ids \$VM_ID --show-details`
+                stage("${img_name_suffix}-deploy") {
+                    def deploy_script = """
+                        ${az_login_script}
+
+                        VM_DETAILS=\$(az vm show --resource-group ${vm_rg_name} \
+                                                --name ${vm_name} \
+                                                --show-details)
 
                         az vm run-command invoke \
                             --resource-group ${vm_rg_name} \
                             --name ${vm_name} \
                             --command-id EnableRemotePS
+                        
+                        PRIVATE_IP=\$(echo \$VM_DETAILS | jq -r '.privateIps')
+                        rm -f ${WORKSPACE}/scripts/ansible/inventory/hosts
+                        echo "[windows-agents]" >> ${WORKSPACE}/scripts/ansible/inventory/hosts
+                        echo "\$PRIVATE_IP" >> ${WORKSPACE}/scripts/ansible/inventory/hosts
+                        echo "ansible_user: ${JENKINS_USER_NAME}" >> ${WORKSPACE}/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
+                        echo "ansible_password: ${JENKINS_USER_PASSWORD}" >> ${WORKSPACE}/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
+                        echo "ansible_winrm_transport: ntlm" >> ${WORKSPACE}/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
+                        echo "launch_configuration: ${launch_configuration}" >> ${WORKSPACE}/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
 
-                        PRIVATE_IP=`echo \$VM_DETAILS | jq -r '.privateIps'`
-                        echo "[windows-agents]" > $WORKSPACE/scripts/ansible/inventory/hosts
-                        echo "\$PRIVATE_IP" >> $WORKSPACE/scripts/ansible/inventory/hosts
-                        echo "ansible_user: ${JENKINS_USER_NAME}" > $WORKSPACE/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
-                        echo "ansible_password: ${JENKINS_USER_PASSWORD}" >> $WORKSPACE/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
-                        echo "ansible_winrm_transport: ntlm" >> $WORKSPACE/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
-                        echo "launch_configuration: ${launch_configuration}" >> $WORKSPACE/scripts/ansible/inventory/host_vars/\$PRIVATE_IP
-
-                        cd $WORKSPACE/scripts/ansible
-                        retrycmd_if_failure 5 10 2h ansible-playbook oe-windows-acc-setup.yml
-                        retrycmd_if_failure 5 10 30m ansible-playbook jenkins-packer.yml
+                        cd ${WORKSPACE}/scripts/ansible
+                        source ${WORKSPACE}/.jenkins/infrastructure/provision/utils.sh
+                        ansible-playbook oe-windows-acc-setup.yml
+                        ansible-playbook jenkins-packer.yml
 
                         az vm run-command invoke \
                             --resource-group ${vm_rg_name} \
                             --name ${vm_name} \
                             --command-id RunPowerShellScript \
-                            --scripts @$WORKSPACE/.jenkins/infrastructure/provision/run-sysprep.ps1
-
-                        az vm deallocate --ids \$VM_ID
-                        az vm generalize --ids \$VM_ID
-
-                        # If the target image doesn't exist, the below command
-                        # will not fail because it is idempotent.
-                        az image delete \
-                            --resource-group ${RESOURCE_GROUP} \
-                            --name ${managed_image_name_id}-${img_name_suffix}
-
-                        MANAGED_IMG_ID=`az image create \
-                            --resource-group ${RESOURCE_GROUP} \
-                            --name ${managed_image_name_id}-${img_name_suffix} \
-                            --hyper-v-generation ${AZURE_IMAGES_MAP[os_series]["generation"]} \
-                            --source \$VM_ID | jq -r '.id'`
-
-                        # If the target image version doesn't exist, the below
-                        # command will not fail because it is idempotent.
-                        az sig image-version delete \
-                            --resource-group ${RESOURCE_GROUP} \
-                            --gallery-name ${GALLERY_NAME} \
-                            --gallery-image-definition ${img_name_suffix} \
-                            --gallery-image-version ${gallery_image_version}
-
-                        az sig image-version create \
-                            --resource-group ${RESOURCE_GROUP} \
-                            --gallery-name ${GALLERY_NAME} \
-                            --gallery-image-definition ${img_name_suffix} \
-                            --gallery-image-version ${gallery_image_version} \
-                            --managed-image \$MANAGED_IMG_ID \
-                            --target-regions ${env.REPLICATION_REGIONS.split(',').join(' ')} \
-                            --replica-count 1
+                            --scripts @${WORKSPACE}/.jenkins/infrastructure/provision/run-sysprep.ps1
                     """
-                    def az_rg_create_script = """
-                        ${az_login_script}
-                        az group create --name ${vm_rg_name} --location ${REGION}
-                    """
+                    cleanWs()
+                    checkout scm
+                    oe.exec_with_retry(10, 30) {
+                        oe.azureEnvironment(deploy_script, params.OE_DEPLOY_IMAGE)
+                    }
+                }
+
+
+                stage("${img_name_suffix}-generalize") {
+                    timeout(GLOBAL_TIMEOUT_MINUTES) {
+                        def generalize_script = """
+                            ${az_login_script}
+
+                            az vm deallocate --resource-group ${vm_rg_name} --name ${vm_name}
+                            az vm generalize --resource-group ${vm_rg_name} --name ${vm_name}
+                        """
+                        oe.exec_with_retry(10, 30) {                           
+                            oe.azureEnvironment(generalize_script, params.OE_DEPLOY_IMAGE)
+                        }
+                    }
+                }
+
+                stage("${img_name_suffix}-capture") {
+                    timeout(GLOBAL_TIMEOUT_MINUTES) {
+                        def capture_script = """
+                            ${az_login_script}
+
+                            VM_ID=\$(az vm show \
+                                --resource-group ${vm_rg_name} \
+                                --name ${vm_name} | jq -r '.id' )
+
+                            # If the target image doesn't exist, the below command
+                            # will not fail because it is idempotent.
+                            az image delete \
+                                --resource-group ${RESOURCE_GROUP} \
+                                --name ${managed_image_name_id}-${img_name_suffix}
+
+                            az image create \
+                                --resource-group ${RESOURCE_GROUP} \
+                                --name ${managed_image_name_id}-${img_name_suffix} \
+                                --hyper-v-generation ${AZURE_IMAGES_MAP[os_series]["generation"]} \
+                                --source \$VM_ID
+                            """
+                        oe.exec_with_retry(10, 30) {
+                            oe.azureEnvironment(capture_script, params.OE_DEPLOY_IMAGE)
+                        }
+                    }
+                }
+
+                stage("${img_name_suffix}-upload") {
+                    timeout(GLOBAL_TIMEOUT_MINUTES) {
+                        def upload_script = """
+                            ${az_login_script}
+
+                            MANAGED_IMG_ID=\$(az image show \
+                                --resource-group ${RESOURCE_GROUP} \
+                                --name ${managed_image_name_id}-${img_name_suffix} \
+                                | jq -r '.id' )
+
+                            # If the target image version doesn't exist, the below
+                            # command will not fail because it is idempotent.
+                            az sig image-version delete \
+                                --resource-group ${RESOURCE_GROUP} \
+                                --gallery-name ${GALLERY_NAME} \
+                                --gallery-image-definition ${img_name_suffix} \
+                                --gallery-image-version ${gallery_image_version}
+
+                            az sig image-version create \
+                                --resource-group ${RESOURCE_GROUP} \
+                                --gallery-name ${GALLERY_NAME} \
+                                --gallery-image-definition ${img_name_suffix} \
+                                --gallery-image-version ${gallery_image_version} \
+                                --managed-image \$MANAGED_IMG_ID \
+                                --target-regions ${env.REPLICATION_REGIONS.split(',').join(' ')} \
+                                --replica-count 1
+                        """
+                        oe.exec_with_retry(10, 30) {                           
+                            oe.azureEnvironment(upload_script, params.OE_DEPLOY_IMAGE)
+                        }
+                    }
+                }
+
+            } finally {
+                stage("${img_name_suffix}-cleanup") {
                     def az_rg_cleanup_script = """
                         ${az_login_script}
                         az group delete --name ${vm_rg_name} --yes
                     """
-                    oe.exec_with_retry(10, 300) {
-                        try {
-                            oe.azureEnvironment(az_rg_create_script, params.OE_DEPLOY_IMAGE)
-                            oe.azureEnvironment(az_build_managed_img_script, params.OE_DEPLOY_IMAGE)
-                        } finally {
-                            oe.azureEnvironment(az_rg_cleanup_script, params.OE_DEPLOY_IMAGE)
-                        }
-                    }
+                    oe.azureEnvironment(az_rg_cleanup_script, params.OE_DEPLOY_IMAGE)
                 }
             }
         }

--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -139,6 +139,10 @@ def buildWindowsManagedImage(String os_series, String img_name_suffix, String la
                     def deploy_script = """
                         ${az_login_script}
 
+                        az vm restart \
+                            --resource-group ${vm_rg_name} \
+                            --name ${vm_name}
+
                         VM_DETAILS=\$(az vm show --resource-group ${vm_rg_name} \
                                                 --name ${vm_name} \
                                                 --show-details)

--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -5,7 +5,7 @@ import java.time.*
 import java.time.format.DateTimeFormatter
 
 OECI_LIB_VERSION = env.OECI_LIB_VERSION ?: "master"
-oe = library("OpenEnclaveCommon@${OECI_LIB_VERSION}").jenkins.common.Openenclave.new()
+oe = library("OpenEnclaveCommonCyan@${OECI_LIB_VERSION}").jenkins.common.Openenclave.new()
 
 GLOBAL_TIMEOUT_MINUTES = 480
 

--- a/.jenkins/infrastructure/build_docker_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_docker_images.Jenkinsfile
@@ -27,6 +27,10 @@ def buildDockerImages() {
                 oeminimal1804 = oe.dockerImage("oetools-minimal-18.04:${DOCKER_TAG}", ".jenkins/infrastructure/dockerfiles/Dockerfile.minimal", "${buildArgs} --build-arg ubuntu_version=18.04")
                 puboeminimal1804 = oe.dockerImage("oeciteam/oetools-minimal-18.04:${DOCKER_TAG}", ".jenkins/infrastructure/dockerfiles/Dockerfile.minimal", "${buildArgs} --build-arg ubuntu_version=18.04")
             }
+            stage("Build Ubuntu 20.04 Full Docker Image") {
+                oefull2004 = oe.dockerImage("oetools-full-20.04:${DOCKER_TAG}", ".jenkins/infrastructure/dockerfiles/Dockerfile.full", "${buildArgs} --build-arg ubuntu_version=20.04 --build-arg devkits_uri=${DEVKITS_URI}")
+                puboefull2004 = oe.dockerImage("oeciteam/oetools-full-20.04:${DOCKER_TAG}", ".jenkins/infrastructure/dockerfiles/Dockerfile.full", "${buildArgs} --build-arg ubuntu_version=20.04 --build-arg devkits_uri=${DEVKITS_URI}")
+            }
             stage("Build Ubuntu Deploy Docker image") {
                 oeDeploy = oe.dockerImage("oetools-deploy:${DOCKER_TAG}", ".jenkins/infrastructure/dockerfiles/Dockerfile.deploy", buildArgs)
                 puboeDeploy = oe.dockerImage("oeciteam/oetools-deploy:${DOCKER_TAG}", ".jenkins/infrastructure/dockerfiles/Dockerfile.deploy", buildArgs)
@@ -34,10 +38,12 @@ def buildDockerImages() {
             stage("Push to OE Docker Registry") {
                 docker.withRegistry(OETOOLS_REPO, OETOOLS_REPO_CREDENTIAL_ID) {
                     oe.exec_with_retry { oefull1804.push() }
+                    oe.exec_with_retry { oefull2004.push() }
                     oe.exec_with_retry { oeminimal1804.push() }
                     oe.exec_with_retry { oeDeploy.push() }
                     if(TAG_LATEST == "true") {
                         oe.exec_with_retry { oefull1804.push('latest') }
+                        oe.exec_with_retry { oefull2004.push('latest') }
                         oe.exec_with_retry { oeminimal1804.push('latest') }
                         oe.exec_with_retry { oeDeploy.push('latest') }
                     }
@@ -47,9 +53,11 @@ def buildDockerImages() {
                 docker.withRegistry('', OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID) {
                     if(TAG_LATEST == "true") {
                         oe.exec_with_retry { puboefull1804.push() }
+                        oe.exec_with_retry { puboefull2004.push() }
                         oe.exec_with_retry { puboeminimal1804.push() }
                         oe.exec_with_retry { puboeDeploy.push() }
                         oe.exec_with_retry { puboefull1804.push('latest') }
+                        oe.exec_with_retry { puboefull2004.push('latest') }
                         oe.exec_with_retry { puboeminimal1804.push('latest') }
                         oe.exec_with_retry { puboeDeploy.push('latest') }
                     }

--- a/.jenkins/infrastructure/e2e_testing.Jenkinsfile
+++ b/.jenkins/infrastructure/e2e_testing.Jenkinsfile
@@ -68,8 +68,6 @@ stage("Run tests on new Agents") {
                        string(name: 'UBUNTU_1804_CUSTOM_LABEL', value: env.UBUNTU_1804_LABEL),
                        string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: env.UBUNTU_NONSGX_LABEL),
                        string(name: 'RHEL_8_CUSTOM_LABEL', value: env.RHEL_8_LABEL),
-                       string(name: 'WINDOWS_2016_CUSTOM_LABEL', value: env.WINDOWS_2016_LABEL),
-                       string(name: 'WINDOWS_2016_DCAP_CUSTOM_LABEL', value: env.WINDOWS_2016_DCAP_LABEL),
                        string(name: 'WINDOWS_2019_CUSTOM_LABEL', value: env.WINDOWS_2019_LABEL),
                        string(name: 'WINDOWS_2019_DCAP_CUSTOM_LABEL', value: env.WINDOWS_2019_DCAP_LABEL),
                        string(name: 'WINDOWS_NONSGX_CUSTOM_LABEL', value: env.WINDOWS_NONSGX_LABEL),

--- a/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/ubuntu-20.04-variables.json
+++ b/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/ubuntu-20.04-variables.json
@@ -1,0 +1,11 @@
+{
+    "managed_image_name_suffix": "ubuntu-20.04-SGX",
+    "os_type": "Linux",
+    "gallery_image_name": "ubuntu-20.04",
+    "vm_size": "Standard_DC2s",
+    "ansible_group": "linux-agents",
+    "playbook_file_name": "oe-linux-acc-setup.yml",
+    "base_gallery_image_version": "latest",
+    "base_gallery_image_name": "Ubuntu_2004_LTS_Gen2",
+    "base_gallery_name": "Vanilla_Images"
+}

--- a/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
+++ b/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
@@ -17,9 +17,7 @@ AZURE_IMAGES_MAP = [
     "ubuntu-18.04":    "${env.IMAGE_ID}-ubuntu-18.04-SGX",
     "ubuntu-20.04":    "${env.IMAGE_ID}-ubuntu-20.04-SGX",
     "rhel-8":          "${env.IMAGE_ID}-rhel-8-SGX",
-    "ws2016-nonSGX":   "${env.IMAGE_ID}-ws2016-nonSGX",
-    "ws2016-SGX":      "${env.IMAGE_ID}-ws2016-SGX",
-    "ws2016-SGX-DCAP": "${env.IMAGE_ID}-ws2016-SGX-DCAP",
+    "ws2019-nonSGX":   "${env.IMAGE_ID}-ws2019-nonSGX",
     "ws2019-SGX":      "${env.IMAGE_ID}-ws2019-SGX",
     "ws2019-SGX-DCAP": "${env.IMAGE_ID}-ws2019-SGX-DCAP"
 ]

--- a/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
+++ b/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
@@ -10,11 +10,12 @@ OETOOLS_REPO_NAME = "oejenkinscidockerregistry.azurecr.io"
 OETOOLS_REPO_CREDENTIAL_ID = "oejenkinscidockerregistry"
 OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID = "oeciteamdockerhub"
 
-DOCKER_IMAGES_NAMES = ["oetools-full-18.04", "oetools-minimal-18.04", "oetools-deploy"]
+DOCKER_IMAGES_NAMES = ["oetools-full-18.04", "oetools-full-20.04", "oetools-minimal-18.04", "oetools-deploy"]
 AZURE_IMAGES_MAP = [
     // Mapping between shared gallery image definition name and
     // generated Azure managed image name
     "ubuntu-18.04":    "${env.IMAGE_ID}-ubuntu-18.04-SGX",
+    "ubuntu-20.04":    "${env.IMAGE_ID}-ubuntu-20.04-SGX",
     "rhel-8":          "${env.IMAGE_ID}-rhel-8-SGX",
     "ws2016-nonSGX":   "${env.IMAGE_ID}-ws2016-nonSGX",
     "ws2016-SGX":      "${env.IMAGE_ID}-ws2016-SGX",

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -11,8 +11,6 @@ GLOBAL_ERROR = null
 DOCKER_TAG = env.DOCKER_TAG ?: "latest"
 AGENTS_LABELS = [
     "ubuntu-nonsgx":    env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX",
-    "acc-win2016":      env.WINDOWS_2016_CUSTOM_LABEL ?: "SGX-Windows-2016",
-    "acc-win2016-dcap": env.WINDOWS_2016_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2016-DCAP",
     "acc-win2019":      env.WINDOWS_2019_CUSTOM_LABEL ?: "SGX-Windows-2019",
     "acc-win2019-dcap": env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP"
 ]
@@ -89,18 +87,6 @@ try{
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
-                "Win2016 Ubuntu1804 clang-8 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-8', 'Debug') },
-                "Win2016 Ubuntu1804 clang-8 Release Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-8', 'Release') },
-                "Win2016 Ubuntu1804 clang-8 Debug Linux-Elf-build LVI":   { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-8', 'Debug', 'ControlFlow') },
-                "Win2016 Ubuntu1804 clang-8 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-8', 'Release', 'ControlFlow') },
-                "Win2016 Sim Debug Cross Compile":                        { windowsCrossCompile('acc-win2016', 'Debug', 'OFF', 'None', '1') },
-                "Win2016 Sim Release Cross Compile":                      { windowsCrossCompile('acc-win2016', 'Release','OFF', 'None', '1') },
-                "Win2016 Sim Debug Cross Compile LVI ":                   { windowsCrossCompile('acc-win2016', 'Debug', 'OFF', 'ControlFlow', '1') },
-                "Win2016 Sim Release Cross Compile LVI ":                 { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1') },
-                "Win2016 Debug Cross Compile with DCAP libs":             { windowsCrossCompile('acc-win2016', 'Debug', 'ON') },
-                "Win2016 Release Cross Compile with DCAP libs":           { windowsCrossCompile('acc-win2016', 'Release', 'ON') },
-                "Win2016 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow') },
-                "Win2016 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow') },
                 "Win2019 Ubuntu1804 clang-8 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Debug') },
                 "Win2019 Ubuntu1804 clang-8 Release Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Release') },
                 "Win2019 Ubuntu1804 clang-8 Debug Linux-Elf-build LVI":   { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Debug', 'ControlFlow') },
@@ -114,8 +100,6 @@ try{
                 "Win2019 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow') },
                 "Win2019 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow') },
 
-                "Win2016 Sim Release Cross Compile LVI snmalloc":         { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
-                "Win2016 Release Cross Compile DCAP LVI snmalloc":        { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) },
                 "Win2019 Sim Debug Cross Compile LVI snmalloc":           { windowsCrossCompile('acc-win2019', 'Debug', 'OFF', 'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
                 "Win2019 Release Cross Compile DCAP LVI snmalloc":        { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) }
             ]
@@ -124,10 +108,6 @@ try{
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "Win2016 Ubuntu1804 clang-8 Release Linux-Elf-build LVI":          { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-8', 'Release', 'ControlFlow', 'ON') },
-                "Win2016 Sim Release Cross Compile LVI ":                          { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
-                "Win2016 Debug Cross Compile DCAP LVI":                            { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
-                "Win2016 Release Cross Compile DCAP LVI":                          { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow', '0', 'ON') },
                 "Win2019 Ubuntu1804 clang-8 Release Linux-Elf-build LVI":          { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Release', 'ControlFlow', 'ON') },
                 "Win2019 Sim Release Cross Compile LVI ":                          { windowsCrossCompile('acc-win2019', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
                 "Win2019 Debug Cross Compile DCAP LVI":                            { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },

--- a/scripts/ansible/oe-linux-acc-setup.yml
+++ b/scripts/ansible/oe-linux-acc-setup.yml
@@ -22,6 +22,7 @@
     - import_role:
         name: linux/az-dcap-client
         tasks_from: stable-install.yml
+      when: ansible_distribution_version != "20.04"
 
     - import_role:
         name: linux/openenclave
@@ -38,3 +39,4 @@
     - import_role:
         name: linux/az-dcap-client
         tasks_from: validation.yml
+      when: ansible_distribution_version != "20.04"

--- a/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
+++ b/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 
 ---
+- name: Include distribution vars
+  include_vars:
+    file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
 
 - name: Install apt-transport-https APT package
   apt:

--- a/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
+++ b/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
@@ -2,11 +2,12 @@
 # Licensed under the MIT License.
 
 ---
+
 - name: Install apt-transport-https APT package
   apt:
     name: apt-transport-https
     state: latest
-  retries: 10
+  retries: 100
   register: add_transport
   until: add_transport is success
 

--- a/scripts/ansible/roles/linux/common/tasks/yum-repo.yml
+++ b/scripts/ansible/roles/linux/common/tasks/yum-repo.yml
@@ -2,14 +2,6 @@
 # Licensed under the MIT License.
 
 ---
-- name: Add YUM repository
-  yum:
-    name: "{{ yum_repository_rpm_url }}"
-    state: present
-  retries: 10
-  register: add_yum_repo
-  until: add_yum_repo is success
-
 - name: Add YUM repository key
   rpm_key:
     key: "{{ yum_repository_key_path }}"
@@ -17,3 +9,11 @@
   retries: 10
   register: add_yum_repo_key
   until: add_yum_repo_key is success
+
+- name: Add YUM repository
+  yum:
+    name: "{{ yum_repository_rpm_url }}"
+    state: present
+  retries: 10
+  register: add_yum_repo
+  until: add_yum_repo is success

--- a/scripts/ansible/roles/linux/common/vars/ubuntu/bionic.yml
+++ b/scripts/ansible/roles/linux/common/vars/ubuntu/bionic.yml
@@ -2,4 +2,4 @@
 # Licensed under the MIT License.
 
 ---
-llvm_apt_repository: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-8 main"
+llvm_apt_repository: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-7 main"

--- a/scripts/ansible/roles/linux/common/vars/ubuntu/bionic.yml
+++ b/scripts/ansible/roles/linux/common/vars/ubuntu/bionic.yml
@@ -1,0 +1,5 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+llvm_apt_repository: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-8 main"

--- a/scripts/ansible/roles/linux/common/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/common/vars/ubuntu/focal.yml
@@ -1,0 +1,5 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+llvm_apt_repository: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-12 main"

--- a/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
@@ -38,3 +38,4 @@
 - import_role:
     name: linux/az-dcap-client
     tasks_from: stable-install.yml
+  when: ansible_distribution_version != "20.04"

--- a/scripts/ansible/roles/linux/docker/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/docker/vars/ubuntu/focal.yml
@@ -1,0 +1,14 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+ci_apt_packages:
+  - "automake"
+  - "dh-exec"
+  - "dpkg-dev"
+  - "gawk"
+  - "git"
+  - "libmbedtls12"
+  - "sudo"
+  - "libcurl4"
+  - "libprotobuf17"

--- a/scripts/ansible/roles/linux/intel/tasks/redhat/sgx-driver-requirements.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/redhat/sgx-driver-requirements.yml
@@ -7,7 +7,7 @@
     tasks_from: yum-repo.yml
   vars:
     yum_repository_rpm_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-    yum_repository_key_path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    yum_repository_key_path: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 - name: Install the Intel libsgx package dependencies
   yum:

--- a/scripts/ansible/roles/linux/intel/tasks/ubuntu/sgx-driver-requirements.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/ubuntu/sgx-driver-requirements.yml
@@ -9,3 +9,6 @@
     state: latest
     update_cache: yes
     install_recommends: no
+  retries: 100
+  register: result
+  until: result is succeeded

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/focal.yml
@@ -1,0 +1,8 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.9/linux/distro/ubuntu20.04-server/sgx_linux_x64_driver_1.36.2.bin"
+intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.13/distro/ubuntu20.04-server/sgx_linux_x64_driver_2.11.0_0373e2e.bin"
+intel_sgx_package_dependencies:
+  - "libprotobuf17"

--- a/scripts/ansible/roles/linux/jenkins/tasks/packer.yml
+++ b/scripts/ansible/roles/linux/jenkins/tasks/packer.yml
@@ -41,6 +41,7 @@
     set -o errexit
     docker login {{ docker_registry }} -u {{ docker_user_name }} -p {{ docker_user_password }}
     docker pull {{ docker_registry }}/oetools-full-18.04:{{ docker_tag }}
+    docker pull {{ docker_registry }}/oetools-full-20.04:{{ docker_tag }}
     docker pull {{ docker_registry }}/oetools-minimal-18.04:{{ docker_tag }}
     docker pull {{ docker_registry }}/oetools-deploy:{{ docker_tag }}
   retries: 10

--- a/scripts/ansible/roles/linux/openenclave/tasks/redhat/packages-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/redhat/packages-install.yml
@@ -7,7 +7,7 @@
     tasks_from: yum-repo.yml
   vars:
     yum_repository_rpm_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-    yum_repository_key_path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    yum_repository_key_path: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 - name: Install all the Open Enclave prerequisites YUM packages for development
   yum:

--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
@@ -14,7 +14,7 @@
     tasks_from: apt-repo.yml
   vars:
     apt_key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
-    apt_repository: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-7 main"
+    apt_repository: "{{ llvm_apt_repository }}"
 
 - name: Install all the Open Enclave prerequisites APT packages for development
   apt:

--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
@@ -22,6 +22,6 @@
     state: latest
     update_cache: yes
     install_recommends: no
-  retries: 10
+  retries: 100
   register: install
   until: install is success

--- a/scripts/ansible/roles/linux/openenclave/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/ubuntu/focal.yml
@@ -1,6 +1,6 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
-cryptography==3.3.2
-ansible==2.9.18
-cmake_format==0.6.9
-pywinrm==0.2.1
+
+---
+gcc_target_version: "9.3.0"
+clang_target_version: "8.0.1"

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -428,7 +428,7 @@ function Install-PSW {
         $psw_dir = Get-Item "$tempInstallDir\Intel*SGX*\PSW_INF*\"
         Start-ExecuteWithRetry -RetryInterval 5 -ScriptBlock {
             pnputil /add-driver $psw_dir\sgx_psw.inf /install
-            Get-Service "AESMService"
+            pnputil /enum-drivers
         }
     }
     Start-ExecuteWithRetry -ScriptBlock {


### PR DESCRIPTION
This will deprecate the image builds and CI runs on Windows Server 2016.

nonsgx builds will be moved to Windows Server 2019 as part of this change.

Depends on these being merged first:
https://github.com/openenclave/openenclave/pull/3864
https://github.com/openenclave/openenclave/pull/3829
https://github.com/openenclave/openenclave/pull/3865

Then this will be rebased onto master and the temporary commits will need to be removed