### PR TITLE
Support the CapturePFGPExceptions preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased][Unreleased_log]
 --------------
 
+### Added
+- Add the CapturePFGPExceptions preference for the SGX2 feature of capturing #PF and #GP exceptions inside an enclave.
+  - Developers can specify the CapturePFGPExceptions with a binary value in the enclave config file or set the value via the newly added OE_SET_ENCLAVE_SGX2 macro, which is used to set SGX2-specific properties.
+  - When setting CapturePFGPExceptions=1, the OE loader will enable the feature when running on an SGX2-capable CPU.
+  - Once enabled, the in-enclave exception handler can capture the #PF (with the OE_EXCEPTION_PAGE_FAULT code) and #GP (with the code OE_EXCEPTION_ACCESS_VIOLATION code) exceptions.
+  - More information about the exceptions can be found in the `faulting_address` and `error_code` members of the `oe_exception_record_t` structure passed into the handler.
+
 [v0.16.1][v0.16.1_log]
 --------------
 ### Added

--- a/host/sgx/cpuid.h
+++ b/host/sgx/cpuid.h
@@ -13,6 +13,10 @@
 #error "oe_get_cpuid(): no cpuid intrinsic mapping for this compiler"
 #endif
 
+#define CPUID_SGX_LEAF 0x12
+#define CPUID_SGX_KSS_MASK 0x80
+#define CPUID_SGX_MISC_EXINFO_MASK 0x01
+
 /* Same as __get_cpuid, but sub-leaf can be specified.
    Need this function as cpuid level 4 needs the sub-leaf to be specified in ECX
 */

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -162,6 +162,10 @@ static sgx_secs_t* _new_secs(
         secs->config_svn = context->config_data->config_svn;
     }
 
+    /* Set the EXINFO bit if CapturePFGPExceptions=1 */
+    if (context->capture_pf_gp_exceptions_enabled)
+        secs->misc_select |= SGX_SECS_MISCSELECT_EXINFO;
+
     return secs;
 }
 
