### PR TITLE
Fix attestation tool and sample

### DIFF
--- a/samples/attested_tls/client/enc/openssl_client.cpp
+++ b/samples/attested_tls/client/enc/openssl_client.cpp
@@ -39,7 +39,7 @@ int communicate_with_server(SSL* ssl)
     // Write an GET request to the server
     printf(TLS_CLIENT "-----> Write to server:\n");
     len = snprintf((char*)buf, sizeof(buf) - 1, CLIENT_PAYLOAD);
-    while ((bytes_written = SSL_write(ssl, buf, (size_t)len)) <= 0)
+    while ((bytes_written = SSL_write(ssl, buf, len)) <= 0)
     {
         error = SSL_get_error(ssl, bytes_written);
         if (error == SSL_ERROR_WANT_WRITE)
@@ -57,7 +57,7 @@ int communicate_with_server(SSL* ssl)
     {
         len = sizeof(buf) - 1;
         memset(buf, 0, sizeof(buf));
-        bytes_read = SSL_read(ssl, buf, (size_t)len);
+        bytes_read = SSL_read(ssl, buf, len);
         if (bytes_read <= 0)
         {
             int error = SSL_get_error(ssl, bytes_read);
@@ -71,8 +71,8 @@ int communicate_with_server(SSL* ssl)
 
         printf(TLS_CLIENT " %d bytes read\n", bytes_read);
         // check to to see if received payload is expected
-        if ((bytes_read != SERVER_PAYLOAD_SIZE) ||
-            (memcmp(SERVER_PAYLOAD, buf, bytes_read) != 0))
+        if (((size_t)bytes_read != SERVER_PAYLOAD_SIZE) ||
+            (memcmp(SERVER_PAYLOAD, buf, (size_t)bytes_read) != 0))
         {
             printf(
                 TLS_CLIENT "ERROR: expected reading %lu bytes but only "
@@ -99,8 +99,6 @@ done:
 int create_socket(char* server_name, char* server_port)
 {
     int sockfd = -1;
-    char* addr_ptr = nullptr;
-    int port = 0;
     struct addrinfo hints, *dest_info = nullptr, *curr_di = nullptr;
     int res;
 

--- a/samples/attested_tls/common/openssl_utility.cpp
+++ b/samples/attested_tls/common/openssl_utility.cpp
@@ -211,7 +211,7 @@ int read_from_session_peer(
     {
         int len = sizeof(buffer) - 1;
         memset(buffer, 0, sizeof(buffer));
-        bytes_read = SSL_read(ssl_session, buffer, (size_t)len);
+        bytes_read = SSL_read(ssl_session, buffer, len);
 
         if (bytes_read <= 0)
         {
@@ -227,8 +227,8 @@ int read_from_session_peer(
         printf(" %d bytes read from session peer\n", bytes_read);
 
         // check to see if received payload is expected
-        if ((bytes_read != payload_length) ||
-            (memcmp(payload, buffer, bytes_read) != 0))
+        if (((size_t)bytes_read != payload_length) ||
+            (memcmp(payload, buffer, (size_t)bytes_read) != 0))
         {
             printf(
                 "ERROR: expected reading %lu bytes but only "
@@ -258,8 +258,8 @@ int write_to_session_peer(
     int bytes_written = 0;
     int ret = 0;
 
-    while ((bytes_written = SSL_write(ssl_session, payload, payload_length)) <=
-           0)
+    while ((bytes_written =
+                SSL_write(ssl_session, payload, (int)payload_length)) <= 0)
     {
         int error = SSL_get_error(ssl_session, bytes_written);
         if (error == SSL_ERROR_WANT_WRITE)

--- a/samples/attested_tls/common/verify_callback.cpp
+++ b/samples/attested_tls/common/verify_callback.cpp
@@ -105,7 +105,7 @@ oe_result_t enclave_claims_verifier(
     if (claim->value_size != sizeof(uint32_t))
     {
         printf(
-            "security_version size(%lu) checking failed\n", claim->value_size);
+            "security_version size(%zu) checking failed\n", claim->value_size);
         goto done;
     }
     printf(TLS_SERVER "\nsecurity_version = %d\n", *claim->value);
@@ -121,7 +121,7 @@ oe_result_t enclave_claims_verifier(
     if (claim->value_size != OE_UNIQUE_ID_SIZE)
     {
         printf(
-            TLS_CLIENT "unique_id size(%lu) checking failed\n",
+            TLS_CLIENT "unique_id size(%zu) checking failed\n",
             claim->value_size);
         goto done;
     }
@@ -143,7 +143,7 @@ oe_result_t enclave_claims_verifier(
     if (claim->value_size != OE_PRODUCT_ID_SIZE)
     {
         printf(
-            TLS_CLIENT "product_id size(%lu) checking failed\n",
+            TLS_CLIENT "product_id size(%zu) checking failed\n",
             claim->value_size);
         goto done;
     }
@@ -163,7 +163,7 @@ oe_result_t enclave_claims_verifier(
     if (claim->value_size != OE_SIGNER_ID_SIZE)
     {
         printf(
-            TLS_CLIENT "signer_id size(%lu) checking failed\n",
+            TLS_CLIENT "signer_id size(%zu) checking failed\n",
             claim->value_size);
         goto done;
     }
@@ -229,7 +229,7 @@ int verify_callback(int preverify_ok, X509_STORE_CTX* ctx)
 
     // convert a cert into a buffer in DER format
     der_len = i2d_X509(crt, nullptr);
-    buff = (unsigned char*)malloc(der_len);
+    buff = (unsigned char*)malloc((size_t)der_len);
     if (buff == nullptr)
     {
         printf(TLS_CLIENT "malloc failed (der_len=%d)\n", der_len);
@@ -257,7 +257,7 @@ int verify_callback(int preverify_ok, X509_STORE_CTX* ctx)
     // verify tls certificate
     oe_verifier_initialize();
     result = oe_verify_attestation_certificate_with_evidence(
-        der, der_len, enclave_claims_verifier, nullptr);
+        der, (size_t)der_len, enclave_claims_verifier, nullptr);
     if (result != OE_OK)
     {
         printf(TLS_CLIENT "result=%s\n", oe_result_str(result));

--- a/samples/attested_tls/non_enc_client/cert_verify_config.cpp
+++ b/samples/attested_tls/non_enc_client/cert_verify_config.cpp
@@ -12,7 +12,7 @@ oe_result_t verify_claim_value(const oe_claim_t* claim)
         if (SERVER_ENCLAVE_MRENCLAVE[i] != (uint8_t)claim->value[i])
         {
             printf(
-                TLS_ENCLAVE "\nunique_id[%lu] expected: 0x%0x  found: 0x%0x ",
+                TLS_ENCLAVE "\nunique_id[%zu] expected: 0x%0x  found: 0x%0x ",
                 i,
                 SERVER_ENCLAVE_MRENCLAVE[i],
                 (uint8_t)claim->value[i]);

--- a/samples/attested_tls/server/enc/openssl_server.cpp
+++ b/samples/attested_tls/server/enc/openssl_server.cpp
@@ -24,7 +24,7 @@ int create_listener_socket(int port, int& server_socket)
     const int reuse = 1;
     struct sockaddr_in addr;
     addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
+    addr.sin_port = htons((uint16_t)port);
     addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
     server_socket = socket(AF_INET, SOCK_STREAM, 0);
@@ -132,9 +132,9 @@ exit:
 int set_up_tls_server(char* server_port, bool keep_server_up)
 {
     int ret = 0;
-    int server_socket_fd;
-    int client_socket_fd;
-    int server_port_number;
+    int server_socket_fd = 0;
+    int client_socket_fd = 0;
+    int server_port_number = 0;
 
     X509* certificate = nullptr;
     EVP_PKEY* pkey = nullptr;
@@ -171,7 +171,7 @@ int set_up_tls_server(char* server_port, bool keep_server_up)
         goto exit;
     }
 
-    server_port_number = (uint16_t)atoi(server_port); // convert to char* to int
+    server_port_number = atoi(server_port); // convert to char* to int
     if (create_listener_socket(server_port_number, server_socket_fd) != 0)
     {
         printf(TLS_SERVER " unable to create listener socket on the server\n ");

--- a/tools/oeutil/host/generate_evidence.cpp
+++ b/tools/oeutil/host/generate_evidence.cpp
@@ -271,12 +271,6 @@ static void _display_help(const char* command)
         "\t\t%s: evidence in OE_FORMAT_UUID_SGX_ECDSA format.\n",
         INPUT_PARAM_OPTION_SGX_ECDSA);
     printf(
-        "\t\t%s: evidence in OE_FORMAT_UUID_SGX_EPID_LINKABLE format.\n",
-        INPUT_PARAM_OPTION_SGX_EPID_LINKABLE);
-    printf(
-        "\t\t%s: evidence in OE_FORMAT_UUID_SGX_EPID_UNLINKABLE format.\n",
-        INPUT_PARAM_OPTION_SGX_EPID_UNLINKABLE);
-    printf(
         "\t%s, %s <in|out>: use SGX in-process or out-of-process quoting.\n",
         SHORT_INPUT_PARAM_OPTION_QUOTE_PROC,
         INPUT_PARAM_OPTION_QUOTE_PROC);
@@ -293,8 +287,7 @@ static void _display_help(const char* command)
         INPUT_PARAM_OPTION_ENDORSEMENTS_FILENAME);
     printf(
         "\t%s, %s: verify the generated remote attestation certificate, "
-        "report, "
-        "or evidence in ECDSA format.\n",
+        "report, or evidence.\n",
         SHORT_INPUT_PARAM_OPTION_VERIFY,
         INPUT_PARAM_OPTION_VERIFY);
     printf(
@@ -1505,8 +1498,7 @@ int _parse_args(int argc, const char* argv[])
         1)
     {
         printf("Please specify to generate a certificate, a report, or "
-               "evidence in SGX_ECDSA, SGX_EPID_LINKABLE or "
-               "SGX_EPID_UNLINKABLE format.\n");
+               "evidence in SGX_ECDSA format.\n");
         return 1;
     }
 

--- a/tools/oeutil/host/host.cpp
+++ b/tools/oeutil/host/host.cpp
@@ -30,7 +30,7 @@ static void _display_help(const char* command)
     printf(
         "\t1. %s: generate evidence, a report, or a certificate.\n",
         COMMAND_GENERATE_EVIDENCE);
-    printf("Options:\n\tType oetuil <command> --help for more information\n");
+    printf("Options:\n\tType oeutil <command> --help for more information\n");
 }
 
 static oeutil_command_t _get_oeutil_command(int argc, const char* argv[])


### PR DESCRIPTION
These days we had a bug bash and found some bugs related to OE attestation. This PR is to

 - Update the usage and description of the `oeutil` tool because there is a typo and evidence in EPID formats cannot be properly generated (and we will look into the logic and functions in the future), and
 - Remove conversion errors due to OpenSSL utility in the `attested_tls` sample, with most of them being `-Wsign-conversion` and `-Wshorten-64-to-32` warnings treated as errors.