### PR TITLE
Allow Simulation mode on Alpine Linux

### DIFF
--- a/3rdparty/openssl/append-unsupported
+++ b/3rdparty/openssl/append-unsupported
@@ -35,7 +35,9 @@ do
     if [[ "${i}" != *"crypto.h" ]] && [[ "${i}" != *"ssl.h" ]] && [[ "${i}" != *"x509_vfy.h" ]]; then
         continue
     fi
-    name="$(basename -s .h $i)"
+    # Use basename + cut which is portable.
+    # Alpine/busybox has very basic implementation of basename.
+    name=$(echo "$(basename $i)" | cut -f 1 -d '.')
     # We assume that every header ends with #endif, which is the case for OpenSSL.
     sed -i '$d' ${i}
     echo -e "#include <openssl/${name}_unsupported.h>\n#endif" >> ${i}

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -136,6 +136,8 @@ if (UNIX)
   list(APPEND PLATFORM_SDK_ONLY_SRC ${PROJECT_SOURCE_DIR}/common/asn1.c
        ${PROJECT_SOURCE_DIR}/common/crypto/openssl/hmac.c
        crypto/openssl/random.c linux/syscall.c)
+  set_source_files_properties(linux/syscall.c PROPERTIES COMPILE_FLAGS
+                                                         "-Wno-conversion")
 elseif (WIN32)
   list(
     APPEND

--- a/host/hostthread.h
+++ b/host/hostthread.h
@@ -31,7 +31,20 @@ typedef pthread_once_t oe_once_type;
 #define OE_H_ONCE_INITIALIZER PTHREAD_ONCE_INIT
 
 typedef pthread_mutex_t oe_mutex;
+#ifdef PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
+// GLIBC
 #define OE_H_MUTEX_INITIALIZER PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
+#else
+// MUSL. From musl/ldso/dynlink.c. _m_type is the first field.
+#define OE_H_MUTEX_INITIALIZER          \
+    {                                   \
+        {                               \
+            {                           \
+                PTHREAD_MUTEX_RECURSIVE \
+            }                           \
+        }                               \
+    }
+#endif
 
 typedef pthread_key_t oe_thread_key;
 

--- a/host/linux/hostthread.c
+++ b/host/linux/hostthread.c
@@ -15,22 +15,22 @@
 */
 int oe_thread_create(oe_thread_t* thread, void* (*func)(void*), void* arg)
 {
-    return pthread_create(thread, NULL, func, arg);
+    return pthread_create((pthread_t*)thread, NULL, func, arg);
 }
 
 int oe_thread_join(oe_thread_t thread)
 {
-    return pthread_join(thread, NULL);
+    return pthread_join((pthread_t)thread, NULL);
 }
 
 oe_thread_t oe_thread_self(void)
 {
-    return pthread_self();
+    return (oe_thread_t)pthread_self();
 }
 
 int oe_thread_equal(oe_thread_t thread1, oe_thread_t thread2)
 {
-    return pthread_equal(thread1, thread2);
+    return pthread_equal((pthread_t)thread1, (pthread_t)thread2);
 }
 
 /*
@@ -60,8 +60,7 @@ int oe_mutex_init(oe_mutex* Lock)
 
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
-    if ((err = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP)) !=
-        0)
+    if ((err = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE)) != 0)
         return err;
     pthread_mutex_init(Lock, &attr);
     pthread_mutexattr_destroy(&attr);

--- a/host/linux/syscall.c
+++ b/host/linux/syscall.c
@@ -9,14 +9,14 @@
 #include <openenclave/corelibc/limits.h>
 #include <openenclave/internal/syscall/sys/uio.h>
 #include <openenclave/internal/syscall/types.h>
+#include <poll.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/epoll.h>
 #include <sys/file.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
-#include <sys/signal.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/uio.h>

--- a/host/sgx/linux/aep.S
+++ b/host/sgx/linux/aep.S
@@ -48,6 +48,6 @@ OE_AEP:
 //
 //==============================================================================
 .globl OE_AEP_ADDRESS
-.section .rodata
+.section .data.rel.local,"aw"
 .align 8
 OE_AEP_ADDRESS:	.quad .aep

--- a/tests/bigmalloc/enc/enc.c
+++ b/tests/bigmalloc/enc/enc.c
@@ -31,7 +31,7 @@ oe_result_t test_malloc()
     }
 
     /* Verify that at least 15.9 gigabytes of heap memory are available */
-    if (!(heap_remaining > (float)(15.9 * (double)GIGABYTE)))
+    if (!((float)heap_remaining > (float)(15.9 * (double)GIGABYTE)))
     {
         return_value = OE_FAILURE;
         goto done;

--- a/tests/crypto/ec_tests.c
+++ b/tests/crypto/ec_tests.c
@@ -48,10 +48,10 @@ static uint8_t _SIGNATURE[max_sign_size];
 static uint8_t x_data[max_coordinates_size];
 static uint8_t y_data[max_coordinates_size];
 
-size_t private_key_size;
-size_t public_key_size;
-size_t sign_size;
-size_t x_size, y_size;
+static size_t private_key_size;
+static size_t public_key_size;
+static size_t sign_size;
+static size_t x_size, y_size;
 
 static const uint8_t _P256_GROUP_ORDER[] = {
     0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF,

--- a/tests/crypto/rsa_tests.c
+++ b/tests/crypto/rsa_tests.c
@@ -36,8 +36,8 @@ static char _DER_CERT[max_cert_size];
 /* RSA exponent of CERT */
 static const char _CERT_RSA_EXPONENT[] = {0x01, 0x00, 0x01};
 
-size_t rsa_modulus_size;
-size_t sign_size;
+static size_t rsa_modulus_size;
+static size_t sign_size;
 
 // Test RSA signing operation over an ASCII alphabet string.
 static void _test_sign()

--- a/tests/memory/enc/stress.c
+++ b/tests/memory/enc/stress.c
@@ -139,7 +139,7 @@ static void _run_malloc_test(size_t size)
 
     // Make sure that the value can fit within a double since we use
     // double arithmetic below.
-    OE_TEST(original_size == (double)original_size);
+    OE_TEST(original_size == (size_t)(double)original_size);
 
     for (int i = 0; i < ITERS; i++)
     {

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -70,7 +70,8 @@ target_include_directories(edl_host PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
                                            ${CMAKE_CURRENT_SOURCE_DIR}/..)
 if (NOT WIN32)
   # Re-enable strict aliasing. TODO: Remove this when #1717 is resolved.
-  target_compile_options(edl_host PUBLIC -fstrict-aliasing
-                                         -Werror=strict-aliasing)
+  target_compile_options(
+    edl_host PUBLIC -fstrict-aliasing -Werror=strict-aliasing
+                    -Wno-unused-parameter)
 endif ()
 target_link_libraries(edl_host oehost)

--- a/tests/tools/oecert/host/evidence.cpp
+++ b/tests/tools/oecert/host/evidence.cpp
@@ -715,7 +715,6 @@ oe_result_t generate_oe_evidence(
 
     oe_attestation_header_t* evidence_header = nullptr;
     oe_report_header_t* report_header = nullptr;
-    uint64_t quote_size = 0;
     sgx_quote_t* quote = nullptr;
 
     log("========== Getting OE evidence\n");
@@ -770,7 +769,6 @@ oe_result_t generate_oe_evidence(
     evidence_header = (oe_attestation_header_t*)evidence;
     report_header = (oe_report_header_t*)evidence_header->data;
     quote = (sgx_quote_t*)report_header->report;
-    quote_size = report_header->report_size;
 
     // Dump evidence
     if (verbose)


### PR DESCRIPTION
Fix compile errors. With the PR and an updated oeedger8r submodule,
OE SDK can be compiled using clang-10 on Alpine Linux.
All tests ought to pass in Simulation Mode.
Ability to compile OE SDK in Apline Linux is important for investigating
dotnet debugger integration for Mystikos.

Description of Changes:
- OpenSSL
  Use basename + cut since basename -s is not available in busybox (Alpine)
- Prevent compiler warnings in clang-10
-host/linux/syscall.c
 Use correct include paths
- hostthread
  Use recursive mutex in Alpine. Use _NP (non portable) only if
  available
- ptracelib
  Signature of ptrace is different but equivalent on Ubuntu and Alpine.
  Ubuntu expects enum __ptrace_request as first parameter whereas alpine
  expects just an int.
  Tweak the library so that it compiles on both platforms. We just int
  as the first parameter for ptrace.
- aep
  OE_AEP_ADDRESS is moved out of .relro section. Defining it in
  .relro section causes a mutable relocation to be generated in
  a readonly section. This causes host applications to fail execution
  on Alpine which compiles executables as PIE by default.
  To fix this, OE_AEP_ADDRESS is defined in .data.rel.local section
  which the compiler uses by default for similar variable in C.
- tests/oeedger8r
  Prevent error from unused variable warning on host side.
- tests/crypto
  Prevent duplicate symbols link error
- host/CMakeLists.txt
  Prevent error due to warnings on Alpine. msghdr structure has
  different data types on Alpine.
- evidence.cpp
  Prevent error due to unused variable warning.

Signed-off-by: Anand Krishnamorthi <anakrish@microsoft.com>