### PR TITLE
Allow oecert for out-of-proc quoting for SGX

### DIFF
--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -178,6 +178,8 @@ def ACCHostVerificationTest(String version, String build_type) {
                            ../../tools/oecert/oecert --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
                            ../../tools/oecert/oecert --report --out sgx_report.bin --verify
                            ../../tools/oecert/oecert --evidence --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
+                           ../../tools/oecert/oecert --evidence --verify --quote-proc in
+                           ../../tools/oecert/oecert --evidence --verify --quote-proc out
                            popd
                            """
                 oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
@@ -273,6 +275,8 @@ def ACCHostVerificationPackageTest(String version, String build_type) {
                            ../../tools/oecert/oecert --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
                            ../../tools/oecert/oecert --report --out sgx_report.bin --verify
                            ../../tools/oecert/oecert --evidence --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
+                           ../../tools/oecert/oecert --evidence --verify --quote-proc in
+                           ../../tools/oecert/oecert --evidence --verify --quote-proc out
                            popd
                            """
                 oe.ContainerRun("oetools-full-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")

--- a/tests/tools/oecert/README.md
+++ b/tests/tools/oecert/README.md
@@ -18,6 +18,7 @@ where `Options` are:
     --cert PRIVKEY PUBKEY : generate der remote attestation certificate.
     --report              : generate binary OE report.
     --evidence            : generate binary OE evidence.
+    --quote-proc <in|out> : use sgx in process or out-of-process quoting, default: use original quote process.
     --out FILENAME        : specify certificate/report/evidence output filename, default: no file output.
     --endorsements        : specify endorsements output filename, default: no endorsements output.
     --verify              : verify generated certificate/report/evidence

--- a/tests/tools/oecert/host/evidence.cpp
+++ b/tests/tools/oecert/host/evidence.cpp
@@ -723,31 +723,33 @@ oe_result_t generate_oe_evidence(
     // verify envidence
     if (endorsements_filename || verify)
     {
+        get_plugin_evidence(
+            enclave,
+            &result,
+            evidence,
+            sizeof(evidence),
+            &evidence_size,
+            endorsements,
+            sizeof(endorsements),
+            &endorsements_size);
         OE_CHECK_MSG(
-            get_plugin_evidence(
-                enclave,
-                &result,
-                evidence,
-                sizeof(evidence),
-                &evidence_size,
-                endorsements,
-                sizeof(endorsements),
-                &endorsements_size),
+            result,
             "Failed to create OE evidence. Error: %s\n",
             oe_result_str(result));
     }
     else
     {
+        get_plugin_evidence(
+            enclave,
+            &result,
+            evidence,
+            sizeof(evidence),
+            &evidence_size,
+            NULL,
+            0,
+            NULL);
         OE_CHECK_MSG(
-            get_plugin_evidence(
-                enclave,
-                &result,
-                evidence,
-                sizeof(evidence),
-                &evidence_size,
-                NULL,
-                0,
-                NULL),
+            result,
             "Failed to create OE evidence. Error: %s\n",
             oe_result_str(result));
 


### PR DESCRIPTION
Add quote-proc param to `oecert` so that `oecert` can specify using in-proc or out-of-proc quoting.

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>