### PR TITLE
oegdb: Implement Multi-Module support

### DIFF
--- a/host/sgx/enclave.h
+++ b/host/sgx/enclave.h
@@ -125,6 +125,7 @@ typedef struct _oe_enclave
 
     /* Meta-data needed by debugrt  */
     oe_debug_enclave_t* debug_enclave;
+    oe_debug_module_t* debug_modules;
 
     /* Manager for switchless calls */
     oe_switchless_call_manager_t* switchless_manager;

--- a/host/sgx/windows/debugrtbridge.c
+++ b/host/sgx/windows/debugrtbridge.c
@@ -17,6 +17,8 @@ static struct
         oe_debug_enclave_t* enclave,
         struct _sgx_tcs* tcs);
     oe_result_t (*pop_thread_binding)(void);
+    oe_result_t (*notify_module_loaded)(oe_debug_module_t* module);
+    oe_result_t (*notify_module_unloaded)(oe_debug_module_t* module);
 } _oedebugrt;
 
 static void get_debugrt_function(const char* name, FARPROC* out)
@@ -60,6 +62,12 @@ static void load_oedebugrt(void)
         get_debugrt_function(
             "oe_debug_pop_thread_binding",
             (FARPROC*)&_oedebugrt.pop_thread_binding);
+        get_debugrt_function(
+            "oe_debug_notify_module_loaded",
+            (FARPROC*)&_oedebugrt.notify_module_loaded);
+        get_debugrt_function(
+            "oe_debug_notify_module_unloaded",
+            (FARPROC*)&_oedebugrt.notify_module_unloaded);
 
         OE_TRACE_INFO(
             "oedebugrtbridge: Loaded oedebugrt.dll. Debugging is available.\n");
@@ -119,6 +127,22 @@ oe_result_t oe_debug_pop_thread_binding()
 {
     if (_oedebugrt.pop_thread_binding)
         return _oedebugrt.pop_thread_binding();
+
+    return OE_OK;
+}
+
+oe_result_t oe_debug_notify_module_loaded(oe_debug_module_t* module)
+{
+    if (_oedebugrt.notify_module_loaded)
+        return _oedebugrt.notify_module_loaded(module);
+
+    return OE_OK;
+}
+
+oe_result_t oe_debug_notify_module_unloaded(oe_debug_module_t* module)
+{
+    if (_oedebugrt.notify_module_unloaded)
+        return _oedebugrt.notify_module_unloaded(module);
 
     return OE_OK;
 }

--- a/include/openenclave/internal/debugrt/common.h
+++ b/include/openenclave/internal/debugrt/common.h
@@ -102,8 +102,7 @@ oe_debug_notify_module_unloaded(oe_debug_module_t* module);
  * module. This can happen if the debugger is attached after the module has been
  * added to the list of modules, but before the hook function is called.
  */
-OE_DEBUGRT_EXPORT oe_result_t
-oe_debug_notify_module_loaded_hook(oe_debug_module_t* module);
+OE_DEBUGRT_EXPORT void oe_debug_module_loaded_hook(oe_debug_module_t* module);
 
 /**
  * The debugger is expected to set a breakpoint in the hook function and read
@@ -112,8 +111,7 @@ oe_debug_notify_module_loaded_hook(oe_debug_module_t* module);
  * it has no record of. This can happen if the debugger is attached after the
  * module has been removed from the list, but before the hook is called.
  */
-OE_DEBUGRT_EXPORT oe_result_t
-oe_debug_notify_module_unloaded_hook(oe_debug_module_t* module);
+OE_DEBUGRT_EXPORT void oe_debug_module_unloaded_hook(oe_debug_module_t* module);
 
 OE_EXTERNC_END
 

--- a/include/openenclave/internal/debugrt/host.h
+++ b/include/openenclave/internal/debugrt/host.h
@@ -145,6 +145,31 @@ OE_DEBUGRT_EXPORT extern oe_debug_thread_binding_t*
  */
 #define OE_DEBUGRT_ENCLAVE_TERMINATED_EVENT 0x0edeb647
 
