### PR TITLE
Expose necessary libc symbols for SymCrypt FIPS module

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -193,13 +193,19 @@ list(APPEND NEEDS_STDC_NAMES ${MUSL_SRC_DIR}/prng/rand.c
 
 list(APPEND W_NO_CONVERSION ${MUSL_SRC_DIR}/prng/rand.c)
 
-set_property(SOURCE ${W_NO_CONVERSION} APPEND_STRING PROPERTY COMPILE_FLAGS
-                                                              "-Wno-conversion")
+set_property(
+  SOURCE ${W_NO_CONVERSION}
+  APPEND_STRING
+  PROPERTY COMPILE_FLAGS "-Wno-conversion")
 
-set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND_STRING
-             PROPERTY COMPILE_FLAGS " -I${CORELIBC_INCLUDES}")
-set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND PROPERTY COMPILE_DEFINITIONS
-                                                        OE_NEED_STDC_NAMES)
+set_property(
+  SOURCE ${NEEDS_STDC_NAMES}
+  APPEND_STRING
+  PROPERTY COMPILE_FLAGS " -I${CORELIBC_INCLUDES}")
+set_property(
+  SOURCE ${NEEDS_STDC_NAMES}
+  APPEND
+  PROPERTY COMPILE_DEFINITIONS OE_NEED_STDC_NAMES)
 
 maybe_build_using_clangw(oecore)
 
@@ -279,6 +285,21 @@ if (OE_SGX)
     -fno-builtin>)
 elseif (OE_TRUSTZONE)
   enclave_compile_options(oecore PUBLIC -fvisibility=hidden ${OE_TZ_TA_C_FLAGS})
+endif ()
+
+if (OE_SGX)
+  list(
+    APPEND
+    DEFAULT_VISIBILITY
+    ${MUSL_SRC_DIR}/sting/memcmp.c
+    ${MUSL_SRC_DIR}/string/x86_64/memcpy.s
+    ${MUSL_SRC_DIR}/string/x86_64/memmove.s
+    ${MUSL_SRC_DIR}/string/x86_64/memset.s)
+
+  set_property(
+    SOURCE ${DEFAULT_VISIBILITY}
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -fvisibility=default")
 endif ()
 
 enclave_compile_options(oecore INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -913,6 +913,25 @@ if (WIN32
                                                                    -O0)
 endif ()
 
+# Expose necessary symbols for the SymCrypt FIPS module
+if (OE_SGX)
+  list(
+    APPEND
+    DEFAULT_VISIBILITY
+    malloc.c # for posix_memalign and free
+    pthread.c # for pthread_mutex_*
+    ${MUSLSRC}/string/memcmp.c
+    ${MUSLSRC}/string/x86_64/memcpy.s
+    ${MUSLSRC}/string/x86_64/memmove.s
+    ${MUSLSRC}/string/x86_64/memset.s
+    ${MUSLSRC}/stdlib/qsort.c)
+
+  set_property(
+    SOURCE ${DEFAULT_VISIBILITY}
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -fvisibility=default")
+endif ()
+
 enclave_compile_definitions(oelibc PRIVATE _XOPEN_SOURCE=700)
 
 if (USE_DEBUG_MALLOC)

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -214,10 +214,15 @@ endfunction ()
 ##
 ##==============================================================================
 
-set(PACKAGE_CONFIG_FILES_LIST oehost-gcc.pc oehost-g++.pc
-                              oehost-clang.pc oehost-clang++.pc
-                              oeenclave-gcc.pc oeenclave-g++.pc
-                              oeenclave-clang.pc oeenclave-clang++.pc)
+set(PACKAGE_CONFIG_FILES_LIST
+    oehost-gcc.pc
+    oehost-g++.pc
+    oehost-clang.pc
+    oehost-clang++.pc
+    oeenclave-gcc.pc
+    oeenclave-g++.pc
+    oeenclave-clang.pc
+    oeenclave-clang++.pc)
 
 ##==============================================================================
 ##
@@ -236,8 +241,8 @@ set(LVI_MITIGATION_PACKAGE_CONFIG_FILES_LIST
 ##==============================================================================
 
 set(HOST_VERIFY_PACKAGE_CONFIG_FILES_LIST
-    oehostverify-gcc.pc oehostverify-g++.pc
-    oehostverify-clang.pc oehostverify-clang++.pc)
+    oehostverify-gcc.pc oehostverify-g++.pc oehostverify-clang.pc
+    oehostverify-clang++.pc)
 
 foreach (file_name ${PACKAGE_CONFIG_FILES_LIST})
   configure_and_install_pkg_config(${file_name} "")

--- a/tests/child_process/CMakeLists.txt
+++ b/tests/child_process/CMakeLists.txt
@@ -9,21 +9,21 @@ endif ()
 
 add_enclave_test(tests/child_process_ecall child_process_host child_process_enc
                  0)
-set_enclave_tests_properties(tests/child_process_ecall PROPERTIES SKIP_RETURN_CODE
-                             2)
-                             
+set_enclave_tests_properties(tests/child_process_ecall PROPERTIES
+                             SKIP_RETURN_CODE 2)
+
 # related issue #3099
 add_enclave_test(tests/child_process_destroy child_process_host
                  child_process_enc 1)
 set_enclave_tests_properties(tests/child_process_destroy PROPERTIES
-                               SKIP_RETURN_CODE 2)
+                             SKIP_RETURN_CODE 2)
 
 add_enclave_test(tests/child_process_create child_process_host
                  child_process_enc 2)
 set_enclave_tests_properties(tests/child_process_create PROPERTIES
-                               SKIP_RETURN_CODE 2)
-                               
+                             SKIP_RETURN_CODE 2)
+
 add_enclave_test(tests/child_process_create_more child_process_host
                  child_process_enc 3)
 set_enclave_tests_properties(tests/child_process_create_more PROPERTIES
-                               SKIP_RETURN_CODE 2)
+                             SKIP_RETURN_CODE 2)

