### PR TITLE
Use new APIs for certificate verification

### DIFF
--- a/samples/host_verify/host.c
+++ b/samples/host_verify/host.c
@@ -245,17 +245,33 @@ oe_result_t verify_cert(const char* filename)
     size_t endorsements_buffer_size = 0;
     oe_policy_t* policies = NULL;
     size_t policies_size = 0;
+    oe_claim_t* claims = NULL;
+    size_t claims_length = 0;
 
     if (read_binary_file(filename, &cert_data, &cert_file_size))
     {
-        result = oe_verify_attestation_certificate_with_evidence(
-            cert_data, cert_file_size, enclave_claims_verifier, NULL);
+        result = oe_verify_attestation_certificate_with_evidence_v2(
+            cert_data,
+            cert_file_size,
+            endorsements_buffer,
+            endorsements_buffer_size,
+            policies,
+            policies_size,
+            &claims,
+            &claims_length);
+
+        if (result == OE_OK)
+        {
+            result = enclave_claims_verifier(claims, claims_length, NULL);
+        }
     }
 
     if (cert_data != NULL)
     {
         free(cert_data);
     }
+
+    oe_free_claims(claims, claims_length);
 
     return result;
 }

--- a/tests/attestation_plugin_cert/enc/enc.cpp
+++ b/tests/attestation_plugin_cert/enc/enc.cpp
@@ -138,10 +138,10 @@ oe_result_t get_tls_cert_signed_with_key(
     size_t* cert_size)
 {
     oe_result_t result = OE_FAILURE;
-    uint8_t* host_cert_buf = nullptr;
+    uint8_t* host_certificate_buffer = nullptr;
 
-    uint8_t* output_cert = nullptr;
-    size_t output_cert_size = 0;
+    uint8_t* output_certificate = nullptr;
+    size_t output_certificate_size = 0;
 
     uint8_t* private_key = nullptr;
     size_t private_key_size = 0;
@@ -150,6 +150,9 @@ oe_result_t get_tls_cert_signed_with_key(
     uint8_t* optional_parameters = nullptr;
     size_t optional_parameters_size = 0;
     const oe_uuid_t format = {OE_FORMAT_UUID_SGX_ECDSA};
+
+    oe_claim_t* claims = nullptr;
+    size_t claims_length = 0;
 
     OE_TRACE_INFO("called into enclave\n");
 
@@ -186,36 +189,60 @@ oe_result_t get_tls_cert_signed_with_key(
         public_key_size,
         optional_parameters,
         optional_parameters_size,
-        &output_cert,
-        &output_cert_size);
+        &output_certificate,
+        &output_certificate_size);
     if (result != OE_OK)
     {
-        OE_TRACE_ERROR(" failed with %s\n", oe_result_str(result));
+        OE_TRACE_ERROR(
+            "oe_get_attestation_certificate_with_evidence_v2 failed with %s\n",
+            oe_result_str(result));
         goto done;
     }
 
-    OE_TRACE_INFO("output_cert_size = 0x%x", output_cert_size);
+    OE_TRACE_INFO("output_certificate_size = 0x%x", output_certificate_size);
 
     oe_verifier_initialize();
     // validate cert inside the enclave
-    result = oe_verify_attestation_certificate_with_evidence(
-        output_cert, output_cert_size, enclave_claims_verifier, nullptr);
+    result = oe_verify_attestation_certificate_with_evidence_v2(
+        output_certificate,
+        output_certificate_size,
+        nullptr,
+        0,
+        nullptr,
+        0,
+        &claims,
+        &claims_length);
+
     OE_TRACE_INFO(
-        "\nFrom inside enclave: verifying the certificate... %s\n",
-        result == OE_OK ? "Success" : "Fail");
+        "\nFrom inside enclave: "
+        "oe_verify_attestation_certificate_with_evidence_v2 verifying the "
+        "certificate... %s\n",
+        oe_result_str(result));
+
+    OE_CHECK(result);
+
+    result = enclave_claims_verifier(claims, claims_length, nullptr);
+
+    OE_TRACE_INFO(
+        "\nFrom inside enclave: enclave_claims_verifier verifying the "
+        "claims... %s\n",
+        oe_result_str(result));
+
+    OE_CHECK(result);
 
     // copy cert to host memory
-    host_cert_buf = (uint8_t*)oe_host_malloc(output_cert_size);
-    if (host_cert_buf == nullptr)
+    host_certificate_buffer = (uint8_t*)oe_host_malloc(output_certificate_size);
+    if (host_certificate_buffer == nullptr)
     {
         result = OE_OUT_OF_MEMORY;
         goto done;
     }
 
     // copy to the host for host-side validation test
-    memcpy(host_cert_buf, output_cert, output_cert_size);
-    *cert_size = output_cert_size;
-    *cert = host_cert_buf;
+    memcpy(
+        host_certificate_buffer, output_certificate, output_certificate_size);
+    *cert_size = output_certificate_size;
+    *cert = host_certificate_buffer;
     OE_TRACE_INFO("*cert = %p", *cert);
     OE_TRACE_INFO("*cert_size = 0x%x", *cert_size);
 
@@ -223,9 +250,12 @@ done:
 
     free(private_key);
     free(public_key);
+    oe_free_claims(claims, claims_length);
+
     oe_attester_shutdown();
     oe_verifier_shutdown();
-    oe_free_attestation_certificate(output_cert);
+
+    oe_free_attestation_certificate(output_certificate);
 
     return result;
 }

--- a/tools/oeverify/oeverify.c
+++ b/tools/oeverify/oeverify.c
@@ -258,19 +258,31 @@ oe_result_t enclave_claims_verifier(
 oe_result_t verify_cert(const char* filename)
 {
     oe_result_t result = OE_FAILURE;
-    size_t cert_file_size = 0;
-    uint8_t* cert_data = NULL;
+    size_t certificate_file_size = 0;
+    uint8_t* certificate_data = NULL;
+    oe_claim_t* claims = NULL;
+    size_t claims_length = 0;
 
-    if (read_binary_file(filename, &cert_data, &cert_file_size))
+    if (read_binary_file(filename, &certificate_data, &certificate_file_size))
     {
-        result = oe_verify_attestation_certificate_with_evidence(
-            cert_data, cert_file_size, enclave_claims_verifier, NULL);
+        result = oe_verify_attestation_certificate_with_evidence_v2(
+            certificate_data,
+            certificate_file_size,
+            NULL,
+            0,
+            NULL,
+            0,
+            &claims,
+            &claims_length);
+
+        if (result == OE_OK)
+        {
+            result = enclave_claims_verifier(claims, claims_length, NULL);
+        }
     }
 
-    if (cert_data != NULL)
-    {
-        free(cert_data);
-    }
+    free(certificate_data);
+    oe_free_claims(claims, claims_length);
 
     return result;
 }


### PR DESCRIPTION
Replace `oe_verify_attestation_certificate_with_evidence()` with `oe_verify_attestation_certificate_with_evidence_v2()`, and then handle the callback part after the verifier function in each occurrence.

Fix #4048; also address part of #3992.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>