### PR TITLE
Use latest OE evidence APIs in existing KSS test

### DIFF
--- a/host/sgx/sgxsign.c
+++ b/host/sgx/sgxsign.c
@@ -648,13 +648,13 @@ static oe_result_t _init_sigstruct(
                 sigstruct->isvfamilyid,
                 sizeof(sigstruct->isvfamilyid),
                 family_id,
-                sizeof(*family_id)));
+                sizeof(sigstruct->isvfamilyid)));
         if (extended_product_id)
             OE_CHECK(oe_memcpy_s(
                 sigstruct->isvextprodid,
                 sizeof(sigstruct->isvextprodid),
                 extended_product_id,
-                sizeof(*extended_product_id)));
+                sizeof(sigstruct->isvextprodid)));
         sigstruct->attributemask.flags |= SGX_FLAGS_KSS;
     }
 

--- a/tests/tools/oesign/test-enclave/enclave/enc.c
+++ b/tests/tools/oesign/test-enclave/enclave/enc.c
@@ -1,11 +1,25 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#include <openenclave/attestation/attester.h>
+#include <openenclave/attestation/sgx/evidence.h>
+#include <openenclave/attestation/verifier.h>
 #include <openenclave/internal/hexdump.h>
+#include <openenclave/internal/raise.h>
 #include <openenclave/internal/report.h>
+#include <openenclave/internal/tests.h>
 #include <stdio.h>
 #include <string.h>
 #include "oesign_test_t.h"
+
+/* Null-terminated hex string buffer size with 2 char per byte */
+const size_t OE_KSS_ID_HEX_BUFFER_SIZE = sizeof(oe_uuid_t) * 2 + 1;
+/* Null-terminated hex string buffer size with 2 char per byte and 4 formatting
+ * chars */
+const size_t FORMATTED_OE_KSS_ID_HEX_BUFFER_SIZE =
+    OE_KSS_ID_HEX_BUFFER_SIZE + 4;
+
+static const oe_uuid_t _ecdsa_uuid = {OE_FORMAT_UUID_SGX_ECDSA};
 
 bool is_test_signed()
 {
@@ -54,20 +68,60 @@ bool is_test_signed()
     return is_test_signed;
 }
 
