### PR TITLE
Avoid always triggering re-compile for the oecert binary

### DIFF
--- a/tests/tools/oecert/CMakeLists.txt
+++ b/tests/tools/oecert/CMakeLists.txt
@@ -2,9 +2,24 @@
 # Licensed under the MIT License.
 
 if (BUILD_ENCLAVES)
-  add_subdirectory(enc)
-  # oecert host depends on a key pair generated during the enclave building.
-  # private key is used to sign the enclave while public key is written in the
-  # header of the oecert executable
+  # Generate a random key pair for enclave signing and output the public key to header file
+  # included by the host
+  add_custom_command(
+    OUTPUT oecert_enc_private.pem oecert_enc_public.pem oecert_enc_pubkey.h
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_pubkey_header.sh
+    COMMAND openssl genrsa -out oecert_enc_private.pem -3 3072
+    COMMAND openssl rsa -in oecert_enc_private.pem -pubout -out
+            oecert_enc_public.pem
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/gen_pubkey_header.sh oecert_enc_pubkey.h
+            oecert_enc_public.pem
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+  # Add the custome target against the generated files that both the host and the enclave
+  # can enforce the dependency
+  add_custom_target(
+    enclave_key_pair DEPENDS oecert_enc_private.pem oecert_enc_public.pem
+                             oecert_enc_pubkey.h)
+
   add_subdirectory(host)
+  add_subdirectory(enc)
 endif ()

--- a/tests/tools/oecert/enc/CMakeLists.txt
+++ b/tests/tools/oecert/enc/CMakeLists.txt
@@ -7,18 +7,6 @@ add_custom_command(
   COMMAND edger8r --trusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecert.edl
           --search-path ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
-# generate a random key pair for enclave signing and output the public key to header file
-add_custom_command(
-  OUTPUT oecert_enc_private.pem oecert_enc_public.pem oecert_enc_pubkey.h
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../gen_pubkey_header.sh
-  COMMAND openssl genrsa -out oecert_enc_private.pem -3 3072
-  COMMAND openssl rsa -in oecert_enc_private.pem -pubout -out
-          oecert_enc_public.pem
-  COMMAND
-    ${CMAKE_CURRENT_SOURCE_DIR}/../gen_pubkey_header.sh
-    ${CMAKE_CURRENT_BINARY_DIR}/../oecert_enc_pubkey.h
-    ${CMAKE_CURRENT_BINARY_DIR}/oecert_enc_public.pem)
-
 # generate the enclave and sign it with the private key
 add_enclave(
   TARGET
@@ -29,7 +17,9 @@ add_enclave(
   CONFIG
   enc.conf
   KEY
-  ${CMAKE_CURRENT_BINARY_DIR}/oecert_enc_private.pem)
+  ${CMAKE_CURRENT_BINARY_DIR}/../oecert_enc_private.pem)
+
+add_enclave_dependencies(oecert_enc enclave_key_pair)
 
 # Need for the generated file oecert_t.h
 enclave_include_directories(oecert_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/tools/oecert/host/CMakeLists.txt
+++ b/tests/tools/oecert/host/CMakeLists.txt
@@ -11,12 +11,14 @@ endif ()
 
 add_custom_command(
   OUTPUT oecert_u.h oecert_u.c oecert_args.h
-  DEPENDS ../oecert.edl edger8r oecert_enclave_signed
+  DEPENDS ../oecert.edl edger8r
   COMMAND edger8r --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../oecert.edl
           --search-path ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX})
 
 add_executable(oecert host.cpp evidence.cpp
                       ${CMAKE_CURRENT_BINARY_DIR}/oecert_u.c)
+
+add_dependencies(oecert enclave_key_pair)
 
 target_include_directories(oecert PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                           -I/usr/include/openssl)


### PR DESCRIPTION
Fix the incorrect dependency that always triggers the re-compilation of the `oecert` binary for each build. More detail of the bug as follows:

The custom command under oecert/host/CMakeLists.txt depends on the `oecert_enclave_signed` defined in the oecert/enc/CMakeLists.txt, which is not in the same scope. Therefore, the custom command treats the `oecert_enclave_signed` as undefined and always gets re-executed (and hence the `oecert` binary that depends on the custom command) for each build.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>