### PR TITLE
0-base enclave implementation for linux

### DIFF
--- a/common/sgx/sgxmeasure.c
+++ b/common/sgx/sgxmeasure.c
@@ -83,7 +83,8 @@ oe_result_t oe_sgx_measure_load_enclave_data(
     oe_result_t result = OE_UNEXPECTED;
     uint64_t vaddr = addr - base;
 
-    if (!context || !base || !addr || !src || !flags || addr < base)
+    /* to support 0-base enclave, base=0 is a legit input parameter */
+    if (!context || !addr || !src || !flags || addr < base)
         OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Measure EADD */

--- a/docs/DesignDocs/CryptoModuleLoadingSupport.md
+++ b/docs/DesignDocs/CryptoModuleLoadingSupport.md
@@ -301,13 +301,13 @@ As a result, the module will be part of the enclave measurement (i.e., `MRENCLAV
   {
        extern void (*__init_array_start)(void);
        extern void (*__init_array_end)(void);
-  +    const uint64_t baseaddr = (uint64_t)__oe_get_enclave_base();
+  +    const uint64_t start_address = (uint64_t)__oe_get_enclave_start_address();
   +    const oe_enclave_module_info_t* module_info = oe_get_module_info();
  
   +    if (module_info->base_rva)
        {
-  +        uint64_t init_array_start = baseaddr + module_info->init_array_rva;
-  +        uint64_t init_array_end = baseaddr + module_info->init_array_rva +
+  +        uint64_t init_array_start = start_address + module_info->init_array_rva;
+  +        uint64_t init_array_end = start_address + module_info->init_array_rva +
   +                                  module_info->init_array_size;
   +        _call_init_functions(
   +            (void (**)(void))(init_array_start),

--- a/enclave/core/init_fini.c
+++ b/enclave/core/init_fini.c
@@ -72,14 +72,14 @@ void oe_call_init_functions(void)
 {
     extern void (*__init_array_start)(void);
     extern void (*__init_array_end)(void);
-    const uint64_t baseaddr = (uint64_t)__oe_get_enclave_base();
+    const uint64_t start_address = (uint64_t)__oe_get_enclave_start_address();
     const oe_enclave_module_info_t* module_info = oe_get_module_info();
 
     if (module_info && module_info->base_rva && module_info->init_array_rva &&
         module_info->init_array_size)
     {
-        uint64_t init_array_start = baseaddr + module_info->init_array_rva;
-        uint64_t init_array_end = baseaddr + module_info->init_array_rva +
+        uint64_t init_array_start = start_address + module_info->init_array_rva;
+        uint64_t init_array_end = start_address + module_info->init_array_rva +
                                   module_info->init_array_size;
         _call_init_functions(
             (void (**)(void))(init_array_start),
@@ -149,7 +149,7 @@ void oe_call_fini_functions(void)
 {
     extern void (*__fini_array_start)(void);
     extern void (*__fini_array_end)(void);
-    const uint64_t baseaddr = (uint64_t)__oe_get_enclave_base();
+    const uint64_t start_address = (uint64_t)__oe_get_enclave_start_address();
     const oe_enclave_module_info_t* module_info = oe_get_module_info();
 
     _call_fini_functions(&__fini_array_start, &__fini_array_end);
@@ -157,8 +157,8 @@ void oe_call_fini_functions(void)
     if (module_info && module_info->base_rva && module_info->fini_array_rva &&
         module_info->fini_array_size)
     {
-        uint64_t fini_array_start = baseaddr + module_info->fini_array_rva;
-        uint64_t fini_array_end = baseaddr + module_info->fini_array_rva +
+        uint64_t fini_array_start = start_address + module_info->fini_array_rva;
+        uint64_t fini_array_end = start_address + module_info->fini_array_rva +
                                   module_info->fini_array_size;
         _call_fini_functions(
             (void (**)(void))(fini_array_start),

--- a/enclave/core/optee/globals.c
+++ b/enclave/core/optee/globals.c
@@ -18,14 +18,30 @@ extern const size_t ta_heap_size;
 **==============================================================================
 */
 
-const void* __oe_get_enclave_base()
+const void* __oe_get_enclave_start_address()
 {
     return (void*)tainfo_get_rva();
 }
 
+const void* __oe_get_enclave_base_address()
+{
+    return __oe_get_enclave_start_address();
+}
+
+uint8_t __oe_get_enclave_create_zero_base_flag()
+{
+    return 0;
+}
+
+uint64_t __oe_get_configured_enclave_start_address()
+{
+    return 0;
+}
+
 const void* __oe_get_enclave_elf_header(void)
 {
-    return (const uint8_t*)__oe_get_enclave_base() + sizeof(struct ta_head);
+    return (const uint8_t*)__oe_get_enclave_start_address() +
+           sizeof(struct ta_head);
 }
 
 /*

--- a/enclave/core/sgx/init.c
+++ b/enclave/core/sgx/init.c
@@ -31,7 +31,8 @@
 static void _check_memory_boundaries(void)
 {
     /* This is a tautology! */
-    if (!oe_is_within_enclave(__oe_get_enclave_base(), __oe_get_enclave_size()))
+    if (!oe_is_within_enclave(
+            __oe_get_enclave_start_address(), __oe_get_enclave_size()))
         oe_abort();
 
     if (!oe_is_within_enclave(__oe_get_reloc_base(), __oe_get_reloc_size()))
@@ -39,6 +40,17 @@ static void _check_memory_boundaries(void)
 
     if (!oe_is_within_enclave(__oe_get_heap_base(), __oe_get_heap_size()))
         oe_abort();
+
+    if (__oe_get_enclave_create_zero_base_flag())
+    {
+        /*
+         * Make sure that the enclave image address and
+         * the configured start address are same.
+         */
+        if (__oe_get_configured_enclave_start_address() !=
+            (uint64_t)__oe_get_enclave_start_address())
+            oe_abort();
+    }
 }
 
 #ifdef OE_WITH_EXPERIMENTAL_EEID
@@ -59,7 +71,7 @@ static oe_result_t _eeid_patch_memory()
 
     if (_is_eeid_base_image(&oe_enclave_properties_sgx))
     {
-        uint8_t* enclave_base = (uint8_t*)__oe_get_enclave_base();
+        uint8_t* enclave_base = (uint8_t*)__oe_get_enclave_start_address();
         uint8_t* heap_base = (uint8_t*)__oe_get_heap_base();
         const oe_eeid_marker_t* marker = (oe_eeid_marker_t*)heap_base;
         oe_eeid_t* eeid = (oe_eeid_t*)(enclave_base + marker->offset);

--- a/enclave/core/sgx/memory.c
+++ b/enclave/core/sgx/memory.c
@@ -8,7 +8,7 @@ bool oe_is_within_enclave(const void* p, size_t n)
 {
     uint64_t range_start = (uint64_t)p;
     uint64_t range_end = range_start + (n == 0 ? 1 : n);
-    uint64_t enclave_start = (uint64_t)__oe_get_enclave_base();
+    uint64_t enclave_start = (uint64_t)__oe_get_enclave_start_address();
     uint64_t enclave_end = enclave_start + __oe_get_enclave_size();
 
     // Disallow nullptr and check that arithmetic operations do not wrap
@@ -27,7 +27,7 @@ bool oe_is_outside_enclave(const void* p, size_t n)
 {
     uint64_t range_start = (uint64_t)p;
     uint64_t range_end = range_start + (n == 0 ? 1 : n);
-    uint64_t enclave_start = (uint64_t)__oe_get_enclave_base();
+    uint64_t enclave_start = (uint64_t)__oe_get_enclave_start_address();
     uint64_t enclave_end = enclave_start + __oe_get_enclave_size();
 
     // Disallow nullptr and check that arithmetic operations do not wrap

--- a/enclave/core/sgx/properties.c
+++ b/enclave/core/sgx/properties.c
@@ -17,13 +17,13 @@ OE_STATIC_ASSERT(
 
 OE_CHECK_SIZE(sizeof(oe_enclave_properties_header_t), 32);
 
-OE_CHECK_SIZE(sizeof(oe_sgx_enclave_config_t), 56);
+OE_CHECK_SIZE(sizeof(oe_sgx_enclave_config_t), 64);
 
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, header), 0);
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, config), 32);
-OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 88);
-OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 136);
-OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 1952);
+OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 96);
+OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 144);
+OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 1960);
 
 //
 // Declare an invalid oeinfo to ensure .oeinfo section exists

--- a/enclave/core/sgx/reloc.c
+++ b/enclave/core/sgx/reloc.c
@@ -22,7 +22,8 @@ bool oe_apply_relocations(void)
 {
     const elf64_rela_t* relocs = (const elf64_rela_t*)__oe_get_reloc_base();
     size_t nrelocs = __oe_get_reloc_size() / sizeof(elf64_rela_t);
-    const uint8_t* baseaddr = (const uint8_t*)__oe_get_enclave_base();
+    const uint8_t* start_address =
+        (const uint8_t*)__oe_get_enclave_start_address();
 
     for (size_t i = 0; i < nrelocs; i++)
     {
@@ -33,7 +34,7 @@ bool oe_apply_relocations(void)
             break;
 
         /* Compute address of reference to be relocated */
-        uint64_t* dest = (uint64_t*)(baseaddr + p->r_offset);
+        uint64_t* dest = (uint64_t*)(start_address + p->r_offset);
 
         uint64_t reloc_type = ELF64_R_TYPE(p->r_info);
 
@@ -43,7 +44,7 @@ bool oe_apply_relocations(void)
             int64_t addend = p->r_addend;
             /* Process only if the symbol is defined */
             if (addend)
-                *dest = (uint64_t)(baseaddr + p->r_addend);
+                *dest = (uint64_t)(start_address + p->r_addend);
         }
     }
 

--- a/enclave/core/sgx/threadlocal.c
+++ b/enclave/core/sgx/threadlocal.c
@@ -308,7 +308,7 @@ oe_result_t oe_thread_local_init(oe_sgx_td_t* td)
         oe_memset_s(tls_start, tls_data_size, 0, tls_data_size);
 
         // Fetch the .tdata template.
-        void* tdata = (uint8_t*)__oe_get_enclave_base() + _tdata_rva;
+        void* tdata = (uint8_t*)__oe_get_enclave_start_address() + _tdata_rva;
 
         // Copy the template
         oe_memcpy_s(tls_start, _tdata_size, tdata, _tdata_size);
@@ -323,7 +323,8 @@ oe_result_t oe_thread_local_init(oe_sgx_td_t* td)
             const elf64_rela_t* relocs =
                 (const elf64_rela_t*)__oe_get_reloc_base();
             size_t nrelocs = __oe_get_reloc_size() / sizeof(elf64_rela_t);
-            const uint8_t* baseaddr = (const uint8_t*)__oe_get_enclave_base();
+            const uint8_t* start_address =
+                (const uint8_t*)__oe_get_enclave_start_address();
 
             for (size_t i = 0; i < nrelocs; i++)
             {
@@ -336,7 +337,7 @@ oe_result_t oe_thread_local_init(oe_sgx_td_t* td)
                 if (ELF64_R_TYPE(p->r_info) == R_X86_64_TPOFF64)
                 {
                     // Compute address of tpoff variable
-                    int64_t* tpoff = (int64_t*)(baseaddr + p->r_offset);
+                    int64_t* tpoff = (int64_t*)(start_address + p->r_offset);
 
                     // Set tpoff to the offset value relative to FS
                     *tpoff = (tls_start + p->r_addend - fs);

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -102,16 +102,17 @@ static oe_result_t _enter_sim(
     oe_sgx_td_t* td = NULL;
 
     /* Reject null parameters */
-    if (!enclave || !enclave->addr || !tcs || !tcs->oentry || !tcs->gsbase)
+    if (!enclave || !enclave->start_address || !tcs || !tcs->oentry ||
+        !tcs->gsbase)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    tcs->u.entry = (void (*)(void))(enclave->addr + tcs->oentry);
+    tcs->u.entry = (void (*)(void))(enclave->start_address + tcs->oentry);
 
     if (!tcs->u.entry)
         OE_RAISE(OE_NOT_FOUND);
 
     /* Set oe_sgx_td_t.simulate flag */
-    td = (oe_sgx_td_t*)(enclave->addr + tcs->gsbase);
+    td = (oe_sgx_td_t*)(enclave->start_address + tcs->gsbase);
     td->simulate = true;
 
     /* Call into enclave */
@@ -345,7 +346,7 @@ static oe_result_t _handle_ocall(
         OE_LOG_LEVEL_VERBOSE,
         "%s 0x%x %s: %s\n",
         enclave->path,
-        enclave->addr,
+        enclave->start_address,
         func == OE_OCALL_CALL_HOST_FUNCTION ? "EDL_OCALL" : "OE_OCALL",
         oe_ocall_str(func));
 
@@ -604,7 +605,7 @@ oe_result_t oe_ecall(
         OE_LOG_LEVEL_VERBOSE,
         "%s 0x%x %s: %s\n",
         enclave->path,
-        enclave->addr,
+        enclave->start_address,
         func == OE_ECALL_CALL_ENCLAVE_FUNCTION ? "EDL_ECALL" : "OE_ECALL",
         oe_ecall_str(func));
 

--- a/host/sgx/enclave.h
+++ b/host/sgx/enclave.h
@@ -99,8 +99,12 @@ typedef struct _oe_enclave
     /* Path of the enclave file */
     char* path;
 
-    /* Base address of enclave within enclave address space (BASEADDR) */
-    uint64_t addr;
+    /* Base address of enclave address range (BASEADDR). If not,
+     * a 0-based enclave, currently base_address = start_address */
+    uint64_t base_address;
+
+    /* Enclave image start address within enclave address space */
+    uint64_t start_address;
 
     /* Size of enclave in bytes */
     uint64_t size;

--- a/host/sgx/enter.c
+++ b/host/sgx/enter.c
@@ -283,8 +283,10 @@ void oe_enter_sim(
         // restored by Windows. To let the enclave chug along in simulation
         // mode, we prepend a vectored exception handler that resets the FS
         // register to the desired value. See host/sgx/create.c.
-        oe_set_fs_register_base((void*)(enclave->addr + sgx_tcs->fsbase));
-        oe_set_gs_register_base((void*)(enclave->addr + sgx_tcs->gsbase));
+        oe_set_fs_register_base(
+            (void*)(enclave->start_address + sgx_tcs->fsbase));
+        oe_set_gs_register_base(
+            (void*)(enclave->start_address + sgx_tcs->gsbase));
 
         // For parity with oe_enter, see comments there.
         if (oe_is_avx_enabled)

--- a/host/sgx/loadelf.c
+++ b/host/sgx/loadelf.c
@@ -569,7 +569,7 @@ static uint64_t _make_secinfo_flags(uint32_t flags)
 
 static oe_result_t _add_relocation_pages(
     oe_sgx_load_context_t* context,
-    uint64_t enclave_base,
+    oe_enclave_t* enclave,
     const oe_enclave_elf_image_t* image,
     uint64_t* vaddr)
 {
@@ -585,13 +585,13 @@ static oe_result_t _add_relocation_pages(
 
         for (size_t i = 0; i < npages; i++)
         {
-            uint64_t addr = enclave_base + *vaddr;
+            uint64_t addr = enclave->start_address + *vaddr;
             uint64_t src = (uint64_t)&pages[i];
             uint64_t flags = SGX_SECINFO_REG | SGX_SECINFO_R;
             bool extend = true;
 
             OE_CHECK(oe_sgx_load_enclave_data(
-                context, enclave_base, addr, src, flags, extend));
+                context, enclave->base_address, addr, src, flags, extend));
             (*vaddr) += sizeof(oe_page_t);
         }
     }
@@ -604,7 +604,7 @@ done:
 
 static oe_result_t _add_segment_pages(
     oe_sgx_load_context_t* context,
-    uint64_t enclave_base,
+    oe_enclave_t* enclave,
     const oe_enclave_elf_image_t* image,
     uint64_t* vaddr)
 {
@@ -635,8 +635,8 @@ static oe_result_t _add_segment_pages(
         {
             OE_CHECK(oe_sgx_load_enclave_data(
                 context,
-                enclave_base,
-                enclave_base + *vaddr + page_rva,
+                enclave->base_address,
+                enclave->start_address + *vaddr + page_rva,
                 (uint64_t)image->image_base + page_rva,
                 flags,
                 true));
@@ -672,14 +672,13 @@ static oe_result_t _add_pages(
     assert(enclave->size > image_size);
 
     /* Add the program segments first */
-    OE_CHECK(_add_segment_pages(context, enclave->addr, &image->elf, vaddr));
+    OE_CHECK(_add_segment_pages(context, enclave, &image->elf, vaddr));
     if (image->submodule)
-        OE_CHECK(_add_segment_pages(
-            context, enclave->addr, image->submodule, vaddr));
+        OE_CHECK(_add_segment_pages(context, enclave, image->submodule, vaddr));
 
     /* The base image points to the merged (base + module), zero-padded
      * relocation data after the patching step. */
-    OE_CHECK(_add_relocation_pages(context, enclave->addr, &image->elf, vaddr));
+    OE_CHECK(_add_relocation_pages(context, enclave, &image->elf, vaddr));
 
     result = OE_OK;
 
@@ -1204,7 +1203,7 @@ static oe_result_t _get_debug_modules(
         debug_module->path_length = strlen(debug_module->path);
 
         debug_module->base_address =
-            (void*)(enclave->addr + image->submodule->image_rva);
+            (void*)(enclave->start_address + image->submodule->image_rva);
         debug_module->size = image->submodule->image_size;
 
         debug_module->enclave = enclave->debug_enclave;

--- a/host/sgx/ocalls/debug.c
+++ b/host/sgx/ocalls/debug.c
@@ -44,7 +44,7 @@ static char** _backtrace_symbols(
         /* Calculate space for each string */
         for (int i = 0; i < size; i++)
         {
-            const uint64_t vaddr = (uint64_t)buffer[i] - enclave->addr;
+            const uint64_t vaddr = (uint64_t)buffer[i] - enclave->start_address;
             const char* name = elf64_get_function_name(&elf, vaddr);
 
             if (!name)
@@ -73,7 +73,7 @@ static char** _backtrace_symbols(
     /* Copy strings into return buffer */
     for (int i = 0; i < size; i++)
     {
-        const uint64_t vaddr = (uint64_t)buffer[i] - enclave->addr;
+        const uint64_t vaddr = (uint64_t)buffer[i] - enclave->start_address;
         const char* name = elf64_get_function_name(&elf, vaddr);
 
         if (!name)

--- a/host/sgx/sgx_enclave_common_wrapper.h
+++ b/host/sgx/sgx_enclave_common_wrapper.h
@@ -43,6 +43,17 @@ void* oe_sgx_enclave_create(
     size_t info_size,
     uint32_t* enclave_error);
 
+void* oe_sgx_enclave_create_ex(
+    void* base_address,
+    size_t virtual_size,
+    size_t initial_commit,
+    uint32_t type,
+    const void* info,
+    size_t info_size,
+    const uint32_t ex_features,
+    const void* ex_features_p[32],
+    uint32_t* enclave_error);
+
 size_t oe_sgx_enclave_load_data(
     void* target_address,
     size_t target_size,

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -328,8 +328,12 @@ oe_result_t oe_sgx_create_enclave(
     uint64_t* enclave_addr)
 {
     oe_result_t result = OE_UNEXPECTED;
-    void* base = NULL;
+    void* image_base = NULL;
+    void* start_address = NULL;
     sgx_secs_t* secs = NULL;
+    sgx_enclave_elrange_t enclave_elrange;
+    uint32_t ex_features = 0;
+    void* ex_features_array[32] = {0};
 
     if (enclave_addr)
         *enclave_addr = 0;
@@ -355,18 +359,55 @@ oe_result_t oe_sgx_create_enclave(
         if (oe_sgx_is_simulation_load_context(context))
         {
             /* Allocation memory-mapped region */
-            if (!(base = _allocate_enclave_memory(enclave_size)))
+            if (!(image_base = _allocate_enclave_memory(enclave_size)))
                 OE_RAISE(OE_OUT_OF_MEMORY);
         }
 #else
         // Wrong code path
         result = OE_UNSUPPORTED;
         goto done;
-#endif // OEHOSTMR
+#endif // !defined(OEHOSTMR)
     }
 
+    /*
+     * Load desired enclave start address. NOTE: Currently, this value is NULL
+     * when zero base enclave is not enabled. Also, start_address has to be
+     * aligned to OE_PAGE_SIZE.
+     */
+    start_address = (void*)context->start_address;
+    if ((uint64_t)start_address % OE_PAGE_SIZE)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    if (context->create_zero_base_enclave)
+    {
+        /*
+         * enclave_image_address is the base address of the image to be
+         * loaded into enclave.
+         */
+        enclave_elrange.enclave_image_address = (uint64_t)start_address;
+        /*
+         * elrange_start_address is base address of the enclave address
+         * range, which needs to be lower than enclave_image_address.
+         */
+        enclave_elrange.elrange_start_address = (uint64_t)OE_ADDRESS_ZERO;
+        /*
+         * elrange_size is the size of the enclave address range. The minimum
+         * required elrange_size is total enclave page size + start_address.
+         * NOTE: SGX requires that this value be a power of 2.
+         */
+        enclave_elrange.elrange_size =
+            oe_round_u64_to_pow2(enclave_commit_size + (uint64_t)start_address);
+
+        ex_features = OE_SGX_ENCLAVE_CREATE_EX_EL_RANGE;
+        ex_features_array[OE_SGX_ENCLAVE_CREATE_EX_EL_RANGE_BIT_IDX] =
+            &enclave_elrange;
+    }
+    else
+        enclave_elrange.elrange_size = enclave_size;
+
     /* Create SECS structure */
-    if (!(secs = _new_secs((uint64_t)base, enclave_size, context)))
+    if (!(secs = _new_secs(
+              (uint64_t)image_base, enclave_elrange.elrange_size, context)))
         OE_RAISE(OE_OUT_OF_MEMORY);
 
     /* Measure this operation */
@@ -375,7 +416,7 @@ oe_result_t oe_sgx_create_enclave(
     if (context->type == OE_SGX_LOAD_TYPE_MEASURE)
     {
         /* Use this phony base address when signing enclaves */
-        base = (void*)0x0000ffff00000000;
+        image_base = (void*)0x0000ffff00000000;
     }
 #if !defined(OEHOSTMR)
     else if (oe_sgx_is_simulation_load_context(context))
@@ -386,26 +427,43 @@ oe_result_t oe_sgx_create_enclave(
     }
     else
     {
-        uint32_t enclave_error;
-        void* base = oe_sgx_enclave_create(
-            NULL, /* Let OS choose the enclave base address */
+        uint32_t enclave_error = 0;
+        image_base = oe_sgx_enclave_create_ex(
+            start_address,
             secs->size,
             enclave_commit_size,
             ENCLAVE_TYPE_SGX1,
             (const void*)secs,
             sizeof(sgx_secs_t),
+            (const uint32_t)ex_features,
+            (const void**)ex_features_array,
             &enclave_error);
 
-        if (!base)
+        if (!image_base)
             OE_RAISE_MSG(
                 OE_PLATFORM_ERROR,
                 "enclave_create with ENCLAVE_TYPE_SGX1 type failed (err=%#x)",
                 enclave_error);
 
-        secs->base = (uint64_t)base;
+        if (context->create_zero_base_enclave)
+        {
+            /* Returned base has to be same as requested start_address */
+            if (image_base != start_address)
+            {
+                OE_RAISE_MSG(
+                    OE_PLATFORM_ERROR,
+                    "enclave_create_ex() failed at requested start address "
+                    "(err=%#x)",
+                    enclave_error);
+            }
+
+            secs->base = (uint64_t)OE_ADDRESS_ZERO;
+        }
+        else
+            secs->base = (uint64_t)image_base;
     }
-#endif // OEHOSTMR
-    *enclave_addr = base ? (uint64_t)base : secs->base;
+#endif // !defined(OEHOSTMR)
+    *enclave_addr = image_base ? (uint64_t)image_base : secs->base;
     context->state = OE_SGX_LOAD_STATE_ENCLAVE_CREATED;
     result = OE_OK;
 
@@ -413,10 +471,12 @@ done:
 #if !defined(OEHOSTMR)
     //  free enclave  memory
     if (result != OE_OK && context != NULL &&
-        context->type == OE_SGX_LOAD_TYPE_CREATE && base != NULL)
+        context->type == OE_SGX_LOAD_TYPE_CREATE && image_base != NULL)
     {
         _sgx_free_enclave_memory(
-            base, enclave_size, oe_sgx_is_simulation_load_context(context));
+            image_base,
+            enclave_elrange.elrange_size,
+            oe_sgx_is_simulation_load_context(context));
     }
 #endif // OEHOSTMR
 
@@ -540,7 +600,8 @@ oe_result_t oe_sgx_load_enclave_data(
 {
     oe_result_t result = OE_UNEXPECTED;
 
-    if (!context || !base || !addr || !src || !flags)
+    /* In 0-base enclaves, base = 0 is a valid input parameter */
+    if (!context || !addr || !src || !flags)
         OE_RAISE(OE_INVALID_PARAMETER);
 
     if (context->state != OE_SGX_LOAD_STATE_ENCLAVE_CREATED)
@@ -693,7 +754,7 @@ oe_result_t oe_sgx_delete_enclave(oe_enclave_t* enclave)
 
     /* free allocate memory. */
     OE_CHECK(_sgx_free_enclave_memory(
-        (void*)enclave->addr, enclave->size, enclave->simulate));
+        (void*)enclave->start_address, enclave->size, enclave->simulate));
     result = OE_OK;
 done:
     return result;

--- a/host/sgx/windows/exception.c
+++ b/host/sgx/windows/exception.c
@@ -35,8 +35,8 @@ static LONG WINAPI _handle_simulation_mode_exception(
         if (enclave->simulate)
         {
             // Determine if the exception happened within the enclave.
-            uint64_t enclave_start = enclave->addr;
-            uint64_t enclave_end = enclave->addr + enclave->size;
+            uint64_t enclave_start = enclave->start_address;
+            uint64_t enclave_end = enclave->start_address + enclave->size;
             if (context->Rip >= enclave_start && context->Rip < enclave_end)
             {
                 // Check if the exception was due to an incorrect FS value.

--- a/include/openenclave/bits/sgx/sgxtypes.h
+++ b/include/openenclave/bits/sgx/sgxtypes.h
@@ -1116,6 +1116,16 @@ typedef enum _quote3_error_t {
 } quote3_error_t;
 // clang-format on
 
+/*
+ * Define sgx_enclave_elrange_t, used by enclave_create_ex.
+ */
+typedef struct sgx_enclave_elrange
+{
+    uint64_t enclave_image_address;
+    uint64_t elrange_start_address;
+    uint64_t elrange_size;
+} sgx_enclave_elrange_t;
+
 OE_EXTERNC_END
 
 #endif /* _OE_SGXTYPES_H */

--- a/include/openenclave/internal/globals.h
+++ b/include/openenclave/internal/globals.h
@@ -12,9 +12,12 @@
 OE_EXTERNC_BEGIN
 
 /* Enclave */
-const void* __oe_get_enclave_base(void);
-size_t __oe_get_enclave_size(void);
+const void* __oe_get_enclave_start_address(void);
+const void* __oe_get_enclave_base_address(void);
 const void* __oe_get_enclave_elf_header(void);
+uint8_t __oe_get_enclave_create_zero_base_flag(void);
+size_t __oe_get_enclave_size(void);
+uint64_t __oe_get_configured_enclave_start_address(void);
 
 /* Reloc */
 const void* __oe_get_reloc_base(void);

--- a/include/openenclave/internal/sgx/sgxproperties.h
+++ b/include/openenclave/internal/sgx/sgxproperties.h
@@ -30,6 +30,11 @@ OE_INLINE bool oe_sgx_is_valid_num_tcs(uint64_t x)
     return x <= OE_SGX_MAX_TCS;
 }
 
+OE_INLINE bool oe_sgx_is_valid_start_address(uint64_t x)
+{
+    return ((x != 0) && !(x % OE_PAGE_SIZE));
+}
+
 OE_INLINE bool oe_sgx_is_unset_uuid(uint8_t* x)
 {
     uint8_t zeros[16] = {0};

--- a/include/openenclave/internal/sgxcreate.h
+++ b/include/openenclave/internal/sgxcreate.h
@@ -72,6 +72,9 @@ struct _oe_sgx_load_context
     bool use_config_id;
 
     bool capture_pf_gp_exceptions_enabled;
+
+    bool create_zero_base_enclave;
+    uint64_t start_address; /* Valid only if create_zero_base_enclave is True */
 };
 
 oe_result_t oe_sgx_initialize_load_context(

--- a/libc/link.c
+++ b/libc/link.c
@@ -26,7 +26,7 @@ int dl_iterate_phdr(
 
     struct dl_phdr_info info;
     memset(&info, 0, sizeof(info));
-    info.dlpi_addr = (Elf64_Addr)__oe_get_enclave_base();
+    info.dlpi_addr = (Elf64_Addr)__oe_get_enclave_start_address();
     info.dlpi_name = "";
     info.dlpi_phdr = (Elf64_Phdr*)((uint8_t*)ehdr + ehdr->e_phoff);
     info.dlpi_phnum = ehdr->e_phnum;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,17 @@ if (LVI_MITIGATION MATCHES ControlFlow AND LVI_MITIGATION_SKIP_TESTS)
   message("LVI_MITIGATION_SKIP_TESTS set - skip all tests with LVI mitigation")
 endif ()
 
+if (OE_SGX AND UNIX)
+  option(ENABLE_ZERO_BASE_TESTS
+         "Build 0-base enclave tests and include in test list" OFF)
+  if (ENABLE_ZERO_BASE_TESTS)
+    message("ENABLE_ZERO_BASE_TESTS set - building all 0-base enclave tests")
+  else ()
+    message(
+      "ENABLE_ZERO_BASE_TESTS not set - not building 0-base enclave tests")
+  endif ()
+endif ()
+
 # Define the `OE_SGX` macro used by the oeedger8r on the SGX build.
 if (OE_SGX)
   set(DEFINE_OE_SGX "-DOE_SGX")
@@ -181,6 +192,11 @@ if (UNIX)
     # longer be used.
     if (NOT CODE_COVERAGE)
       add_subdirectory(child_process)
+    endif ()
+    if (ENABLE_ZERO_BASE_TESTS)
+      # 0-base enclave creation is currently available only in SGX and UNIX
+      # platforms.
+      add_subdirectory(sgx_zerobase) # Disabled until PSW update
     endif ()
   endif ()
   add_subdirectory(libc)

--- a/tests/config_id/enc/props_kss.c
+++ b/tests/config_id/enc/props_kss.c
@@ -11,6 +11,8 @@ OE_SET_ENCLAVE_SGX2(
     true,  /* Debug */
     false, /* CapturePFGPExceptions */
     true,  /* RequireKSS */
+    false, /* CreateZeroBaseEnclave */
+    0,     /* StartAddress */
     1024,  /* NumHeapPages */
     1024,  /* NumStackPages */
     1);    /* NumTCS */

--- a/tests/debugger/enc/contract.c
+++ b/tests/debugger/enc/contract.c
@@ -24,13 +24,13 @@ void assert_debugger_binary_contract_enclave_side()
     oe_sgx_td_t* td = oe_sgx_get_td();
     sgx_tcs_t* tcs = (sgx_tcs_t*)td_to_tcs(td);
 
-    // Assert that enclave base address can be computed just from tcs.
+    // Assert that enclave start address can be computed just from tcs.
     // See: debugger/ptraceLib/enclave_context.c
     if (td->simulate)
     {
-        const void* enclave_base_address = __oe_get_enclave_base();
+        const void* enclave_start_address = __oe_get_enclave_start_address();
         void* computed_address = (uint8_t*)tcs + OE_PAGE_SIZE - tcs->ossa;
-        OE_TEST(enclave_base_address == computed_address);
+        OE_TEST(enclave_start_address == computed_address);
     }
     else
     {

--- a/tests/ecall/enc/enc.cpp
+++ b/tests/ecall/enc/enc.cpp
@@ -44,7 +44,7 @@ void enc_test(test_args* args)
     }
 
     /* Get enclave offsets and bases */
-    args->base = const_cast<void*>(__oe_get_enclave_base());
+    args->base = const_cast<void*>(__oe_get_enclave_start_address());
     args->base_heap_page = oe_get_base_heap_page();
     args->num_heap_pages = oe_get_num_heap_pages();
     args->num_pages = oe_get_num_pages();

--- a/tests/ecall_ocall/enc/enc.cpp
+++ b/tests/ecall_ocall/enc/enc.cpp
@@ -3,7 +3,7 @@
 
 #include <openenclave/edger8r/enclave.h>
 #include <openenclave/enclave.h>
-#include <openenclave/internal/globals.h> // for __oe_get_enclave_base()
+#include <openenclave/internal/globals.h> // for __oe_get_enclave_start_address()
 #include <openenclave/internal/tests.h>
 #include <openenclave/internal/thread.h>
 #include <openenclave/internal/trace.h>
@@ -23,8 +23,8 @@ class static_init_ocaller
   public:
     static_init_ocaller() : m_result(OE_FAILURE)
     {
-        m_result =
-            init_ocall_handler(const_cast<void*>(__oe_get_enclave_base()));
+        m_result = init_ocall_handler(
+            const_cast<void*>(__oe_get_enclave_start_address()));
         OE_TEST(m_result == OE_OK);
     }
 
@@ -46,14 +46,14 @@ oe_result_t enc_get_init_ocall_result()
 }
 
 // Set custom enclave ID for later tracking
-oe_result_t enc_set_enclave_id(unsigned id, const void** base_addr)
+oe_result_t enc_set_enclave_id(unsigned id, const void** start_address)
 {
     oe_result_t result = OE_OK;
 
     if (g_enclave_id == ~0u)
     {
         g_enclave_id = id;
-        *base_addr = __oe_get_enclave_base();
+        *start_address = __oe_get_enclave_start_address();
     }
     else
     {

--- a/tests/pf_gp_exceptions/enc/enc.c
+++ b/tests/pf_gp_exceptions/enc/enc.c
@@ -72,6 +72,8 @@ OE_SET_ENCLAVE_SGX2(
     true,  /* Debug */
     true,  /* CapturePFGPExceptions */
     false, /* RequireKSS */
+    false, /* CreateZeroBaseEnclave */
+    0,     /* StartAddress */
     1024,  /* NumHeapPages */
     1024,  /* NumStackPages */
     1);    /* NumTCS */

--- a/tests/sgx_zerobase/CMakeLists.txt
+++ b/tests/sgx_zerobase/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/sgx_zerobase sgx_zerobase_host sgx_zerobase_enc)

--- a/tests/sgx_zerobase/enc/CMakeLists.txt
+++ b/tests/sgx_zerobase/enc/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../sgx_zerobase.edl)
+
+add_custom_command(
+  OUTPUT sgx_zerobase_t.h sgx_zerobase_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(TARGET sgx_zerobase_enc SOURCES enc.cpp
+            ${CMAKE_CURRENT_BINARY_DIR}/sgx_zerobase_t.c)
+
+enclave_include_directories(
+  sgx_zerobase_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/sgx_zerobase/enc/enc.cpp
+++ b/tests/sgx_zerobase/enc/enc.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/tests.h>
+#include "sgx_zerobase_t.h"
+
+const char* protected_message = "Hello world from Enclave\n\0";
+
+int secure_string_patching(
+    const char* source,
+    char* output,
+    size_t output_length)
+{
+    const char* running_source = source;
+    size_t running_length = output_length;
+    while (running_length > 0 && *running_source != '\0')
+    {
+        *output = *running_source;
+        running_length--;
+        running_source++;
+        output++;
+    }
+    const char* ptr = protected_message;
+    while (running_length > 0 && *ptr != '\0')
+    {
+        *output = *ptr;
+        running_length--;
+        ptr++;
+        output++;
+    }
+    if (running_length < 1)
+    {
+        return -1;
+    }
+    *output = '\0';
+    int rval = -1;
+    OE_TEST(
+        unsecure_string_patching(&rval, source, output, output_length) ==
+        OE_OK);
+    return rval;
+}
+
+OE_SET_ENCLAVE_SGX2(
+    1,       /* ProductID */
+    1,       /* SecurityVersion */
+    {0},     /* ExtendedProductID */
+    {0},     /* FamilyID */
+    true,    /* Debug */
+    false,   /* CapturePFGPExceptions */
+    false,   /* RequireKSS */
+    true,    /* CreateZeroBaseEnclave */
+    0x21000, /* StartAddress */
+    1024,    /* NumHeapPages */
+    1024,    /* NumStackPages */
+    4);      /* NumTCS */

--- a/tests/sgx_zerobase/host/CMakeLists.txt
+++ b/tests/sgx_zerobase/host/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../sgx_zerobase.edl)
+
+add_custom_command(
+  OUTPUT sgx_zerobase_u.h sgx_zerobase_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(sgx_zerobase_host host.cpp sgx_zerobase_u.c)
+
+target_include_directories(
+  sgx_zerobase_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+                            ${CMAKE_CURRENT_SOURCE_DIR})
+
+# TODO issue #4130: Need to find a way around hard-coding host application base address
+# on the application CMakeList.txt.
+target_link_libraries(sgx_zerobase_host oehost -Wl,-Ttext-segment,0x10000000)
+
+target_link_libraries(sgx_zerobase_host oehost)

--- a/tests/sgx_zerobase/host/host.cpp
+++ b/tests/sgx_zerobase/host/host.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/tests.h>
+#include <iostream>
+#include <vector>
+#include "sgx_zerobase_u.h"
+
+const char* message = "Hello world from Host\n\0";
+
+int unsecure_string_patching(
+    const char* source,
+    char* output,
+    size_t output_length)
+{
+    size_t running_length = output_length;
+    while (running_length > 0 && *source != '\0')
+    {
+        *output = *source;
+        running_length--;
+        source++;
+        output++;
+    }
+    const char* ptr = message;
+    while (running_length > 0 && *ptr != '\0')
+    {
+        *output = *ptr;
+        running_length--;
+        ptr++;
+        output++;
+    }
+    if (running_length < 1)
+    {
+        return -1;
+    }
+    *output = '\0';
+    return 0;
+}
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(
+            stderr,
+            "Usage: sgx_zerobase_host.exe <path to  packaged enc/dev dll>\n"
+            "Example: sgx_zerobase_host.exe "
+            "sgx_zerobase_enc.dev.pkg\\sgx_zerobase_enc.dll\n");
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    result = oe_create_sgx_zerobase_enclave(
+        argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);
+    if (result != OE_OK)
+    {
+        fprintf(stderr, "Could not create enclave, result=%d\n", result);
+        return 1;
+    }
+    char output[1024];
+    const char* source = "My First App\n";
+    int res = -1;
+    OE_TEST(
+        secure_string_patching(
+            enclave, &res, source, output, OE_COUNTOF(output)) == OE_OK);
+
+    if (res != 0)
+    {
+        fprintf(stderr, "%s: enclave called failed\n", argv[0]);
+        exit(1);
+    }
+
+    const char expect[] = "My First App\n"
+                          "Hello world from Enclave\n"
+                          "My First App\n"
+                          "Hello world from Host\n";
+
+    if (strcmp(output, expect) != 0)
+    {
+        fprintf(stderr, "%s: returned string don't match\n", argv[0]);
+        return 1;
+    }
+
+    if (oe_terminate_enclave(enclave) != OE_OK)
+    {
+        fprintf(stderr, "oe_terminate_enclave(): failed: result=%d\n", result);
+        return 1;
+    }
+
+    printf("=== passed all tests (sgx_zerobase)\n");
+
+    return 0;
+}

--- a/tests/sgx_zerobase/sgx_zerobase.edl
+++ b/tests/sgx_zerobase/sgx_zerobase.edl
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+    from "openenclave/edl/sgx/platform.edl" import *;
+
+    trusted {
+        public int secure_string_patching(
+            [in, string] const char* src,
+            [out, size=dst_length] char* dst,
+            size_t dst_length);
+    };
+
+    untrusted {
+        int unsecure_string_patching(
+            [in, string] const char* src,
+            [in, out, size=dst_length] char* dst,
+            size_t dst_length);
+    };
+};

--- a/tests/tools/oesign/test-inputs/CMakeLists.txt
+++ b/tests/tools/oesign/test-inputs/CMakeLists.txt
@@ -113,6 +113,21 @@ add_custom_command(
     ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
     family_id_too_short.conf --family_id 57183823-2574-4bfd-b411-99ed177d3e4)
 
+add_custom_command(
+  OUTPUT create_zero_base_enclave.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND
+    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    create_zero_base_enclave.conf --create_zero_base_enclave 1)
+
+add_custom_command(
+  OUTPUT create_zero_base_enclave_w_start_address.conf
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py
+  COMMAND
+    python ${CMAKE_CURRENT_SOURCE_DIR}/make-oesign-config.py --config_file
+    create_zero_base_enclave_w_start_address.conf --create_zero_base_enclave 1
+    --start_address 196608)
+
 # Generate empty config file
 add_custom_command(
   OUTPUT empty.conf COMMAND cmake -E touch
@@ -141,6 +156,8 @@ add_custom_target(
           ext_prod_id_too_short.conf
           family_id_too_long.conf
           family_id_too_short.conf
+          create_zero_base_enclave.conf
+          create_zero_base_enclave_w_start_address.conf
           valid.conf)
 
 # Generate a valid SGX signing key-pair and signing certificate

--- a/tests/tools/oesign/test-inputs/make-oesign-config.py
+++ b/tests/tools/oesign/test-inputs/make-oesign-config.py
@@ -17,6 +17,8 @@ if __name__ == "__main__":
     arg_parser.add_argument('--security_version', default="1", type=str, help="Value for the SecurityVersion property. Defaults to 1.")
     arg_parser.add_argument('--extended_product_id', type=str, help="Value for the ExtendedProductID property. Defaults to empty string")
     arg_parser.add_argument('--family_id', type=str, help="Value for the FamilyID property. Defaults to empty string.")
+    arg_parser.add_argument('--create_zero_base_enclave', default="0", type=str, help="Value for the CreateZeroBaseEnclave property. Defaults to 0.")
+    arg_parser.add_argument('--start_address', default="131072", type=str, help="Value for the StartAddress property. Defaults to 131072(0x20000).")
 
     args = arg_parser.parse_args()
     print("Generating {} ...".format(args.config_file))
@@ -33,4 +35,8 @@ if __name__ == "__main__":
         out_file.write("ExtendedProductID={}\n".format(args.extended_product_id))
     if args.family_id:
         out_file.write("FamilyID={}\n".format(args.family_id))
+    if args.create_zero_base_enclave:
+        out_file.write("CreateZeroBaseEnclave={}\n".format(args.create_zero_base_enclave))
+    if args.start_address:
+        out_file.write("StartAddress={}\n".format(args.start_address))
     out_file.close()

--- a/tests/tools/oesign/test-sign/CMakeLists.txt
+++ b/tests/tools/oesign/test-sign/CMakeLists.txt
@@ -267,3 +267,31 @@ add_test(
 set_tests_properties(
   tests/oesign-sign-familyid-tooshort PROPERTIES PASS_REGULAR_EXPRESSION
                                                  "bad value for 'FamilyID'")
+
+if (ENABLE_ZERO_BASE_TESTS)
+  # Test enclave creation at 0-base
+  add_test(
+    NAME tests/oesign-create-zero-base
+    COMMAND
+      oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+      ${OESIGN_TEST_INPUTS_DIR}/create_zero_base_enclave.conf -k
+      ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+  set_tests_properties(
+    tests/oesign-create-zero-base
+    PROPERTIES PASS_REGULAR_EXPRESSION "Created" FAIL_REGULAR_EXPRESSION
+               "ERROR;Fail;Error")
+
+  # Test enclave creation at 0-base
+  add_test(
+    NAME tests/oesign-create-zero-base-start-address
+    COMMAND
+      oesign sign -e $<TARGET_FILE:oesign_test_enc> -c
+      ${OESIGN_TEST_INPUTS_DIR}/create_zero_base_enclave_w_start_address.conf
+      -k ${OESIGN_TEST_INPUTS_DIR}/sign_key.private.pem)
+
+  set_tests_properties(
+    tests/oesign-create-zero-base-start-address
+    PROPERTIES PASS_REGULAR_EXPRESSION "Created" FAIL_REGULAR_EXPRESSION
+               "ERROR;Fail;Error")
+endif ()

--- a/tools/oesign/main.c
+++ b/tools/oesign/main.c
@@ -64,6 +64,11 @@ static const char _usage_sign[] =
     "  -o, --output-file        [optional] file name (with path) where the\n"
     "                           signature of the enclave image will be\n"
     "                           written.\n"
+    "  -z, --zero-base          [optional] enable/disable creation of enclave\n"
+    "                           at address 0x0 by passing in 1/0\n"
+    "  -s, --start-address      [optional] if zero-base enclave is enabled,\n"
+    "                           the enclave image will be created with this\n"
+    "                           start address\n"
 #if HAS_ENGINE_SUPPORT
     "\n"
     "  OR\n"
@@ -290,6 +295,8 @@ int sign_parser(int argc, const char* argv[])
     const char* keyfile = NULL;
     const char* digest_signature = NULL;
     const char* output_file = NULL;
+    const char* zero_base = NULL;
+    const char* start_address = NULL;
     const char* x509 = NULL;
     const char* engine_id = NULL;
     const char* engine_load_path = NULL;
@@ -303,6 +310,8 @@ int sign_parser(int argc, const char* argv[])
         {"digest-signature", required_argument, NULL, 'd'},
         {"output-file", required_argument, NULL, 'o'},
         {"x509", required_argument, NULL, 'x'},
+        {"zero-base", required_argument, NULL, 'z'},
+        {"start-address", required_argument, NULL, 's'},
 #if HAS_ENGINE_SUPPORT
         {"engine", required_argument, NULL, 'n'},
         {"load-path", required_argument, NULL, 'p'},
@@ -310,7 +319,7 @@ int sign_parser(int argc, const char* argv[])
 #endif
         {NULL, 0, NULL, 0},
     };
-    const char short_options[] = "he:c:k:n:p:i:d:o:x:";
+    const char short_options[] = "he:c:k:n:p:i:d:o:x:z:s:";
 
     int c;
 
@@ -354,6 +363,11 @@ int sign_parser(int argc, const char* argv[])
             case 'x':
                 x509 = optarg;
                 break;
+            case 'z':
+                zero_base = optarg;
+                break;
+            case 's':
+                start_address = optarg;
 #if HAS_ENGINE_SUPPORT
             case 'n':
                 engine_id = optarg;


### PR DESCRIPTION
Modified OE-SDK's enclave creation and measurements to be able to use the new 0-base enclave creation feature from Intel SGX.

Added tests/SampleAppZeroBase to test and demonstrate use of this new feature.

Added oesign capability to enable/ disable zero base enclaves using commandline options and configuration file. Added corresponding tests.

NOTE: To enable testing 0-base enclave creation, set variable ENABLE_ZERO_BASE_TESTS to "Yes" when running the cmake command during build.