### PR TITLE
Enable oecert to skip verify

### DIFF
--- a/tests/tools/oecert/README.md
+++ b/tests/tools/oecert/README.md
@@ -19,6 +19,7 @@ where Options are:
     --evidence            : generate binary OE evidence.
     --out FILENAME        : specify certificate/report/evidence output filename.
     --endorsements        : specify endorsements output filename.
+    --verify              : verify generated certificate/report/evidence
     --log LOG_FILENAME    : log file name, default: oecert.log
     --verbose             : dump verbose info of evidence
 

--- a/tests/tools/oecert/enc/enc.cpp
+++ b/tests/tools/oecert/enc/enc.cpp
@@ -142,22 +142,24 @@ oe_result_t get_plugin_evidence(
         0,
         &local_evidence,
         &local_evidence_size,
-        &local_endorsements,
-        &local_endorsements_size));
-
+        endorsements ? &local_endorsements : NULL,
+        endorsements ? &local_endorsements_size : 0));
     if (local_evidence_size > evidence_size ||
         local_endorsements_size > endorsements_size)
         return OE_BUFFER_TOO_SMALL;
 
     oe_memcpy_s(evidence, evidence_size, local_evidence, local_evidence_size);
-    oe_memcpy_s(
-        endorsements,
-        endorsements_size,
-        local_endorsements,
-        local_endorsements_size);
-
     *evidence_out_size = local_evidence_size;
-    *endorsements_out_size = local_endorsements_size;
+
+    if (endorsements)
+    {
+        oe_memcpy_s(
+            endorsements,
+            endorsements_size,
+            local_endorsements,
+            local_endorsements_size);
+        *endorsements_out_size = local_endorsements_size;
+    }
 
     OE_CHECK(oe_attester_shutdown());
 
@@ -165,7 +167,8 @@ oe_result_t get_plugin_evidence(
 
 done:
     oe_free_evidence(local_evidence);
-    oe_free_endorsements(local_endorsements);
+    if (local_endorsements)
+        oe_free_endorsements(local_endorsements);
 
     return result;
 }

--- a/tests/tools/oecert/host/evidence.h
+++ b/tests/tools/oecert/host/evidence.h
@@ -45,12 +45,14 @@ oe_result_t generate_oe_report(
     oe_enclave_t* enclave,
     const char* report_filename,
     const char* endorsements_filename,
+    bool verify,
     bool verbose);
 
 oe_result_t generate_oe_evidence(
     oe_enclave_t* enclave,
     const char* evidence_filename,
     const char* endorsements_filename,
+    bool verify,
     bool verbose);
 
 #endif // _SGX_QUOTE


### PR DESCRIPTION
Added new parameter "--verify" to `oecert`.
`oecert` will only verify a generated certificate/report/evidence when `--verify` is passed in.

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>