### PR TITLE
Explicitly disable the use of getrandom flags in OE

### DIFF
--- a/include/openenclave/internal/random.h
+++ b/include/openenclave/internal/random.h
@@ -6,10 +6,6 @@
 
 #include <openenclave/bits/result.h>
 
-/* Flags for use with getrandom.  */
-#define OE_GRND_NONBLOCK 0x01
-#define OE_GRND_RANDOM 0x02
-
 OE_EXTERNC_BEGIN
 
 /**

--- a/syscall/syscall.c
+++ b/syscall/syscall.c
@@ -1076,15 +1076,8 @@ OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_getrandom)
     size_t buflen = (size_t)arg2;
     unsigned int flags = (unsigned int)arg3;
 
-    if (!buf || !buflen)
-    {
-        oe_errno = OE_EINVAL;
-        goto done;
-    }
-
-    /* Maintain the compatibility with the valid flags (though the flags
-     * are not effective) */
-    if (flags && flags != OE_GRND_RANDOM && flags != OE_GRND_NONBLOCK)
+    /* Flags (e.g., GRND_RANDOM and GRND_NONBLOCK) are not supported. */
+    if (!buf || !buflen || flags)
     {
         oe_errno = OE_EINVAL;
         goto done;

--- a/tests/syscall/getrandom/enc/enc.c
+++ b/tests/syscall/getrandom/enc/enc.c
@@ -19,18 +19,14 @@ void test_getrandom()
     size_t buflen = 256;
     ssize_t size;
 
-    /* Test with the zero flags */
+    /* Test with the zero flags (required by OE) */
     size = getrandom((void*)buf, sizeof(buflen), 0);
     OE_TEST((size_t)size == sizeof(buflen));
 
-    /* Test with valid flags */
-    size = getrandom((void*)buf, sizeof(buflen), GRND_RANDOM);
-    OE_TEST((size_t)size == sizeof(buflen));
-    size = getrandom((void*)buf, sizeof(buflen), GRND_NONBLOCK);
-    OE_TEST((size_t)size == sizeof(buflen));
-
-    /* Test with invalid flags */
-    OE_TEST(getrandom((void*)buf, sizeof(buflen), 3) == -1);
+    /* Test with unsupported flags */
+    OE_TEST(getrandom((void*)buf, sizeof(buflen), GRND_RANDOM) == -1);
+    OE_TEST(errno == EINVAL);
+    OE_TEST(getrandom((void*)buf, sizeof(buflen), GRND_NONBLOCK) == -1);
     OE_TEST(errno == EINVAL);
 }
 


### PR DESCRIPTION
The flags of getrandom are not implemented/supported in OE. Explicitly return failure when the flags are set. 

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>