@@ -262,6 +266,7 @@ static oe_result_t _get_sig_struct(
             properties->config.attributes,
             properties->config.product_id,
             properties->config.security_version,
+            &properties->config.flags,
             OE_DEBUG_SIGN_KEY,
             OE_DEBUG_SIGN_KEY_SIZE,
             properties->config.family_id,

--- a/host/sgx/sgxsign.c
+++ b/host/sgx/sgxsign.c
@@ -571,6 +571,7 @@ static oe_result_t _init_sigstruct(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const oe_sgx_enclave_flags_t* flags,
     const uint8_t* family_id,
     const uint8_t* extended_product_id,
     sgx_sigstruct_t* sigstruct)
@@ -620,7 +621,10 @@ static oe_result_t _init_sigstruct(
     sigstruct->miscselect = SGX_SIGSTRUCT_MISCSELECT;
 
     /* sgx_sigstruct_t.miscmask */
-    sigstruct->miscmask = SGX_SIGSTRUCT_MISCMASK;
+    if (flags && flags->capture_pf_gp_exceptions)
+        sigstruct->miscmask = SGX_SIGSTRUCT_MISCMASK_EXINFO;
+    else
+        sigstruct->miscmask = SGX_SIGSTRUCT_MISCMASK;
 
     /* sgx_sigstruct_t.attributes */
     sigstruct->attributes.flags = attributes;
@@ -681,6 +685,7 @@ oe_result_t oe_sgx_sign_enclave_from_engine(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const oe_sgx_enclave_flags_t* flags,
     const char* engine_id,
     const char* engine_load_path,
     const char* key_id,
@@ -709,6 +714,7 @@ oe_result_t oe_sgx_sign_enclave_from_engine(
         attributes,
         product_id,
         security_version,
+        flags,
         family_id,
         extended_product_id,
         sigstruct));
@@ -728,6 +734,7 @@ oe_result_t oe_sgx_sign_enclave(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const oe_sgx_enclave_flags_t* flags,
     const uint8_t* pem_data,
     size_t pem_size,
     const uint8_t* family_id,
@@ -755,6 +762,7 @@ oe_result_t oe_sgx_sign_enclave(
         attributes,
         product_id,
         security_version,
+        flags,
         family_id,
         extended_product_id,
         sigstruct));
@@ -774,6 +782,7 @@ oe_result_t oe_sgx_get_sigstruct_digest(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const oe_sgx_enclave_flags_t* flags,
     const uint8_t* family_id,
     const uint8_t* extended_product_id,
     OE_SHA256* digest)
@@ -794,6 +803,7 @@ oe_result_t oe_sgx_get_sigstruct_digest(
         attributes,
         product_id,
         security_version,
+        flags,
         family_id,
         extended_product_id,
         &sigstruct));
@@ -810,6 +820,7 @@ oe_result_t oe_sgx_digest_sign_enclave(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const oe_sgx_enclave_flags_t* flags,
     const uint8_t* cert_pem_data,
     size_t cert_pem_size,
     const uint8_t* digest_signature,
@@ -845,6 +856,7 @@ oe_result_t oe_sgx_digest_sign_enclave(
         attributes,
         product_id,
         security_version,
+        flags,
         family_id,
         extended_product_id,
         sigstruct));

--- a/include/openenclave/bits/exception.h
+++ b/include/openenclave/bits/exception.h
@@ -77,6 +77,56 @@ OE_EXTERNC_BEGIN
 #define OE_EXCEPTION_FLAGS_SOFTWARE 0x2
 
 /**
+ * The following flags are used to interpret the error_code of the
+ * oe_exception_record_t struct when a PF or GP exception occurs. Note that
+ * these exceptions are captured only with SGX2 CPU and the MISCSELCT[0] is set
+ * to 1.
+ */
+
+/**
+ * Page-protection violation flag
+ * 0 - The fault was caused by a non-present page.
+ * 1 - The fault was caused by a page-protection violation.
+ */
+#define OE_SGX_PAGE_FAULT_P_FLAG 0x1
+/**
+ * Read/Write flag
+ * 0 - The fault was caused by a read.
+ * 1 - The fault was caused by a write.
+ */
+#define OE_SGX_PAGE_FAULT_WR_FLAG 0x2
+/**
+ * U/S flag
+ * 0 - The fault was caused by a supervisor-mode access.
+ * 1 - The fault was caused by a user-mode access.
+ */
+#define OE_SGX_PAGE_FAULT_US_FLAG 0x4
+/**
+ * RSVD flag
+ * 0 - The fault was not caused by a reserved bit violation.
+ * 1 - The fault was caused by a reserved bit set to 1
+ */
+#define OE_SGX_PAGE_FAULT_RSVD 0x8
+/**
+ * I/D flag
+ * 0 - The fault was not caused by an instruction fetch.
+ * 1 - The fault was caused by an instruction fetch.
+ */
+#define OE_SGX_PAGE_FAULT_ID_FLAG 0x10
+/**
+ * Protection Key flag
+ * 0 - The fault was not caused by protection keys.
+ * 1 - The fault was caused by protection-key violation.
+ */
+#define OE_SGX_PAGE_FAULT_PK_FLAG 0x20
+/**
+ * SGX flag
+ * 0 - The fault was not related to SGX.
+ * 1 - The fault is SGX-specific (e.g., access violation).
+ */
+#define OE_SGX_PAGE_FAULT_SGX_FLAG 0x8000
+
+/**
  * Blob that contains X87 and SSE data.
  */
 typedef struct _oe_basic_xstate
@@ -153,6 +203,12 @@ typedef struct _oe_exception_record
     uint32_t flags; /**< Exception flags */
 
     uint64_t address; /**< Exception address */
+
+    /* Information for PF/GP exceptions, which are only available
+     * for SGX2 and requires application opt-in (set CapturePFGPExceptions=1).
+     */
+    uint64_t faulting_address;
+    uint32_t error_code;
 
     oe_context_t* context; /**< Exception context */
 } oe_exception_record_t;

--- a/include/openenclave/bits/sgx/sgxproperties.h
+++ b/include/openenclave/bits/sgx/sgxproperties.h
@@ -34,13 +34,18 @@ typedef struct _oe_sgx_enclave_image_info_t
 #define OE_SGX_FLAGS_KSS 0x0000000000000080ULL
 #define OE_SGX_SIGSTRUCT_SIZE 1808
 
