### PR TITLE
add quotes around string sub

### DIFF
--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -28,7 +28,7 @@ def get_image_version() {
     def now = LocalDateTime.now()
     return (now.format(DateTimeFormatter.ofPattern("yyyy")) + "." + \
             now.format(DateTimeFormatter.ofPattern("MM")) + "." + \
-            now.format(DateTimeFormatter.ofPattern("dd")) + env.$BUILD_NUMBER)
+            now.format(DateTimeFormatter.ofPattern("dd")) + "${BUILD_NUMBER}")
 }
 
 def get_commit_id() {


### PR DESCRIPTION
There is a minor issue that appears in end-to-end testing where the string is substituted incorrectly for the managed image builds and a null value is submitted. This pr substitutes the correct value.

Signed-off-by: brmclare <brmclare@microsoft.com>