### PR TITLE
Remove the double call pattern for oe_get_supported_attester_format_ids_ocall

### DIFF
--- a/enclave/sgx/attester.c
+++ b/enclave/sgx/attester.c
@@ -27,9 +27,7 @@
  */
 oe_result_t _oe_get_supported_attester_format_ids_ocall(
     oe_result_t* _retval,
-    void* format_ids,
-    size_t format_ids_size,
-    size_t* format_ids_size_out);
+    format_ids_t* format_ids);
 
 /**
  * Make the following OCALL weak to support the system EDL opt-in.
@@ -40,13 +38,9 @@ oe_result_t _oe_get_supported_attester_format_ids_ocall(
  */
 oe_result_t _oe_get_supported_attester_format_ids_ocall(
     oe_result_t* _retval,
-    void* format_ids,
-    size_t format_ids_size,
-    size_t* format_ids_size_out)
+    format_ids_t* format_ids)
 {
     OE_UNUSED(format_ids);
-    OE_UNUSED(format_ids_size);
-    OE_UNUSED(format_ids_size_out);
 
     if (_retval)
         *_retval = OE_UNSUPPORTED;
@@ -343,8 +337,7 @@ static oe_result_t _get_attester_plugins(
 {
     oe_result_t result = OE_UNEXPECTED;
     oe_result_t retval = OE_UNEXPECTED;
-    size_t temporary_buffer_size = 0;
-    uint8_t* temporary_buffer = NULL;
+    format_ids_t format_ids = {0};
     oe_uuid_t* uuid_list = NULL;
     size_t uuid_count = 0;
 
@@ -352,37 +345,11 @@ static oe_result_t _get_attester_plugins(
         OE_RAISE(OE_INVALID_PARAMETER);
 
     // Get the size of the needed buffer
-    result = oe_get_supported_attester_format_ids_ocall(
-        (uint32_t*)&retval, NULL, 0, &temporary_buffer_size);
-    OE_CHECK(result);
-    if (retval != OE_OK && retval != OE_BUFFER_TOO_SMALL)
-    {
-        OE_TRACE_ERROR("unexpected retval=%s", oe_result_str(retval));
-        OE_RAISE(retval);
-    }
-    // It's possible that there is no supported format
-    if (temporary_buffer_size >= sizeof(oe_uuid_t))
-    {
-        size_t allocated_buffer_size = temporary_buffer_size;
-        // Allocate buffer to held the format IDs
-        temporary_buffer = (uint8_t*)oe_malloc(temporary_buffer_size);
-        if (temporary_buffer == NULL)
-            OE_RAISE(OE_OUT_OF_MEMORY);
+    OE_CHECK(oe_get_supported_attester_format_ids_ocall(&retval, &format_ids));
+    OE_CHECK(retval);
 
-        // Get the format IDs
-        result = oe_get_supported_attester_format_ids_ocall(
-            (uint32_t*)&retval,
-            temporary_buffer,
-            allocated_buffer_size,
-            &temporary_buffer_size);
-        OE_CHECK(result);
-        OE_CHECK(retval);
-        if (temporary_buffer_size != allocated_buffer_size)
-            OE_RAISE(OE_UNEXPECTED);
-    }
-
-    uuid_list = (oe_uuid_t*)temporary_buffer;
-    uuid_count = temporary_buffer_size / sizeof(oe_uuid_t);
+    uuid_list = (oe_uuid_t*)format_ids.data;
+    uuid_count = format_ids.size / sizeof(oe_uuid_t);
 
     OE_TRACE_INFO("uuid_count=%lu", uuid_count);
 
@@ -425,10 +392,10 @@ done:
             "from \"openenclave/edl/sgx/attestation.edl\" import *;\n\n"
             "in the edl file.\n");
 
-    if (temporary_buffer)
+    if (format_ids.data)
     {
-        oe_free(temporary_buffer);
-        temporary_buffer = NULL;
+        oe_free(format_ids.data);
+        format_ids.data = NULL;
     }
     return result;
 }

--- a/host/sgx/ocalls/ocalls.c
+++ b/host/sgx/ocalls/ocalls.c
@@ -264,20 +264,10 @@ oe_result_t oe_get_qetarget_info_ocall(
         format_id, opt_params, opt_params_size, target_info);
 }
 
-oe_result_t oe_get_supported_attester_format_ids_ocall(
-    void* format_ids,
-    size_t format_ids_size,
-    size_t* format_ids_size_out)
+oe_result_t oe_get_supported_attester_format_ids_ocall(format_ids_t* format_ids)
 {
-    oe_result_t result;
-
-    result =
-        sgx_get_supported_attester_format_ids(format_ids, &format_ids_size);
-
-    if (format_ids_size_out)
-        *format_ids_size_out = format_ids_size;
-
-    return result;
+    return sgx_get_supported_attester_format_ids(
+        &format_ids->data, &format_ids->size);
 }
 
 oe_result_t oe_verify_quote_ocall(

--- a/host/sgx/quote.c
+++ b/host/sgx/quote.c
@@ -115,16 +115,16 @@ done:
 }
 
 oe_result_t sgx_get_supported_attester_format_ids(
-    void* format_ids,
+    void** format_ids_data,
     size_t* format_ids_size)
 {
     oe_result_t result = OE_UNEXPECTED;
 
-    if (!format_ids && !format_ids_size)
+    if (!format_ids_data || !format_ids_size)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    result =
-        oe_sgx_get_supported_attester_format_ids(format_ids, format_ids_size);
+    result = oe_sgx_get_supported_attester_format_ids(
+        format_ids_data, format_ids_size);
 
 done:
     return result;

--- a/host/sgx/quote.h
+++ b/host/sgx/quote.h
@@ -62,7 +62,7 @@ oe_result_t sgx_get_quote(
 **==============================================================================
 */
 oe_result_t sgx_get_supported_attester_format_ids(
-    void* format_ids,
+    void** format_ids,
     size_t* format_ids_size);
 
 oe_result_t oe_verify_report_internal(

--- a/host/sgx/sgxquote.h
+++ b/host/sgx/sgxquote.h
@@ -31,7 +31,7 @@ oe_result_t oe_sgx_qe_get_quote(
     uint8_t* quote);
 
 oe_result_t oe_sgx_get_supported_attester_format_ids(
-    void* format_ids,
+    void** format_ids,
     size_t* format_ids_size);
 
 oe_result_t oe_sgx_get_supplemental_data_size(

--- a/include/openenclave/edl/sgx/attestation.edl
+++ b/include/openenclave/edl/sgx/attestation.edl
@@ -23,6 +23,12 @@ enclave
     // contiguous memory.
     include "openenclave/bits/sgx/sgxtypes.h"
 
+    struct format_ids_t
+    {
+        [size=size] void* data;
+        size_t size;
+    };
+
     trusted
     {
         public oe_result_t oe_get_sgx_report_ecall(
@@ -45,14 +51,9 @@ enclave
 
     untrusted
     {
-        // Input and output size values in number of bytes,
-        //    not number of UUIDs
-        // If format_ids buffer is NULL or too small,
-        // return needed buffer size in format_ids_size_out
+        // Output size values in number of bytes, not number of UUIDs
         oe_result_t oe_get_supported_attester_format_ids_ocall(
-            [out, size=format_ids_size] void* format_ids,
-            size_t format_ids_size,
-            [out] size_t* format_ids_size_out);
+            [out] format_ids_t* format_ids);
 
         oe_result_t oe_get_qetarget_info_ocall(
             [in] const oe_uuid_t* format_id,

--- a/tests/edl_opt_out/enc/enc.c
+++ b/tests/edl_opt_out/enc/enc.c
@@ -131,13 +131,8 @@ void enc_edl_opt_out()
         oe_result_t result = OE_OK;
 
         OE_TEST(
-            oe_get_supported_attester_format_ids_ocall(
-                &result, NULL, 0, NULL) == OE_UNSUPPORTED);
-        OE_TEST(result == OE_UNSUPPORTED);
-        result = OE_OK;
-        OE_TEST(
-            oe_get_supported_attester_format_ids_ocall(
-                &result, NULL, 0, NULL) == OE_UNSUPPORTED);
+            oe_get_supported_attester_format_ids_ocall(&result, NULL) ==
+            OE_UNSUPPORTED);
         OE_TEST(result == OE_UNSUPPORTED);
         result = OE_OK;
         OE_TEST(


### PR DESCRIPTION
Remove the double call pattern for oe_get_supported_attester_format_ids_ocall with the use of deep-copy feature.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>