### PR TITLE
fix snmalloc errors and remove forced delay in openssl test cases

### DIFF
--- a/tests/tls_e2e/host/host.cpp
+++ b/tests/tls_e2e/host/host.cpp
@@ -19,13 +19,6 @@
 #include <mutex>
 #include <thread>
 
-#if defined(_WIN32)
-#include <windows.h>
-#define sleep(x) Sleep(1000 * (x))
-#else
-#include <unistd.h>
-#endif
-
 #define SERVER_PORT "12345"
 #define SERVER_IP "127.0.0.1"
 
@@ -342,16 +335,6 @@ int run_scenarios_tests()
                 "This is a %s test case. Expect %s errors\n",
                 (unittests_configs[j].negative_test ? "negative" : "positive"),
                 (unittests_configs[j].negative_test ? "" : "no"));
-
-#ifdef OE_USE_OPENSSL
-            if (j == 1)
-                sleep(90);
-                // This delay is introduced intentionally.
-                // After successful OpenSSL client/server communication, sockets
-                // are staying in TIME_WAIT state for a minute.
-                // https://superuser.com/questions/173535/what-are-close-wait-and-time-wait-states
-                // Issue is observed on ubuntu too.
-#endif
 
             ret = run_test_with_config(&test_configs);
             if (ret)

--- a/tests/tls_e2e/server_enc/mbedtls_server.cpp
+++ b/tests/tls_e2e/server_enc/mbedtls_server.cpp
@@ -387,6 +387,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    512,  /* NumHeapPages */
-    128,  /* NumStackPages */
+    1024, /* NumHeapPages */
+    512,  /* NumStackPages */
     1);   /* NumTCS */

--- a/tests/tls_e2e/server_enc/openssl_server.cpp
+++ b/tests/tls_e2e/server_enc/openssl_server.cpp
@@ -258,6 +258,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    512,  /* NumHeapPages */
-    128,  /* NumStackPages */
+    1024, /* NumHeapPages */
+    512,  /* NumStackPages */
     1);   /* NumTCS */


### PR DESCRIPTION
1) Increases heap size to avoid snmalloc errors
2) Remove delay in openssl test cases 
Signed-off-by: manoj rupireddy <marupire@microsoft.com>