### PR TITLE
Change output directory of oecert

### DIFF
--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -174,12 +174,12 @@ def ACCHostVerificationTest(String version, String build_type) {
                            openssl ec -in keyec.pem -pubout -out publicec.pem
                            openssl genrsa -out keyrsa.pem 2048
                            openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
-                           ../../../tools/oecert/oecert --cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
-                           ../../../tools/oecert/oecert --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
-                           ../../../tools/oecert/oecert --report --out sgx_report.bin --verify
-                           ../../../tools/oecert/oecert --evidence --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
-                           ../../../tools/oecert/oecert --evidence --verify --quote-proc in
-                           ../../../tools/oecert/oecert --evidence --verify --quote-proc out
+                           ../../../output/bin/oecert --cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
+                           ../../../output/bin/oecert --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
+                           ../../../output/bin/oecert --report --out sgx_report.bin --verify
+                           ../../../output/bin/oecert --evidence --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
+                           ../../../output/bin/oecert --evidence --verify --quote-proc in
+                           ../../../output/bin/oecert --evidence --verify --quote-proc out
                            popd
                            """
                 oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
@@ -271,12 +271,12 @@ def ACCHostVerificationPackageTest(String version, String build_type) {
                            openssl ec -in keyec.pem -pubout -out publicec.pem
                            openssl genrsa -out keyrsa.pem 2048
                            openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
-                           ../../../tools/oecert/oecert --cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
-                           ../../../tools/oecert/oecert --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
-                           ../../../tools/oecert/oecert --report --out sgx_report.bin --verify
-                           ../../../tools/oecert/oecert --evidence --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
-                           ../../../tools/oecert/oecert --evidence --verify --quote-proc in
-                           ../../../tools/oecert/oecert --evidence --verify --quote-proc out
+                           ../../../output/bin/oecert --cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
+                           ../../../output/bin/oecert --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
+                           ../../../output/bin/oecert --report --out sgx_report.bin --verify
+                           ../../../output/bin/oecert --evidence --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
+                           ../../../output/bin/oecert --evidence --verify --quote-proc in
+                           ../../../output/bin/oecert --evidence --verify --quote-proc out
                            popd
                            """
                 oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")

--- a/tools/oecert/enc/CMakeLists.txt
+++ b/tools/oecert/enc/CMakeLists.txt
@@ -28,10 +28,10 @@ enclave_link_libraries(oecert_enc oeenclave oelibc)
 
 # Generate the enclave binary in the the same directory with the oecert binary
 set_enclave_properties(oecert_enc PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                       "${CMAKE_CURRENT_BINARY_DIR}/..")
+                       ${OE_BINDIR})
 
 add_custom_target(oecert_enclave_signed DEPENDS oecert_enc.signed
                                                 oecert_enc_pubkey.h)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/../oecert_enc.signed
+install(FILES ${OE_BINDIR}/oecert_enc.signed
         DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/oecert/host/CMakeLists.txt
+++ b/tools/oecert/host/CMakeLists.txt
@@ -34,8 +34,7 @@ if (WIN32)
 endif ()
 
 # Generate the oecert binary in the the same directory with enclave binary
-set_target_properties(oecert PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                                        "${CMAKE_CURRENT_BINARY_DIR}/..")
+set_target_properties(oecert PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
 install(
   TARGETS oecert


### PR DESCRIPTION
Change the output directory of `oecert` (since it has been moved from `tests` to `tools`) so that

1. `oecert` and `oecert_enc.signed` will show up in the same directory, `build/output/bin`, after doing `make`,
2. `oecert` and `oecert_enc.signed` will show up in `/opt/openenclave/bin` after doing `make install` (done in #3947 already), and
3. `build/tools/oecert` will only contain CMake files and Makefiles just like the other tools.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>