### PR TITLE
Cleaning up ocall_buffer allocated in _setup_ecall_context

### DIFF
--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -1274,17 +1274,15 @@ oe_result_t oe_terminate_enclave(oe_enclave_t* enclave)
          * Track failures reported by the platform, but do not exit early */
         result = oe_sgx_delete_enclave(enclave);
 
-#if defined(_WIN32)
-
-        /* Release Windows events created during enclave creation */
         for (size_t i = 0; i < enclave->num_bindings; i++)
         {
             oe_thread_binding_t* binding = &enclave->bindings[i];
+#if defined(_WIN32)
+            /* Release Windows events created during enclave creation */
             CloseHandle(binding->event.handle);
+#endif
             free(binding->ocall_buffer);
         }
-
-#endif
 
         /* Free the path name of the enclave image file */
         free(enclave->path);


### PR DESCRIPTION
Fixing a leak scenario detected during fuzzing.
Signed-off-by: Ragavan Dasarathan <mrragava@gmail.com>

==9977==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 16384 byte(s) in 1 object(s) allocated from:
    #0 0x551523 in __interceptor_malloc /home/ragava/Desktop/labs/llvm/oe-llvm/compiler-rt/lib/asan/asan_malloc_linux.cc:146:3
    #1 0x83cddb in _setup_ecall_context /home/ragava/oefuzz/openenclave-security/sut/openenclave/host/sgx/enter.c:143:33
    #2 0x83cddb in __morestack /home/ragava/oefuzz/openenclave-security/sut/openenclave/host/sgx/enter.c:202
    #3 0x82d120 in _do_eenter /home/ragava/oefuzz/openenclave-security/sut/openenclave/host/sgx/calls.c:193:13
    #4 0x82d120 in oe_ecall /home/ragava/oefuzz/openenclave-security/sut/openenclave/host/sgx/calls.c:612
    #5 0x66328d in _initialize_enclave /home/ragava/oefuzz/openenclave-security/sut/openenclave/host/sgx/create.c:464:5
    #6 0x660fe9 in oe_create_enclave /home/ragava/oefuzz/openenclave-security/sut/openenclave/host/sgx/create.c:1190:5
    #7 0x59c8e5 in oe_create_hostapis_enclave /home/ragava/oefuzz/openenclave-security/build/fuzzing_build/src/dynamic/fuzzing/hostapis/host/hostapis_u.c:3925:12
    #8 0x583431 in hostapi_fuzzer::hostapi_fuzzer() /home/ragava/oefuzz/openenclave-security/build/fuzzing_build/../../src/dynamic/fuzzing/hostapis/host/host.cpp:58:13
    #9 0x582bea in parse_report_fuzz::parse_report_fuzz() /home/ragava/oefuzz/openenclave-security/build/fuzzing_build/../../src/dynamic/fuzzing/hostapis/host/host.cpp:119:7
    #10 0x581e2f in std::_MakeUniq<parse_report_fuzz>::__single_object std::make_unique<parse_report_fuzz>() /usr/lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/unique_ptr.h:821:34
    #11 0x581bb1 in LLVMFuzzerTestOneInput /home/ragava/oefuzz/openenclave-security/build/fuzzing_build/../../src/dynamic/fuzzing/hostapis/host/host.cpp:213:18
...
...
