### PR TITLE
upgrade ci infrastracture to rhel 8.3

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -16,7 +16,7 @@ FULL_TEST_SUITE = env.FULL_TEST_SUITE ?: false
 AGENTS_LABELS = [
     "acc-ubuntu-18.04": env.UBUNTU_1804_CUSTOM_LABEL ?: "ACC-1804",
     "ubuntu-nonsgx":    env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX",
-    "acc-rhel-8":       env.RHEL_8_CUSTOM_LABEL ?: "ACC-RHEL-8",
+    "acc-rhel-8":       env.RHEL_8_CUSTOM_LABEL ?: "ACC-RHEL-83",
     "acc-win2019":      env.WINDOWS_2019_CUSTOM_LABEL ?: "SGX-Windows-2019",
     "acc-win2019-dcap": env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP",
     "windows-nonsgx":   env.WINDOWS_NONSGX_CUSTOM_LABEL ?: "nonSGX-Windows"

--- a/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/rhel-8-variables.json
+++ b/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/rhel-8-variables.json
@@ -1,10 +1,10 @@
 {
     "managed_image_name_suffix": "rhel-8-SGX",
     "os_type": "Linux",
-    "gallery_image_name": "rhel-8",
+    "gallery_image_name": "rhel-83",
     "image_publisher": "RedHat",
     "image_offer": "RHEL",
-    "image_sku": "8-gen2",
+    "image_sku": "83-gen2",
     "vm_size": "Standard_DC2s",
     "ansible_group": "linux-agents",
     "playbook_file_name": "oe-linux-acc-setup.yml",

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -11,11 +11,11 @@ GLOBAL_ERROR = null
 DOCKER_TAG = env.DOCKER_TAG ?: "latest"
 AGENTS_LABELS = [
     "acc-ubuntu-18.04":         env.UBUNTU_1804_CUSTOM_LABEL ?: "ACC-1804",
-    "acc-rhel-8":               env.RHEL_8_CUSTOM_LABEL ?: "ACC-RHEL-8",
+    "acc-rhel-8":               env.RHEL_8_CUSTOM_LABEL ?: "ACC-RHEL-83",
     "ubuntu-nonsgx":            env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX",
     "windows-nonsgx":           env.WINDOWS_NONSGX_CUSTOM_LABEL ?: "nonSGX-Windows",
     "acc-ubuntu-18.04-vanilla": env.UBUNTU_VANILLA_1804_CUSTOM_LABEL ?: "vanilla-ubuntu-1804",
-    "acc-rhel-8-vanilla":       env.RHEL_8_VANILLA_CUSTOM_LABEL ?: "vanilla-rhel-8"
+    "acc-rhel-8-vanilla":       env.RHEL_8_VANILLA_CUSTOM_LABEL ?: "vanilla-rhel-83"
 ]
 
 def ACCCodeCoverageTest(String label, String compiler, String build_type) {


### PR DESCRIPTION
This PR attaches new labels to our infrastructure testing for RHEL 8. The new labels correspond to an RHEL 8.3 upgrade of the existing infrastructure along with all required permissions etc.

Signed-off-by: brmclare <brmclare@microsoft.com>