### PR TITLE
Update oecert parameters and usages

### DIFF
--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -174,12 +174,12 @@ def ACCHostVerificationTest(String version, String build_type) {
                            openssl ec -in keyec.pem -pubout -out publicec.pem
                            openssl genrsa -out keyrsa.pem 2048
                            openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
-                           ../../../output/bin/oecert --cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
-                           ../../../output/bin/oecert --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
-                           ../../../output/bin/oecert --report --out sgx_report.bin --verify
-                           ../../../output/bin/oecert --evidence --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
-                           ../../../output/bin/oecert --evidence --verify --quote-proc in
-                           ../../../output/bin/oecert --evidence --verify --quote-proc out
+                           ../../../output/bin/oecert --format cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
+                           ../../../output/bin/oecert --format cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
+                           ../../../output/bin/oecert --format legacy_report_remote --out sgx_report.bin --verify
+                           ../../../output/bin/oecert --format sgx_ecdsa --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
+                           ../../../output/bin/oecert --format sgx_ecdsa --quote-proc in --verify
+                           ../../../output/bin/oecert --format sgx_ecdsa --quote-proc out --verify
                            popd
                            """
                 oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
@@ -271,12 +271,12 @@ def ACCHostVerificationPackageTest(String version, String build_type) {
                            openssl ec -in keyec.pem -pubout -out publicec.pem
                            openssl genrsa -out keyrsa.pem 2048
                            openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
-                           ../../../output/bin/oecert --cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
-                           ../../../output/bin/oecert --cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
-                           ../../../output/bin/oecert --report --out sgx_report.bin --verify
-                           ../../../output/bin/oecert --evidence --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
-                           ../../../output/bin/oecert --evidence --verify --quote-proc in
-                           ../../../output/bin/oecert --evidence --verify --quote-proc out
+                           ../../../output/bin/oecert --format cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
+                           ../../../output/bin/oecert --format cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
+                           ../../../output/bin/oecert --format legacy_report_remote --out sgx_report.bin --verify
+                           ../../../output/bin/oecert --format sgx_ecdsa --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
+                           ../../../output/bin/oecert --format sgx_ecdsa --quote-proc in --verify
+                           ../../../output/bin/oecert --format sgx_ecdsa --quote-proc out --verify
                            popd
                            """
                 oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-8", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")

--- a/tools/oecert/README.md
+++ b/tools/oecert/README.md
@@ -15,27 +15,32 @@ Usage: `oecert Options`
 
 where `Options` are:
 
-    --cert PRIVKEY PUBKEY : generate der remote attestation certificate.
-    --report              : generate binary OE report.
-    --evidence            : generate binary OE evidence.
-    --quote-proc <in|out> : use sgx in process or out-of-process quoting, default: use original quote process.
-    --out FILENAME        : specify certificate/report/evidence output filename, default: no file output.
-    --endorsements        : specify endorsements output filename, default: no endorsements output.
-    --verify              : verify generated certificate/report/evidence
-    --log LOG_FILENAME    : log file name, default: oecert.log
-    --verbose             : dump verbose info of evidence
+    -f, --format <format_option>: generate evidence, a report, or a certificate, where format_option can be one of the following (case insensitive):
+        cert <private_key> <public_key>: a remote attestation certificate in DER format.
+        LEGACY_REPORT_REMOTE: a report in OE_FORMAT_UUID_LEGACY_REPORT_REMOTE format.
+        SGX_ECDSA: evidence in OE_FORMAT_UUID_SGX_ECDSA format.
+        SGX_EPID_LINKABLE: evidence in OE_FORMAT_UUID_SGX_EPID_LINKABLE format.
+        SGX_EPID_UNLINKABLE: evidence in OE_FORMAT_UUID_SGX_EPID_UNLINKABLE format.
+    -p, --quote-proc <in|out>: use SGX in-process or out-of-process quoting.
+    -o, --out <filename>: generate an output file for a remote attestation certificate, a report, or evidence.
+    -e, --endorsements <filename>: output a report or evidence, and also its endorsements binary.
+    -v, --verify: verify the generated remote attestation certificate, report, or evidence.
+    -l, --log <filename>: generate a log file (default: oecert.log).
+    --verbose: enable verbose output.
+
+Note that parameters are not case-sensitive.
 
 Example 1 Generate, verify and dump a ceritificate. Without "--out", there will be no certificate output file:
 
-    ./oecert --cert keyecec.pem publickeyec.pem --verify --verbose
+    ./oecert --format cert keyecec.pem publickeyec.pem --verify --verbose
 
 Example 2 Generate an OE report and output its endorsements binary to "endorsements.bin", and output OE report to "report.bin":
 
