### PR TITLE
Error log CPUSVN and PCESVN at invalid tcb level

### DIFF
--- a/common/sgx/tcbinfo.h
+++ b/common/sgx/tcbinfo.h
@@ -89,7 +89,7 @@ typedef struct _oe_parsed_tcb_info
  * @param[in] tcb_level_status The tcb_status to parse.
  */
 oe_sgx_tcb_status_t oe_tcb_level_status_to_sgx_tcb_status(
-    const oe_tcb_level_status_t* tcb_level_status);
+    oe_tcb_level_status_t tcb_level_status);
 
 /*!
  * Retrieve a string description for an oe_sgx_tcb_status_t code.

--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -233,7 +233,7 @@ static oe_result_t _fill_with_known_claims(
     size_t claims_index = 0;
     bool flag;
     oe_sgx_tcb_status_t tcb_status =
-        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level->status);
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level->status);
 
     if (claims_length < OE_REQUIRED_CLAIMS_COUNT + OE_SGX_REQUIRED_CLAIMS_COUNT)
         OE_RAISE(OE_INVALID_PARAMETER);
@@ -848,7 +848,7 @@ oe_result_t oe_sgx_verify_evidence(
                 "Inconsistent TCB status: verify quote(%s), tcb status(%s)",
                 oe_result_str(result_verify_quote),
                 oe_sgx_tcb_status_str(oe_tcb_level_status_to_sgx_tcb_status(
-                    &platform_tcb_level.status)));
+                    platform_tcb_level.status)));
         }
     }
 

--- a/tests/report/host/tcbinfo.cpp
+++ b/tests/report/host/tcbinfo.cpp
@@ -254,7 +254,7 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         OE_OK,
         version);
     OE_TEST(
-        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status) ==
         OE_SGX_TCB_STATUS_UP_TO_DATE);
     printf("UptoDate TCB Level determination test passed.\n");
 
@@ -270,7 +270,7 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         OE_OK,
         version);
     OE_TEST(
-        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status) ==
         OE_SGX_TCB_STATUS_SW_HARDENING_NEEDED);
     printf("SWHardeningNeeded TCB Level determination test passed.\n");
 
@@ -286,7 +286,7 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         OE_TCB_LEVEL_INVALID,
         version);
     OE_TEST(
-        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status) ==
         OE_SGX_TCB_STATUS_CONFIGURATION_AND_SW_HARDENING_NEEDED);
     printf("ConfigurationAndSWHardeningNeeded TCB Level determination test "
            "passed.\n");
@@ -303,7 +303,7 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         OE_TCB_LEVEL_INVALID,
         version);
     OE_TEST(
-        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status) ==
         OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED);
     printf(
         "OutOfDateConfigurationNeeded TCB Level determination test passed.\n");
@@ -320,7 +320,7 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         OE_TCB_LEVEL_INVALID,
         version);
     OE_TEST(
-        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status) ==
         OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED);
     printf("ConfigurationNeeded TCB Level determination test passed.\n");
 
@@ -336,7 +336,7 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         OE_TCB_LEVEL_INVALID,
         version);
     OE_TEST(
-        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status) ==
         OE_SGX_TCB_STATUS_OUT_OF_DATE);
     printf("OutOfDate TCB Level determination test passed.\n");
 
@@ -352,7 +352,7 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
         OE_TCB_LEVEL_INVALID,
         version);
     OE_TEST(
-        oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status) ==
         OE_SGX_TCB_STATUS_REVOKED);
     printf("Revoked TCB Level determination test passed.\n");
 
@@ -371,7 +371,7 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
             OE_TCB_LEVEL_INVALID,
             version);
         OE_TEST(
-            oe_tcb_level_status_to_sgx_tcb_status(&platform_tcb_level.status) ==
+            oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status) ==
             OE_SGX_TCB_STATUS_INVALID);
         platform_tcb_level.sgx_tcb_comp_svn[i] = 2;
     }


### PR DESCRIPTION
Add CPUSVN and PCESVN to error log when invalid tcb level error occurs.

Signed-off-by: Yen Lee <yenlee@microsoft.com>