### PR TITLE
Attestation not terminate at OE_TCB_LEVEL_INVALID and return TCB claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 --------------
 ### Added
 - Add the support for SGX quote verification collateral version 3 with the CRL in DER format by default. Refer to [Get Quote Verification Collateral](https://download.01.org/intel-sgx/sgx-dcap/1.10/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf) section 3.3.1.5.
+- Add the following attestation claims from oe_verify_evidence():
+  - OE_CLAIM_TCB_STATUS
+  - OE_CLAIM_TCB_DATE
 
 [v0.16.0][v0.16.0_log]
 --------------

--- a/common/sgx/collateral.h
+++ b/common/sgx/collateral.h
@@ -10,6 +10,7 @@
 #include <openenclave/internal/crypto/cert.h>
 #include <openenclave/internal/report.h>
 #include "endorsements.h"
+#include "tcbinfo.h"
 
 OE_EXTERNC_BEGIN
 
@@ -24,12 +25,14 @@ OE_EXTERNC_BEGIN
  *
  * @param[in] pck_cert The PCK certificate.
  * @param[in] sgx_endorsements The SGX endorsements.
+ * @param[out] platform_tcb_level Optional pointer to the platform tcb level.
  * @param[out] validity_from The date from which the revocation info is valid.
  * @param[out] validity_until The date which the revocation info expires.
  */
 oe_result_t oe_validate_revocation_list(
     oe_cert_t* pck_cert,
     const oe_sgx_endorsements_t* sgx_endorsements,
+    oe_tcb_info_tcb_level_t* platform_tcb_level,
     oe_datetime_t* validity_from,
     oe_datetime_t* validity_until);
 

--- a/common/sgx/quote.c
+++ b/common/sgx/quote.c
@@ -487,6 +487,7 @@ oe_result_t oe_verify_sgx_quote(
         &sgx_endorsements,
         input_validation_time,
         NULL,
+        NULL,
         NULL));
 
     result = OE_OK;
@@ -503,10 +504,12 @@ oe_result_t oe_verify_quote_with_sgx_endorsements(
     size_t quote_size,
     const oe_sgx_endorsements_t* sgx_endorsements,
     oe_datetime_t* input_validation_time,
+    oe_tcb_info_tcb_level_t* platform_tcb_level,
     oe_datetime_t* valid_from,
     oe_datetime_t* valid_until)
 {
     oe_result_t result = OE_UNEXPECTED;
+    oe_result_t get_sgx_quote_validity_result = OE_UNEXPECTED;
     oe_datetime_t validity_from = {0};
     oe_datetime_t validity_until = {0};
     oe_datetime_t validation_time = {0};
@@ -613,11 +616,13 @@ oe_result_t oe_verify_quote_with_sgx_endorsements(
             NULL);
     }
 
