### PR TITLE
Environment to enable out of proc attestation for SGX

### DIFF
--- a/.jenkins/infrastructure/dockerfiles/linux/Dockerfile.full
+++ b/.jenkins/infrastructure/dockerfiles/linux/Dockerfile.full
@@ -45,6 +45,11 @@
 # the oejenkinscidockerregistry Container registry in Azure at this link,
 # assuming you have proper permissions:
 # https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/e5839dfd-61f0-4b2f-b06f-de7fc47b5998/resourceGroups/OE-Jenkins-CI/providers/Microsoft.ContainerRegistry/registries/oejenkinscidockerregistry/overview
+#
+# This image includes out-of-proc attestation using Intel SGX by default.
+# To allow this, the Intel SGX AESM Service will need to be made available by creating the container with the following parameter:
+#   --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
+# 
 
 ARG ubuntu_version=18.04
 
@@ -78,3 +83,6 @@ RUN echo "${UNAME} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 # Setup devkit
 RUN curl ${devkits_uri} | tar xvz --no-same-permissions --no-same-owner
 RUN echo ${devkits_uri##*/} > /devkits/TARBALL
+
+# Set up out-of-proc attestation
+ENV SGX_AESM_ADDR=1

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -110,7 +110,7 @@ def ACCContainerTest(String label, String version, List extra_cmake_args = []) {
                            ninja -v
                            ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
                            """
-                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx")
+                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
             }
         }
     }
@@ -149,7 +149,7 @@ def ACCPackageTest(String label, String version, List extra_cmake_args = []) {
                                fi
                            done
                            """
-                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx")
+                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
             }
         }
     }
@@ -180,7 +180,7 @@ def ACCHostVerificationTest(String version, String build_type) {
                            ../../tools/oecert/oecert --evidence --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
                            popd
                            """
-                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx")
+                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
 
                 def ec_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_ec.der'
                 def rsa_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_rsa.der'
@@ -275,7 +275,7 @@ def ACCHostVerificationPackageTest(String version, String build_type) {
                            ../../tools/oecert/oecert --evidence --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
                            popd
                            """
-                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx")
+                oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
 
                 def ec_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_ec.der'
                 def rsa_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_rsa.der'

--- a/scripts/ansible/roles/linux/docker/tasks/redhat/stable-install.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/redhat/stable-install.yml
@@ -2,6 +2,12 @@
 # Licensed under the MIT License.
 
 ---
+# Runc conflicts with Docker installation
+- name: Uninstall runc if present
+  yum:
+    name: runc
+    state: absent
+
 - name: Enable Docker CE stable repository
   get_url:
     url: https://download.docker.com/linux/centos/docker-ce.repo

--- a/scripts/ansible/roles/linux/docker/vars/redhat/main.yml
+++ b/scripts/ansible/roles/linux/docker/vars/redhat/main.yml
@@ -3,7 +3,7 @@
 
 ---
 docker_packages:
-  - "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.4.3-3.1.el7.x86_64.rpm"
+  - "https://download.docker.com/linux/centos/8/x86_64/stable/Packages/containerd.io-1.4.4-3.1.el8.x86_64.rpm"
   - "docker-ce"
 
 docker_target_version: "18.06"

--- a/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
@@ -57,3 +57,9 @@
     state: started
     enabled: yes
   when: "'aesmd.service' in ansible_facts.services"
+
+- name: Set out-of-proc attestation by default
+  lineinfile:
+    path: /etc/environment
+    state: present
+    line: SGX_AESM_ADDR=1


### PR DESCRIPTION
This sets the environment for enabling out-of-proc attestation by default by ensuring availability of the AESM service and by setting SGX_AESM_ADDR=1. In-proc attestation can used by unsetting SGX_AESM_ADDR.

Notes:
- This PR includes upstream changes from https://github.com/openenclave/openenclave/pull/3920 which should be merged first.
- libsgx-quote-ex is installed as part of Ansible changes in another PR by Ryan: https://github.com/openenclave/openenclave/pull/3882
- Docker run commands needs /var/run/aesmd/aesm.socket to be made available to the container:
  For example: `--volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket`
- This also fixes a RHEL 8 build issue where an out-of-date Docker package could no longer be installed.

Signed-off-by: Chris Yan chrisyan@microsoft.com