--- a/tests/module_loading/commands.gdb
+++ b/tests/module_loading/commands.gdb
@@ -14,7 +14,7 @@ end
 
 # Set a breakpoint in enc.c (enclave)
 # This is a pending break point.
-b enc.c:36
+b enc.c:37
 commands 2
     printf "** Hit breakpoint in enclave\n"
 
@@ -39,7 +39,7 @@ commands 3
 end
 
 # Set a breakpoint by line number
-b module.c:13
+b module.c:17
 commands 4
     # Check that value has been set.
     if is_module_init != 1
@@ -58,7 +58,7 @@ commands 5
 end
 
 # Set breakpoint in square function
-b module.c:26
+b module.c:30
 commands 6
     # Evaluate expression
     set var r = a * a
@@ -66,7 +66,7 @@ commands 6
 end
 
 # Set conditional breakpoint
-b module.c:38
+b module.c:42
 commands 7
     p t
     set var t = a + b + k

--- a/tests/module_loading/commands.py
+++ b/tests/module_loading/commands.py
@@ -26,7 +26,7 @@ def bp_main(frame, bp_loc, dict):
     return False
 
 # Breakpoint in enc.c
-def bp_enc_c_36(frame, bp_loc, dict):
+def bp_enc_c_37(frame, bp_loc, dict):
     print("** Hit breakpoint in enclave")
 
     # Set debugger_test
@@ -46,7 +46,7 @@ def bp_init_module(frame, bp_loc, dict):
     return False
 
 # Breakpoint by line number in module
-def bp_module_c_13(frame, bp_loc, dict):
+def bp_module_c_17(frame, bp_loc, dict):
     # Check that value has been set
     is_module_init = lldb_eval("is_module_init")
     if int(is_module_init.value) != 1:
@@ -63,12 +63,12 @@ def bp_fini_module(frame, bp_loc, dict):
     return False
 
 # Breakpoint in square function
-def bp_module_c_26(frame, bp_loc, dict):
+def bp_module_c_30(frame, bp_loc, dict):
     lldb_expr("r = a * a")
     return False
 
 # Another breakpoint to test variable lookup
-def bp_module_c_38(frame, bp_loc, dict):
+def bp_module_c_42(frame, bp_loc, dict):
     lldb_expr(" t = a + b + k")
     t = lldb_eval("t")
     print("t = %s" % t.value)
@@ -81,23 +81,23 @@ def run_test():
     bp = target.BreakpointCreateByName("main")
     bp.SetScriptCallbackFunction('commands.bp_main')
 
