### PR TITLE
Fix compatibility issues between oeutil and oeverify

### DIFF
--- a/samples/host_verify/README.md
+++ b/samples/host_verify/README.md
@@ -10,9 +10,10 @@ Prerequisites: you may want to read [Common Sample Information](../README.md#com
 
 When an application is doing host-side enclave verification, it means that a host application is trying to authenticate a remote enclave's hardware and software settings so that the application can determine whether or not to trust the remote enclave.
 
-The sample does remote host-side enclave attestation by taking either of the two arguments:
+The sample does remote host-side enclave attestation by taking one of the following three arguments:
 
 - An SGX report
+- Evidence in SGX_ECDSA format
 - An SGX certificate
 
 The sample also accepts an endorsement file as input. See the end of the file for usage.
@@ -33,7 +34,8 @@ When you see the following message displayed on the screen, it means you have su
 ```bash
 Usage:
   ./host_verify -r <report_file> [-e <endorsement_file>]
+  ./host_verify -v <evidence_file> [-e <endorsement_file>]
   ./host_verify -c <certificate_file>
-Verify the integrity of enclave remote report or attestation certificate.
+Verify the integrity of enclave remote report, enclave attestation evidence in SGX_ECDSA format, or attestation certificate.
 WARNING: host_verify does not have a stable CLI interface. Use with caution.
 ```

--- a/samples/host_verify/host.c
+++ b/samples/host_verify/host.c
@@ -157,6 +157,7 @@ oe_result_t verify_evidence(
     oe_result_t result = OE_FAILURE;
     uint8_t *evidence = NULL, *endorsements = NULL;
     size_t evidence_size = 0, endorsements_size = 0;
+    static const oe_uuid_t _uuid_sgx_ecdsa = {OE_FORMAT_UUID_SGX_ECDSA};
 
     if (read_binary_file(evidence_filename, &evidence, &evidence_size))
     {
@@ -171,7 +172,7 @@ oe_result_t verify_evidence(
         size_t claims_length = 0;
 
         result = oe_verify_evidence(
-            NULL,
+            &_uuid_sgx_ecdsa,
             evidence,
             evidence_size,
             endorsements,
@@ -272,8 +273,8 @@ void print_syntax(const char* program_name)
         program_name);
     fprintf(
         stdout,
-        "Verify the integrity of enclave remote report or attestation "
-        "certificate.\n");
+        "Verify the integrity of enclave remote report, enclave attestation "
+        "evidence in SGX_ECDSA format, or attestation certificate.\n");
     fprintf(
         stdout,
         "WARNING: %s does not have a stable CLI interface. Use with "

--- a/tests/host_verify/host/host.cpp
+++ b/tests/host_verify/host/host.cpp
@@ -283,6 +283,7 @@ static int _verify_evidence(
     oe_result_t result = OE_FAILURE;
     oe_claim_t* claims = NULL;
     size_t claims_length = 0;
+    static const oe_uuid_t _uuid_sgx_ecdsa = {OE_FORMAT_UUID_SGX_ECDSA};
 
     OE_TRACE_INFO(
         "\n\nVerifying evidence %s, endorsements: %s\n",
@@ -297,7 +298,7 @@ static int _verify_evidence(
     OE_TEST(oe_verifier_initialize() == OE_OK);
 
     result = oe_verify_evidence(
-        NULL,
+        &_uuid_sgx_ecdsa,
         evidence,
         evidence_size,
         NULL,

--- a/tools/oeutil/enc/generate_evidence_enc.cpp
+++ b/tools/oeutil/enc/generate_evidence_enc.cpp
@@ -134,7 +134,7 @@ oe_result_t get_plugin_evidence(
 
     OE_CHECK(oe_get_evidence(
         &evidence_format,
-        OE_EVIDENCE_FLAGS_EMBED_FORMAT_ID,
+        0,
         NULL,
         0,
         NULL,

--- a/tools/oeverify/oeverify.c
+++ b/tools/oeverify/oeverify.c
@@ -21,9 +21,7 @@ typedef struct _evidence_uuid_desc
     XX(SGX_ECDSA)                   \
     XX(LEGACY_REPORT_REMOTE)        \
     XX(RAW_SGX_QUOTE_ECDSA)         \
-    XX(SGX_LOCAL_ATTESTATION)       \
-    XX(SGX_EPID_LINKABLE)           \
-    XX(SGX_EPID_UNLINKABLE)
+    XX(SGX_LOCAL_ATTESTATION)
 
 static char* allowed_evidence_formats =
 #define XX(id) #id " "


### PR DESCRIPTION
Remove header information generated by `oe_get_evidence()` and pass the desired evidence format into `oe_verify_evidence()` in order to fix the compatibility issues between `oeutil` and `oeverify`.

Also, since evidence in `SGX_EPID_LINKABLE` or `SGX_EPID_UNLINKABLE` format can only be verified by Intel Attestation Service (IAS), modify `oeutil` and `oeverify` so that evidence in either EPID format will not be verified.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>