### PR TITLE
Implements syscall clock_nanosleep, to support MUSL 1.2.2 and higher

### DIFF
--- a/docs/SystemEdls.md
+++ b/docs/SystemEdls.md
@@ -136,6 +136,7 @@ oe_syscall_getnameinfo_ocall | N/A | Used by internal APIs to resolve `addrinfo`
 Ocall | Dependent syscall | Comments |
 :---|:---:|:---|
 oe_syscall_nanosleep_ocall | nanosleep | - |
+oe_syscall_clock_nanosleep_ocall | clock_nanosleep | In Windows, only flag = 0 is supported. |
 
 ### unistd.edl
 Ocall | Dependent syscall | Comments |

--- a/host/linux/syscall.c
+++ b/host/linux/syscall.c
@@ -1485,3 +1485,26 @@ int oe_syscall_nanosleep_ocall(struct oe_timespec* req, struct oe_timespec* rem)
 
     return nanosleep((struct timespec*)req, (struct timespec*)rem);
 }
+
+/*
+**==============================================================================
+**
+** clock_nanosleep():
+**
+**==============================================================================
+*/
+
+int oe_syscall_clock_nanosleep_ocall(
+    oe_clockid_t clockid,
+    int flag,
+    struct oe_timespec* req,
+    struct oe_timespec* rem)
+{
+    errno = 0;
+
+    return clock_nanosleep(
+        (clockid_t)clockid,
+        (int)flag,
+        (struct timespec*)req,
+        (struct timespec*)rem);
+}

--- a/include/openenclave/bits/types.h
+++ b/include/openenclave/bits/types.h
@@ -180,4 +180,9 @@ typedef struct _oe_datetime
     uint32_t seconds; /* range: 0-59 */
 } oe_datetime_t;
 
+/**
+ * This type defines a system internal clock ID.
+ */
+typedef int oe_clockid_t;
+
 #endif /* _OE_BITS_TYPES_H */

