### PR TITLE
Allow oecert to not have output file

### DIFF
--- a/tests/tools/oecert/README.md
+++ b/tests/tools/oecert/README.md
@@ -1,33 +1,34 @@
 oecert
 =====
 
-oecert is a utility that generates certificates (in der format),
-evidence (OE report and OE evidence), and endorsements for evidence in binary format. For certificates, the user can pass
-in the public/private key.
+`oecert` is a utility that generates the following files in binary format, or dump them in readable text, and verify them:
 
- 1. Self-signed certificates used for remote attestation over TLS.
- 2. Binary file format of an OE report.
- 3. Binary file format of an OE evidence.
- 4. Binary file format of an endorsement.
+ 1. Self-signed certificates (in der format) used for remote attestation over TLS.
+ 2. An OE report.
+ 3. An OE evidence.
+ 4. An endorsement for OE report/evidence.
 
-Usage: oecert Options
+For certificates, the user can pass in the public/private key.
 
-where Options are:
+
+Usage: `oecert Options`
+
+where `Options` are:
 
     --cert PRIVKEY PUBKEY : generate der remote attestation certificate.
     --report              : generate binary OE report.
     --evidence            : generate binary OE evidence.
-    --out FILENAME        : specify certificate/report/evidence output filename, default: out.bin
-    --endorsements        : specify endorsements output filename.
+    --out FILENAME        : specify certificate/report/evidence output filename, default: no file output.
+    --endorsements        : specify endorsements output filename, default: no endorsements output.
     --verify              : verify generated certificate/report/evidence
     --log LOG_FILENAME    : log file name, default: oecert.log
     --verbose             : dump verbose info of evidence
 
-Example 1 Generate, verify and dump a ceritificate, output certificate to default output file "out.bin":
+Example 1 Generate, verify and dump a ceritificate. Without "--out", there will be no certificate output file:
 
     ./oecert --cert keyecec.pem publickeyec.pem --verify --verbose
 
-Example 2 Generate an OE report and output its endorsements binary, output OE report to "report.bin":
+Example 2 Generate an OE report and output its endorsements binary to "endorsements.bin", and output OE report to "report.bin":
 
     ./oecert --report --endorsements endorsements.bin --out report.bin
 

--- a/tests/tools/oecert/host/evidence.cpp
+++ b/tests/tools/oecert/host/evidence.cpp
@@ -287,7 +287,7 @@ oe_result_t output_file(
     fopen_s(&output, file_name, "wb");
     if (!output)
     {
-        log("Failed to open report file %s\n", file_name);
+        log("Failed to open output file %s\n", file_name);
         return OE_FAILURE;
     }
     fwrite(data, data_size, 1, output);
@@ -617,10 +617,13 @@ oe_result_t generate_oe_report(
     quote_size = header->report_size;
 
     // Write report to file
-    OE_CHECK_MSG(
-        output_file(report_filename, remote_report, report_size),
-        "Failed to open report file %s\n",
-        report_filename);
+    if (report_filename)
+    {
+        OE_CHECK_MSG(
+            output_file(report_filename, remote_report, report_size),
+            "Failed to open report file %s\n",
+            report_filename);
+    }
 
     // Dump report
     if (verbose)
@@ -756,10 +759,13 @@ oe_result_t generate_oe_evidence(
     log("========== Got OE evidence, size = %zu\n\n", evidence_size);
 
     // Write evidence to file
-    OE_CHECK_MSG(
-        output_file(evidence_filename, evidence, evidence_size),
-        "Failed to open evidence file %s\n",
-        evidence_filename);
+    if (evidence_filename)
+    {
+        OE_CHECK_MSG(
+            output_file(evidence_filename, evidence, evidence_size),
+            "Failed to open evidence file %s\n",
+            evidence_filename);
+    }
 
     evidence_header = (oe_attestation_header_t*)evidence;
     report_header = (oe_report_header_t*)evidence_header->data;


### PR DESCRIPTION
Gave oecert option not to generate report/evidence/certificate output file

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>