### PR TITLE
Sign oecert enclave and verify signer id

### DIFF
--- a/tests/tools/oecert/CMakeLists.txt
+++ b/tests/tools/oecert/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 if (BUILD_ENCLAVES)
   add_subdirectory(enc)
+  # oecert host depends on a key pair generated during the enclave building.
+  # private key is used to sign the enclave while public key is written in the
+  # header of the oecert executable
+  add_subdirectory(host)
 endif ()
-
-add_subdirectory(host)

--- a/tests/tools/oecert/README.md
+++ b/tests/tools/oecert/README.md
@@ -1,7 +1,7 @@
 oecert
 =====
 
-`oecert` is a utility that generates the following files in binary format, or dump them in readable text, and verify them:
+`oecert` is a debugging utility that generates the following files in binary format, or dump them in readable text, and verify them:
 
  1. Self-signed certificates (in der format) used for remote attestation over TLS.
  2. An OE report.
@@ -9,7 +9,7 @@ oecert
  4. An endorsement for OE report/evidence.
 
 For certificates, the user can pass in the public/private key.
-
+`oecert` is not suitable for production use.
 
 Usage: `oecert Options`
 

--- a/tests/tools/oecert/enc/CMakeLists.txt
+++ b/tests/tools/oecert/enc/CMakeLists.txt
@@ -7,6 +7,19 @@ add_custom_command(
   COMMAND edger8r --trusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecert.edl
           --search-path ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
+# generate a random key pair for enclave signing and output the public key to header file
+add_custom_command(
+  OUTPUT oecert_enc_private.pem oecert_enc_public.pem oecert_enc_pubkey.h
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../gen_pubkey_header.sh
+  COMMAND openssl genrsa -out oecert_enc_private.pem -3 3072
+  COMMAND openssl rsa -in oecert_enc_private.pem -pubout -out
+          oecert_enc_public.pem
+  COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/../gen_pubkey_header.sh
+    ${CMAKE_CURRENT_BINARY_DIR}/../oecert_enc_pubkey.h
+    ${CMAKE_CURRENT_BINARY_DIR}/oecert_enc_public.pem)
+
+# generate the enclave and sign it with the private key
 add_enclave(
   TARGET
   oecert_enc
@@ -14,7 +27,9 @@ add_enclave(
   enc.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/oecert_t.c
   CONFIG
-  enc.conf)
+  enc.conf
+  KEY
+  ${CMAKE_CURRENT_BINARY_DIR}/oecert_enc_private.pem)
 
 # Need for the generated file oecert_t.h
 enclave_include_directories(oecert_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
@@ -24,3 +39,6 @@ enclave_link_libraries(oecert_enc oeenclave oelibc)
 # Generate the enclave binary in the the same directory with the oecert binary
 set_enclave_properties(oecert_enc PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                        "${CMAKE_CURRENT_BINARY_DIR}/..")
+
+add_custom_target(oecert_enclave_signed DEPENDS oecert_enc.signed
+                                                oecert_enc_pubkey.h)

--- a/tests/tools/oecert/gen_pubkey_header.sh
+++ b/tests/tools/oecert/gen_pubkey_header.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+destfile="$1"
+pubkey_file="$2"
+
+cat > "$destfile" << EOF
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef OECERT_PUBKEY_H
+#define OECERT_PUBKEY_H
+
+EOF
+
+printf 'static const char OECERT_ENC_PUBLIC_KEY[] =' >> "$destfile"
+while IFS="" read -r p || [ -n "$p" ]
+do
+    # Sometimes openssl can insert carriage returns into the PEM files. Let's remove those!
+    CR=$(printf "\r")
+    p=$(echo "$p" | tr -d "$CR")
+    printf '\n    \"%s\\n\"' "$p" >> "$destfile"
+done < "$pubkey_file"
+printf ';\n' >> "$destfile"
+
+cat >> "$destfile" << EOF
+
+#endif /* OECERT_ENC_PUBLIC_KEY */
+EOF

--- a/tests/tools/oecert/host/CMakeLists.txt
+++ b/tests/tools/oecert/host/CMakeLists.txt
@@ -2,7 +2,8 @@
 # Licensed under the MIT License.
 
 if (WIN32)
-  set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};C:\\oe_prereqs\\OpenSSL\\x64\\release")
+  set(CMAKE_PREFIX_PATH
+      "${CMAKE_PREFIX_PATH};C:\\oe_prereqs\\OpenSSL\\x64\\release")
   find_package(OpenSSL REQUIRED)
 else ()
   find_package(OpenSSL REQUIRED)
@@ -10,7 +11,7 @@ endif ()
 
 add_custom_command(
   OUTPUT oecert_u.h oecert_u.c oecert_args.h
-  DEPENDS ../oecert.edl edger8r
+  DEPENDS ../oecert.edl edger8r oecert_enclave_signed
   COMMAND edger8r --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecert.edl
           --search-path ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 

--- a/tests/tools/oecert/host/evidence.h
+++ b/tests/tools/oecert/host/evidence.h
@@ -6,34 +6,26 @@
 
 #include <openenclave/host.h>
 #include "../../../../host/sgx/platformquoteprovider.h"
+#include "../oecert_enc_pubkey.h"
 
 void log(const char* fmt, ...);
 void oecert_quote_provider_log(sgx_ql_log_level_t level, const char* message);
 void set_log_callback();
 
 void dump_certificate(const uint8_t* data, size_t data_len);
-void decode_certificate_pem(FILE* file, const uint8_t* data, size_t data_len);
-void decode_crl_pem(const uint8_t* data, size_t data_len);
-void parse_certificate_extension(const uint8_t* data, size_t data_len);
-void dump_certificate_chain(
-    const uint8_t* data,
-    size_t data_len,
-    bool is_report_buffer);
-void dump_claims(const oe_claim_t* claims, size_t claims_size);
 
 oe_result_t output_file(
     const char* file_name,
     const uint8_t* data,
     size_t data_size);
-oe_result_t dump_sgx_quote(
-    const uint8_t* quote_buffer,
-    const uint8_t* boundary,
-    size_t boundary_size);
+
+oe_result_t verify_signer_id(
+    const char* siging_public_key,
+    size_t siging_public_key_size,
+    uint8_t* signer_id,
+    size_t signer_id_size);
+
 oe_result_t dump_oe_report(const uint8_t* report, size_t report_size);
-oe_result_t dump_oe_evidence(const uint8_t* evidence, size_t evidence_size);
-oe_result_t dump_oe_endorsements(
-    const uint8_t* endorsements,
-    size_t endorsements_size);
 
 oe_result_t get_oe_report_from_certificate(
     const uint8_t* certificate_in_der,

--- a/tests/tools/oecert/host/host.cpp
+++ b/tests/tools/oecert/host/host.cpp
@@ -84,13 +84,23 @@ oe_result_t enclave_identity_verifier(oe_identity_t* identity, void* arg)
     // Dump an enclave's unique ID, signer ID and Product ID. They are
     // MRENCLAVE, MRSIGNER and ISVPRODID for SGX enclaves.  In a real scenario,
     // custom id checking should be done here
-    printf("identity->signer_id :\n");
+    printf("identity->unique_id :\n");
     for (int i = 0; i < OE_UNIQUE_ID_SIZE; i++)
-        printf("0x%0x ", (uint8_t)identity->signer_id[i]);
+        printf("0x%0x ", (uint8_t)identity->unique_id[i]);
 
     printf("\nidentity->signer_id :\n");
     for (int i = 0; i < OE_SIGNER_ID_SIZE; i++)
         printf("0x%0x ", (uint8_t)identity->signer_id[i]);
+
+    // verify signer id
+    OE_CHECK_MSG(
+        verify_signer_id(
+            (char*)OECERT_ENC_PUBLIC_KEY,
+            sizeof(OECERT_ENC_PUBLIC_KEY),
+            identity->signer_id,
+            sizeof(identity->signer_id)),
+        "Failed to verify signer id. Error: (%s)\n",
+        oe_result_str(result));
 
     printf("\nidentity->product_id :\n");
     for (int i = 0; i < OE_PRODUCT_ID_SIZE; i++)
@@ -591,7 +601,8 @@ done:
 int main(int argc, const char* argv[])
 {
     int ret = 0;
-
+    printf("NOTICE: oecert is purely a debugging utility and not suitable for "
+           "production use.\n\n");
     if (!oe_has_sgx_quote_provider())
     {
         fprintf(


### PR DESCRIPTION
Generate random key pair at `oecert` build time. Sign the `oecert_enc` with the private key and verify the `signer_id` with the public key.
Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>