### PR TITLE
Add Clang-10 to CI

### DIFF
--- a/scripts/ansible/roles/linux/common/vars/ubuntu/bionic.yml
+++ b/scripts/ansible/roles/linux/common/vars/ubuntu/bionic.yml
@@ -3,3 +3,4 @@
 
 ---
 llvm_apt_repository: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-7 main"
+llvm_apt_repository_10: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-10 main"

--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/lvi-setup.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/lvi-setup.yml
@@ -53,14 +53,14 @@
 
 - name: Create symbolic link to as
   file:
-    src: '{{ local_lvi_directory }}/external/toolset/ubuntu18.04/as'
+    src: '{{ local_lvi_directory }}/external/toolset/ubuntu{{ ansible_distribution_version }}/as'
     dest: '{{ local_lvi_directory }}/bin/as'
     state: link
     force: yes
 
 - name: Create symbolic link to ld
   file:
-    src: '{{ local_lvi_directory }}/external/toolset/ubuntu18.04/ld'
+    src: '{{ local_lvi_directory }}/external/toolset/ubuntu{{ ansible_distribution_version }}/ld'
     dest: '{{ local_lvi_directory }}/bin/ld'
     state: link
     force: yes

--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
@@ -16,6 +16,13 @@
     apt_key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
     apt_repository: "{{ llvm_apt_repository }}"
 
+- include_role:
+    name: linux/common
+    tasks_from: apt-repo.yml
+  vars:
+    apt_key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
+    apt_repository: "{{ llvm_apt_repository_10 }}"
+
 - name: Install all the Open Enclave prerequisites APT packages for development
   apt:
     name: "{{ apt_packages }}"

--- a/scripts/ansible/roles/linux/openenclave/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/ubuntu/main.yml
@@ -33,6 +33,8 @@ apt_packages:
   - "libncurses5-dev"
   - "clang-8"
   - "clang-format-8"
+  - "clang-10"
+  - "clang-format-10"
 
 apt_arm_packages:
   - "gcc-arm-linux-gnueabi"
@@ -49,6 +51,7 @@ apt_arm_packages:
 validation_distribution_binaries:
   - "/usr/bin/shellcheck"
   - "/usr/bin/clang-8"
+  - "/usr/bin/clang-10"
 
 validation_distribution_files:
   - "/usr/lib/x86_64-linux-gnu/libssl.so"


### PR DESCRIPTION
Preemptively add Clang-10 to Ubuntu CI images. There are issues with multiple clang versions on RHEL, and Window; those will be updated once code changes for Clang-10/11 are merged.