-    ./oecert --report --endorsements endorsements.bin --out report.bin
+    ./oecert --format legacy_report_remote --endorsements endorsements.bin --out report.bin
 
-Example 3 Generate and verify an evidence, and dump evidence buffer and its verified claims, output OE evidence to "evidence.bin":
+Example 3 Generate and verify OE evidence in SGX_ECDSA format, dump evidence buffer and its verified claims, and output OE evidence to "evidence.bin":
 
-    ./oecert --evidence --verify --verbose --out evidence.bin
+    ./oecert --format sgx_ecdsa --verify --verbose --out evidence.bin
 
 
 Creating RSA and EC keys pairs in linux using openssl.

--- a/tools/oecert/enc/enc.cpp
+++ b/tools/oecert/enc/enc.cpp
@@ -116,6 +116,7 @@ done:
 }
 
 oe_result_t get_plugin_evidence(
+    const oe_uuid_t evidence_format,
     uint8_t* evidence,
     size_t evidence_size,
     size_t* evidence_out_size,
@@ -129,12 +130,10 @@ oe_result_t get_plugin_evidence(
     uint8_t* local_endorsements = NULL;
     size_t local_endorsements_size = 0;
 
-    static const oe_uuid_t _ecdsa_uuid = {OE_FORMAT_UUID_SGX_ECDSA};
-
     OE_CHECK(oe_attester_initialize());
 
     OE_CHECK(oe_get_evidence(
-        &_ecdsa_uuid,
+        &evidence_format,
         OE_EVIDENCE_FLAGS_EMBED_FORMAT_ID,
         NULL,
         0,

--- a/tools/oecert/host/evidence.cpp
+++ b/tools/oecert/host/evidence.cpp
@@ -4,6 +4,7 @@
 #include "evidence.h"
 
 #include <ctype.h>
+#include <openenclave/attestation/sgx/evidence.h>
 #include <openenclave/attestation/sgx/report.h>
 #include <openenclave/attestation/verifier.h>
 #include <openenclave/host.h>
@@ -768,6 +769,7 @@ done:
 
 oe_result_t generate_oe_evidence(
     oe_enclave_t* enclave,
+    const oe_uuid_t evidence_format,
     const char* evidence_filename,
     const char* endorsements_filename,
     bool verify,
@@ -792,6 +794,7 @@ oe_result_t generate_oe_evidence(
         get_plugin_evidence(
             enclave,
             &result,
+            evidence_format,
             evidence,
             sizeof(evidence),
             &evidence_size,
@@ -808,6 +811,7 @@ oe_result_t generate_oe_evidence(
         get_plugin_evidence(
             enclave,
             &result,
+            evidence_format,
             evidence,
             sizeof(evidence),
             &evidence_size,

--- a/tools/oecert/host/evidence.h
+++ b/tools/oecert/host/evidence.h
@@ -4,6 +4,7 @@
 #ifndef _SGX_QUOTE
 #define _SGX_QUOTE
 
+#include <openenclave/attestation/sgx/evidence.h>
 #include <openenclave/host.h>
 #include "../../../host/sgx/platformquoteprovider.h"
 #include "../oecert_enc_pubkey.h"
@@ -42,6 +43,7 @@ oe_result_t generate_oe_report(
 
 oe_result_t generate_oe_evidence(
     oe_enclave_t* enclave,
+    oe_uuid_t evidence_format,
     const char* evidence_filename,
     const char* endorsements_filename,
     bool verify,

--- a/tools/oecert/oecert.edl
+++ b/tools/oecert/oecert.edl
@@ -21,12 +21,13 @@ enclave {
             [out] size_t *data_size);
 
         public oe_result_t get_plugin_evidence(
-          [out, size=evidence_size] uint8_t* evidence_out,
-          size_t evidence_size,
-          [out] size_t* evidence_out_size,
-          [out, size=endorsements_size] uint8_t* endorsements,
-          size_t endorsements_size,
-          [out] size_t* endorsements_out_size
+            oe_uuid_t evidence_format,
+            [out, size=evidence_size] uint8_t* evidence_out,
+            size_t evidence_size,
+            [out] size_t* evidence_out_size,
+            [out, size=endorsements_size] uint8_t* endorsements,
+            size_t endorsements_size,
+            [out] size_t* endorsements_out_size
         );
     };
 };


### PR DESCRIPTION
Update the parameters and usages for the `oecert` tool; the biggest difference is the `--format` parameter, which is intended to replace the old `--cert`, `--report` and `--evidence` parameters.

Also rewrite the "options" section in the README file so that it matches the description of the `oecert` tool, which shows up if there are no parameters or there is an invalid combination of parameters.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>