### PR TITLE
Add getrandom support based on oe_random_internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add the initial support of cryptographic module loading in SGX enclaves. Refer to the [design document](docs/DesignDocs/CryptoModuleLoadingSupport.md) for more detail.
+- Add the support of getrandom libc API and syscall in enclaves.
 
 ### Changed
 - The OpenEnclave CMake configuration now explicitly sets CMAKE_SKIP_RPATH to TRUE. This change should not affect fully static-linked enclaves.

--- a/include/openenclave/internal/random.h
+++ b/include/openenclave/internal/random.h
@@ -6,6 +6,10 @@
 
 #include <openenclave/bits/result.h>
 
+/* Flags for use with getrandom.  */
+#define OE_GRND_NONBLOCK 0x01
+#define OE_GRND_RANDOM 0x02
+
 OE_EXTERNC_BEGIN
 
 /**

--- a/include/openenclave/internal/syscall/declarations.h
+++ b/include/openenclave/internal/syscall/declarations.h
@@ -194,6 +194,8 @@ OE_DECLARE_SYSCALL0(SYS_getpgrp);
 #endif
 OE_DECLARE_SYSCALL0(SYS_getpid);
 OE_DECLARE_SYSCALL0(SYS_getppid);
+/* musl getrandom() invokes the syscall via syscall_cp */
+OE_DECLARE_SYSCALL3_M(SYS_getrandom);
 OE_DECLARE_SYSCALL3_M(SYS_getsockname);
 OE_DECLARE_SYSCALL5_M(SYS_getsockopt);
 OE_DECLARE_SYSCALL2(SYS_gettimeofday);

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -238,6 +238,7 @@ add_enclave_library(
   ${MUSLSRC}/locale/textdomain.c
   ${MUSLSRC}/locale/wcscoll.c
   ${MUSLSRC}/locale/wcsxfrm.c
+  ${MUSLSRC}/linux/getrandom.c
   ${MUSLSRC}/linux/mount.c
   ${MUSLSRC}/linux/epoll.c
   ${MUSLSRC}/linux/flock.c

--- a/syscall/syscall.c
+++ b/syscall/syscall.c
@@ -8,6 +8,7 @@
 #include <openenclave/corelibc/stdlib.h>
 #include <openenclave/corelibc/string.h>
 #include <openenclave/internal/print.h>
+#include <openenclave/internal/random.h>
 #include <openenclave/internal/safemath.h>
 #include <openenclave/internal/syscall/device.h>
 #include <openenclave/internal/syscall/dirent.h>
@@ -1067,6 +1068,40 @@ OE_WEAK OE_DEFINE_SYSCALL2(SYS_umount2)
     return oe_umount(target);
 }
 
+OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_getrandom)
+{
+    oe_errno = 0;
+    long ret = -1;
+    void* buf = (void*)arg1;
+    size_t buflen = (size_t)arg2;
+    unsigned int flags = (unsigned int)arg3;
+
+    if (!buf || !buflen)
+    {
+        oe_errno = OE_EINVAL;
+        goto done;
+    }
+
+    /* Maintain the compatibility with the valid flags (though the flags
+     * are not effective) */
+    if (flags && flags != OE_GRND_RANDOM && flags != OE_GRND_NONBLOCK)
+    {
+        oe_errno = OE_EINVAL;
+        goto done;
+    }
+
+    if (oe_random_internal(buf, buflen) != OE_OK)
+    {
+        oe_errno = OE_EAGAIN;
+        goto done;
+    }
+
+    ret = (long)buflen;
+
+done:
+    return ret;
+}
+
 static long _syscall(
     long number,
     long arg1,
@@ -1190,6 +1225,7 @@ static long _syscall(
 #endif
         OE_SYSCALL_DISPATCH(SYS_unlinkat, arg1, arg2, arg3);
         OE_SYSCALL_DISPATCH(SYS_umount2, arg1, arg2);
+        OE_SYSCALL_DISPATCH(SYS_getrandom, arg1, arg2, arg3);
     }
 
     oe_errno = OE_ENOSYS;

--- a/tests/syscall/CMakeLists.txt
+++ b/tests/syscall/CMakeLists.txt
@@ -2,6 +2,11 @@
 # Licensed under the MIT License.
 
 add_subdirectory(cpio)
+# Though getrandom is a Linux-specific syscall, OE supports it
+# based on the TEE-specific rand API (i.e., oe_random_internal).
+# Therefore, the in-enclave getrandom should work on both Linux
+# and Windows.
+add_subdirectory(getrandom)
 add_subdirectory(resolver)
 add_subdirectory(socket)
 add_subdirectory(tool)

--- a/tests/syscall/README.md
+++ b/tests/syscall/README.md
@@ -4,6 +4,7 @@ Test for SYSCALL feature
 This directory contains tests for the Open Enclave SYSCALL feature, including:
 
 - dup - tests the dup() function.
+- getrandom - test for the getrandom SYSCALL.
 - fs - file system tests.
 - hostfs - host file system tests.
 - ids - tests the getuid(), getgid(), etc.

--- a/tests/syscall/getrandom/CMakeLists.txt
+++ b/tests/syscall/getrandom/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/getrandom getrandom_host getrandom_enc)

