### PR TITLE
remove redundant oe_get_sgx_quote_validity()

### DIFF
--- a/common/sgx/quote.c
+++ b/common/sgx/quote.c
@@ -482,7 +482,12 @@ oe_result_t oe_verify_sgx_quote(
 
     // Endorsements verification
     OE_CHECK(oe_verify_quote_with_sgx_endorsements(
-        quote, quote_size, &sgx_endorsements, input_validation_time));
+        quote,
+        quote_size,
+        &sgx_endorsements,
+        input_validation_time,
+        NULL,
+        NULL));
 
     result = OE_OK;
 
@@ -497,7 +502,9 @@ oe_result_t oe_verify_quote_with_sgx_endorsements(
     const uint8_t* quote,
     size_t quote_size,
     const oe_sgx_endorsements_t* sgx_endorsements,
-    oe_datetime_t* input_validation_time)
+    oe_datetime_t* input_validation_time,
+    oe_datetime_t* valid_from,
+    oe_datetime_t* valid_until)
 {
     oe_result_t result = OE_UNEXPECTED;
     oe_datetime_t validity_from = {0};
@@ -650,7 +657,11 @@ oe_result_t oe_verify_quote_with_sgx_endorsements(
             vtime,
             vuntil);
     }
-
+    if (valid_from && valid_until)
+    {
+        *valid_from = validity_from;
+        *valid_until = validity_until;
+    }
     result = OE_OK;
 
 done:

