### PR TITLE
Support dynamic section relocation for the FIPS module

### DIFF
--- a/include/openenclave/internal/elf.h
+++ b/include/openenclave/internal/elf.h
@@ -137,10 +137,17 @@ ELF_EXTERNC_BEGIN
 #define STT_HIPROC 15
 
 /* elf64_dyn.d_tag */
+#define DT_NULL 0
 #define DT_NEEDED 1
 #define DT_STRTAB 5
+#define DT_SYMTAB 6
+#define DT_RELA 7
+#define DT_RELASZ 8
+#define DT_RELAENT 9
 #define DT_RPATH 15
 #define DT_RUNPATH 29
+#define DT_GNU_HASH 0x6ffffef5
+#define DT_VERSYM 0x6ffffff0
 
 /* elf64_rel.r_info */
 #define R_X86_64_64 1


### PR DESCRIPTION
With this PR, the enclave will perform relocation over selective entries in the dynamic section, which conforms the behavior of `ld.so`. These entry relocations are required by the integrity test of the SymCrypt FIPS module.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>