### PR TITLE
Add Felix to the CGC

### DIFF
--- a/docs/Community/governance/README.md
+++ b/docs/Community/governance/README.md
@@ -24,6 +24,7 @@ Members
 | Dave Thaler          | Microsoft   | dthaler@microsoft.com         | dthaler        |
 | Mark Shanahan        | Intel       | mark.shanahan@intel.com       | MWShan         |
 | Radhika Jandhyala    | Microsoft   | radhikaj@microsoft.com        | radhikaj       |
+| Felix Schuster       | Edgeless    | fs@edgeless.systems           | flxflx         |
 
 Emeritus Members
 ----------------


### PR DESCRIPTION
This commit adds Felix, based on unanimous CGC member vote
held on 7 June 2021.

Signed-off-by: Aeva Black <806320+AevaOnline@users.noreply.github.com>