### PR TITLE
Align the internal data type definitions with musl

### DIFF
--- a/include/openenclave/corelibc/pthread.h
+++ b/include/openenclave/corelibc/pthread.h
@@ -44,7 +44,7 @@ typedef struct _oe_pthread_mutexattr
 
 typedef struct _oe_pthread_mutex
 {
-    uint64_t __private[4];
+    uint64_t __private[5];
 } oe_pthread_mutex_t;
 
 typedef struct _oe_pthread_condattr
@@ -54,7 +54,7 @@ typedef struct _oe_pthread_condattr
 
 typedef struct _oe_pthread_cond
 {
-    uint64_t __private[4];
+    uint64_t __private[6];
 } oe_pthread_cond_t;
 
 typedef struct _oe_pthread_rwlockattr
@@ -64,7 +64,7 @@ typedef struct _oe_pthread_rwlockattr
 
 typedef struct _oe_pthread_rwlock
 {
-    uint64_t __private[5];
+    uint64_t __private[7];
 } oe_pthread_rwlock_t;
 
 oe_pthread_t oe_pthread_self(void);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -161,6 +161,7 @@ if (UNIX
   add_subdirectory(c99_compliant)
   add_subdirectory(create-errors)
   add_subdirectory(crypto)
+  add_subdirectory(data_types)
   add_subdirectory(edl_opt_out)
   add_subdirectory(hexdump)
   add_subdirectory(hostcalls)

--- a/tests/data_types/CMakeLists.txt
+++ b/tests/data_types/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/data_types data_types_host data_types_enc)

--- a/tests/data_types/data_types.edl
+++ b/tests/data_types/data_types.edl
@@ -1,0 +1,15 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/fcntl.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public void ecall_test();
+    };
+};

--- a/tests/data_types/enc/CMakeLists.txt
+++ b/tests/data_types/enc/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../data_types.edl)
+
+# Invoke oeedger8r to generate edge routines (*_t.c, *_t.h, and *_args.h)
+add_custom_command(
+  OUTPUT data_types_t.h data_types_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(
+  TARGET
+  data_types_enc
+  UUID
+  338a3b09-60dd-4808-8e51-afe019a11f99
+  SOURCES
+  enc.c
+  ${CMAKE_CURRENT_BINARY_DIR}/data_types_t.c)
+
+# Add include paths
+enclave_include_directories(data_types_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/data_types/enc/enc.c
+++ b/tests/data_types/enc/enc.c
@@ -1,0 +1,44 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/corelibc/pthread.h>
+#include <openenclave/enclave.h>
+#include <openenclave/internal/print.h>
+#include <openenclave/internal/tests.h>
+#include <pthread.h>
+#include "data_types_t.h"
+
+void ecall_test()
+{
+    OE_TEST(sizeof(oe_pthread_attr_t) == sizeof(pthread_attr_t));
+    OE_TEST(sizeof(oe_pthread_mutexattr_t) == sizeof(pthread_mutexattr_t));
+    OE_TEST(sizeof(oe_pthread_mutex_t) == sizeof(pthread_mutex_t));
+    OE_TEST(sizeof(oe_pthread_condattr_t) == sizeof(pthread_condattr_t));
+    OE_TEST(sizeof(oe_pthread_cond_t) == sizeof(pthread_cond_t));
+    OE_TEST(sizeof(oe_pthread_rwlockattr_t) == sizeof(pthread_rwlockattr_t));
+    OE_TEST(sizeof(oe_pthread_rwlock_t) == sizeof(pthread_rwlock_t));
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    1);   /* NumTCS */
+
+#define TA_UUID                                            \
+    { /* 338a3b09-60dd-4808-8e51-afe019a11f99 */           \
+        0x338a3b09, 0x60dd, 0x4808,                        \
+        {                                                  \
+            0x8e, 0x51, 0xaf, 0xe0, 0x19, 0xa1, 0x1f, 0x99 \
+        }                                                  \
+    }
+
+OE_SET_ENCLAVE_OPTEE(
+    TA_UUID,
+    1 * 1024 * 1024,
+    12 * 1024,
+    0,
+    "1.0.0",
+    "Data types test")

--- a/tests/data_types/host/CMakeLists.txt
+++ b/tests/data_types/host/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../data_types.edl)
+
+add_custom_command(
+  OUTPUT data_types_u.h data_types_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(data_types_host host.c data_types_u.c)
+
+target_include_directories(data_types_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(data_types_host oehost)

--- a/tests/data_types/host/host.c
+++ b/tests/data_types/host/host.c
@@ -1,0 +1,41 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <limits.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "data_types_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    if ((result = oe_create_data_types_enclave(
+             argv[1], OE_ENCLAVE_TYPE_AUTO, flags, NULL, 0, &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    result = ecall_test(enclave);
+
+    if (result != OE_OK)
+        oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (data_types)\n");
+
+    return 0;
+}


### PR DESCRIPTION
This PR updates few internal data types that are different from the musl definitions, which could lead to binary incompatibility. Also, add tests to compare the size of internal data types against musl's.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>