### PR TITLE
Support the OE_ENCLAVE_FLAG_DEBUG_AUTO flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the initial support of cryptographic module loading in SGX enclaves. Refer to the [design document](docs/DesignDocs/CryptoModuleLoadingSupport.md) for more detail.
 - Add the support of getrandom libc API and syscall in enclaves.
 - Add `libsgx-quote-ex`, `sgx-aesm-service` and several SGX AESM plugins to Ansible scripts so that users will be able to select in-process or out-of-process call path for quote generation. Refer to the [attestation sample](samples/attestation/README.md#determining-call-path-for-sgx-quote-generation) for more information.
+- Add the support of the OE_ENCLAVE_FLAG_DEBUG_AUTO flag to the oe_create_enclave API. When the flag is set and the OE_ENCLAVE_FLAG_DEBUG flag is cleared, the debug mode is automatically turned on/off based on the value of Debug specified in the enclave config file.
 
 ### Changed
 - The OpenEnclave CMake configuration now explicitly sets CMAKE_SKIP_RPATH to TRUE. This change should not affect fully static-linked enclaves.

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -839,6 +839,11 @@ oe_result_t oe_sgx_build_enclave(
     /* Validate the enclave prop_override structure */
     OE_CHECK(oe_sgx_validate_enclave_properties(&props, NULL));
 
+    /* If the OE_ENCLAVE_FLAG_DEBUG_AUTO is set and the OE_ENCLAVE_FLAG_DEBUG is
+     * cleared, set enclave->debug based on the attributes in the properties. */
+    if (!enclave->debug && oe_sgx_is_debug_auto_load_context(context))
+        enclave->debug = props.config.attributes & OE_SGX_FLAGS_DEBUG;
+
     /* Consolidate enclave-debug-flag with create-debug-flag */
     if (props.config.attributes & OE_SGX_FLAGS_DEBUG)
     {

--- a/host/sgx/sgxload.h
+++ b/host/sgx/sgxload.h
@@ -22,6 +22,13 @@ OE_INLINE bool oe_sgx_is_debug_load_context(
     return (context && (context->attributes.flags & OE_ENCLAVE_FLAG_DEBUG));
 }
 
+OE_INLINE bool oe_sgx_is_debug_auto_load_context(
+    const oe_sgx_load_context_t* context)
+{
+    return (
+        context && (context->attributes.flags & OE_ENCLAVE_FLAG_DEBUG_AUTO));
+}
+
 OE_INLINE bool oe_sgx_is_kss_load_context(const oe_sgx_load_context_t* context)
 {
     return (context && (context->attributes.flags & OE_ENCLAVE_FLAG_SGX_KSS));

--- a/include/openenclave/host.h
+++ b/include/openenclave/host.h
@@ -62,6 +62,14 @@ OE_EXTERNC_BEGIN
 #define OE_ENCLAVE_FLAG_DEBUG 0x00000001u
 
 /**
+ * Flag passed into oe_create_enclave that allows the host to automatically
+ * decide to run the enclave in debug mode or not based on the Debug value
+ * specified in the enclave configuration file. When both this and
+ * OE_ENCLAVE_FLAG_DEBUG flags are set, OE_ENCLAVE_FLAG_DEBUG takes precedence.
+ */
+#define OE_ENCLAVE_FLAG_DEBUG_AUTO 0x000000010u
+
+/**
  *  Flag passed into oe_create_enclave to run the enclave in simulation mode.
  */
 #define OE_ENCLAVE_FLAG_SIMULATE 0x00000002u
@@ -76,8 +84,9 @@ OE_EXTERNC_BEGIN
  */
 #define OE_ENCLAVE_FLAG_SGX_KSS 0x00000004u
 
-#define OE_ENCLAVE_FLAG_RESERVED \
-    (~(OE_ENCLAVE_FLAG_DEBUG | OE_ENCLAVE_FLAG_SIMULATE))
+#define OE_ENCLAVE_FLAG_RESERVED                            \
+    (~(OE_ENCLAVE_FLAG_DEBUG | OE_ENCLAVE_FLAG_DEBUG_AUTO | \
+       OE_ENCLAVE_FLAG_SIMULATE))
 
 /**
  * @endcond


### PR DESCRIPTION
Add the support of the OE_ENCLAVE_FLAG_DEBUG_AUTO flag based on @dthaler's suggestion in #3953.
The flag is only effective when the OE_ENCLAVE_FLAG_DEBUG is not set.

Fixes #3953

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>