### PR TITLE
Update oeedger-cpp with the default count=1 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The OpenEnclave CMake configuration now explicitly sets CMAKE_SKIP_RPATH to TRUE. This change should not affect fully static-linked enclaves.
 - oe_verify_attestation_certificate_with_evidence() has been deprecated because it has been deemed insufficient for security. Use the new, experimental oe_verify_attestation_certificate_with_evidence_v2() instead to generate a self-signed certificate for use in the TLS handshaking process.
+- In/out parameters in EDL now have the default count equals to one if the `count` attribute is not used.
 
 [v0.15.0][v0.15.0_log]
 --------------

--- a/include/openenclave/edl/epoll.edl
+++ b/include/openenclave/edl/epoll.edl
@@ -37,7 +37,7 @@ enclave
             int64_t epfd,
             int op,
             int64_t fd,
-            [in, count=1] struct oe_epoll_event* event)
+            [in] struct oe_epoll_event* event)
             propagate_errno;
 
         int oe_syscall_epoll_close_ocall(

--- a/include/openenclave/edl/socket.edl
+++ b/include/openenclave/edl/socket.edl
@@ -73,7 +73,7 @@ enclave
             oe_host_fd_t sockfd,
             [out, size=addrlen_in] struct oe_sockaddr* addr,
             oe_socklen_t addrlen_in,
-            [out, count=1] oe_socklen_t* addrlen_out)
+            [out] oe_socklen_t* addrlen_out)
             propagate_errno;
 
         int oe_syscall_bind_ocall(
@@ -91,13 +91,13 @@ enclave
             oe_host_fd_t sockfd,
             [out, size=msg_namelen] void* msg_name,
             oe_socklen_t msg_namelen,
-            [out, count=1] oe_socklen_t* msg_namelen_out,
+            [out] oe_socklen_t* msg_namelen_out,
             [in, out, size=msg_iov_buf_size] void* msg_iov_buf,
             size_t msg_iovlen,
             size_t msg_iov_buf_size,
             [out, size=msg_controllen] void* msg_control,
             size_t msg_controllen,
-            [out, count=1] size_t* msg_controllen_out,
+            [out] size_t* msg_controllen_out,
             int flags)
             propagate_errno;
 
@@ -127,7 +127,7 @@ enclave
             int flags,
             [out, size=addrlen_in] struct oe_sockaddr* src_addr,
             oe_socklen_t addrlen_in,
-            [out, count=1] oe_socklen_t* addrlen_out)
+            [out] oe_socklen_t* addrlen_out)
             propagate_errno;
 
         ssize_t oe_syscall_send_ocall(
@@ -199,21 +199,21 @@ enclave
         int oe_syscall_getaddrinfo_open_ocall(
             [in, string] const char* node,
             [in, string] const char* service,
-            [in, count=1] const struct oe_addrinfo* hints,
-            [out, count=1] uint64_t* handle)
+            [in] const struct oe_addrinfo* hints,
+            [out] uint64_t* handle)
             propagate_errno;
 
         int oe_syscall_getaddrinfo_read_ocall(
             uint64_t handle,
-            [out, count=1] int* ai_flags,
-            [out, count=1] int* ai_family,
-            [out, count=1] int* ai_socktype,
-            [out, count=1] int* ai_protocol,
+            [out] int* ai_flags,
+            [out] int* ai_family,
+            [out] int* ai_socktype,
+            [out] int* ai_protocol,
             oe_socklen_t ai_addrlen_in,
-            [out, count=1] oe_socklen_t* ai_addrlen,
+            [out] oe_socklen_t* ai_addrlen,
             [out, size=ai_addrlen_in] struct oe_sockaddr* ai_addr,
             size_t ai_canonnamelen_in,
-            [out, count=1] size_t* ai_canonnamelen,
+            [out] size_t* ai_canonnamelen,
             [out, size=ai_canonnamelen_in] char* ai_canonname)
             propagate_errno;
 

--- a/include/openenclave/edl/utsname.edl
+++ b/include/openenclave/edl/utsname.edl
@@ -29,7 +29,7 @@ enclave
     untrusted
     {
         int oe_syscall_uname_ocall(
-            [out, count=1] struct oe_utsname* buf)
+            [out] struct oe_utsname* buf)
             propagate_errno;
     };
 };


### PR DESCRIPTION
Update the oeedger-cpp, which now supports default count equals to one for in/out parameters.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>