### PR TITLE
increase heap size/stack size to fix snmalloc errors

### DIFF
--- a/tests/tls_e2e/client_enc/mbedtls_client.cpp
+++ b/tests/tls_e2e/client_enc/mbedtls_client.cpp
@@ -348,6 +348,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    512,  /* NumHeapPages */
-    128,  /* NumStackPages */
+    1024, /* NumHeapPages */
+    512,  /* NumStackPages */
     1);   /* NumTCS */

--- a/tests/tls_e2e/client_enc/openssl_client.cpp
+++ b/tests/tls_e2e/client_enc/openssl_client.cpp
@@ -229,6 +229,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    512,  /* NumHeapPages */
-    128,  /* NumStackPages */
+    1024, /* NumHeapPages */
+    512,  /* NumStackPages */
     1);   /* NumTCS */


### PR DESCRIPTION
increase heap size/stack size to fix snmalloc errors
Signed-off-by: manoj rupireddy <marupire@microsoft.com>