--- a/tests/syscall/getrandom/enc/CMakeLists.txt
+++ b/tests/syscall/getrandom/enc/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../getrandom.edl)
+
+add_custom_command(
+  OUTPUT getrandom_t.h getrandom_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(TARGET getrandom_enc SOURCES enc.c
+            ${CMAKE_CURRENT_BINARY_DIR}/getrandom_t.c)
+enclave_include_directories(getrandom_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+maybe_build_using_clangw(getrandom_enc)
+enclave_link_libraries(getrandom_enc oelibc oeenclave)

--- a/tests/syscall/getrandom/enc/enc.c
+++ b/tests/syscall/getrandom/enc/enc.c
@@ -1,0 +1,43 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <openenclave/enclave.h>
+#include <openenclave/internal/print.h>
+#include <openenclave/internal/syscall/sys/syscall.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <sys/random.h>
+
+#include "getrandom_t.h"
+
+void test_getrandom()
+{
+    /* Test getrandom SYSCALL via the libc API */
+    char buf[256];
+    size_t buflen = 256;
+    ssize_t size;
+
+    /* Test with the zero flags */
+    size = getrandom((void*)buf, sizeof(buflen), 0);
+    OE_TEST((size_t)size == sizeof(buflen));
+
+    /* Test with valid flags */
+    size = getrandom((void*)buf, sizeof(buflen), GRND_RANDOM);
+    OE_TEST((size_t)size == sizeof(buflen));
+    size = getrandom((void*)buf, sizeof(buflen), GRND_NONBLOCK);
+    OE_TEST((size_t)size == sizeof(buflen));
+
+    /* Test with invalid flags */
+    OE_TEST(getrandom((void*)buf, sizeof(buflen), 3) == -1);
+    OE_TEST(errno == EINVAL);
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    512,  /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/syscall/getrandom/getrandom.edl
+++ b/tests/syscall/getrandom/getrandom.edl
@@ -1,0 +1,16 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public void test_getrandom();
+    };
+};

--- a/tests/syscall/getrandom/host/CMakeLists.txt
+++ b/tests/syscall/getrandom/host/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../getrandom.edl)
+
+add_custom_command(
+  OUTPUT getrandom_u.h getrandom_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(getrandom_host host.c getrandom_u.c)
+
+target_include_directories(getrandom_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(getrandom_host oehost)

--- a/tests/syscall/getrandom/host/host.c
+++ b/tests/syscall/getrandom/host/host.c
@@ -1,0 +1,38 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include "getrandom_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result = OE_UNEXPECTED;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    result = oe_create_getrandom_enclave(
+        argv[1], OE_ENCLAVE_TYPE_AUTO, flags, NULL, 0, &enclave);
+    if (result != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    result = test_getrandom(enclave);
+    if (result != OE_OK)
+        oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (getrandom)\n");
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds the support the `getrandom` (both libc API and the syscall) and the test. Although the syscall is Linux-specific, OE supports the API (and the syscall) based on the TEE-specific rand API (`oe_random_internal`) to get the random bytes. Therefore, the support of the API/syscall inside the enclave is platform-agnostic.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>