+typedef struct _oe_sgx_enclave_flags_t
+{
+    uint32_t capture_pf_gp_exceptions : 1;
+    uint32_t reserved : 31;
+} oe_sgx_enclave_flags_t;
+
 typedef struct oe_sgx_enclave_config_t
 {
     uint16_t product_id;
     uint16_t security_version;
 
-    /* Padding to make packed and unpacked size the same */
-    uint32_t padding;
+    oe_sgx_enclave_flags_t flags;
 
     uint8_t family_id[16];
     uint8_t extended_product_id[16];
@@ -99,7 +104,10 @@ typedef struct _oe_sgx_enclave_properties
  * @param[in] ALLOW_DEBUG If true, allows the enclave to be created with
  * OE_ENCLAVE_FLAG_DEBUG and debugged at runtime
  * @param[in] REQUIRE_KSS If true, allows the enclave to be created with
- * kss properties
+ * KSS properties
+ * @param[in] CAPTURE_PF_GP_EXCEPTIONS If true, allows the enclave to capture
+ * #PF and #GP exceptions if the CPU supports the feature. The setting is
+ * ignored otherwise
  * @param[in] HEAP_PAGE_COUNT Number of heap pages to allocate in the enclave
  * @param[in] STACK_PAGE_COUNT Number of stack pages per thread to reserve in
  * the enclave
@@ -114,7 +122,8 @@ typedef struct _oe_sgx_enclave_properties
     EXTENDED_PRODUCT_ID,                                                  \
     FAMILY_ID,                                                            \
     ALLOW_DEBUG,                                                          \
-    REQUIRE_KSS,                                                            \
+    REQUIRE_KSS,                                                          \
+    CAPTURE_PF_GP_EXCEPTIONS,                                             \
     HEAP_PAGE_COUNT,                                                      \
     STACK_PAGE_COUNT,                                                     \
     TCS_COUNT)                                                            \
@@ -136,7 +145,8 @@ typedef struct _oe_sgx_enclave_properties
         {                                                                 \
             .product_id = PRODUCT_ID,                                     \
             .security_version = SECURITY_VERSION,                         \
-            .padding = 0,                                                 \
+            .flags.capture_pf_gp_exceptions = CAPTURE_PF_GP_EXCEPTIONS,   \
+            .flags.reserved = 0,                                          \
             .family_id = FAMILY_ID,                                       \
             .extended_product_id = EXTENDED_PRODUCT_ID,                   \
             .attributes = OE_MAKE_ATTRIBUTES(ALLOW_DEBUG, REQUIRE_KSS)    \
@@ -184,6 +194,7 @@ typedef struct _oe_sgx_enclave_properties
     {0},                                                                  \
     ALLOW_DEBUG,                                                          \
     false,                                                                \
+    0,                                                                    \
     HEAP_PAGE_COUNT,                                                      \
     STACK_PAGE_COUNT,                                                     \
     TCS_COUNT)
@@ -223,6 +234,57 @@ typedef struct _oe_sgx_enclave_properties
     FAMILY_ID,                                                            \
     ALLOW_DEBUG,                                                          \
     true,                                                                 \
+    0,                                                                    \
+    HEAP_PAGE_COUNT,                                                      \
+    STACK_PAGE_COUNT,                                                     \
+    TCS_COUNT)
+
+/**
+ * Defines the SGX2 properties for an enclave
+ *
+ * The enclave properties should only be defined once for all code compiled into
+ * an enclave binary. These properties can be overwritten at sign time by
+ * the oesign tool.
+ *
+ * @param[in] PRODUCT_ID ISV assigned Product ID (ISVPRODID) to use in the
+ * enclave signature
+ * @param[in] SECURITY_VERSION ISV assigned Security Version number (ISVSVN)
+ * to use in the enclave signature
+ * @param[in] EXTENDED_PRODUCT_ID ISV assigned Extended Product ID (ISVEXTPRODID)
+ *  to use in the enclave signature (SGX2 feature)
+ * @param[in] FAMILY_ID ISV assigned Product Family ID (ISVFAMILYID)
+ * to use in the enclave signature (SGX2 feature)
+ * @param[in] ALLOW_DEBUG If true, allows the enclave to be created with
+ * OE_ENCLAVE_FLAG_DEBUG and debugged at runtime
+ * @param[in] REQUIRE_KSS If true, allows the enclave to be created with
+ * KSS properties (SGX2 feature)
+ * @param[in] CAPTURE_PF_GP_EXCEPTIONS If true, allows the enclave to capture
+ * #PF and #GP exceptions if the CPU supports the feature. The setting is
+ * ignored otherwise (SGX2 feature)
+ * @param[in] HEAP_PAGE_COUNT Number of heap pages to allocate in the enclave
+ * @param[in] STACK_PAGE_COUNT Number of stack pages per thread to reserve in
+ * the enclave
+ * @param[in] TCS_COUNT Number of concurrent threads in an enclave to support
+ */
+ #define OE_SET_ENCLAVE_SGX2(                                             \
+    PRODUCT_ID,                                                           \
+    SECURITY_VERSION,                                                     \
+    EXTENDED_PRODUCT_ID,                                                  \
+    FAMILY_ID,                                                            \
+    ALLOW_DEBUG,                                                          \
+    CAPTURE_PF_GP_EXCEPTIONS,                                             \
+    REQUIRE_KSS,                                                          \
+    HEAP_PAGE_COUNT,                                                      \
+    STACK_PAGE_COUNT,                                                     \
+    TCS_COUNT)                                                            \
+ _OE_SET_ENCLAVE_SGX_IMPL(                                                \
+    PRODUCT_ID,                                                           \
+    SECURITY_VERSION,                                                     \
+    EXTENDED_PRODUCT_ID,                                                  \
+    FAMILY_ID,                                                            \
+    ALLOW_DEBUG,                                                          \
+    REQUIRE_KSS,                                                          \
+    CAPTURE_PF_GP_EXCEPTIONS,                                             \
     HEAP_PAGE_COUNT,                                                      \
     STACK_PAGE_COUNT,                                                     \
     TCS_COUNT)