--- a/common/sgx/quote.h
+++ b/common/sgx/quote.h
@@ -66,12 +66,19 @@ oe_result_t oe_verify_sgx_quote(
  * if the input time is after than the endorsement creation time, then the
  * CRLs might have updated in the period between the input time and the
  * endorsement creation time.
+ * @param[out] valid_from Optional pointer to the endorsement validity period
+ * that can be extraced by verifier and written to OE_CLAIM_VALIDITY_FROM.
+ * @param[out] valid_until Optional pointer to the endorsement validity period
+ * that can be extraced by verifier and written to OE_CLAIM_VALIDITY_UNTIL.
+ *
  */
 oe_result_t oe_verify_quote_with_sgx_endorsements(
     const uint8_t* quote,
     size_t quote_size,
     const oe_sgx_endorsements_t* endorsements,
-    oe_datetime_t* input_validation_time);
+    oe_datetime_t* input_validation_time,
+    oe_datetime_t* valid_from,
+    oe_datetime_t* valid_until);
 
 /*!
  * Find the valid datetime range for the given quote and sgx endorsements.

--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -217,8 +217,9 @@ static oe_result_t _fill_with_known_claims(
     const sgx_evidence_format_type_t format_type,
     const oe_uuid_t* format_id,
     const uint8_t* report_body,
-    size_t report_body_size,
     const oe_sgx_endorsements_t* sgx_endorsements,
+    oe_datetime_t* valid_from,
+    oe_datetime_t* valid_until,
     oe_claim_t* claims,
     size_t claims_length,
     size_t* claims_added)
@@ -228,8 +229,6 @@ static oe_result_t _fill_with_known_claims(
     oe_identity_t* id = &parsed_report.identity;
     const sgx_report_body_t* sgx_report_body = NULL;
     size_t claims_index = 0;
-    oe_datetime_t valid_from = {0};
-    oe_datetime_t valid_until = {0};
     bool flag;
 
     if (claims_length < OE_REQUIRED_CLAIMS_COUNT + OE_SGX_REQUIRED_CLAIMS_COUNT)
@@ -391,29 +390,21 @@ static oe_result_t _fill_with_known_claims(
 
     if (format_type != SGX_FORMAT_TYPE_LOCAL)
     {
-        // Get quote validity periods to get validity from and until claims.
-        OE_CHECK(oe_get_sgx_quote_validity(
-            report_body,
-            report_body_size,
-            sgx_endorsements,
-            &valid_from,
-            &valid_until));
-
         // Validity from.
         OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_VALIDITY_FROM,
             sizeof(OE_CLAIM_VALIDITY_FROM),
-            &valid_from,
-            sizeof(valid_from)));
+            valid_from,
+            sizeof(*valid_from)));
 
         // Validity to.
         OE_CHECK(oe_sgx_add_claim(
             &claims[claims_index++],
             OE_CLAIM_VALIDITY_UNTIL,
             sizeof(OE_CLAIM_VALIDITY_UNTIL),
-            &valid_until,
-            sizeof(valid_until)));
+            valid_until,
+            sizeof(*valid_until)));
 
         // TCB info
         OE_CHECK(oe_sgx_add_claim(
@@ -530,6 +521,8 @@ oe_result_t oe_sgx_extract_claims(
     const uint8_t* custom_claims_buffer,
     size_t custom_claims_buffer_size,
     const oe_sgx_endorsements_t* sgx_endorsements,
+    oe_datetime_t* valid_from,
+    oe_datetime_t* valid_until,
     oe_claim_t** claims_out,
     size_t* claims_length_out)
 {
@@ -540,6 +533,8 @@ oe_result_t oe_sgx_extract_claims(
     size_t claims_added = 0;
     size_t additional_claim = 0;
     sgx_report_data_t report_data;
+    oe_datetime_t local_valid_from = {0};
+    oe_datetime_t local_valid_until = {0};
 
     // Note: some callers can have custom_claims_buffer pointing to a non-NULL
     // buffer containing a zero-sized array.
@@ -586,13 +581,28 @@ oe_result_t oe_sgx_extract_claims(
     if (claims == NULL)
         OE_RAISE(OE_OUT_OF_MEMORY);
 
+    if (!valid_from || !valid_until)
+    {
+        // Get quote validity periods to get validity from and until claims if
+        // valid_from and valid_until is not provided.
+        OE_CHECK(oe_get_sgx_quote_validity(
+            report_body,
+            report_body_size,
+            sgx_endorsements,
+            &local_valid_from,
+            &local_valid_until));
+        valid_from = &local_valid_from;
+        valid_until = &local_valid_until;
+    }
+
     // Fill the list with the known claims.
     OE_CHECK(_fill_with_known_claims(
         format_type,
         format_id,
         report_body,
-        report_body_size,
         sgx_endorsements,
+        valid_from,
+        valid_until,
         claims,
         claims_length,
         &claims_added));
@@ -649,6 +659,8 @@ oe_result_t oe_sgx_verify_evidence(
 {
     oe_result_t result = OE_UNEXPECTED;
     oe_datetime_t* time = NULL;
+    oe_datetime_t valid_from = {0};
+    oe_datetime_t valid_until = {0};
     uint8_t* local_endorsements_buffer = NULL;
     size_t local_endorsements_buffer_size = 0;
     oe_sgx_endorsements_t sgx_endorsements;
@@ -789,7 +801,12 @@ oe_result_t oe_sgx_verify_evidence(
 
         // Verify the quote now.
         OE_CHECK(oe_verify_quote_with_sgx_endorsements(
-            report_body, report_body_size, &sgx_endorsements, time));
+            report_body,
+            report_body_size,
+            &sgx_endorsements,
+            time,
+            &valid_from,
+            &valid_until));
     }
 
     // Last step is to return the required and custom claims.
@@ -803,6 +820,8 @@ oe_result_t oe_sgx_verify_evidence(
             custom_claims_buffer,
             custom_claims_buffer_size,
             &sgx_endorsements,
+            &valid_from,
+            &valid_until,
             claims,
             claims_length));
 

--- a/include/openenclave/internal/sgx/plugin.h
+++ b/include/openenclave/internal/sgx/plugin.h
@@ -38,6 +38,10 @@ typedef enum _sgx_evidence_format_type_t
  * format_type has the right value.
  * @param[in] custom_claims_buffer_size The size of the custom_claims buffer.
  * @param[in] sgx_endorsements Pointer to the endorsements buffer.
+ * @param[in] valid_from Pointer to the datetime from which the evidence and
+ * endorsements are valid.
+ * @param[in] valid_until Pointer to the datetime at which the evidence and
+ * endorsements expire.
  * @param[out] claims_out Pointer to the address of a dynamically allocated
  * buffer holding the list of claims (including base and custom claims).
  * @param[out] claims_length_out The length of the claims_out list.
@@ -54,6 +58,8 @@ oe_result_t oe_sgx_extract_claims(
     const uint8_t* custom_claims_buffer,
     size_t custom_claims_buffer_size,
     const struct _oe_sgx_endorsements_t* sgx_endorsements,
+    oe_datetime_t* valid_from,
+    oe_datetime_t* valid_until,
     oe_claim_t** claims_out,
     size_t* claims_length_out);
 


### PR DESCRIPTION
In `oe_sgx_verify_evidence()` code path, `oe_get_sgx_quote_validity()` is called twice. 1st call is to verify sgx quote's validity, including validity period checking and 2nd call is to extract validity period for required claims.
2nd call is redundant as validity period can be fetched in the 1st call and `oe_get_sgx_quote_validity()` is relatively time consuming in enclave. Multiple memory allocations are required in this call.

After the fix, `oe_sgx_verify_evidence()` enclave running time reduced from 125 ms to 80ms in Linux.

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>