### PR TITLE
Windows 2016 CI deprecation

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -17,8 +17,6 @@ AGENTS_LABELS = [
     "acc-ubuntu-18.04": env.UBUNTU_1804_CUSTOM_LABEL ?: "ACC-1804",
     "ubuntu-nonsgx":    env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX",
     "acc-rhel-8":       env.RHEL_8_CUSTOM_LABEL ?: "ACC-RHEL-8",
-    "acc-win2016":      env.WINDOWS_2016_CUSTOM_LABEL ?: "SGX-Windows-2016",
-    "acc-win2016-dcap": env.WINDOWS_2016_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2016-DCAP",
     "acc-win2019":      env.WINDOWS_2019_CUSTOM_LABEL ?: "SGX-Windows-2019",
     "acc-win2019-dcap": env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP",
     "windows-nonsgx":   env.WINDOWS_NONSGX_CUSTOM_LABEL ?: "nonSGX-Windows"
@@ -61,8 +59,6 @@ try {
                                   string(name: 'BRANCH_NAME', value: BRANCH_NAME),
                                   string(name: 'DOCKER_TAG', value: DOCKER_TAG),
                                   string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: AGENTS_LABELS["ubuntu-nonsgx"]),
-                                  string(name: 'WINDOWS_2016_CUSTOM_LABEL', value: AGENTS_LABELS["acc-win2016"]),
-                                  string(name: 'WINDOWS_2016_DCAP_CUSTOM_LABEL', value: AGENTS_LABELS["acc-win2016-dcap"]),
                                   string(name: 'WINDOWS_2019_CUSTOM_LABEL', value: AGENTS_LABELS["acc-win2019"]),
                                   string(name: 'WINDOWS_2019_DCAP_CUSTOM_LABEL', value: AGENTS_LABELS["acc-win2019-dcap"]),
                                   string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),