--- a/include/openenclave/bits/sgx/sgxtypes.h
+++ b/include/openenclave/bits/sgx/sgxtypes.h
@@ -47,6 +47,8 @@ OE_EXTERNC_BEGIN
 #define SGX_SECINFO_TCS 0x0000000000000000100
 #define SGX_SECINFO_REG 0x0000000000000000200
 
+#define SGX_SECS_MISCSELECT_EXINFO 0x0000000000000001UL
+
 #define SGX_SE_EPID_SIG_RL_VERSION 0x200
 #define SGX_SE_EPID_SIG_RL_ID 0xE00
 
@@ -132,6 +134,7 @@ OE_CHECK_SIZE(sizeof(sgx_attributes_t), 16);
 
 /* sgx_sigstruct_t.miscmask */
 #define SGX_SIGSTRUCT_MISCMASK 0xffffffff
+#define SGX_SIGSTRUCT_MISCMASK_EXINFO 0xfffffffe
 
 /* sgx_sigstruct_t.flags */
 /* Mask all bits except bit 2 for MODE64BIT */
@@ -367,6 +370,17 @@ typedef struct sgx_ssa_gpr_t
     uint64_t fs_base;
     uint64_t gs_base;
 } sgx_ssa_gpr_t, *PSGX_SsaGpr;
+
+typedef struct _sgx_exinfo_t
+{
+    /*
+     * The naming and size of the members follows the Table 37-13 in the Intel
+     * Software Developer's Manual Volume 3.
+     */
+    uint64_t maddr;
+    uint32_t errcd;
+    uint8_t reserved[4];
+} sgx_exinfo_t;
 
 /*
 **==============================================================================
@@ -1052,7 +1066,7 @@ typedef struct _sgx_key
 
 /* Enclave MISCSELECT Flags Bit Masks, additional information to an SSA frame */
 /* If set, then the enclave page fault and general protection exception are
- * reported*/
+ * reported */
 #define SGX_MISC_FLAGS_PF_GP_EXIT_INFO 0x0000000000000001ULL
 
 /* Enclave Flags Bit Masks */

--- a/include/openenclave/internal/constants_x64.h
+++ b/include/openenclave/internal/constants_x64.h
@@ -24,6 +24,7 @@
 #define OE_DEFAULT_SSA_FRAME_SIZE 0x1
 #define OE_SGX_GPR_BYTE_SIZE 0xb8
 #define OE_SGX_TCS_HEADER_BYTE_SIZE 0x48
+#define OE_SGX_MISC_BYTE_SIZE 0x10
 
 //
 // SGX control pages, excluding thread data and local storage:

--- a/include/openenclave/internal/sgx/td.h
+++ b/include/openenclave/internal/sgx/td.h
@@ -81,7 +81,7 @@ oe_thread_data_t* oe_get_thread_data(void);
  * Due to the inability to use OE_OFFSETOF on a struct while defining its
  * members, this value is computed and hard-coded.
  */