+/**
+ * The following event is raised by the runtime after a module is loaded:
+ *   ULONG_PTR args[1] = { oe_debug_module_t_ptr };
+ *   RaiseException(OE_DEBUGRT_MODULE_LOADED_EVENT,
+ *                  0,  // dwExceptionFlags
+ *                  1,  // always 1 (number of argument)
+ *                  args)
+ * The oe_debug_module_t structure corresponding to the loaded module is
+ * passed as the sole element of the argument array.
+ */
+#define OE_DEBUGRT_MODULE_LOADED_EVENT 0x0edeb648
+
+/**
+ * The following event is raised by the runtime after a module has been
+ * unloaded:
+ *   ULONG_PTR args[1] = { oe_debug_module_t_ptr };
+ *   RaiseException(OE_DEBUGRT_MODULE_UNLOADED_EVENT,
+ *                  0,  // dwExceptionFlags
+ *                  1,  // always 1 (number of argument)
+ *                  args)
+ * The oe_debug_module_t structure corresponding to the unloaded module is
+ * passed as the sole element of the argument array.
+ */
+#define OE_DEBUGRT_MODULE_UNLOADED_EVENT 0x0edeb649
+
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/openenclave/internal/load.h
+++ b/include/openenclave/internal/load.h
@@ -7,6 +7,7 @@
 #include <openenclave/bits/defs.h>
 #include <openenclave/bits/result.h>
 #include <openenclave/bits/types.h>
+#include <openenclave/internal/debugrt/host.h>
 #include <openenclave/internal/elf.h>
 #include "types.h"
 
@@ -38,6 +39,8 @@ typedef struct _oe_elf_segment
 struct _oe_enclave_elf_image
 {
     elf64_t elf;
+
+    const char* path; /* Path of the ELF binary */
 
     char* image_base;   /* Base of the loaded segment contents */
     uint64_t image_rva; /* RVA of the loaded segment contents */
@@ -109,6 +112,11 @@ struct _oe_enclave_image
         uint64_t* vaddr);
 
     oe_result_t (*sgx_patch)(oe_enclave_image_t* image, size_t enclave_size);