--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -266,8 +266,6 @@ def buildWindowsManagedImage(String os_series, String img_name_suffix, String la
 parallel "Build Ubuntu 18.04"              : { buildLinuxManagedImage("ubuntu", "18.04") },
          "Build Ubuntu 20.04"              : { buildLinuxManagedImage("ubuntu", "20.04") },
          "Build RHEL 8"                    : { buildLinuxManagedImage("rhel", "8") },
-         "Build Windows 2016 SGX1"         : { buildWindowsManagedImage("win2016", "ws2016-SGX", "SGX1") },
-         "Build Windows 2016 SGX1FLC DCAP" : { buildWindowsManagedImage("win2016", "ws2016-SGX-DCAP", "SGX1FLC") },
          "Build Windows 2016 nonSGX"       : { buildWindowsManagedImage("win2016", "ws2016-nonSGX", "SGX1FLC-NoIntelDrivers") },
          "Build Windows 2019 SGX1"         : { buildWindowsManagedImage("win2019", "ws2019-SGX", "SGX1") },
          "Build Windows 2019 SGX1FLC DCAP" : { buildWindowsManagedImage("win2019", "ws2019-SGX-DCAP", "SGX1FLC") }

--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -13,10 +13,6 @@ JENKINS_USER_CREDS_ID = "oeadmin-credentials"
 OETOOLS_REPO = "oejenkinscidockerregistry.azurecr.io"
 OETOOLS_REPO_CREDENTIALS_ID = "oejenkinscidockerregistry"
 AZURE_IMAGES_MAP = [
-    "win2016": [
-        "image": "MicrosoftWindowsServer:WindowsServer:2016-datacenter-gensecond:latest",
-        "generation": "V2"
-    ],
     "win2019": [
         "image": "MicrosoftWindowsServer:WindowsServer:2019-datacenter-gensecond:latest",
         "generation": "V2"
@@ -266,6 +262,6 @@ def buildWindowsManagedImage(String os_series, String img_name_suffix, String la
 parallel "Build Ubuntu 18.04"              : { buildLinuxManagedImage("ubuntu", "18.04") },
          "Build Ubuntu 20.04"              : { buildLinuxManagedImage("ubuntu", "20.04") },
          "Build RHEL 8"                    : { buildLinuxManagedImage("rhel", "8") },
-         "Build Windows 2016 nonSGX"       : { buildWindowsManagedImage("win2016", "ws2016-nonSGX", "SGX1FLC-NoIntelDrivers") },
+         "Build Windows 2019 nonSGX"       : { buildWindowsManagedImage("win2019", "ws2019-nonSGX", "SGX1FLC-NoIntelDrivers") },
          "Build Windows 2019 SGX1"         : { buildWindowsManagedImage("win2019", "ws2019-SGX", "SGX1") },
          "Build Windows 2019 SGX1FLC DCAP" : { buildWindowsManagedImage("win2019", "ws2019-SGX-DCAP", "SGX1FLC") }

--- a/.jenkins/infrastructure/e2e_testing.Jenkinsfile
+++ b/.jenkins/infrastructure/e2e_testing.Jenkinsfile
@@ -68,8 +68,6 @@ stage("Run tests on new Agents") {
                        string(name: 'UBUNTU_1804_CUSTOM_LABEL', value: env.UBUNTU_1804_LABEL),
                        string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: env.UBUNTU_NONSGX_LABEL),
                        string(name: 'RHEL_8_CUSTOM_LABEL', value: env.RHEL_8_LABEL),
-                       string(name: 'WINDOWS_2016_CUSTOM_LABEL', value: env.WINDOWS_2016_LABEL),
-                       string(name: 'WINDOWS_2016_DCAP_CUSTOM_LABEL', value: env.WINDOWS_2016_DCAP_LABEL),
                        string(name: 'WINDOWS_2019_CUSTOM_LABEL', value: env.WINDOWS_2019_LABEL),
                        string(name: 'WINDOWS_2019_DCAP_CUSTOM_LABEL', value: env.WINDOWS_2019_DCAP_LABEL),
                        string(name: 'WINDOWS_NONSGX_CUSTOM_LABEL', value: env.WINDOWS_NONSGX_LABEL),

--- a/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
+++ b/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
@@ -17,9 +17,7 @@ AZURE_IMAGES_MAP = [
     "ubuntu-18.04":    "${env.IMAGE_ID}-ubuntu-18.04-SGX",
     "ubuntu-20.04":    "${env.IMAGE_ID}-ubuntu-20.04-SGX",
     "rhel-8":          "${env.IMAGE_ID}-rhel-8-SGX",
-    "ws2016-nonSGX":   "${env.IMAGE_ID}-ws2016-nonSGX",
-    "ws2016-SGX":      "${env.IMAGE_ID}-ws2016-SGX",
-    "ws2016-SGX-DCAP": "${env.IMAGE_ID}-ws2016-SGX-DCAP",
+    "ws2019-nonSGX":   "${env.IMAGE_ID}-ws2019-nonSGX",,
     "ws2019-SGX":      "${env.IMAGE_ID}-ws2019-SGX",
     "ws2019-SGX-DCAP": "${env.IMAGE_ID}-ws2019-SGX-DCAP"
 ]

--- a/.jenkins/pipelines/Azure/Nightly/Packaging.Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Nightly/Packaging.Jenkinsfile
@@ -54,12 +54,7 @@ try{
          "1804 SGX1FLC Package Release" :            { LinuxPackaging('1804', 'Release') },
          "1804 SGX1FLC Package Release LVI" :        { LinuxPackaging('1804', 'Release', 'ControlFlow') },
          "1804 SGX1FLC Package RelWithDebInfo" :     { LinuxPackaging('1804', 'RelWithDebInfo') },
-         "1804 SGX1FLC Package RelWithDebInfo LVI" : { LinuxPackaging('1804', 'RelWithDebInfo', 'ControlFlow') },
-         "Windows 2016 Debug" :                      { WindowsPackaging('2016','Debug') },
-         "Windows 2016 Debug LVI" :                  { WindowsPackaging('2016','Debug', 'ControlFlow') },
-         "Windows 2016 Release" :                    { WindowsPackaging('2016','Release') },
-         "Windows 2016 Release LVI" :                { WindowsPackaging('2016','Release', 'ControlFlow') },
-         "Windows 2019 Debug" :                      { WindowsPackaging('2019','Debug') },
+         "1804 SGX1FLC Package RelWithDebInfo LVI" : { LinuxPackaging('1804', 'RelWithDebInfo', 'ControlFlow') },"Windows 2019 Debug" :                      { WindowsPackaging('2019','Debug') },
          "Windows 2019 Debug LVI" :                  { WindowsPackaging('2019','Debug', 'ControlFlow') },
          "Windows 2019 Release" :                    { WindowsPackaging('2019','Release') },
          "Windows 2019 Release LVI" :                { WindowsPackaging('2019','Release', 'ControlFlow') }

--- a/.jenkins/pipelines/Azure/Nightly/Packaging.Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Nightly/Packaging.Jenkinsfile
@@ -54,7 +54,8 @@ try{
          "1804 SGX1FLC Package Release" :            { LinuxPackaging('1804', 'Release') },
          "1804 SGX1FLC Package Release LVI" :        { LinuxPackaging('1804', 'Release', 'ControlFlow') },
          "1804 SGX1FLC Package RelWithDebInfo" :     { LinuxPackaging('1804', 'RelWithDebInfo') },
-         "1804 SGX1FLC Package RelWithDebInfo LVI" : { LinuxPackaging('1804', 'RelWithDebInfo', 'ControlFlow') },"Windows 2019 Debug" :                      { WindowsPackaging('2019','Debug') },
+         "1804 SGX1FLC Package RelWithDebInfo LVI" : { LinuxPackaging('1804', 'RelWithDebInfo', 'ControlFlow') },
+         "Windows 2019 Debug" :                      { WindowsPackaging('2019','Debug') },
          "Windows 2019 Debug LVI" :                  { WindowsPackaging('2019','Debug', 'ControlFlow') },
          "Windows 2019 Release" :                    { WindowsPackaging('2019','Release') },
          "Windows 2019 Release LVI" :                { WindowsPackaging('2019','Release', 'ControlFlow') }

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -11,8 +11,6 @@ GLOBAL_ERROR = null
 DOCKER_TAG = env.DOCKER_TAG ?: "latest"
 AGENTS_LABELS = [
     "ubuntu-nonsgx":    env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX",
-    "acc-win2016":      env.WINDOWS_2016_CUSTOM_LABEL ?: "SGX-Windows-2016",
-    "acc-win2016-dcap": env.WINDOWS_2016_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2016-DCAP",
     "acc-win2019":      env.WINDOWS_2019_CUSTOM_LABEL ?: "SGX-Windows-2019",
     "acc-win2019-dcap": env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP"
 ]
@@ -89,19 +87,7 @@ try{
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
-                "Win2016 Ubuntu1804 clang-8 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-8', 'Debug') },
-                "Win2016 Ubuntu1804 clang-8 Release Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-8', 'Release') },
-                "Win2016 Ubuntu1804 clang-8 Debug Linux-Elf-build LVI":   { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-8', 'Debug', 'ControlFlow') },
-                "Win2016 Ubuntu1804 clang-8 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-8', 'Release', 'ControlFlow') },
-                "Win2016 Sim Debug Cross Compile":                        { windowsCrossCompile('acc-win2016', 'Debug', 'OFF', 'None', '1') },
-                "Win2016 Sim Release Cross Compile":                      { windowsCrossCompile('acc-win2016', 'Release','OFF', 'None', '1') },
-                "Win2016 Sim Debug Cross Compile LVI ":                   { windowsCrossCompile('acc-win2016', 'Debug', 'OFF', 'ControlFlow', '1') },
-                "Win2016 Sim Release Cross Compile LVI ":                 { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1') },
-                "Win2016 Debug Cross Compile with DCAP libs":             { windowsCrossCompile('acc-win2016', 'Debug', 'ON') },
-                "Win2016 Release Cross Compile with DCAP libs":           { windowsCrossCompile('acc-win2016', 'Release', 'ON') },
-                "Win2016 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow') },
-                "Win2016 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow') },
-                "Win2019 Ubuntu1804 clang-8 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Debug') },
+               "Win2019 Ubuntu1804 clang-8 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Debug') },
                 "Win2019 Ubuntu1804 clang-8 Release Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Release') },
                 "Win2019 Ubuntu1804 clang-8 Debug Linux-Elf-build LVI":   { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Debug', 'ControlFlow') },
                 "Win2019 Ubuntu1804 clang-8 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Release', 'ControlFlow') },
@@ -114,8 +100,6 @@ try{
                 "Win2019 Debug Cross Compile DCAP LVI":                   { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow') },
                 "Win2019 Release Cross Compile DCAP LVI":                 { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow') },
 
-                "Win2016 Sim Release Cross Compile LVI snmalloc":         { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
-                "Win2016 Release Cross Compile DCAP LVI snmalloc":        { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) },
                 "Win2019 Sim Debug Cross Compile LVI snmalloc":           { windowsCrossCompile('acc-win2019', 'Debug', 'OFF', 'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
                 "Win2019 Release Cross Compile DCAP LVI snmalloc":        { windowsCrossCompile('acc-win2019', 'Release', 'ON', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) }
             ]
@@ -124,10 +108,6 @@ try{
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "Win2016 Ubuntu1804 clang-8 Release Linux-Elf-build LVI":          { windowsLinuxElfBuild('acc-win2016-dcap', '18.04', 'clang-8', 'Release', 'ControlFlow', 'ON') },
-                "Win2016 Sim Release Cross Compile LVI ":                          { windowsCrossCompile('acc-win2016', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
-                "Win2016 Debug Cross Compile DCAP LVI":                            { windowsCrossCompile('acc-win2016', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },
-                "Win2016 Release Cross Compile DCAP LVI":                          { windowsCrossCompile('acc-win2016', 'Release', 'ON', 'ControlFlow', '0', 'ON') },
                 "Win2019 Ubuntu1804 clang-8 Release Linux-Elf-build LVI":          { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Release', 'ControlFlow', 'ON') },
                 "Win2019 Sim Release Cross Compile LVI ":                          { windowsCrossCompile('acc-win2019', 'Release', 'OFF', 'ControlFlow', '1', 'ON') },
                 "Win2019 Debug Cross Compile DCAP LVI":                            { windowsCrossCompile('acc-win2019', 'Debug', 'ON', 'ControlFlow', '0', 'ON') },

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -87,7 +87,7 @@ try{
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
-               "Win2019 Ubuntu1804 clang-8 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Debug') },
+                "Win2019 Ubuntu1804 clang-8 Debug Linux-Elf-build":       { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Debug') },
                 "Win2019 Ubuntu1804 clang-8 Release Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Release') },
                 "Win2019 Ubuntu1804 clang-8 Debug Linux-Elf-build LVI":   { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Debug', 'ControlFlow') },
                 "Win2019 Ubuntu1804 clang-8 Release Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-8', 'Release', 'ControlFlow') },

--- a/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
@@ -6,7 +6,7 @@
  Note: To check if your system has support for SGX1 with or without FLC, please look [here](../SGXSupportLevel.md).
  
 - A version of Windows OS with native support for SGX features:
-   - For server: Windows Server 2016 or 2019
+   - For server: Windows Server 2019
    - For client: Windows 10 64-bit version 1709 or newer
    - To check your Windows version, run `winver` on the command line.
 

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1FLCDCAPPrereqs.md
@@ -2,13 +2,11 @@
 
 ## [Intel Platform Software for Windows (PSW) v2.12]https://registrationcenter-download.intel.com/akdlm/irc_nas/17361/Intel%20SGX%20PSW%20for%20Windows%20v2.12.100.4.exe)
 
-The PSW only needs to be manually installed if you are running on Windows Server
-2016 or a version of Windows client lower than 1709. It should be installed automatically
-with Windows Update on newer versions of Windows client and Windows Server 2019.
+The PSW only needs to be manually installed if you are running a version of Windows client lower than 1709. It should be installed automatically with Windows Update on newer versions of Windows client and Windows Server 2019.
 You can check your version of Windows by running `winver` on the command line.
 Ensure that you have the latest drivers on Windows 10 and Windows Server 2019 by checking for updates and installing all updates.
 
-To install the PSW on Windows Server 2016 and Windows client < 1709, unpack the self-extracting
+To install the PSW on Windows client < 1709, unpack the self-extracting
 ZIP executable, and run the installer under `PSW_EXE_RS2_and_before`:
 
 ```cmd
@@ -77,12 +75,6 @@ The following summary will assume that the contents were extracted to `C:\Intel 
 2. Install or update the drivers:
     - Refer to the PSW section above for notes on acquiring and using `devcon.exe`.
     - Please note that the following commands will be ran from the `C:\Intel SGX DCAP for Windows v1.9.100.3` folder.
-    - On Windows Server 2016, the drivers can be installed using:
-
-      ```cmd
-      devcon.exe install base\WindowsServer2016\sgx_base_dev.inf root\SgxLCDevice
-      devcon.exe install dcap\WindowsServer2016\sgx_dcap_dev.inf root\SgxLCDevice_DCAP
-      ```
 
     - On Windows Server 2019, the drivers can be manually updated using:
 

--- a/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualSGX1Prereqs.md
@@ -2,12 +2,10 @@
 
 ## [Intel Platform Software for Windows (PSW) v2.12]https://registrationcenter-download.intel.com/akdlm/irc_nas/17361/Intel%20SGX%20PSW%20for%20Windows%20v2.12.100.4.exe)
 
-The PSW only needs to be manually installed if you are running on Windows Server
-2016 or a version of Windows client lower than 1709. It should be installed automatically
-with Windows Update on newer versions of Windows client and Windows Server 2019.
+The PSW only needs to be manually installed if you are running on version of Windows client lower than 1709. It should be installed automatically with Windows Update on newer versions of Windows client and Windows Server 2019.
 You can check your version of Windows by running `winver` on the command line.
 
-To install the PSW on Windows Server 2016 and Windows client < 1709, unpack the self-extracting
+To install the PSW on Windows client < 1709, unpack the self-extracting
 ZIP executable, and run the installer under `PSW_EXE_RS2_and_before`:
 
 ```cmd

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
@@ -7,7 +7,7 @@ Intel® X86-64bit architecture with SGX1 and Flexible Launch Control (FLC) suppo
 Note: To check if your system has support for SGX1 with FLC, please look [here](../SGXSupportLevel.md).
 
 A version of Windows OS with native support for SGX features:
-- For server: Windows Server 2016 or 2019
+- For server: Windows Server 2019
 - For client: Windows 10 64-bit version 1709 or newer
 - To check your Windows version, run `winver` from the command line
 

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1GettingStarted.md
@@ -7,7 +7,7 @@ Intel® X86-64bit architecture with SGX1.
 Note: To check if your system has support for SGX1, please look [here](../SGXSupportLevel.md).
 
 A version of Windows OS with native support for SGX features:
-- For server: Windows Server 2016 or 2019
+- For server: Windows Server 2019
 - For client: Windows 10 64-bit version 1709 or newer
 - To check your Windows version, run `winver` from the command line
 

--- a/docs/GettingStartedDocs/Contributors/WindowsSimulatorGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSimulatorGettingStarted.md
@@ -5,7 +5,7 @@
 Intel® X86-64bit architecture
 
 A version of Windows OS :
-- For server: Windows Server 2016 or 2019
+- For server: Windows Server 2019
 - For client: Windows 10 64-bit version 1709 or newer
 - To check your Windows version, run `winver` from the command line
 

--- a/docs/GettingStartedDocs/install_host_verify_Windows.md
+++ b/docs/GettingStartedDocs/install_host_verify_Windows.md
@@ -2,7 +2,7 @@
 
 ## Platform requirements
 
-- Windows 10, Server 2016 or Server 2019
+- Windows 10 or Windows Server 2019
 
 ## Software Prerequisites
 

--- a/docs/GettingStartedDocs/install_oe_sdk-Windows.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Windows.md
@@ -7,7 +7,7 @@
 - Check if your system has support for SGX1 with or without FLC, please look [here](./SGXSupportLevel.md)
     - If your system does not support SGX1+FLC, simulation mode can be used.
 
-- Windows Server 2016 or 2019, or Windows 10 (1709 or newer)
+- Windows Server 2019 or Windows 10 (1709 or newer)
 
 ## Software Prerequisites
 

--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -60,4 +60,4 @@ ansible-playbook jenkins-setup.yml
 * Ubuntu 16.04
 * Ubuntu 18.04
 * Red Hat Enterprise Linux 8
-* Windows Server 2016 (ACC VM)
+* Windows Server 2019 (ACC VM)

--- a/scripts/ansible/inventory/README.md
+++ b/scripts/ansible/inventory/README.md
@@ -5,12 +5,12 @@ Make sure to update the [hosts](/scripts/ansible/inventory/hosts) file with the 
 The hosts targeted by Ansible are grouped into:
 
 * `linux-agents` - represent any Linux (Ubuntu 16.04 and Ubuntu 18.04) to be configured
-* `windows-agents` - represent any Windows Server 2016 ACC machine to be configured
+* `windows-agents` - represent any Windows Server ACC machine to be configured
 
 Ensure that [group_vars](/scripts/ansible/inventory/group_vars) contain the right details to connect to the targeted servers. There are 3 files with global variables applied to the machines:
 
 * `all` - global variables applied to every Ansible targeted machine
 * `linux-agents` - global variables applied only to the Linux machines declared in the [hosts](/scripts/ansible/inventory/hosts) file
-* `windows-agents` - global variables applied only to the Windows Server 2016 ACC machines declared in the [hosts](/scripts/ansible/inventory/hosts) file
+* `windows-agents` - global variables applied only to the Windows Server 2019 ACC machines declared in the [hosts](/scripts/ansible/inventory/hosts) file
 
 If you want to granularly apply configs only to a single Ansible target machine, you need to create a new file under [host_vars](/scripts/ansible/inventory/host_vars) directory. The file name must be the machine address as declared in the [hosts](/scripts/ansible/inventory/hosts) file. For more information on this, see the README from the [host_vars](/scripts/ansible/inventory/host_vars) directory.


### PR DESCRIPTION
This PR deprecates Windows 2016 server support from open enclave SDK
   - Doc changes
   - Removal of CI testing logic
   - Update any non-sgx windows vm's to use 2019 (host verification tests) within ci
   - Removal of Windows server 2016 shared image gallery builders
   
Note: this PR does not deprecate the windows install-windows-prereqs.ps1 script, which will happen in a subsequent PR due to avoiding convolution.