-    OE_CHECK_MSG(
+    OE_CHECK_NO_TCB_LEVEL_MSG(
+        get_sgx_quote_validity_result,
         oe_get_sgx_quote_validity(
             quote,
             quote_size,
             sgx_endorsements,
+            platform_tcb_level,
             &validity_from,
             &validity_until),
         "Failed to validate quote. %s",
@@ -662,7 +667,7 @@ oe_result_t oe_verify_quote_with_sgx_endorsements(
         *valid_from = validity_from;
         *valid_until = validity_until;
     }
-    result = OE_OK;
+    result = get_sgx_quote_validity_result;
 
 done:
 
@@ -673,10 +678,12 @@ oe_result_t oe_get_sgx_quote_validity(
     const uint8_t* quote,
     const size_t quote_size,
     const oe_sgx_endorsements_t* sgx_endorsements,
+    oe_tcb_info_tcb_level_t* platform_tcb_level,
     oe_datetime_t* valid_from,
     oe_datetime_t* valid_until)
 {
     oe_result_t result = OE_UNEXPECTED;
+    oe_result_t validate_revocation_list_result = OE_UNEXPECTED;
 
     sgx_quote_t* sgx_quote = NULL;
     sgx_quote_auth_data_t* quote_auth_data = NULL;
@@ -758,8 +765,10 @@ oe_result_t oe_get_sgx_quote_validity(
     _update_validity(&latest_from, &earliest_until, &from, &until);
 
     // Fetch revocation info validity dates.
-    OE_CHECK_MSG(
-        oe_validate_revocation_list(&pck_cert, sgx_endorsements, &from, &until),
+    OE_CHECK_NO_TCB_LEVEL_MSG(
+        validate_revocation_list_result,
+        oe_validate_revocation_list(
+            &pck_cert, sgx_endorsements, platform_tcb_level, &from, &until),
 
         "Failed to validate revocation info. %s",
         oe_result_str(result));
@@ -785,7 +794,7 @@ oe_result_t oe_get_sgx_quote_validity(
     *valid_from = latest_from;
     *valid_until = earliest_until;
 
-    result = OE_OK;
+    result = validate_revocation_list_result;
 
 done:
     oe_cert_free(&pck_cert);

--- a/common/sgx/quote.h
+++ b/common/sgx/quote.h
@@ -10,6 +10,7 @@
 #include <openenclave/internal/crypto/cert.h>
 #include <openenclave/internal/datetime.h>
 #include "endorsements.h"
+#include "tcbinfo.h"
 
 OE_EXTERNC_BEGIN
 
@@ -66,6 +67,9 @@ oe_result_t oe_verify_sgx_quote(
  * if the input time is after than the endorsement creation time, then the
  * CRLs might have updated in the period between the input time and the
  * endorsement creation time.
+ * @param[out] platform_tcb_level Optional pointer to the platform tcb level
+ * from which verifier can extract tcb status, tcb date and advisory IDs and
+ * write to custom claims.
  * @param[out] valid_from Optional pointer to the endorsement validity period
  * that can be extraced by verifier and written to OE_CLAIM_VALIDITY_FROM.
  * @param[out] valid_until Optional pointer to the endorsement validity period
@@ -77,6 +81,7 @@ oe_result_t oe_verify_quote_with_sgx_endorsements(
     size_t quote_size,
     const oe_sgx_endorsements_t* endorsements,
     oe_datetime_t* input_validation_time,
+    oe_tcb_info_tcb_level_t* platform_tcb_level,
     oe_datetime_t* valid_from,
     oe_datetime_t* valid_until);
 
@@ -101,13 +106,15 @@ oe_result_t oe_verify_quote_with_sgx_endorsements(
  * @param[in] quote Input quote.
  * @param[in] quote_size The size of the quote.
  * @param[in] sgx_endorsements SGX endorsements related to the quote.
+ * @param[out] platform_tcb_level Optional pointer to the platform tcb level.
  * @param[out] valid_from validity_from The date from which the quote is valid.
  * @param[out] valid_until validity_until The date which the quote expires.
  */
 oe_result_t oe_get_sgx_quote_validity(
     const uint8_t* quote,
     const size_t quote_size,
-    const oe_sgx_endorsements_t* sgx_endorsements,
+    const oe_sgx_endorsements_t* endorsements,
+    oe_tcb_info_tcb_level_t* platform_tcb_level,
     oe_datetime_t* valid_from,
     oe_datetime_t* valid_until);
 

--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -8,6 +8,17 @@
 #include <openenclave/internal/utils.h>
 #include "../common.h"
 
+#define SGX_TCB_STATUS_UP_TO_DATE "UpToDate"
+#define SGX_TCB_STATUS_OUT_OF_DATE "OutOfDate"
+#define SGX_TCB_STATUS_REVOKED "Revoked"
+#define SGX_TCB_STATUS_CONFIGURATION_NEEDED "ConfigurationNeeded"
+#define SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED \
+    "OutOfDateConfigurationNeeded"
+#define SGX_TCB_STATUS_SW_HARDENING_NEEDED "SWHardeningNeeded"
+#define SGX_TCB_STATUS_CONFIGURATION_AND_SW_HARDENING_NEEDED \
+    "ConfigurationAndSWHardeningNeeded"
+#define SGX_TCB_STATUS_INVALID "Invalid"
+
 // Public key of Intel's root certificate.
 static const char* _trusted_root_key_pem =
     "-----BEGIN PUBLIC KEY-----\n"
@@ -221,21 +232,28 @@ done:
 }
 
 static oe_tcb_level_status_t _parse_tcb_status(
-    const uint8_t* str,
+    const uint8_t* tcb_status_string,
     size_t length)
 {
     oe_tcb_level_status_t status;
     status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
 
-    if (_json_str_equal(str, length, "UpToDate"))
+    if (_json_str_equal(tcb_status_string, length, SGX_TCB_STATUS_UP_TO_DATE))
         status.fields.up_to_date = 1;
-    else if (_json_str_equal(str, length, "OutOfDate"))
+    else if (_json_str_equal(
+                 tcb_status_string, length, SGX_TCB_STATUS_OUT_OF_DATE))
         status.fields.outofdate = 1;
-    else if (_json_str_equal(str, length, "Revoked"))
+    else if (_json_str_equal(tcb_status_string, length, SGX_TCB_STATUS_REVOKED))
         status.fields.revoked = 1;
-    else if (_json_str_equal(str, length, "ConfigurationNeeded"))
+    else if (_json_str_equal(
+                 tcb_status_string,
+                 length,
+                 SGX_TCB_STATUS_CONFIGURATION_NEEDED))
         status.fields.configuration_needed = 1;
-    else if (_json_str_equal(str, length, "OutOfDateConfigurationNeeded"))
+    else if (_json_str_equal(
+                 tcb_status_string,
+                 length,
+                 SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED))
     {
         status.fields.qe_identity_out_of_date = 1;
         status.fields.configuration_needed = 1;
@@ -244,18 +262,69 @@ static oe_tcb_level_status_t _parse_tcb_status(
     // as sgx cannot tell if enclave writer has implemented SW mitigations for
     // LVI. Set status SWHardeningNeeded as up_to_date for now to make sure
     // services for those tcbs are not affected.
-    else if (_json_str_equal(str, length, "SWHardeningNeeded"))
+    else if (_json_str_equal(
+                 tcb_status_string, length, SGX_TCB_STATUS_SW_HARDENING_NEEDED))
     {
         status.fields.up_to_date = 1;
         status.fields.sw_hardening_needed = 1;
     }
-    else if (_json_str_equal(str, length, "ConfigurationAndSWHardeningNeeded"))
+    else if (_json_str_equal(
+                 tcb_status_string,
+                 length,
+                 SGX_TCB_STATUS_CONFIGURATION_AND_SW_HARDENING_NEEDED))
     {
         status.fields.configuration_needed = 1;
         status.fields.sw_hardening_needed = 1;
     }
 
     return status;
+}
+
+oe_sgx_tcb_status_t oe_tcb_level_status_to_sgx_tcb_status(
+    const oe_tcb_level_status_t* tcb_level_status)
+{
+    if (tcb_level_status->fields.revoked == 1)
+        return OE_SGX_TCB_STATUS_REVOKED;
+    if (tcb_level_status->fields.up_to_date == 1 &&
+        tcb_level_status->fields.sw_hardening_needed == 1)
+        return OE_SGX_TCB_STATUS_SW_HARDENING_NEEDED;
+    if (tcb_level_status->fields.up_to_date == 1)
+        return OE_SGX_TCB_STATUS_UP_TO_DATE;
+    if (tcb_level_status->fields.sw_hardening_needed == 1 &&
+        tcb_level_status->fields.configuration_needed == 1)
+        return OE_SGX_TCB_STATUS_CONFIGURATION_AND_SW_HARDENING_NEEDED;
+    if (tcb_level_status->fields.outofdate == 1 &&
+        tcb_level_status->fields.configuration_needed == 1)
+        return OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED;
+    if (tcb_level_status->fields.configuration_needed == 1)
+        return OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED;
+    if (tcb_level_status->fields.outofdate == 1)
+        return OE_SGX_TCB_STATUS_OUT_OF_DATE;
+    return OE_SGX_TCB_STATUS_INVALID;
+}
+
+const char* oe_sgx_tcb_status_str(const oe_sgx_tcb_status_t sgx_tcb_status)
+{
+    switch (sgx_tcb_status)
+    {
+        case OE_SGX_TCB_STATUS_UP_TO_DATE:
+            return SGX_TCB_STATUS_UP_TO_DATE;
+        case OE_SGX_TCB_STATUS_OUT_OF_DATE:
+            return SGX_TCB_STATUS_OUT_OF_DATE;
+        case OE_SGX_TCB_STATUS_REVOKED:
+            return SGX_TCB_STATUS_REVOKED;
+        case OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED:
+            return SGX_TCB_STATUS_CONFIGURATION_NEEDED;
+        case OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED:
+            return SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED;
+        case OE_SGX_TCB_STATUS_SW_HARDENING_NEEDED:
+            return SGX_TCB_STATUS_SW_HARDENING_NEEDED;
+        case OE_SGX_TCB_STATUS_CONFIGURATION_AND_SW_HARDENING_NEEDED:
+            return SGX_TCB_STATUS_CONFIGURATION_AND_SW_HARDENING_NEEDED;
+        default:
+            break;
+    }
+    return SGX_TCB_STATUS_INVALID;
 }
 
 /**
@@ -518,6 +587,10 @@ static oe_result_t _read_tcb_info_tcb_level_v2(
         // Optimization
         if (platform_tcb_level->status.AsUINT32 != OE_TCB_LEVEL_STATUS_UNKNOWN)
         {
+            // tcb_date represents the date and time when the TCB level was
+            // certified.
+            platform_tcb_level->tcb_date = tcb_level->tcb_date;
+
             // Found matching TCB level, go to the end of the array.
             _move_to_end_of_tcb_levels(itr, end);
         }
@@ -724,8 +797,11 @@ oe_result_t oe_parse_tcb_info_json(
 
     OE_CHECK(_read('}', &itr, end));
 
+    // Finish TCB info parsing, check TCB status and advisory IDs
     if (itr == end)
     {
+        result = OE_OK;
+
         if (platform_tcb_level->status.fields.up_to_date != 1)
         {
             for (uint32_t i = 0;
@@ -736,10 +812,10 @@ oe_result_t oe_parse_tcb_info_json(
                     i,
                     platform_tcb_level->sgx_tcb_comp_svn[i]);
             OE_TRACE_VERBOSE("pce_svn = 0x%x", platform_tcb_level->pce_svn);
-            OE_RAISE_MSG(
-                OE_TCB_LEVEL_INVALID,
+            OE_TRACE_WARNING(
                 "Platform TCB (%d) is not up-to-date",
                 platform_tcb_level->status);
+            result = OE_TCB_LEVEL_INVALID;
         }
 
         // Display any advisory IDs as warnings
@@ -749,8 +825,6 @@ oe_result_t oe_parse_tcb_info_json(
                 "Found %d AdvisoryIDs for this tcb level.",
                 platform_tcb_level->advisory_ids_size);
         }
-
-        result = OE_OK;
     }
 done:
     return result;

--- a/common/sgx/tcbinfo.h
+++ b/common/sgx/tcbinfo.h
@@ -4,6 +4,7 @@
 #ifndef _OE_COMMON_TCBINFO_H
 #define _OE_COMMON_TCBINFO_H
 
+#include <openenclave/attestation/sgx/evidence.h>
 #include <openenclave/bits/defs.h>
 #include <openenclave/bits/result.h>
 #include <openenclave/bits/sgx/sgxtypes.h>
@@ -85,6 +86,25 @@ typedef struct _oe_parsed_tcb_info
     size_t tcb_info_size;
 
 } oe_parsed_tcb_info_t;
+
+/*!
+ * Parse an oe_tcb_info_tcb_level_t struct to an oe_sgx_tcb_status_t type.
+ *
+ * @param[in] tcb_level_status The tcb_status to parse.
+ */
+oe_sgx_tcb_status_t oe_tcb_level_status_to_sgx_tcb_status(
+    const oe_tcb_level_status_t* tcb_level_status);
+
+/*!
+ * Retrieve a string description for an oe_sgx_tcb_status_t code.
+ *
+ * @param[in] sgx_tcb_status Retrieve string description for this SGX TCB status
+ * code.
+ *
+ * @returns Returns a pointer to a static string description.
+ *
+ */
+const char* oe_sgx_tcb_status_str(const oe_sgx_tcb_status_t sgx_tcb_status);
 
 /**
  * oe_parse_tcb_info_json parses the given tcb info json string

--- a/include/openenclave/attestation/sgx/evidence.h
+++ b/include/openenclave/attestation/sgx/evidence.h
@@ -4,7 +4,8 @@
 /**
  * @file attestation/sgx/evidence.h
  *
- * This file defines macros for SGX evidence format IDs and claims.
+ * This file defines macros and structures for SGX evidence format IDs and
+ * claims.
  *
  * A number of SGX specific format IDs are defined for evidence generation
  * and verification.
@@ -151,6 +152,60 @@ OE_EXTERNC_BEGIN
 // Additional SGX specific claim: for the report data embedded in the SGX quote.
 
 #define OE_CLAIM_SGX_REPORT_DATA "sgx_report_data"
+
+/**
+ * TCB level status of SGX platform. This enumeration type defines return codes
+ * for SGX TCB status, which is the claim value for ::OE_CLAIM_TCB_STATUS.
+ */
+typedef enum _oe_sgx_tcb_status
+{
+    /**
+     * TCB level of SGX platform is up-to-date.
+     */
+    OE_SGX_TCB_STATUS_UP_TO_DATE = 0,
+
+    /**
+     * TCB level of SGX platform is outdated.
+     */
+    OE_SGX_TCB_STATUS_OUT_OF_DATE = 1,
+
+    /**
+     * TCB level of SGX platform is revoked. The platform is not trustworthy.
+     */
+    OE_SGX_TCB_STATUS_REVOKED = 2,
+
+    /**
+     * TCB level of the SGX platform is up-to-date but additional configuration
+     * of SGX platform may be needed.
+     */
+    OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED = 3,
+
+    /**
+     * TCB level of SGX platform is outdated and additional configuration of SGX
+     * platform may be needed.
+     */
+    OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED = 4,
+
+    /**
+     * TCB level of the SGX platform is up-to-date but due to certain issues
+     * affecting the platform, additional Software Hardening in the attesting
+     * SGX enclaves may be needed.
+     */
+    OE_SGX_TCB_STATUS_SW_HARDENING_NEEDED = 5,
+
+    /**
+     * TCB level of the SGX platform is up-to-date but additional configuration
+     * for the platform and Software Hardening in the attesting SGX enclaves may
+     * be needed.
+     */
+    OE_SGX_TCB_STATUS_CONFIGURATION_AND_SW_HARDENING_NEEDED = 6,
+
+    /**
+     * TCB level is not valid.
+     */
+    OE_SGX_TCB_STATUS_INVALID = OE_ENUM_MAX,
+
+} oe_sgx_tcb_status_t;
 
 OE_EXTERNC_END
 

--- a/include/openenclave/attestation/verifier.h
+++ b/include/openenclave/attestation/verifier.h
@@ -155,6 +155,9 @@ oe_result_t oe_verifier_free_format_settings(uint8_t* settings);
  * custom).
  * @param[out] claims_length If not NULL, the length of the claims list.
  * @retval OE_OK The function succeeded.
+ * @retval OE_TCB_LEVEL_INVALID The function succeeded. The TCB is not
+ * considered up-to-date, and the claims OE_CLAIM_TCB_STATUS and OE_TCB_DATE
+ * contain more information.
  * @retval OE_INVALID_PARAMETER At least one of the parameters is invalid.
  * @retval other appropriate error code.
  */

--- a/include/openenclave/bits/evidence.h
+++ b/include/openenclave/bits/evidence.h
@@ -60,7 +60,7 @@ typedef struct _oe_claim
  */
 
 /**
- * Claims version.
+ * Version of the structure to represent the identity of an enclave.
  */
 #define OE_CLAIM_ID_VERSION "id_version"
 
@@ -114,6 +114,18 @@ extern const char* OE_REQUIRED_CLAIMS[OE_REQUIRED_CLAIMS_COUNT];
  */
 
 /**
+ * The status of the evidence's TCB level (::oe_sgx_tcb_status_t for SGX).
+ * This status comes from the endorsement.
+ */
+#define OE_CLAIM_TCB_STATUS "tcb_status"
+
+/**
+ * The date and time when the evidence's TCB level was certified. This time
+ * comes from the endorsement.
+ */
+#define OE_CLAIM_TCB_DATE "tcb_date"
+
+/**
  * Overall datetime from which the evidence and endorsements are valid.
  */
 #define OE_CLAIM_VALIDITY_FROM "validity_from"
@@ -128,7 +140,7 @@ extern const char* OE_REQUIRED_CLAIMS[OE_REQUIRED_CLAIMS_COUNT];
  *
  */
 
-#define OE_OPTIONAL_CLAIMS_COUNT 2
+#define OE_OPTIONAL_CLAIMS_COUNT 4
 // This array is needed for tests
 extern const char* OE_OPTIONAL_CLAIMS[OE_OPTIONAL_CLAIMS_COUNT];
 

--- a/include/openenclave/internal/raise.h
+++ b/include/openenclave/internal/raise.h
@@ -185,6 +185,33 @@ OE_EXTERNC_BEGIN
             OE_RAISE_MSG(_result_, fmt, ##__VA_ARGS__); \
     } while (0)
 
+// This macro checks the expression argument without considering the invalid
+// tcb level. It is used in OE attestation verification as an invalid TCB level
+// does not terminate the verification.
+#define OE_CHECK_NO_TCB_LEVEL(RESULT, EXPRESSION)              \
+    do                                                         \
+    {                                                          \
+        RESULT = (EXPRESSION);                                 \
+        if (RESULT != OE_OK && RESULT != OE_TCB_LEVEL_INVALID) \
+            OE_RAISE(RESULT);                                  \
+    } while (0)
+
+#define OE_CHECK_NO_TCB_LEVEL_NO_TRACE(RESULT, EXPRESSION)     \
+    do                                                         \
+    {                                                          \
+        RESULT = (EXPRESSION);                                 \
+        if (RESULT != OE_OK && RESULT != OE_TCB_LEVEL_INVALID) \
+            OE_RAISE_NO_TRACE(RESULT);                         \
+    } while (0)
+
+#define OE_CHECK_NO_TCB_LEVEL_MSG(RESULT, EXPRESSION, fmt, ...) \
+    do                                                          \
+    {                                                           \
+        RESULT = (EXPRESSION);                                  \
+        if (RESULT != OE_OK && RESULT != OE_TCB_LEVEL_INVALID)  \
+            OE_RAISE_MSG(RESULT, fmt, ##__VA_ARGS__);           \
+    } while (0)
+
 OE_EXTERNC_END
 
 #endif /* _OE_RAISE_H */

--- a/include/openenclave/internal/sgx/plugin.h
+++ b/include/openenclave/internal/sgx/plugin.h
@@ -38,6 +38,7 @@ typedef enum _sgx_evidence_format_type_t
  * format_type has the right value.
  * @param[in] custom_claims_buffer_size The size of the custom_claims buffer.
  * @param[in] sgx_endorsements Pointer to the endorsements buffer.
+ * @param[in] platform_tcb_level Pointer to the platform tcb info.
  * @param[in] valid_from Pointer to the datetime from which the evidence and
  * endorsements are valid.
  * @param[in] valid_until Pointer to the datetime at which the evidence and
@@ -50,6 +51,7 @@ typedef enum _sgx_evidence_format_type_t
  * @retval An appropriate error code on failure.
  */
 struct _oe_sgx_endorsements_t;
+struct _oe_tcb_info_tcb_level;
 oe_result_t oe_sgx_extract_claims(
     const sgx_evidence_format_type_t format_type,
     const oe_uuid_t* format_id,
@@ -58,6 +60,7 @@ oe_result_t oe_sgx_extract_claims(
     const uint8_t* custom_claims_buffer,
     size_t custom_claims_buffer_size,
     const struct _oe_sgx_endorsements_t* sgx_endorsements,
+    const struct _oe_tcb_info_tcb_level* platform_tcb_level,
     oe_datetime_t* valid_from,
     oe_datetime_t* valid_until,
     oe_claim_t** claims_out,

--- a/tests/report/common/tests.cpp
+++ b/tests/report/common/tests.cpp
@@ -298,6 +298,7 @@ static oe_result_t oe_get_quote_validity_with_collaterals(
             header->report,
             header->report_size,
             &sgx_endorsements,
+            nullptr,
             valid_from,
             valid_until));
     }


### PR DESCRIPTION
Fix issue #3969, `oe_verify_evidence()` will not terminate when TCB level is invalid and returns TCB claims.
When `oe_verify_evidence()` succeed to verify the evidence and extract the claims, it returns `OE_OK` when TCB level is "up_to_date" or "sw_hardening_needed", or returns `OE_TCB_LEVEL_INVALID` otherwise. The error code along with TCB claims (`tcb_status` and `tcb_date`) will be sent back to user.
The error code and claim value are checked in `attestation_plugin` ctest.