### PR TITLE
Added an optional {-o/--output-file} argument to oesign sign.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - -Wno-<option>: Disable the corresponding warning.
   - -Werror: Turn warnings into errors.
   - -Werror=<option>: Turn the specified warning into an error.
+- oesign sign now allows option -o/--output-file, to specify location to write signature of enclave image.
 
 ### Changed
 - oe_get_attestation_certificate_with_evidence() has been deprecated because it has been deemed insufficient for security. Use the new, experimental oe_get_attestation_certificate_with_evidence_v2() instead to generate a self-signed certificate for use in the TLS handshaking process.

--- a/tests/tools/oesign/test-sign/CMakeLists.txt
+++ b/tests/tools/oesign/test-sign/CMakeLists.txt
@@ -16,7 +16,7 @@ add_custom_target(
 
 # Test oesign succeeds with valid short form of engine signing parameters
 set(OESIGN_SIGN_VALID_SHORT_ARGS
-    "[-c,${OESIGN_TEST_INPUTS_DIR}/valid.conf,-k,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem]"
+    "[-c,${OESIGN_TEST_INPUTS_DIR}/valid.conf,-k,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem,-o,test_enclave.signed]"
 )
 
 add_test(
@@ -32,7 +32,7 @@ set_tests_properties(
 
 # Test oesign succeeds with valid long form of engine signing parameters
 set(OESIGN_SIGN_VALID_LONG_ARGS
-    "[--config-file,${OESIGN_TEST_INPUTS_DIR}/valid.conf,--key-file,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem]"
+    "[--config-file,${OESIGN_TEST_INPUTS_DIR}/valid.conf,--key-file,${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem,--output-file,test_enclave.signed]"
 )
 
 add_test(

--- a/tools/oesign/main.c
+++ b/tools/oesign/main.c
@@ -22,6 +22,7 @@ int oesign(
     const char* conffile,
     const char* keyfile,
     const char* digest_signature,
+    const char* output_file,
     const char* x509,
     const char* engine_id,
     const char* engine_load_path,
@@ -60,6 +61,9 @@ static const char _usage_sign[] =
     "                           certificate used to sign the digest file.\n"
     "  -d, --digest-file        path to the signed digest file matching the\n"
     "                           enclave image and specified configuration.\n"
+    "  -o, --output-file        [optional] file name (with path) where the\n"
+    "                           signature of the enclave image will be\n"
+    "                           written.\n"
 #if HAS_ENGINE_SUPPORT
     "\n"
     "  OR\n"
@@ -285,6 +289,7 @@ int sign_parser(int argc, const char* argv[])
     const char* conffile = NULL;
     const char* keyfile = NULL;
     const char* digest_signature = NULL;
+    const char* output_file = NULL;
     const char* x509 = NULL;
     const char* engine_id = NULL;
     const char* engine_load_path = NULL;
@@ -296,6 +301,7 @@ int sign_parser(int argc, const char* argv[])
         {"config-file", required_argument, NULL, 'c'},
         {"key-file", required_argument, NULL, 'k'},
         {"digest-signature", required_argument, NULL, 'd'},
+        {"output-file", required_argument, NULL, 'o'},
         {"x509", required_argument, NULL, 'x'},
 #if HAS_ENGINE_SUPPORT
         {"engine", required_argument, NULL, 'n'},
@@ -304,7 +310,7 @@ int sign_parser(int argc, const char* argv[])
 #endif
         {NULL, 0, NULL, 0},
     };
-    const char short_options[] = "he:c:k:n:p:i:d:x:";
+    const char short_options[] = "he:c:k:n:p:i:d:o:x:";
 
     int c;
 
@@ -341,6 +347,9 @@ int sign_parser(int argc, const char* argv[])
                 break;
             case 'd':
                 digest_signature = optarg;
+                break;
+            case 'o':
+                output_file = optarg;
                 break;
             case 'x':
                 x509 = optarg;
@@ -429,6 +438,7 @@ int sign_parser(int argc, const char* argv[])
             conffile,
             keyfile,
             digest_signature,
+            output_file,
             x509,
             engine_id,
             engine_load_path,

--- a/tools/oesign/oeinfo.c
+++ b/tools/oesign/oeinfo.c
@@ -52,6 +52,7 @@ static char* _make_signed_lib_name(const char* path)
 
 oe_result_t oe_write_oeinfo_sgx(
     const char* path,
+    const char* output_file,
     const oe_sgx_enclave_properties_t* properties)
 {
     oe_result_t result = OE_FAILURE;
@@ -72,7 +73,11 @@ oe_result_t oe_write_oeinfo_sgx(
 
     /* Write new signed executable */
     {
-        char* p = _make_signed_lib_name(path);
+        char* p;
+        if (output_file != NULL)
+            p = (char*)output_file;
+        else
+            p = _make_signed_lib_name(path);
 
         if (!p)
         {
@@ -102,7 +107,8 @@ oe_result_t oe_write_oeinfo_sgx(
 
         printf("Created %s\n", p);
 
-        free(p);
+        if (output_file == NULL)
+            free(p);
     }
 
     result = OE_OK;

--- a/tools/oesign/oeinfo.h
+++ b/tools/oesign/oeinfo.h
@@ -9,4 +9,5 @@ oe_result_t oe_read_oeinfo_sgx(
 
 oe_result_t oe_write_oeinfo_sgx(
     const char* path,
+    const char* output_file,
     const oe_sgx_enclave_properties_t* properties);

--- a/tools/oesign/oesign.c
+++ b/tools/oesign/oesign.c
@@ -597,6 +597,7 @@ int oesign(
     const char* conffile,
     const char* keyfile,
     const char* digest_signature,
+    const char* output_file,
     const char* x509,
     const char* engine_id,
     const char* engine_load_path,
@@ -713,7 +714,7 @@ int oesign(
 
     /* Create signature section and write out new file */
     OE_CHECK_ERR(
-        oe_write_oeinfo_sgx(enclave, &properties),
+        oe_write_oeinfo_sgx(enclave, output_file, &properties),
         "oe_write_oeinfo_sgx(): result=%s (%#x)",
         oe_result_str(result),
         result);


### PR DESCRIPTION
Fixes  #3281.