+
+    oe_result_t (*sgx_get_debug_modules)(
+        oe_enclave_image_t* image,
+        oe_enclave_t* enclave,
+        oe_debug_module_t** modules);
 
     oe_result_t (*sgx_load_enclave_properties)(
         const oe_enclave_image_t* image,

--- a/tests/module_loading/CMakeLists.txt
+++ b/tests/module_loading/CMakeLists.txt
@@ -43,3 +43,18 @@ add_enclave_test(tests/module_loading_negative_runpath module_loading_host
 set_enclave_tests_properties(
   tests/module_loading_negative_runpath PROPERTIES PASS_REGULAR_EXPRESSION
   "RPATH or RUNPATH should not be used in the enclave binary")
+
+string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
+if (BUILD_TYPE_UPPER STREQUAL "DEBUG" OR BUILD_TYPE_UPPER STREQUAL
+                                         "RELWITHDEBINFO")
+  if (UNIX)
+    add_test(
+      NAME oegdb-multi-module-test
+      COMMAND
+        ${OE_BINDIR}/oegdb --batch -nh # Do not use user's gdbinit
+        --command=${CMAKE_CURRENT_SOURCE_DIR}/commands.gdb
+        --return-child-result # This fails the test in case of any error.
+        -arg host/module_loading_host enc/module_loading_enc)
+
+  endif ()
+endif ()

--- a/tests/module_loading/commands.gdb
+++ b/tests/module_loading/commands.gdb
@@ -1,0 +1,92 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# Enable pending breakpoints
+set breakpoint pending on
+
+# Set a breakpoint in main (host)
+b main
+commands 1
+    printf "** Hit breakpoint in main"
+    printf "** enclave = %s\n", argv[1]
+    continue
+end
+
+# Set a breakpoint in enc.c (enclave)
+# This is a pending break point.
+b enc.c:36
+commands 2
+    printf "** Hit breakpoint in enclave\n"
+
+    # Set debugger test
+    set debugger_test = 1
+    printf "** debugger_test = %d\n", debugger_test
+
+    if debugger_test != 1
+       printf "** Error: failed to set debugger_test\n"
+       quit 1
+    end
+
+    continue
+end
+
+# Set a breakpoint in module constructor
+b init_module
+commands 3
+    # Check that debugger is able to set variable.
+    set var is_module_init=1
+    continue
+end
+
+# Set a breakpoint by line number
+b module.c:13
+commands 4
+    # Check that value has been set.
+    if is_module_init != 1
+       printf "** Error: is_module_init != 1\n"
+       quite 1
+    end
+    continue
+end
+
+# Set a breakpoint in module destructor
+b fini_module
+commands 5
+    # Test ability to call function
+    p notify_module_done_wrapper()
+    continue
+end
+
+# Set breakpoint in square function
+b module.c:26
+commands 6
+    # Evaluate expression
+    set var r = a * a
+    continue
+end
+
+# Set conditional breakpoint
+b module.c:38
+commands 7
+    p t
+    set var t = a + b + k
+    printf "** t=%d\n", t
+    p t
+    fini
+    continue
+end
+
+# Run the program
+run
+continue
+
+# Run the program again.
+# This asserts that module is correctly unloaded by debugger.
+run
+continue
+
+# Check if program aborted or returned non zero.
+if $_isvoid($_exitcode) || $_exitcode
+    printf "** Test aborted\n"
+    quit 1
+end

--- a/tests/module_loading/enc/enc.c
+++ b/tests/module_loading/enc/enc.c
@@ -7,12 +7,13 @@
 
 #include "module_loading_t.h"
 
-int square(int a);
-__attribute__((weak)) int add_with_constant(int a, int b);
+int square(volatile int a);
+__attribute__((weak)) int add_with_constant(volatile int a, volatile int b);
 __attribute__((weak)) int sub(int a, int b);
 
 int is_enclave_init;
 
+__attribute__((visibility("default"))) int debugger_test;
 __attribute__((visibility("default"))) int is_module_init;
 
 __attribute__((constructor)) void init_enclave()

--- a/tests/module_loading/module/module.c
+++ b/tests/module_loading/module/module.c
@@ -1,28 +1,39 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+extern int debugger_test;
 extern int is_module_init;
 
 void notify_module_done_wrapper();
 
 __attribute__((constructor)) void init_module()
 {
-    is_module_init = 1;
+    if (!debugger_test)
+        is_module_init = 1;
 }
 
 __attribute__((destructor)) void fini_module()
 {
-    notify_module_done_wrapper();
+    if (!debugger_test)
+        notify_module_done_wrapper();
 }
 
-int square(int a)
+int square(volatile int a)
 {
-    return a * a;
+    volatile int r = 0;
+    if (!debugger_test)
+        r = a * a;
+    return r;
 }
 
 int k = 500;
 
-int add_with_constant(int a, int b)
+int add_with_constant(volatile int a, volatile int b)
 {
-    return a + b + k;
+    volatile int t = 0;
+    if (!debugger_test)
+        t = a + b + k;
+    else
+        t = -1;
+    return t;
 }


### PR DESCRIPTION
Extended multi-module test for locking down gdb.
When testing debugger, the secondary module functions become no-ops.
The debugger is expected to execute the logic the functions so that the test
passes.

Locks down
- breakpoints (name and line number)
- variable lookup
- expression evaluation
- function call

Signed-off-by: Anand Krishnamorthi <anakrish@microsoft.com>