-    bp = target.BreakpointCreateByLocation("enc.c", 36)
-    bp.SetScriptCallbackFunction('commands.bp_enc_c_36')
+    bp = target.BreakpointCreateByLocation("enc.c", 37)
+    bp.SetScriptCallbackFunction('commands.bp_enc_c_37')
 
     bp = target.BreakpointCreateByName("init_module")
     bp.SetScriptCallbackFunction('commands.bp_init_module')
 
-    bp = target.BreakpointCreateByLocation("module.c", 13)
-    bp.SetScriptCallbackFunction('commands.bp_module_c_13')
+    bp = target.BreakpointCreateByLocation("module.c", 17)
+    bp.SetScriptCallbackFunction('commands.bp_module_c_17')
 
     bp = target.BreakpointCreateByName("fini_module")
     bp.SetScriptCallbackFunction('commands.bp_fini_module')
 
-    bp = target.BreakpointCreateByLocation("module.c", 26)
-    bp.SetScriptCallbackFunction('commands.bp_module_c_26')
+    bp = target.BreakpointCreateByLocation("module.c", 30)
+    bp.SetScriptCallbackFunction('commands.bp_module_c_30')
 
-    bp = target.BreakpointCreateByLocation("module.c", 38)
-    bp.SetScriptCallbackFunction('commands.bp_module_c_38')
+    bp = target.BreakpointCreateByLocation("module.c", 42)
+    bp.SetScriptCallbackFunction('commands.bp_module_c_42')
 
     # The `personality` syscall is used by lldb to turn off ASLR.
     # This syscall may not be permitted within containers.

--- a/tests/module_loading/enc/enc.c
+++ b/tests/module_loading/enc/enc.c
@@ -10,6 +10,7 @@
 int square(volatile int a);
 __attribute__((weak)) int add_with_constant(volatile int a, volatile int b);
 __attribute__((weak)) int sub(int a, int b);
+int test_libc_symbols();
 
 int is_enclave_init;
 
@@ -41,6 +42,8 @@ void enc_module_test()
 
     OE_TEST(is_enclave_init == 1);
     OE_TEST(is_module_init == 1);
+
+    OE_TEST(test_libc_symbols() == 1);
 }
 
 OE_SET_ENCLAVE_SGX(

--- a/tests/module_loading/module/CMakeLists.txt
+++ b/tests/module_loading/module/CMakeLists.txt
@@ -47,6 +47,10 @@ enclave_compile_options(
   -fno-builtin-calloc
   -fno-builtin>)
 
+add_enclave_dependencies(module oelibc_includes)
+
+enclave_include_directories(module PRIVATE ${OE_INCDIR}/openenclave/libc)
+
 enclave_link_libraries(
   module
   PRIVATE

--- a/tests/module_loading/module/module.c
+++ b/tests/module_loading/module/module.c
@@ -1,6 +1,10 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
 extern int debugger_test;
 extern int is_module_init;
 
@@ -36,4 +40,32 @@ int add_with_constant(volatile int a, volatile int b)
     else
         t = -1;
     return t;
+}
+
+#define TEST_SYMBOL(name)                 \
+    do                                    \
+    {                                     \
+        volatile void* ptr = (void*)name; \
+        (void)ptr;                        \
+    } while (0)
+
+int test_libc_symbols()
+{
+    TEST_SYMBOL(memcmp);
+    TEST_SYMBOL(memcpy);
+    TEST_SYMBOL(memmove);
+    TEST_SYMBOL(memset);
+    TEST_SYMBOL(pthread_mutex_destroy);
+    TEST_SYMBOL(pthread_mutex_init);
+    TEST_SYMBOL(pthread_mutex_lock);
+    TEST_SYMBOL(pthread_mutex_unlock);
+    TEST_SYMBOL(posix_memalign);
+    TEST_SYMBOL(free);
+    TEST_SYMBOL(qsort);
+
+    /* The size of pthread_mutex_t is required to be 40 to be
+     * compatible with musl and glibc. */
+    if (sizeof(pthread_mutex_t) == 40)
+        return 1;
+    return 0;
 }


### PR DESCRIPTION
Expose the necessary symbols required by the SymCrypt FIPS module based on its final implementation.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>