### PR TITLE
Fix return value of SYS_getcwd

### DIFF
--- a/syscall/syscall.c
+++ b/syscall/syscall.c
@@ -345,7 +345,7 @@ OE_WEAK OE_DEFINE_SYSCALL2(SYS_getcwd)
     }
     else
     {
-        ret = (long)size;
+        ret = (long)oe_strlen(buf) + 1;
     }
 
     return ret;

--- a/tests/syscall/fs/enc/enc.cpp
+++ b/tests/syscall/fs/enc/enc.cpp
@@ -6,6 +6,7 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/print.h>
 #include <openenclave/internal/syscall/device.h>
+#include <openenclave/internal/syscall/sys/syscall.h>
 #include <openenclave/internal/syscall/unistd.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
@@ -826,6 +827,13 @@ void test_fs(const char* src_dir, const char* tmp_dir)
     {
         char buf[OE_PATH_MAX];
         OE_TEST(oe_getcwd(buf, sizeof(buf)));
+        OE_TEST(strcmp(buf, "/") == 0);
+    }
+
+    /* Test SYS_getcwd */
+    {
+        char buf[OE_PATH_MAX];
+        OE_TEST(syscall(OE_SYS_getcwd, buf, sizeof(buf)) == 2);
         OE_TEST(strcmp(buf, "/") == 0);
     }
 


### PR DESCRIPTION
The syscall should return the number of bytes written.