### PR TITLE
Use the github mirror of musl as submodule to avoid using git protocols

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,7 +29,8 @@
 	url = https://github.com/intel/intel-sgx-ssl
 [submodule "3rdparty/musl/musl"]
 	path = 3rdparty/musl/musl
-	url = git://git.musl-libc.org/musl
+	url = https://github.com/openenclave/openenclave-musl.git
+	branch = openenclave-musl-1.1.21
 [submodule "3rdparty/musl/libc-test"]
 	path = 3rdparty/musl/libc-test
-	url = git://repo.or.cz/libc-test.git
+	url = https://repo.or.cz/libc-test.git

--- a/3rdparty/musl/README.md
+++ b/3rdparty/musl/README.md
@@ -4,14 +4,15 @@ musl libc
 This directory contains the musl libc library and the accompanying libc-test test
 suite. The structure of the directory is as follows.
 
-- musl/ (tag: `v1.1.21`)
+- musl/ (branch: `openenclave-musl-1.1.21`)
 
-  The clone of musl libc that is included as a git submodule, which points to
-  a recent release tag. To update the submodule, we use the following procedure:
-  - Checkout the tag that we want to update to.
+  The clone of musl libc mirror (hosted under the openenclave github organization) that
+  is included as a git submodule, which points to a branch corresponding to a musl's release tag.
+  To update the submodule, we use the following procedure:
+  - Checkout the tag that we want to update to (assume the mirror has the corresponding branch)
     ```
     cd musl
-    git checkout <new tag>
+    git checkout <openenclave-musl-1.x.x>
     ```
   - Check the diff between the tag and the previous tag and update the <openenclave-root>/libc/ correspondingly.
     ```


### PR DESCRIPTION
This PR avoids the use of git protocols (which lack authentication) to fetch submodules. Currently, musl does not officially host a non-git server so we make a mirror of it under the openenclave organization (https://github.com/openenclave/openenclave-musl), similar to https://github.com/openenclave/openenclave-mbedtls.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>