### PR TITLE
Provide crypto choice from VS extension

### DIFF
--- a/devex/vsextension/ProjectWizard/VCTargets/1033/openenclave-general.xml
+++ b/devex/vsextension/ProjectWizard/VCTargets/1033/openenclave-general.xml
@@ -35,6 +35,16 @@
                   Category="General">
   </StringProperty>
 
+  <EnumProperty Name="CryptoLib"
+                DisplayName="Crypto Library"
+                Description="Crypto Library to link with."
+                Category="General"
+                IsRequired="true"
+                Default="mbedtls">
+    <EnumValue Name="mbedtls" DisplayName="Mbed TLS" />
+    <EnumValue Name="openssl" DisplayName="OpenSSL" />
+  </EnumProperty>
+
   <BoolProperty Name="UseLldLink"
                 DisplayName="Use lld-link"
                 Description="Use lld-link for linking.  If this option is disabled, the Microsoft linker (link.exe) will be used instead."

--- a/devex/vsextension/ProjectWizard/VCTargets/OpenEnclave.Cpp.Clang.targets
+++ b/devex/vsextension/ProjectWizard/VCTargets/OpenEnclave.Cpp.Clang.targets
@@ -273,7 +273,7 @@ that use Clang Front-End.
       <OutDirTrimmed>$(OutDir.TrimEnd({'\\'))</OutDirTrimmed>
     </PropertyGroup>
 
-    <Exec Command='"$(ClangToolExe)" -target x86_64-pc-linux $(ObjectsListSpaced) -o "$(OutDir)$(TargetName).elf" -nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,-pie,--build-id -Wl,-z,noexecstack -Wl,-z,now -Wl,-gc-sections -fuse-ld=lld %(Link.AdditionalOptions) "-L$(OutDirTrimmed)" $(LibsListSpaced) -loeenclave -loelibcxx -loelibc -loecryptombedtls -lmbedtls -lmbedx509 -lmbedcrypto -loelibc -loesyscall -loecore'>
+    <Exec Command='"$(ClangToolExe)" -target x86_64-pc-linux $(ObjectsListSpaced) -o "$(OutDir)$(TargetName).elf" -nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,-pie,--build-id -Wl,-z,noexecstack -Wl,-z,now -Wl,-gc-sections -fuse-ld=lld %(Link.AdditionalOptions) "-L$(OutDirTrimmed)" $(LibsListSpaced) -loeenclave -loelibcxx -loelibc $(CryptoLibs) -loesyscall -loecore'>
     </Exec>
   </Target>
 

--- a/devex/vsextension/msbuild/open-enclave-cross.targets
+++ b/devex/vsextension/msbuild/open-enclave-cross.targets
@@ -81,6 +81,22 @@
         </When>
     </Choose>
 
+    <!-- CryptoLib Shorthands -->
+    <Choose>
+        <When Condition="'$(CryptoLib)' == 'openssl'">
+            <PropertyGroup>
+                <CryptoLibs>-loecryptoopenssl -lopensslssl -lopensslcrypto</CryptoLibs>
+                <CryptoDependencies>oecryptoopenssl;opensslssl;opensslcrypto</CryptoDependencies>
+            </PropertyGroup>
+        </When>
+        <Otherwise>
+            <PropertyGroup>
+                <CryptoLibs>-loecryptombedtls -lmbedtls -lmbedx509 -lmbedcrypto</CryptoLibs>
+                <CryptoDependencies>oecryptombedtls;mbedtls;mbedx509;mbedcrypto</CryptoDependencies>
+            </PropertyGroup>
+        </Otherwise>
+    </Choose>
+
     <!-- TEE Shorthands -->
     <Choose>
         <When Condition="('$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Prerelease' Or '$(Configuration)' == 'Release' Or '$(Configuration)' == 'SGX-Debug') And ($(OEIsX86) == True Or $(OEIsX64) == True)">
@@ -344,7 +360,7 @@
             <IgnoreAllDefaultLibraries Condition="!($(OEIsTz) == True And $(OEIsSim) == True)">True</IgnoreAllDefaultLibraries>
 
             <AdditionalOptions Condition="$(OEIsSgx) == True And $(OEIsLinux) == True">-nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id %(AdditionalOptions)</AdditionalOptions>
-            <LibraryDependencies>oeenclave;mbedx509;mbedcrypto;oelibcxx;oelibc;oecore;%(LibraryDependencies)</LibraryDependencies>
+            <LibraryDependencies>oeenclave;$(CryptoDependencies);oelibcxx;oelibc;oecore;%(LibraryDependencies)</LibraryDependencies>
         </Link>
     </ItemDefinitionGroup>
 


### PR DESCRIPTION
Fixes #3887

Please check if the set of crypto libs is correct.  (This PR is scoped to only the crypto libs, but in general the intent is to move the details to open-enclave-cross.targets, which is updated with the nuget package, and out of OpenEnclave.Cpp.Clang.targets which is only updated with the VS extension.)

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>