### PR TITLE
fix clang10 speculative load hardening errors on windows

### DIFF
--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -57,16 +57,9 @@ add_enclave_library(
 # future and promise constructs of C++ are not working as expected and resulting in
 # SIGBUS errors. Disable speculative load hardening till this issue is addressed
 # in clang-10 compiler codebase.
-
-set(NO_SPECTRE_MITIGATION_FLAGS -mno-speculative-load-hardening)
-check_c_compiler_flag("${NO_SPECTRE_MITIGATION_FLAGS}"
-                      SPECTRE_MITIGATION_C_FLAGS_SUPPORTED)
-check_cxx_compiler_flag("${NO_SPECTRE_MITIGATION_FLAGS}"
-                        SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
-if (SPECTRE_MITIGATION_C_FLAGS_SUPPORTED
-    AND SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
+if (WIN32 OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
   set_property(SOURCE libcxx/src/future.cpp
-               PROPERTY COMPILE_FLAGS "${NO_SPECTRE_MITIGATION_FLAGS}")
+               PROPERTY COMPILE_FLAGS -mno-speculative-load-hardening)
 endif ()
 
 maybe_build_using_clangw(libcxx)

--- a/cmake/maybe_build_using_clangw.cmake
+++ b/cmake/maybe_build_using_clangw.cmake
@@ -48,8 +48,7 @@ function (maybe_build_using_clangw OE_TARGET)
       -fno-builtin-malloc
       -fno-builtin-calloc
       -fno-builtin
-      -mllvm
-      -x86-speculative-load-hardening)
+      -mspeculative-load-hardening)
   else ()
     target_compile_options(
       ${OE_TARGET}
@@ -64,8 +63,7 @@ function (maybe_build_using_clangw OE_TARGET)
               -fno-builtin-malloc
               -fno-builtin-calloc
               -fno-builtin
-              -mllvm
-              -x86-speculative-load-hardening)
+              -mspeculative-load-hardening)
   endif ()
 
   # Setup static library names variables

--- a/tests/cppException/enc/CMakeLists.txt
+++ b/tests/cppException/enc/CMakeLists.txt
@@ -23,15 +23,11 @@ add_enclave(
 
 enclave_compile_features(cppException_enc PRIVATE cxx_generalized_initializers)
 
-set(NO_SPECTRE_MITIGATION_FLAGS -mno-speculative-load-hardening)
-check_c_compiler_flag("${NO_SPECTRE_MITIGATION_FLAGS}"
-                      SPECTRE_MITIGATION_C_FLAGS_SUPPORTED)
-check_cxx_compiler_flag("${NO_SPECTRE_MITIGATION_FLAGS}"
-                        SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
-if (SPECTRE_MITIGATION_C_FLAGS_SUPPORTED
-    AND SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
+# disable speculative load hardening if cxx compiler is clang
+# On windows cxx compiler used is always clang
+if (WIN32 OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
   enclave_compile_options(cppException_enc PRIVATE
-                          ${NO_SPECTRE_MITIGATION_FLAGS})
+                          -mno-speculative-load-hardening)
 endif ()
 
 enclave_include_directories(

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -37,12 +37,6 @@ list(
   std_thread_futures_futures.promise_set_value_const.pass
   std_utilities_variant_variant.variant_variant.assign_T.pass)
 
-set(NO_SPECTRE_MITIGATION_FLAGS -mno-speculative-load-hardening)
-check_c_compiler_flag("${NO_SPECTRE_MITIGATION_FLAGS}"
-                      SPECTRE_MITIGATION_C_FLAGS_SUPPORTED)
-check_cxx_compiler_flag("${NO_SPECTRE_MITIGATION_FLAGS}"
-                        SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
-
 enclave_link_libraries(libcxxtest-support PRIVATE oelibcxx oeenclave)
 enclave_link_libraries(libcxxtest-support INTERFACE -Wl,--undefined=Test)
 
@@ -102,10 +96,9 @@ function (add_libcxx_test_enc NAME CXXFILE)
   # when speculative load hardening is enabled with Clang 10. Disable speculative load hardening
   # for those test cases NOTE: This only matters when `ENABLE_FULL_LIBCXX_TESTS=ON`.
   if (NAME IN_LIST CLANG_10_FAILED_TESTS_WITH_SPECULATIVE_LOAD_HARDENING)
-    if (SPECTRE_MITIGATION_C_FLAGS_SUPPORTED
-        AND SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
+    if (WIN32 OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
       enclave_compile_options(libcxxtest-${NAME}_enc PRIVATE
-                              ${NO_SPECTRE_MITIGATION_FLAGS})
+                              -mno-speculative-load-hardening)
     endif ()
   endif ()
 


### PR DESCRIPTION
Disable speculative load hardening for selected files when using clang10 compiler 
Signed-off-by: manoj rupireddy <marupire@microsoft.com>