### PR TITLE
Fix der crl reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased][Unreleased_log]
 --------------
+### Added
+- Add the support for SGX quote verification collateral version 3 with the CRL in DER format by default. Refer to [Get Quote Verification Collateral](https://download.01.org/intel-sgx/sgx-dcap/1.10/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf) section 3.3.1.5.
 
 [v0.16.0][v0.16.0_log]
 --------------

--- a/common/sgx/collateral.c
+++ b/common/sgx/collateral.c
@@ -325,14 +325,21 @@ oe_result_t oe_validate_revocation_list(
                 "Failed to read CRL. %s",
                 oe_result_str(result));
         }
-        // Otherwise, CRL should have v3 structure which is Der encoded
+        // Otherwise, CRL should have v3 structure which is DER encoded
         else
         {
+            size_t der_data_size = sgx_endorsements->items[i].size;
+            if (der_data_size == 0)
+                OE_RAISE(OE_INVALID_PARAMETER);
+
+            // If DER CRL buffer has null terminator, need to remove it before
+            // send the DER data to crypto API for reading.
+            if (sgx_endorsements->items[i].data[der_data_size - 1] == 0)
+                der_data_size -= 1;
+
             OE_CHECK_MSG(
                 oe_crl_read_der(
-                    &crls[j],
-                    sgx_endorsements->items[i].data,
-                    sgx_endorsements->items[i].size),
+                    &crls[j], sgx_endorsements->items[i].data, der_data_size),
                 "Failed to read CRL. %s",
                 oe_result_str(result));
         }


### PR DESCRIPTION
Fix DER CRL reading in `oe_validate_revocation_list`.
All endorsement entries have a trailing null terminator copied from DCAP collateral. While mbedtls API cannot handle the trailing zero for DER data. This PR remove the trailing zero for DER crl specifically.

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>