### PR TITLE
Child_process tests are not supported by Legacy driver (LLC)

### DIFF
--- a/tests/child_process/CMakeLists.txt
+++ b/tests/child_process/CMakeLists.txt
@@ -9,13 +9,21 @@ endif ()
 
 add_enclave_test(tests/child_process_ecall child_process_host child_process_enc
                  0)
-
+set_enclave_tests_properties(tests/child_process_ecall PROPERTIES SKIP_RETURN_CODE
+                             2)
+                             
 # related issue #3099
 add_enclave_test(tests/child_process_destroy child_process_host
                  child_process_enc 1)
+set_enclave_tests_properties(tests/child_process_destroy PROPERTIES
+                               SKIP_RETURN_CODE 2)
 
 add_enclave_test(tests/child_process_create child_process_host
                  child_process_enc 2)
-
+set_enclave_tests_properties(tests/child_process_create PROPERTIES
+                               SKIP_RETURN_CODE 2)
+                               
 add_enclave_test(tests/child_process_create_more child_process_host
                  child_process_enc 3)
+set_enclave_tests_properties(tests/child_process_create_more PROPERTIES
+                               SKIP_RETURN_CODE 2)

--- a/tests/child_process/host/host.cpp
+++ b/tests/child_process/host/host.cpp
@@ -4,6 +4,8 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/error.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -17,6 +19,7 @@
 #define DESTROY_IN_CHILD_PROCESS 1
 #define CREATE_IN_CHILD_PROCESS 2
 #define CREATE_IN_CHILD_PROCESSES 3
+#define SKIP_RETURN_CODE 2
 
 bool multi_process_flag = true;
 
@@ -32,6 +35,12 @@ int main(int argc, const char* argv[])
     {
         fprintf(stderr, "Usage: %s ENCLAVE_PATH TEST_NUMBER\n", argv[0]);
         exit(1);
+    }
+    if (!oe_has_sgx_quote_provider())
+    {
+        // this test should not run on any platforms where FLC is not supported
+        OE_TRACE_INFO("=== tests skipped when DCAP libraries are not found.\n");
+        return SKIP_RETURN_CODE;
     }
     oe_enclave_t* enclave = NULL;
     const uint32_t flags = oe_get_create_flags();


### PR DESCRIPTION
Similarly to attestation tests,
Child_process tests are only supported by DCAP driver.
Added check whether DCAP is installed or not.

More info: #3942 