### PR TITLE
Remove python2 dependency

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,14 @@ if (OE_SGX)
   set(DEFINE_OE_SGX "-DOE_SGX")
 endif ()
 
+if (UNIX)
+  # On Linux prefer python3 since python may not be available.
+  find_program(PYTHON NAMES python3 python)
+else ()
+  # On Windows and other systems, use the available python executable.
+  set(PYTHON "python")
+endif ()
+
 add_subdirectory(mem)
 add_subdirectory(safecrt)
 add_subdirectory(safemath)

--- a/tests/mbed/enc/CMakeLists.txt
+++ b/tests/mbed/enc/CMakeLists.txt
@@ -40,7 +40,7 @@ function (add_mbed_test_enclave NAME)
       " --out-dir ${CMAKE_CURRENT_BINARY_DIR}")
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/test_suite_${NAME}.c
-    COMMAND ${OE_BASH} -c "python ${GEN_TEST_CODE_SCRIPT}"
+    COMMAND ${OE_BASH} -c "${PYTHON} ${GEN_TEST_CODE_SCRIPT}"
     DEPENDS mbedcrypto
             ${MBEDTLS_TESTS_DIR}/scripts/generate_test_code.py
             ${MBEDTLS_TESTS_DIR}/suites/helpers.function

--- a/tests/tools/oesign/test-digest/CMakeLists.txt
+++ b/tests/tools/oesign/test-digest/CMakeLists.txt
@@ -57,7 +57,7 @@ set(OESIGN_DIGEST_VALID_SHORT_ARGS
 add_test(
   NAME tests/oesign-digest-valid-short-args
   COMMAND
-    python sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
+    ${PYTHON} sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
     --enclave-path $<TARGET_FILE:oesign_test_enc> --oesign-path
     $<TARGET_FILE:oesign> --digest-args ${OESIGN_DIGEST_VALID_SHORT_ARGS}
     --pkeyutl-args ${OESIGN_PKEYUTL_ARGS} --oesign-args
@@ -78,7 +78,7 @@ set(OESIGN_DIGEST_VALID_LONG_ARGS
 add_test(
   NAME tests/oesign-digest-valid-long-args
   COMMAND
-    python sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
+    ${PYTHON} sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
     --enclave-path $<TARGET_FILE:oesign_test_enc> --oesign-path
     $<TARGET_FILE:oesign> --digest-args ${OESIGN_DIGEST_VALID_LONG_ARGS}
     --pkeyutl-args ${OESIGN_PKEYUTL_ARGS} --oesign-args
@@ -101,7 +101,7 @@ set(OESIGN_DIGEST_VALID_DEV_CONFIG_ARGS
 add_test(
   NAME tests/oesign-digest-valid-dev-config-args
   COMMAND
-    python sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
+    ${PYTHON} sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
     --enclave-path $<TARGET_FILE:oesign_test_alt_enc> --oesign-path
     $<TARGET_FILE:oesign> --digest-args ${OESIGN_DIGEST_VALID_DEV_CONFIG_ARGS}
     --pkeyutl-args ${OESIGN_PKEYUTL_DEV_CONFIG_ARGS} --oesign-args

--- a/tests/tools/oesign/test-engine/CMakeLists.txt
+++ b/tests/tools/oesign/test-engine/CMakeLists.txt
@@ -31,7 +31,7 @@ set(OESIGN_ENGINE_VALID_SHORT_ARGS
 add_test(
   NAME tests/oesign-engine-valid-short-args
   COMMAND
-    python sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
+    ${PYTHON} sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
     --enclave-path $<TARGET_FILE:oesign_test_enc> --oesign-path
     $<TARGET_FILE:oesign> --oesign-args ${OESIGN_ENGINE_VALID_SHORT_ARGS})
 
@@ -47,7 +47,7 @@ set(OESIGN_ENGINE_VALID_LONG_ARGS
 add_test(
   NAME tests/oesign-engine-valid-long-args
   COMMAND
-    python sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
+    ${PYTHON} sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
     --enclave-path $<TARGET_FILE:oesign_test_enc> --oesign-path
     $<TARGET_FILE:oesign> --oesign-args ${OESIGN_ENGINE_VALID_LONG_ARGS})
 

--- a/tests/tools/oesign/test-inputs/CMakeLists.txt
+++ b/tests/tools/oesign/test-inputs/CMakeLists.txt
@@ -22,63 +22,63 @@ add_custom_command(
 add_custom_command(
   OUTPUT valid.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file valid.conf)
 
 add_custom_command(
   OUTPUT negative_num_heap_pages.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file negative_num_heap_pages.conf --num_heap_pages -3)
 
 # Generate variant valid configurations
 add_custom_command(
   OUTPUT non_debug.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file non_debug.conf --debug 0)
 
 add_custom_command(
   OUTPUT debug_out_of_range.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file debug_out_of_range.conf --debug 333)
 
 add_custom_command(
   OUTPUT more_num_heap_pages.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file more_num_heap_pages.conf --num_heap_pages 2048)
 
 add_custom_command(
   OUTPUT more_num_stack_pages.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file more_num_stack_pages.conf --num_stack_pages 2048)
 
 add_custom_command(
   OUTPUT more_num_tcs.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file more_num_tcs.conf --num_tcs 4)
 
 add_custom_command(
   OUTPUT new_product_id.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file new_product_id.conf --product_id 2)
 
 add_custom_command(
   OUTPUT new_security_version.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
           --config_file new_security_version.conf --security_version 2)
 
 add_custom_command(
   OUTPUT kss_valid.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
   COMMAND
-    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
     kss_valid.conf --extended_product_id 2768c720-1e28-11eb-adc1-0242ac120002
     --family_id 57183823-2574-4bfd-b411-99ed177d3e43)
 
@@ -86,7 +86,7 @@ add_custom_command(
   OUTPUT ext_prod_id_too_long.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
   COMMAND
-    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
     ext_prod_id_too_long.conf --extended_product_id
     2768c720-1e28-11eb-adc1-0242ac1200023)
 
@@ -94,7 +94,7 @@ add_custom_command(
   OUTPUT ext_prod_id_too_short.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
   COMMAND
-    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
     ext_prod_id_too_short.conf --extended_product_id
     2768c720-1e28-11eb-adc1-0242ac12000)
 
@@ -102,7 +102,7 @@ add_custom_command(
   OUTPUT family_id_too_long.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
   COMMAND
-    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
     family_id_too_long.conf --family_id
     57183823-2574-4bfd-b411-99ed177d3e433e433)
 
@@ -110,7 +110,7 @@ add_custom_command(
   OUTPUT family_id_too_short.conf
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
   COMMAND
-    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
     family_id_too_short.conf --family_id 57183823-2574-4bfd-b411-99ed177d3e4)
 
 # Generate empty config file

--- a/tests/tools/oesign/test-sign/CMakeLists.txt
+++ b/tests/tools/oesign/test-sign/CMakeLists.txt
@@ -22,7 +22,7 @@ set(OESIGN_SIGN_VALID_SHORT_ARGS
 add_test(
   NAME tests/oesign-sign-valid-short-args
   COMMAND
-    python sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
+    ${PYTHON} sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
     --enclave-path $<TARGET_FILE:oesign_test_enc> --oesign-path
     $<TARGET_FILE:oesign> --oesign-args ${OESIGN_SIGN_VALID_SHORT_ARGS})
 
@@ -38,7 +38,7 @@ set(OESIGN_SIGN_VALID_LONG_ARGS
 add_test(
   NAME tests/oesign-sign-valid-long-args
   COMMAND
-    python sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
+    ${PYTHON} sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
     --enclave-path $<TARGET_FILE:oesign_test_enc> --oesign-path
     $<TARGET_FILE:oesign> --oesign-args ${OESIGN_SIGN_VALID_LONG_ARGS})
 
@@ -212,7 +212,7 @@ set(OESIGN_SIGN_VALID_KSS
 add_test(
   NAME tests/oesign-sign-valid-kss
   COMMAND
-    python sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
+    ${PYTHON} sign-and-verify.py --host-path $<TARGET_FILE:oesign_test_host>
     --enclave-path $<TARGET_FILE:oesign_test_enc> --oesign-path
     $<TARGET_FILE:oesign> --oesign-args ${OESIGN_SIGN_VALID_KSS})
 


### PR DESCRIPTION
Look for python3 executable and use it if found.
Otherwise revert to python (python2).
Newer systems may not have python2 since it is deprecated.

On Windows, the python executable is named python irrespective
of the version.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>