### PR TITLE
Fix tcb status error logging and correct changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - When setting CapturePFGPExceptions=1, the OE loader will enable the feature when running on an SGX2-capable CPU.
   - Once enabled, the in-enclave exception handler can capture the #PF (with the OE_EXCEPTION_PAGE_FAULT code) and #GP (with the code OE_EXCEPTION_ACCESS_VIOLATION code) exceptions.
   - More information about the exceptions can be found in the `faulting_address` and `error_code` members of the `oe_exception_record_t` structure passed into the handler.
+- Add the following attestation claims from oe_verify_evidence():
+  - OE_CLAIM_TCB_STATUS
+  - OE_CLAIM_TCB_DATE
 
 [v0.16.1][v0.16.1_log]
 --------------
 ### Added
 - Add the support for SGX quote verification collateral version 3 with the CRL in DER format by default. Refer to [Get Quote Verification Collateral](https://download.01.org/intel-sgx/sgx-dcap/1.10/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf) section 3.3.1.5.
-- Add the following attestation claims from oe_verify_evidence():
-  - OE_CLAIM_TCB_STATUS
-  - OE_CLAIM_TCB_DATE
 
 [v0.16.0][v0.16.0_log]
 --------------

--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -255,7 +255,7 @@ static oe_tcb_level_status_t _parse_tcb_status(
                  length,
                  SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED))
     {
-        status.fields.qe_identity_out_of_date = 1;
+        status.fields.outofdate = 1;
         status.fields.configuration_needed = 1;
     }
     // Due to sgx LVI update, UpToDate tcb would be marked as SWHardeningNeeded,

--- a/common/sgx/tcbinfo.h
+++ b/common/sgx/tcbinfo.h
@@ -26,11 +26,6 @@ typedef union _oe_tcb_level_status
         uint32_t outofdate : 1;            //! "OutOfDate"
         uint32_t configuration_needed : 1; //! "ConfigurationNeeded"
         uint32_t up_to_date : 1;           //! "UpToDate"
-        /*! "OutOfDateConfigurationNeeded"
-         *
-         * This tcb status indicates that the QE Identity Info is out of date
-         * and the TCB Info requires configuration "ConfigurationNeeded"
-         */
         uint32_t qe_identity_out_of_date : 1;
         uint32_t sw_hardening_needed : 1; //! "SWHardeningNeeded"
     } fields;

--- a/docs/DesignDocs/SGX_Endorsements_V2.md
+++ b/docs/DesignDocs/SGX_Endorsements_V2.md
@@ -104,12 +104,6 @@ typedef union _oe_tcb_level_status
         uint32_t outofdate : 1;                     //! "OutOfDate"
         uint32_t configuration_needed : 1;          //! "ConfigurationNeeded"
         uint32_t up_to_date : 1;                    //! "UpToDate"
-
-        /*! "OutOfDateConfigurationNeeded"
-        *
-        * This tcb status indicates that the QE Identity Info is out of date and
-        * the TCB Info requires configuration "ConfigurationNeeded"
-        */
         uint32_t qe_identity_out_of_date : 1;
     } fields;
     uint32_t AsUINT32;

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -914,7 +914,8 @@ void verify_sgx_evidence(
         OE_TRACE_ERROR(
             "oe_verify_evidence result: %s. TCB Status: %s\n",
             oe_result_str(result),
-            _find_claim(claims, claims_size, OE_CLAIM_TCB_STATUS));
+            oe_sgx_tcb_status_str(*(oe_sgx_tcb_status_t*)_find_claim(
+                claims, claims_size, OE_CLAIM_TCB_STATUS)));
     }
 
     _test_claims(

--- a/tests/report/host/tcbinfo.cpp
+++ b/tests/report/host/tcbinfo.cpp
@@ -253,7 +253,9 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         &parsed_info,
         OE_OK,
         version);
-    OE_TEST(platform_tcb_level.status.fields.up_to_date == 1);
+    OE_TEST(
+        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        OE_SGX_TCB_STATUS_UP_TO_DATE);
     printf("UptoDate TCB Level determination test passed.\n");
 
     // Set platform pce svn to 7 and assert that
@@ -267,8 +269,9 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         &parsed_info,
         OE_OK,
         version);
-    OE_TEST(platform_tcb_level.status.fields.up_to_date == 1);
-    OE_TEST(platform_tcb_level.status.fields.sw_hardening_needed == 1);
+    OE_TEST(
+        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        OE_SGX_TCB_STATUS_SW_HARDENING_NEEDED);
     printf("SWHardeningNeeded TCB Level determination test passed.\n");
 
     // Set platform pce svn to 6 and assert that
@@ -282,8 +285,9 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         &parsed_info,
         OE_TCB_LEVEL_INVALID,
         version);
-    OE_TEST(platform_tcb_level.status.fields.configuration_needed == 1);
-    OE_TEST(platform_tcb_level.status.fields.sw_hardening_needed == 1);
+    OE_TEST(
+        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        OE_SGX_TCB_STATUS_CONFIGURATION_AND_SW_HARDENING_NEEDED);
     printf("ConfigurationAndSWHardeningNeeded TCB Level determination test "
            "passed.\n");
 
@@ -298,8 +302,9 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         &parsed_info,
         OE_TCB_LEVEL_INVALID,
         version);
-    OE_TEST(platform_tcb_level.status.fields.qe_identity_out_of_date == 1);
-    OE_TEST(platform_tcb_level.status.fields.configuration_needed == 1);
+    OE_TEST(
+        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED);
     printf(
         "OutOfDateConfigurationNeeded TCB Level determination test passed.\n");
 
@@ -314,7 +319,9 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         &parsed_info,
         OE_TCB_LEVEL_INVALID,
         version);
-    OE_TEST(platform_tcb_level.status.fields.configuration_needed == 1);
+    OE_TEST(
+        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED);
     printf("ConfigurationNeeded TCB Level determination test passed.\n");
 
     // Set platform pce svn to 3 and assert that
@@ -328,7 +335,9 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         &parsed_info,
         OE_TCB_LEVEL_INVALID,
         version);
-    OE_TEST(platform_tcb_level.status.fields.outofdate == 1);
+    OE_TEST(
+        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        OE_SGX_TCB_STATUS_OUT_OF_DATE);
     printf("OutOfDate TCB Level determination test passed.\n");
 
     // Set platform pce svn to 2 and assert that
@@ -342,7 +351,9 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         &parsed_info,
         OE_TCB_LEVEL_INVALID,
         version);
-    OE_TEST(platform_tcb_level.status.fields.revoked == 1);
+    OE_TEST(
+        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        OE_SGX_TCB_STATUS_REVOKED);
     printf("Revoked TCB Level determination test passed.\n");
 
     // Set each of the fields to a value not listed in the json and
@@ -360,7 +371,8 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
             OE_TCB_LEVEL_INVALID,
             version);
         OE_TEST(
-            platform_tcb_level.status.AsUINT32 == OE_TCB_LEVEL_STATUS_UNKNOWN);
+            oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+            OE_SGX_TCB_STATUS_INVALID);
         platform_tcb_level.sgx_tcb_comp_svn[i] = 2;
     }
     printf("Unknown TCB Level determination test passed.\n");


### PR DESCRIPTION
TCB status is an enum type instead of a char *. 
Updated the error tracing for it.
Added test coverage for `oe_tcb_level_status_to_sgx_tcb_status()`

Signed-off-by: Qiucheng Wang <qiucwang@microsoft.com>