### PR TITLE
refactor/move windows packaging jobs into local jenkinsfile

### DIFF
--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -58,6 +58,10 @@ def windowsLinuxElfBuild(String label, String version, String compiler, String b
     }
 }
 
+/**
+ * Compile open-enclave on Windows platform, generate NuGet package out of it, 
+ * install the generated NuGet package, and run samples tests against the installation.
+ */
 def windowsCrossCompile(String label, String build_type, String lvi_mitigation = 'None', String OE_SIMULATION = "0", String lvi_mitigation_skip_tests = 'OFF', List extra_cmake_args = []) {
     def node_label = AGENTS_LABELS["${label}-dcap"]
 
@@ -65,8 +69,31 @@ def windowsCrossCompile(String label, String build_type, String lvi_mitigation =
         node(node_label) {
             withEnv(["OE_SIMULATION=${OE_SIMULATION}"]) {
                 timeout(GLOBAL_TIMEOUT_MINUTES) {
-                    // OFF value of quote provider until https://github.com/openenclave/openenclave-ci/pull/29 is merged
-                    oe.WinCompilePackageTest("build/X64-${build_type}", build_type, 'OFF', CTEST_TIMEOUT_SECONDS, lvi_mitigation, lvi_mitigation_skip_tests, extra_cmake_args)
+                    cleanWs()
+                    checkout scm
+                    dir("build/X64-${build_type}") {
+                        bat """
+                            vcvars64.bat x64 && \
+                            cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_ENCLAVES=ON -DLVI_MITIGATION=${lvi_mitigation} -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -DCPACK_GENERATOR=NuGet -Wdev ${extra_cmake_args.join(' ')} && \
+                            ninja.exe && \
+                            ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT_SECONDS} && \
+                            cpack.exe -D CPACK_NUGET_COMPONENT_INSTALL=ON -DCPACK_COMPONENTS_ALL=OEHOSTVERIFY && \
+                            cpack.exe && \
+                            (if exist C:\\oe rmdir /s/q C:\\oe) && \
+                            nuget.exe install open-enclave -Source %cd% -OutputDirectory C:\\oe -ExcludeVersion && \
+                            set CMAKE_PREFIX_PATH=C:\\oe\\open-enclave\\openenclave\\lib\\openenclave\\cmake && \
+                            cd C:\\oe\\open-enclave\\openenclave\\share\\openenclave\\samples && \
+                            setlocal enabledelayedexpansion && \
+                            for /d %%i in (*) do (
+                                cd C:\\oe\\open-enclave\\openenclave\\share\\openenclave\\samples\\"%%i"
+                                mkdir build
+                                cd build
+                                cmake .. -G Ninja -DNUGET_PACKAGE_PATH=C:\\oe_prereqs -DLVI_MITIGATION=${lvi_mitigation} || exit /b %errorlevel%
+                                ninja || exit /b %errorlevel%
+                                ninja run || exit /b %errorlevel%
+                            )
+                            """
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR contains no logic changes. It moves the function contained at [openenclave-ci](https://github.com/openenclave/openenclave-ci/blob/master/src/jenkins/common/Openenclave.groovy#L130) locally to remove the global shared library dependency which makes maintenance easier.

Signed-off-by: brmclare <brmclare@microsoft.com>