### PR TITLE
Windows 2016 Developer set up deprecation

### DIFF
--- a/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
+++ b/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
@@ -17,7 +17,7 @@ AZURE_IMAGES_MAP = [
     "ubuntu-18.04":    "${env.IMAGE_ID}-ubuntu-18.04-SGX",
     "ubuntu-20.04":    "${env.IMAGE_ID}-ubuntu-20.04-SGX",
     "rhel-8":          "${env.IMAGE_ID}-rhel-8-SGX",
-    "ws2019-nonSGX":   "${env.IMAGE_ID}-ws2019-nonSGX",,
+    "ws2019-nonSGX":   "${env.IMAGE_ID}-ws2019-nonSGX",
     "ws2019-SGX":      "${env.IMAGE_ID}-ws2019-SGX",
     "ws2019-SGX-DCAP": "${env.IMAGE_ID}-ws2019-SGX-DCAP"
 ]


### PR DESCRIPTION
This PR deprecates the 2016 installation setup components as the second half of #3905 . As windows, 2019 ~= for Windows 10 in regards to the installation of components with respect to Intel SGX, also tacked on some consolidation to simplify the script.