### PR TITLE
Add supported v3 collateral version number

### DIFF
--- a/host/sgx/sgxquoteprovider.c
+++ b/host/sgx/sgxquoteprovider.c
@@ -91,12 +91,12 @@ oe_result_t oe_get_sgx_quote_verification_collateral(
         OE_RAISE(OE_QUOTE_PROVIDER_CALL_ERROR);
     }
 
-    if (collateral->version != SGX_QL_QVE_COLLATERAL_VERSION)
+    if (collateral->version != SGX_QL_QVE_COLLATERAL_VERSION_1 &&
+        collateral->version != SGX_QL_QVE_COLLATERAL_VERSION_3)
     {
         OE_RAISE_MSG(
             OE_INVALID_ENDORSEMENT,
-            "Expected version to be %d, but got %d",
-            SGX_QL_QVE_COLLATERAL_VERSION,
+            "Invalid collateral version %d",
             collateral->version);
     }
 

--- a/host/sgx/sgxquoteprovider.h
+++ b/host/sgx/sgxquoteprovider.h
@@ -31,8 +31,14 @@ typedef struct _oe_sgx_quote_provider
 #define SGX_QL_FREE_QUOTE_VERIFICATION_COLLATERAL_NAME \
     "sgx_ql_free_quote_verification_collateral"
 
-/*! Version of the supported SGX quote verification collateral  */
-#define SGX_QL_QVE_COLLATERAL_VERSION (1)
+/**
+ * Version of the supported SGX quote verification collateral, which will
+ * reflect the version of the PCCS/PCS API used to retrieve the collateral.
+ * For V1 and V2 APIs, the ‘version’ field with have a value of 1.
+ * For V3 APIs, the ‘version’ field will have the value of 3."
+ */
+#define SGX_QL_QVE_COLLATERAL_VERSION_1 (1)
+#define SGX_QL_QVE_COLLATERAL_VERSION_3 (3)
 
 OE_EXTERNC_END
 


### PR DESCRIPTION
According to Intel [SGX ECDSA QuoteLibReference page 20](https://download.01.org/intel-sgx/sgx-dcap/1.10/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf):
"See the sgx_ql_qve_collateral_t definition.
The ‘version’ field of the gx_ql_qve_collateral_t structure will reflect the version of the
PCCS/PCS API used to retrieve the collateral. For V1 and V2 APIs, the ‘version’ field with have
a value of 1. For V3 APIs, the ‘version’ field will have the value of 3."

Current OESDK support v3 collateral. But it only treat 1 as valid collateral version number. Need to be compatible with default SGX QPL.

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>