--- a/include/openenclave/edl/time.edl
+++ b/include/openenclave/edl/time.edl
@@ -14,7 +14,7 @@
 
 enclave
 {
-    // Needed for integral type time_t
+    // Needed for integral type time_t, oe_clockid_t
     include "openenclave/bits/types.h"
 
     struct oe_timespec
@@ -26,6 +26,13 @@ enclave
     untrusted
     {
         int oe_syscall_nanosleep_ocall(
+            [in] struct oe_timespec* req,
+            [in, out] struct oe_timespec* rem)
+            propagate_errno;
+
+        int oe_syscall_clock_nanosleep_ocall(
+            oe_clockid_t clockid,
+            int flag,
             [in] struct oe_timespec* req,
             [in, out] struct oe_timespec* rem)
             propagate_errno;

--- a/include/openenclave/internal/syscall/unistd.h
+++ b/include/openenclave/internal/syscall/unistd.h
@@ -81,6 +81,11 @@ int oe_getdomainname(char* name, size_t len);
 unsigned int oe_sleep(unsigned int seconds);
 
 int oe_nanosleep(struct oe_timespec* req, struct oe_timespec* rem);
+int oe_clock_nanosleep(
+    oe_clockid_t clockid,
+    int flag,
+    struct oe_timespec* req,
+    struct oe_timespec* rem);
 
 int oe_flock(int fd, int operation);
 

--- a/include/openenclave/internal/time.h
+++ b/include/openenclave/internal/time.h
@@ -6,6 +6,20 @@
 
 #include <openenclave/bits/types.h>
 
+/*
+ * The IDs of the various system clocks (for POSIX.1b interval timers):
+ */
+#define CLOCK_REALTIME 0
+#define CLOCK_MONOTONIC 1
+#define CLOCK_PROCESS_CPUTIME_ID 2
+#define CLOCK_THREAD_CPUTIME_ID 3
+#define CLOCK_MONOTONIC_RAW 4
+#define CLOCK_REALTIME_COARSE 5
+#define CLOCK_MONOTONIC_COARSE 6
+#define CLOCK_BOOTTIME 7
+#define CLOCK_REALTIME_ALARM 8
+#define CLOCK_BOOTTIME_ALARM 9
+
 OE_EXTERNC_BEGIN
 
 /*

--- a/syscall/hostcalls.c
+++ b/syscall/hostcalls.c
@@ -1282,6 +1282,39 @@ oe_result_t _oe_syscall_nanosleep_ocall(
 }
 OE_WEAK_ALIAS(_oe_syscall_nanosleep_ocall, oe_syscall_nanosleep_ocall);
 
+/**
+ * Declare the prototypes of the following functions to avoid the
+ * missing-prototypes warning.
+ */
+oe_result_t _oe_syscall_clock_nanosleep_ocall(
+    int* _retval,
+    oe_clockid_t clockid,
+    int flag,
+    struct oe_timespec* req,
+    struct oe_timespec* rem);
+
+/**
+ * Implement the functions and make them as the weak aliases of
+ * the public ocall wrappers.
+ */
+oe_result_t _oe_syscall_clock_nanosleep_ocall(
+    int* _retval,
+    oe_clockid_t clockid,
+    int flag,
+    struct oe_timespec* req,
+    struct oe_timespec* rem)
+{
+    OE_UNUSED(_retval);
+    OE_UNUSED(clockid);
+    OE_UNUSED(flag);
+    OE_UNUSED(req);
+    OE_UNUSED(rem);
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(
+    _oe_syscall_clock_nanosleep_ocall,
+    oe_syscall_clock_nanosleep_ocall);
+
 /*
 **==============================================================================
 **

--- a/syscall/syscall.c
+++ b/syscall/syscall.c
@@ -72,15 +72,14 @@ OE_WEAK OE_DEFINE_SYSCALL1(SYS_chdir)
     return oe_chdir(path);
 }
 
-// TODO issue #3933: Implement correctly and add tests
 OE_WEAK OE_DEFINE_SYSCALL4_M(SYS_clock_nanosleep)
 {
-    OE_UNUSED(arg1);
-    OE_UNUSED(arg2);
     oe_errno = 0;
+    oe_clockid_t clockid = (oe_clockid_t)arg1;
+    int flag = (int)arg2;
     struct oe_timespec* req = (struct oe_timespec*)arg3;
     struct oe_timespec* rem = (struct oe_timespec*)arg4;
-    return (long)oe_nanosleep(req, rem);
+    return (long)oe_clock_nanosleep(clockid, flag, req, rem);
 }
 
 OE_WEAK OE_DEFINE_SYSCALL1_M(SYS_close)

--- a/syscall/unistd.c
+++ b/syscall/unistd.c
@@ -145,6 +145,17 @@ int oe_nanosleep(struct oe_timespec* req, struct oe_timespec* rem)
     return ret;
 }
 
+int oe_clock_nanosleep(
+    int clockid,
+    int flag,
+    struct oe_timespec* req,
+    struct oe_timespec* rem)
+{
+    int ret = 0;
+    oe_syscall_clock_nanosleep_ocall(&ret, clockid, flag, req, rem);
+    return ret;
+}
+
 oe_pid_t oe_getpid(void)
 {
     oe_pid_t ret = 0;

--- a/tests/edl_opt_out/enc/enc.c
+++ b/tests/edl_opt_out/enc/enc.c
@@ -98,6 +98,9 @@ void enc_edl_opt_out()
 
     /* time.edl */
     OE_TEST(oe_syscall_nanosleep_ocall(NULL, NULL, NULL) == OE_UNSUPPORTED);
+    OE_TEST(
+        oe_syscall_clock_nanosleep_ocall(NULL, 0, 0, NULL, NULL) ==
+        OE_UNSUPPORTED);
 
     /* unistd.edl */
     OE_TEST(oe_syscall_getpid_ocall(NULL) == OE_UNSUPPORTED);

--- a/tests/stdc/enc/enc.cpp
+++ b/tests/stdc/enc/enc.cpp
@@ -224,6 +224,25 @@ static void _test_time_functions(void)
 
         OE_TEST(after > before);
     }
+
+    /* Test clock_nanosleep() */
+    {
+        const uint64_t SLEEP_SECS = 3;
+        clockid_t clockid = CLOCK_REALTIME;
+        uint64_t before, after;
+
+        /* Sleep for SLEEP_SECS seconds */
+        {
+            before = oe_get_time();
+            int flag = 0;
+            timespec req = {SLEEP_SECS, 0};
+            timespec rem;
+            OE_TEST(clock_nanosleep(clockid, flag, &req, &rem) == 0);
+            after = oe_get_time();
+        }
+
+        OE_TEST(after > before);
+    }
 }
 
 int test(char buf1[BUFSIZE], char buf2[BUFSIZE])


### PR DESCRIPTION
Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>