### PR TITLE
Add initialization hook for the OpenSSL SymCrypt engine

### DIFF
--- a/cmake/add_enclave.cmake
+++ b/cmake/add_enclave.cmake
@@ -204,7 +204,7 @@ function (add_enclave_sgx)
   elseif (ENCLAVE_CRYPTO_LIB_LOWER STREQUAL "openssl")
     enclave_link_libraries(${ENCLAVE_TARGET} oecryptoopenssl)
   else ()
-    message(FATAL_ERROR "Unsupported crypto library ${ENCLAVE_CRYPTO_LIB}.")
+    message(WARNING "Unsupported crypto library ${ENCLAVE_CRYPTO_LIB}.")
   endif ()
 
   if (ENCLAVE_CXX)

--- a/enclave/crypto/mbedtls/init.c
+++ b/enclave/crypto/mbedtls/init.c
@@ -3,11 +3,24 @@
 
 #include <openenclave/internal/crypto/init.h>
 
-/*
- * oe_crypto_initialize will be invoked during the enclave initialization.
+/* Forward declaration */
+int SYMCRYPT_ENGINE_Initialize();
+
+/* Add the implementation of the function (only available for OpenSSL)
+ * to fulfill the linker requirement */
+int SYMCRYPT_ENGINE_Initialize()
+{
+    return 0;
+}
+
+/* oe_crypto_initialize will be invoked during the enclave initialization.
  * Do nothing here given that Mbed TLS does not require initialization
- * (while OpenSSL does).
- */
+ * (while OpenSSL does). */
 void oe_crypto_initialize(void)
 {
+}
+
+int oe_is_symcrypt_engine_available()
+{
+    return 0;
 }

--- a/enclave/crypto/openssl/CMakeLists.txt
+++ b/enclave/crypto/openssl/CMakeLists.txt
@@ -19,7 +19,8 @@ add_enclave_library(
   ${PROJECT_SOURCE_DIR}/common/crypto/openssl/sha.c
   cert.c
   gcm.c
-  init.c)
+  init.c
+  symcrypt_engine.c)
 
 maybe_build_using_clangw(oecryptoopenssl)
 

--- a/enclave/crypto/openssl/symcrypt_engine.c
+++ b/enclave/crypto/openssl/symcrypt_engine.c
@@ -1,0 +1,15 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/bits/defs.h>
+
+/* When the enclave does not opt into the SymCrypt engine at link time,
+ * the following implementation (weak) will be picked by the linker.
+ * Note that we have to put the function in a separated source file from
+ * init.c to prevent the linker pulls in the symbol along with the
+ * oe_crypto_initialize function. */
+int _SYMCRYPT_ENGINE_Initialize()
+{
+    return 0;
+}
+OE_WEAK_ALIAS(_SYMCRYPT_ENGINE_Initialize, SYMCRYPT_ENGINE_Initialize);

--- a/enclave/link.c
+++ b/enclave/link.c
@@ -8,6 +8,9 @@
 #include <openenclave/internal/malloc.h>
 #include "core_t.h"
 
+/* Forward declarartion */
+int SYMCRYPT_ENGINE_Initialize();
+
 //
 // start.S (the compilation unit containing the entry point) contains a
 // reference to this function, which sets up a dependency chain from the
@@ -24,12 +27,14 @@ const void* oe_link_enclave(void)
         oe_verify_report_ecall,
         oe_get_public_key_by_policy_ecall,
         oe_get_public_key_ecall,
-        // Specify oe_allocator_malloc so that there is a direct link from
-        // enclave entry-point to pluggable allocator functions. This will
-        // cause the first definitions of these functions to be picked up.
+        /* Specify the following functions so that there are direct links from
+         * enclave entry-point to these functions. This will cause the first
+         * definitions of these functions to be picked up, which allow for
+         * (weak) symbol overwritten */
         oe_allocator_malloc,
         oe_debug_malloc_tracking_start,
         oe_crypto_initialize,
+        SYMCRYPT_ENGINE_Initialize,
 #if defined(OE_USE_DEBUG_MALLOC)
         oe_debug_malloc_check,
 #endif /* defined(OE_USE_DEBUG_MALLOC) */

