### PR TITLE
[tests] Fixes incorrect data structure usage when testing fd_file_system, tests/syscall/fs

### DIFF
--- a/tests/syscall/fs/enc/file_system.h
+++ b/tests/syscall/fs/enc/file_system.h
@@ -131,12 +131,12 @@ class oe_fd_file_system
         return oe_rmdir(pathname);
     }
 
-    int stat(const char* pathname, struct oe_stat_t* buf)
+    int stat(const char* pathname, stat_type* buf)
     {
         return oe_stat(pathname, buf);
     }
 
-    int fstat(file_handle file, struct oe_stat_t* buf)
+    int fstat(file_handle file, stat_type* buf)
     {
         return oe_fstat(file, buf);
     }
@@ -192,7 +192,7 @@ class fd_file_system
   public:
     typedef int file_handle;
     typedef DIR* dir_handle;
-    typedef struct oe_stat_t stat_type;
+    typedef struct stat stat_type;
     typedef struct dirent dirent_type;
 
     static constexpr file_handle invalid_file_handle = -1;
@@ -296,12 +296,12 @@ class fd_file_system
         return ::rmdir(pathname);
     }
 
-    int stat(const char* pathname, struct oe_stat_t* buf)
+    int stat(const char* pathname, stat_type* buf)
     {
         return ::stat(pathname, (struct stat*)buf);
     }
 
-    int fstat(file_handle file, struct oe_stat_t* buf)
+    int fstat(file_handle file, stat_type* buf)
     {
         return ::fstat(file, (struct stat*)buf);
     }
@@ -579,12 +579,12 @@ class stream_file_system
         return ::rmdir(pathname);
     }
 
-    int stat(const char* pathname, struct stat* buf)
+    int stat(const char* pathname, stat_type* buf)
     {
         return ::stat(pathname, buf);
     }
 
-    int fstat(file_handle file, struct stat* buf)
+    int fstat(file_handle file, stat_type* buf)
     {
         return ::fstat(fileno(file), buf);
     }


### PR DESCRIPTION
Replaced 'struct oe_stat_t' with 'struct stat' when testing the libc/ stat and fstat syscalls. 

Addresses #3933 partially.
