### PR TITLE
Install Azure DCAP package on Ubuntu 20.04

### DIFF
--- a/scripts/ansible/oe-linux-acc-setup.yml
+++ b/scripts/ansible/oe-linux-acc-setup.yml
@@ -22,7 +22,6 @@
     - import_role:
         name: linux/az-dcap-client
         tasks_from: stable-install.yml
-      when: ansible_distribution_version != "20.04"
 
     - import_role:
         name: linux/openenclave
@@ -39,4 +38,3 @@
     - import_role:
         name: linux/az-dcap-client
         tasks_from: validation.yml
-      when: ansible_distribution_version != "20.04"

--- a/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
@@ -38,4 +38,3 @@
 - import_role:
     name: linux/az-dcap-client
     tasks_from: stable-install.yml
-  when: ansible_distribution_version != "20.04"


### PR DESCRIPTION
This is to reinstate installation of the Azure DCAP package on Ubuntu 20.04 from repo when it is available.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>