### PR TITLE
Skipping for non-FLC SGX platforms

### DIFF
--- a/tests/debug-mode/host/host.c
+++ b/tests/debug-mode/host/host.c
@@ -127,7 +127,13 @@ int main(int argc, const char* argv[])
             argv[0]);
         exit(1);
     }
-
+    if (!oe_has_sgx_quote_provider())
+    {
+        // this test should not run on any platforms where FLC is not supported
+        printf("=== Skipped - unsupported test by non-FLC platform "
+               "(debug)\n");
+        return SKIP_RETURN_CODE;
+    }
     const uint32_t flags = oe_get_create_flags();
     if ((flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
     {


### PR DESCRIPTION
According to it's Readme, these tests require FLC platform.

It is failing on LLC machine (Non DCAP driver) due to lack of QPL.

```
: ../tests/debug-mode/host/host.c(49): error: oe_create_debug_mode_enclave(): result=21
2021-05-31T18:43:07+0000.898682Z [(H)ERROR] tid(0x7f0981243b80) | sgxquoteprovider: libdcap_quoteprov.so libdcap_quoteprov.so: cannot open shared object file: No such file or directory
 [../host/sgx/linux/sgxquoteproviderloader.c:oe_load_quote_provider:81]
2021-05-31T18:43:07+0000.898689Z [(H)ERROR] tid(0x7f0981243b80) | oe_initialize_quote_provider failed (oe_result_t=OE_QUOTE_PROVIDER_LOAD_ERROR) [../host/sgx/sgxquoteprovider.c:oe_initialize_quote_provider:48]
2021-05-31T18:43:08+0000.052128Z [(H)ERROR] tid(0x7f0981243b80) | enclave_initialize failed (err=0x6) (oe_result_t=OE_PLATFORM_ERROR) [../host/sgx/sgxload.c:oe_sgx_initialize_enclave:670]
2021-05-31T18:43:08+0000.052142Z [(H)ERROR] tid(0x7f0981243b80) | :OE_PLATFORM_ERROR [../host/sgx/create.c:oe_sgx_build_enclave:964]
2021-05-31T18:43:08+0000.052486Z [(H)ERROR] tid(0x7f0981243b80) | :OE_PLATFORM_ERROR [../host/sgx/create.c:oe_create_enclave:1159]

```

```
The following tests FAILED:
	120 - tests/debug-unsigned (Failed)
	121 - tests/debug-unsigned-lvi-cfg (Failed)
	122 - tests/debug-signed (Failed)
	123 - tests/debug-signed-lvi-cfg (Failed)
```

Added skip condition before calling oe_get_create_flags()