--- a/include/openenclave/internal/crypto/init.h
+++ b/include/openenclave/internal/crypto/init.h
@@ -7,4 +7,6 @@
 /* Initialize OE crypto. */
 void oe_crypto_initialize(void);
 
+int oe_is_symcrypt_engine_available();
+
 #endif /* _OE_INTERNAL_CRYPTO_INIT_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,6 +153,7 @@ if (UNIX
     endif ()
 
     if (BUILD_OPENSSL)
+      add_subdirectory(symcrypt_engine)
       add_subdirectory(openssl)
       add_subdirectory(openssl_unsupported)
     endif ()

--- a/tests/symcrypt_engine/CMakeLists.txt
+++ b/tests/symcrypt_engine/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/symcrypt_engine symcrypt_engine_host
+                 sgx_symcrypt_engine_enc)

--- a/tests/symcrypt_engine/enc/CMakeLists.txt
+++ b/tests/symcrypt_engine/enc/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../symcrypt_engine.edl)
+
+add_enclave_library(symcrypt_engine_test STATIC symcrypt_engine_test.c)
+enclave_link_libraries(symcrypt_engine_test oe_includes)
+maybe_build_using_clangw(symcrypt_engine_test)
+
+# Invoke oeedger8r to generate edge routines (*_t.c, *_t.h, and *_args.h)
+add_custom_command(
+  OUTPUT symcrypt_engine_t.h symcrypt_engine_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(
+  TARGET
+  sgx_symcrypt_engine_enc
+  CRYPTO_LIB
+  # Specify an unsupported option so that we can exercise the link-time
+  # symbol replacement
+  None
+  SOURCES
+  enc.c
+  ${CMAKE_CURRENT_BINARY_DIR}/symcrypt_engine_t.c)
+
+enclave_link_libraries(sgx_symcrypt_engine_enc symcrypt_engine_test
+                       oecryptoopenssl)
+
+# Add include paths
+enclave_include_directories(sgx_symcrypt_engine_enc PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/symcrypt_engine/enc/enc.c
+++ b/tests/symcrypt_engine/enc/enc.c
@@ -1,0 +1,21 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/crypto/init.h>
+#include <openenclave/internal/print.h>
+#include <openenclave/internal/tests.h>
+#include "symcrypt_engine_t.h"
+
+void ecall_test()
+{
+    OE_TEST(oe_is_symcrypt_engine_available() == 1);
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/symcrypt_engine/enc/symcrypt_engine_test.c
+++ b/tests/symcrypt_engine/enc/symcrypt_engine_test.c
@@ -1,0 +1,10 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/* We do not have the SymCrypt engine available yet, defining a mock initializer
+ * with the same function prototype and returns 1, mimicking the expected
+ * behavior. */
+int SYMCRYPT_ENGINE_Initialize()
+{
+    return 1;
+}

--- a/tests/symcrypt_engine/host/CMakeLists.txt
+++ b/tests/symcrypt_engine/host/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../symcrypt_engine.edl)
+
+add_custom_command(
+  OUTPUT symcrypt_engine_u.h symcrypt_engine_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(symcrypt_engine_host host.c symcrypt_engine_u.c)
+
+target_include_directories(symcrypt_engine_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(symcrypt_engine_host oehost)

--- a/tests/symcrypt_engine/host/host.c
+++ b/tests/symcrypt_engine/host/host.c
@@ -1,0 +1,41 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <limits.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "symcrypt_engine_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    if ((result = oe_create_symcrypt_engine_enclave(
+             argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    result = ecall_test(enclave);
+
+    if (result != OE_OK)
+        oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (symcrypt_engine)\n");
+
+    return 0;
+}

--- a/tests/symcrypt_engine/symcrypt_engine.edl
+++ b/tests/symcrypt_engine/symcrypt_engine.edl
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import *; // Support OE_TEST and oe_host_printf
+    from "openenclave/edl/fcntl.edl" import *; // Support code coverage analysis
+    from "openenclave/edl/sgx/platform.edl" import *;
+
+    trusted {
+        public void ecall_test();
+    };
+};


### PR DESCRIPTION
Add the initialization hook for registering the OpenSSL SymCrypt engine. The hook allows an enclave to opt into the SymCrypt engine at link time.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>