+static void* _find_claim(
+    const oe_claim_t* claims,
+    size_t claims_size,
+    const char* name)
+{
+    for (size_t i = 0; i < claims_size; i++)
+    {
+        // Claim names are case sensitive.
+        if (strcmp(claims[i].name, name) == 0)
+            return claims[i].value;
+    }
+    return NULL;
+}
+
+void formatted_string_from_uuid(
+    uint8_t* uuid,
+    size_t uuid_size,
+    char* formatted_string,
+    size_t formatted_string_size)
+{
+    // Release builds may optimize the oe_assert statement involving
+    // formatted_string_size away
+    OE_UNUSED(formatted_string_size);
+
+    // Expect the formatted_str_id size to be
+    // FORMATTED_OE_KSS_ID_HEX_BUFFER_SIZE
+    oe_assert(formatted_string_size == FORMATTED_OE_KSS_ID_HEX_BUFFER_SIZE);
+
+    char unformatted_string[OE_KSS_ID_HEX_BUFFER_SIZE] = {0};
+
+    oe_hex_string(
+        unformatted_string, OE_KSS_ID_HEX_BUFFER_SIZE, uuid, uuid_size);
+
+    size_t i;
+    size_t k;
+    for (i = k = 0; k < OE_KSS_ID_HEX_BUFFER_SIZE; i++, k++)
+    {
+        if (i == 8 || i == 13 || i == 18 || i == 23)
+            formatted_string[i++] = '-';
+        formatted_string[i] = unformatted_string[k];
+    }
+}
+
 oe_result_t check_kss_extended_ids(
     oe_uuid_t* family_id,
     oe_uuid_t* extended_product_id)
 {
-    /* Null-terminated hex string buffer size with 2 char per byte */
-    const size_t OE_KSS_ID_HEX_BUFFER_SIZE = sizeof(oe_uuid_t) * 2 + 1;
-
     oe_result_t result = OE_UNEXPECTED;
     size_t report_size = OE_MAX_REPORT_SIZE;
     uint8_t* remote_report = NULL;
     oe_report_header_t* header = NULL;
     sgx_quote_t* quote = NULL;
 
-    char isvid_hex[OE_KSS_ID_HEX_BUFFER_SIZE];
+    char formatted_isvid_hex[FORMATTED_OE_KSS_ID_HEX_BUFFER_SIZE];
 
     printf("========== Getting report with KSS feature\n");
 
@@ -90,28 +144,107 @@ oe_result_t check_kss_extended_ids(
         sgx_report_body_t* report_body =
             (sgx_report_body_t*)&quote->report_body;
 
-        oe_hex_string(
-            isvid_hex,
-            OE_KSS_ID_HEX_BUFFER_SIZE,
+        formatted_string_from_uuid(
             report_body->isvfamilyid,
-            sizeof(report_body->isvfamilyid));
-        printf("Enclave ISV Family ID = %s\n", isvid_hex);
+            sizeof(report_body->isvfamilyid),
+            formatted_isvid_hex,
+            sizeof(formatted_isvid_hex));
 
-        oe_hex_string(
-            isvid_hex,
-            OE_KSS_ID_HEX_BUFFER_SIZE,
+        OE_TRACE_INFO(
+            "Enclave ISV Family ID from report = %s\n", formatted_isvid_hex);
+
+        formatted_string_from_uuid(
             report_body->isvextprodid,
-            sizeof(report_body->isvextprodid));
-        printf("Enclave ISV Extended ProductID = %s\n", isvid_hex);
+            sizeof(report_body->isvextprodid),
+            formatted_isvid_hex,
+            sizeof(formatted_isvid_hex));
 
-        if (!memcmp(report_body->isvfamilyid, &family_id, sizeof(oe_uuid_t)) ||
-            !memcmp(
+        OE_TRACE_INFO(
+            "Enclave ISV Extended ProductID from report = %s\n",
+            formatted_isvid_hex);
+
+        if (memcmp(report_body->isvfamilyid, family_id, sizeof(oe_uuid_t)) ||
+            memcmp(
                 report_body->isvextprodid,
-                &extended_product_id,
+                extended_product_id,
                 sizeof(oe_uuid_t)))
             result = OE_REPORT_PARSE_ERROR;
     }
+
+    // Use updated APIs
+    uint8_t* evidence = NULL;
+    size_t evidence_size = 0;
+    oe_claim_t* claims = NULL;
+    size_t claims_length = 0;
+
+    printf("========== Getting evidence with KSS feature\n");
+
+    OE_CHECK(oe_attester_initialize());
+
+    oe_uuid_t selected_format;
+    oe_attester_select_format(&_ecdsa_uuid, 1, &selected_format);
+
+    OE_CHECK(oe_get_evidence(
+        &selected_format,
+        OE_EVIDENCE_FLAGS_EMBED_FORMAT_ID,
+        NULL,
+        0,
+        NULL,
+        0,
+        &evidence,
+        &evidence_size,
+        NULL,
+        0));
+
+    OE_CHECK(oe_verifier_initialize());
+
+    OE_CHECK(oe_verify_evidence(
+        NULL,
+        evidence,
+        evidence_size,
+        NULL,
+        0,
+        NULL,
+        0,
+        &claims,
+        &claims_length));
+
+    oe_uuid_t* is_v_family_id_value;
+    oe_uuid_t* is_v_ext_prod_id_value;
+    is_v_family_id_value = (oe_uuid_t*)_find_claim(
+        claims, claims_length, OE_CLAIM_SGX_ISV_FAMILY_ID);
+    is_v_ext_prod_id_value = (oe_uuid_t*)_find_claim(
+        claims, claims_length, OE_CLAIM_SGX_ISV_EXTENDED_PRODUCT_ID);
+
+    formatted_string_from_uuid(
+        (uint8_t*)is_v_family_id_value,
+        sizeof(oe_uuid_t),
+        formatted_isvid_hex,
+        sizeof(formatted_isvid_hex));
+
+    OE_TRACE_INFO(
+        "Enclave ISV Family ID from evidence = %s", formatted_isvid_hex);
+
+    formatted_string_from_uuid(
+        (uint8_t*)is_v_ext_prod_id_value,
+        sizeof(oe_uuid_t),
+        formatted_isvid_hex,
+        sizeof(formatted_isvid_hex));
+
+    OE_TRACE_INFO(
+        "Enclave ISV Extended ProductID from evidence = %s",
+        formatted_isvid_hex);
+
+    if (memcmp(is_v_family_id_value, family_id, sizeof(oe_uuid_t)) ||
+        memcmp(is_v_ext_prod_id_value, extended_product_id, sizeof(oe_uuid_t)))
+        result = OE_REPORT_PARSE_ERROR;
+
+done:
     oe_free_report(remote_report);
+    OE_CHECK(oe_free_evidence(evidence));
+    OE_CHECK(oe_free_claims(claims, claims_length));
+    OE_CHECK(oe_attester_shutdown());
+    OE_CHECK(oe_verifier_shutdown());
 
     return result;
 }


### PR DESCRIPTION
This PR resolves #3890 by making use of the latest OE evidence APIs to validate claims about recently introduced fields in the `sgx_report_body_t`: `isv_family_id` and `isv_ext_prod_id`.

@yentsanglee 

Signed-off-by: Matthew Boddewyn <mboddewy@microsoft.com>