-#define OE_THREAD_SPECIFIC_DATA_SIZE (3744)
+#define OE_THREAD_SPECIFIC_DATA_SIZE (3732)
 
 typedef struct _oe_callsite oe_callsite_t;
 
@@ -162,6 +162,14 @@ typedef struct _td
     /* TLS atexit functions (see enclave/core/sgx/threadlocal.c) */
     oe_tls_atexit_t* tls_atexit_functions;
     uint64_t num_tls_atexit_functions;
+
+    /* The following information is only available for SGX2 and MISCSELECT is
+     * set to 1 */
+    /* The faulting address associated with the PF exception. Should be zero
+     * for other exception types. */
+    uint64_t faulting_address;
+    /* The error code for PF and GP exceptions. */
+    uint32_t error_code;
 
     /* Reserved for thread specific data. */
     uint8_t thread_specific_data[OE_THREAD_SPECIFIC_DATA_SIZE];

--- a/include/openenclave/internal/sgxcreate.h
+++ b/include/openenclave/internal/sgxcreate.h
@@ -70,6 +70,8 @@ struct _oe_sgx_load_context
 
     const oe_config_data_t* config_data;
     bool use_config_id;
+
+    bool capture_pf_gp_exceptions_enabled;
 };
 
 oe_result_t oe_sgx_initialize_load_context(

--- a/include/openenclave/internal/sgxsign.h
+++ b/include/openenclave/internal/sgxsign.h
@@ -23,6 +23,7 @@ OE_EXTERNC_BEGIN
  * @param attributes[in] ATTRIBUTES flag values for the SGX sigstruct
  * @param product_id[in] ISVPRODID value for the SGX sigstruct
  * @param security_version[in] ISVSVN value for the SGX sigstruct
+ * @param flags[in] flags for OE-specific features opt-in/out
  * @param pem_data[in] PEM buffer containing the signing key
  * @param pem_size[in] size of the PEM buffer
  * @param family_id[in] ISVFAMILYID value for the SGX sigstruct
@@ -36,6 +37,7 @@ oe_result_t oe_sgx_sign_enclave(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const oe_sgx_enclave_flags_t* flags,
     const uint8_t* pem_data,
     size_t pem_size,
     const uint8_t* family_id,
@@ -54,6 +56,7 @@ oe_result_t oe_sgx_sign_enclave(
  * @param attributes[in] ATTRIBUTES flag values for the SGX sigstruct
  * @param product_id[in] ISVPRODID value for the SGX sigstruct
  * @param security_version[in] ISVSVN value for the SGX sigstruct
+ * @param flags[in] flags for OE-specific features opt-in/out
  * @param engine_id[in] text name of the engine to use
  * @param engine_load_path[in] file path to the openssl engine to use
  * @param key_id[in] integer handle for the key to use
@@ -68,6 +71,7 @@ oe_result_t oe_sgx_sign_enclave_from_engine(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const oe_sgx_enclave_flags_t* flags,
     const char* engine_id,
     const char* engine_load_path,
     const char* key_id,
@@ -83,6 +87,7 @@ oe_result_t oe_sgx_sign_enclave_from_engine(
  * @param attributes[in] ATTRIBUTES flag values for the SGX sigstruct
  * @param product_id[in] ISVPRODID value for the SGX sigstruct
  * @param security_version[in] ISVSVN value for the SGX sigstruct
+ * @param flags[in] flags for OE-specific features opt-in/out
  * @param family_id[in] ISVFAMILYID value for the SGX sigstruct
  * @param extended_product_id[in] ISVEXTPRODID value for the SGX sigstruct
  * @param digest[out] the digest of the sigstruct to be signed
@@ -94,6 +99,7 @@ oe_result_t oe_sgx_get_sigstruct_digest(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const oe_sgx_enclave_flags_t* flags,
     const uint8_t* family_id,
     const uint8_t* extended_product_id,
     OE_SHA256* digest);
@@ -113,6 +119,7 @@ oe_result_t oe_sgx_get_sigstruct_digest(
  * @param attributes[in] ATTRIBUTES flag values for the SGX sigstruct
  * @param product_id[in] ISVPRODID value for the SGX sigstruct
  * @param security_version[in] ISVSVN value for the SGX sigstruct
+ * @param flags[in] flags for OE-specific features opt-in/out
  * @param cert_pem_data[in] PEM buffer containing the public signing cert
  * @param cert_pem_size[in] size of the PEM buffer
  * @param digest_signature[in] binary data of the sigstruct digest signature
@@ -128,6 +135,7 @@ oe_result_t oe_sgx_digest_sign_enclave(
     uint64_t attributes,
     uint16_t product_id,
     uint16_t security_version,
+    const oe_sgx_enclave_flags_t* flags,
     const uint8_t* cert_pem_data,
     size_t cert_pem_size,
     const uint8_t* digest_signature,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ if (UNIX
     add_subdirectory(module_loading)
     add_subdirectory(ocall-create)
     add_subdirectory(oeedger8r)
+    add_subdirectory(pf_gp_exceptions)
     add_subdirectory(print)
     add_subdirectory(props)
     add_subdirectory(qeidentity)

--- a/tests/pf_gp_exceptions/CMakeLists.txt
+++ b/tests/pf_gp_exceptions/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/pf_gp_exceptions pf_gp_exceptions_host
+                 sgx_pf_gp_exceptions_enc)
+
+add_enclave_test(tests/pf_gp_exceptions_unsigned pf_gp_exceptions_host
+                 sgx_pf_gp_exceptions_enc_unsigned)

--- a/tests/pf_gp_exceptions/enc/CMakeLists.txt
+++ b/tests/pf_gp_exceptions/enc/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../pf_gp_exceptions.edl)
+
+add_custom_command(
+  OUTPUT pf_gp_exceptions_t.h pf_gp_exceptions_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(
+  TARGET
+  sgx_pf_gp_exceptions_enc
+  CONFIG
+  sign.conf
+  SOURCES
+  enc.c
+  ${CMAKE_CURRENT_BINARY_DIR}/pf_gp_exceptions_t.c)
+
+add_enclave(TARGET sgx_pf_gp_exceptions_enc_unsigned SOURCES enc.c
+            ${CMAKE_CURRENT_BINARY_DIR}/pf_gp_exceptions_t.c)
+
+enclave_include_directories(sgx_pf_gp_exceptions_enc PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})
+
+enclave_include_directories(sgx_pf_gp_exceptions_enc_unsigned PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/pf_gp_exceptions/enc/enc.c
+++ b/tests/pf_gp_exceptions/enc/enc.c
@@ -1,0 +1,79 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/print.h>
+#include <openenclave/internal/tests.h>
+#include "pf_gp_exceptions_t.h"
+
+static uint64_t faulting_address;
+static uint32_t error_code;
+
+uint64_t test_pfgp_handler(oe_exception_record_t* exception_record)
+{
+    if (exception_record->code == OE_EXCEPTION_PAGE_FAULT)
+    {
+        const int MOV_INSTRUCTION_BYTES = 3;
+        faulting_address = exception_record->faulting_address;
+        error_code = exception_record->error_code;
+        exception_record->context->rip += MOV_INSTRUCTION_BYTES;
+        oe_host_printf(
+            "#PF: addr: 0x%lx, code: %u\n",
+            exception_record->faulting_address,
+            exception_record->error_code);
+    }
+    else if (exception_record->code == OE_EXCEPTION_ACCESS_VIOLATION)
+    {
+        const int LGDT_INSTRUCTION_BYTES = 8;
+        faulting_address = exception_record->faulting_address;
+        error_code = exception_record->error_code;
+        exception_record->context->rip += LGDT_INSTRUCTION_BYTES;
+        oe_host_printf(
+            "#GP: addr: 0x%lx, code: %u\n",
+            exception_record->faulting_address,
+            exception_record->error_code);
+    }
+    else
+    {
+        oe_host_printf("Unhandled code: %u\n", exception_record->code);
+        oe_abort();
+    }
+
+    return OE_EXCEPTION_CONTINUE_EXECUTION;
+}
+
+int enc_pf_gp_exceptions()
+{
+    oe_result_t result;
+
+    result = oe_add_vectored_exception_handler(false, test_pfgp_handler);
+    if (result != OE_OK)
+    {
+        return -1;
+    }
+
+    /* Trigger #PF */
+    faulting_address = 1;
+    asm volatile("xor %rax, %rax\n\t"
+                 "mov (%rax), %rax");
+    OE_TEST(faulting_address == 0);
+
+    /* Trigger #GP */
+    faulting_address = 1;
+    asm volatile("lgdt 0x00");
+    OE_TEST(faulting_address == 0);
+
+    return 0;
+}
+
+OE_SET_ENCLAVE_SGX2(
+    1,     /* ProductID */
+    1,     /* SecurityVersion */
+    {0},   /* ExtendedProductID */
+    {0},   /* FamilyID */
+    true,  /* Debug */
+    true,  /* CapturePFGPExceptions */
+    false, /* RequireKSS */
+    1024,  /* NumHeapPages */
+    1024,  /* NumStackPages */
+    1);    /* NumTCS */

--- a/tests/pf_gp_exceptions/enc/sign.conf
+++ b/tests/pf_gp_exceptions/enc/sign.conf
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# Enclave settings:
+Debug=1
+CapturePFGPExceptions=1
+NumHeapPages=1024
+NumStackPages=1024
+NumTCS=1
+ProductID=1
+SecurityVersion=1

--- a/tests/pf_gp_exceptions/host/CMakeLists.txt
+++ b/tests/pf_gp_exceptions/host/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../pf_gp_exceptions.edl)
+
+add_custom_command(
+  OUTPUT pf_gp_exceptions_u.h pf_gp_exceptions_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(pf_gp_exceptions_host host.c pf_gp_exceptions_u.c)
+
+target_include_directories(pf_gp_exceptions_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(pf_gp_exceptions_host oehost)

--- a/tests/pf_gp_exceptions/host/host.c
+++ b/tests/pf_gp_exceptions/host/host.c
@@ -1,0 +1,67 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <limits.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "../host/sgx/cpuid.h"
+#include "pf_gp_exceptions_u.h"
+
+static bool _is_misc_region_supported()
+{
+    uint32_t eax, ebx, ecx, edx;
+    eax = ebx = ecx = edx = 0;
+
+    // Obtain feature information using CPUID
+    oe_get_cpuid(CPUID_SGX_LEAF, 0x0, &eax, &ebx, &ecx, &edx);
+
+    // Check if EXINFO is supported by the processor
+    if (!(ebx & CPUID_SGX_MISC_EXINFO_MASK))
+        return false;
+    else
+        return true;
+}
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+    int return_value;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    result = oe_create_pf_gp_exceptions_enclave(
+        argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);
+    /* The enclave creation should succeed on both SGX1 and SGX2 machines. */
+    if (result != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    if (_is_misc_region_supported())
+    {
+        result = enc_pf_gp_exceptions(enclave, &return_value);
+        if (result != OE_OK)
+            oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+        OE_TEST(return_value == 0);
+    }
+    else
+        printf("CPU does not support the CapturePFGPExceptions=1 "
+               "configuration. Skip "
+               "the test ECALL.\n");
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (pf_gp_exceptions)\n");
+
+    return 0;
+}

--- a/tests/pf_gp_exceptions/pf_gp_exceptions.edl
+++ b/tests/pf_gp_exceptions/pf_gp_exceptions.edl
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/fcntl.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/sgx/platform.edl" import *;
+
+    trusted {
+        public int enc_pf_gp_exceptions();
+    };
+};

--- a/tests/props/host/host.c
+++ b/tests/props/host/host.c
@@ -33,7 +33,8 @@ static void _check_properties(
     /* Check the SGX config */
     OE_TEST(config->product_id == product_id);
     OE_TEST(config->security_version == security_version);
-    OE_TEST(config->padding == 0);
+    OE_TEST(config->flags.capture_pf_gp_exceptions == 0);
+    OE_TEST(config->flags.reserved == 0);
     OE_TEST(config->attributes == attributes);
 
     /* Initialize a zero-filled sigstruct */


### PR DESCRIPTION
Expose the CapturePFGPExceptions configuration as part of SGX2 features, allowing the enclave to capture #PF and #GP exceptions. More detailed about the PR
- Add the CapturePFGPExceptions preference to the enclave config file. `oesign` now is able to parse the option (expected to be a binary value)
- oesign can sign the enclave with CapturePFGPExceptions=1 on both SGX1 and SGX2 machines.
- When  CapturePFGPExceptions=1, the OE loader will enable the feature when running on an SGX2-capable CPU.
- When feature is enabled on SGX2 machines, the `OE_EXCEPTION_PAGE_FAULT` and `OE_EXCEPTION_ACCESS_VIOLATION` code can be used to check if the exception is #PF or #GP, respectively.
- `faulting_address` and `error_code` of the `oe_exception_record_t` struct will contain the information of the exceptions.
- `include/openenclave/bits/exception.h` includes the information based on Intel SDM (Table 37.14) used to interpret the `error_code`

Fixes #3923

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>