### PR TITLE
Rework OpenSSL Dependency location

### DIFF
--- a/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsManualInstallPrereqs.md
@@ -16,7 +16,7 @@
 - [Clang/LLVM for Windows 64-bit](https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/LLVM-8.0.1-win64.exe)
 - [Python 3](https://www.python.org/downloads/windows/)
 - [ShellCheck](https://oejenkins.blob.core.windows.net/oejenkins/shellcheck-v0.7.0.zip)
-- [OpenSSL 1.1.1](https://slproweb.com/products/Win32OpenSSL.html)
+- [OpenSSL 1.1.1](https://oejenkins.blob.core.windows.net/oejenkins/openssl.1.1.1506.73.nupkg)
 - [cmake format](https://github.com/cheshirekow/cmake_format)
 
 ## Prerequisites specific to SGX support on your system
@@ -77,7 +77,9 @@ Inside it there is a shellcheck-v0.7.0.exe which must be copied to a directory i
 
 ## OpenSSL
 
-Download and install the latest [Win64 OpenSSL 1.1.1](https://slproweb.com/products/Win32OpenSSL.html). Do not choose the light version; for example, use Win64OpenSSL-1_1_1g.exe, not Win64OpenSSL_Light-1_1_1g.exe.
+Download and install the latest build of OpenSSL for Windows from one of the following [locations](https://wiki.openssl.org/index.php/Binaries) or build and install it from source.
+
+Alternatively, you can use the latest version of OpenSSL that the OpenEnclave CI team [publishes](https://oejenkins.blob.core.windows.net/oejenkins/openssl.1.1.1506.73.nupkg) which is distributed under the [dual OpenSSL and SSLeay license](https://www.openssl.org/source/license-openssl-ssleay.txt) without further legal obligations.
 
 ## cmake format
 

--- a/samples/attested_tls/non_enc_client/CMakeLists.txt
+++ b/samples/attested_tls/non_enc_client/CMakeLists.txt
@@ -1,7 +1,12 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-find_package(OpenSSL REQUIRED)
+if (WIN32)
+  set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};C:\\oe_prereqs\\OpenSSL\\x64\\release")
+  find_package(OpenSSL REQUIRED)
+else ()
+  find_package(OpenSSL REQUIRED)
+endif ()
 
 add_executable(tls_non_enc_client client.cpp cert_verify_config.cpp
                                   ../common/verify_callback.cpp)

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -5,8 +5,8 @@
 Param(
     [string]$GitURL = 'https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/Git-2.19.1-64-bit.exe',
     [string]$GitHash = '5E11205840937DD4DFA4A2A7943D08DA7443FAA41D92CCC5DAFBB4F82E724793',
-    [string]$OpenSSLURL = 'https://slproweb.com/download/Win64OpenSSL-1_1_1k.exe',
-    [string]$OpenSSLHash = 'E04B056B83572E8395AA680733FB988C6FC005B86E45F9AC0569796DFCBEAF13',
+    [string]$OpenSSLURL = 'https://oejenkins.blob.core.windows.net/oejenkins/openssl.1.1.1506.73.nupkg',
+    [string]$OpenSSLHash = '1744DF0BCCC11C5C31846E450D8DF02D5F376073EB4AC77BA1F7B2DD82093A26',
     [string]$SevenZipURL = 'https://www.7-zip.org/a/7z1806-x64.msi',
     [string]$SevenZipHash = 'F00E1588ED54DDF633D8652EB89D0A8F95BD80CCCFC3EED362D81927BEC05AA5',
     # We skip the hash check for the vs_buildtools.exe file because it is regularly updated without a change to the URL, unfortunately.
@@ -103,7 +103,7 @@ $PACKAGES = @{
     "openssl" = @{
         "url" = $OpenSSLURL
         "hash" = $OpenSSLHash
-        "local_file" = Join-Path $PACKAGES_DIRECTORY "Win64OpenSSL-1_1_1g.exe"
+        "local_file" = Join-Path $PACKAGES_DIRECTORY "openssl.nupkg"
     }
     "python3" = @{
         "url" = $Python3ZipURL
@@ -365,11 +365,8 @@ function Install-Git {
 }
 
 function Install-OpenSSL {
-    $installDir = Join-Path $env:ProgramFiles "OpenSSL-Win64"
-    Install-Tool -InstallerPath $PACKAGES["openssl"]["local_file"] `
-                 -InstallDirectory $installDir `
-                 -ArgumentList @("/silent", "/eula=accept") `
-                 -EnvironmentPath @("$installDir\bin")
+    $installDir = Join-Path $InstallPath "OpenSSL"
+    nuget.exe install openssl -Source $PACKAGES_DIRECTORY -OutputDirectory $InstallPath -ExcludeVersion
 }
 
 function Install-7Zip {
@@ -602,7 +599,6 @@ try {
     Install-Nuget
     Install-Python3
     Install-VisualStudio
-    Install-OpenSSL
     Install-LLVM
     Install-Git
     Install-Shellcheck
@@ -611,7 +607,10 @@ try {
     if (($LaunchConfiguration -ne "SGX1FLC-NoIntelDrivers") -and ($LaunchConfiguration -ne "SGX1-NoIntelDrivers") -or ($DCAPClientType -eq "Azure")) {
         Install-DCAP-Dependencies
     }
-
+    # There is a bug with the dcap dependency installation where it will overwrite the installation path folder. 
+    # This is a bug in the upstream DCAP package itself. 
+    # As we want OpenSSL installed in the same location to be picked up automatically by cmake, just install after dcap installation.
+    Install-OpenSSL
     Install-VCRuntime
 
 

--- a/tests/tools/oecert/host/CMakeLists.txt
+++ b/tests/tools/oecert/host/CMakeLists.txt
@@ -1,7 +1,12 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-find_package(OpenSSL REQUIRED)
+if (WIN32)
+  set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};C:\\oe_prereqs\\OpenSSL\\x64\\release")
+  find_package(OpenSSL REQUIRED)
+else ()
+  find_package(OpenSSL REQUIRED)
+endif ()
 
 add_custom_command(
   OUTPUT oecert_u.h oecert_u.c oecert_args.h

--- a/tests/tools/oecertdump/host/CMakeLists.txt
+++ b/tests/tools/oecertdump/host/CMakeLists.txt
@@ -1,7 +1,12 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-find_package(OpenSSL REQUIRED)
+if (WIN32)
+  set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};C:\\oe_prereqs\\OpenSSL\\x64\\release")
+  find_package(OpenSSL REQUIRED)
+else ()
+  find_package(OpenSSL REQUIRED)
+endif ()
 
 add_custom_command(
   OUTPUT oecertdump_u.h oecertdump_u.c oecertdump_args.h


### PR DESCRIPTION
This PR deprecates the dependency of OpenSSL from the slproweb site and changes the pull location to a cached OpenSSL dependency that the oe ci team will publish/maintain. This feature was requested to ensure that users of the oesdk can set up their environments without broken links.