### PR TITLE
Fix the bug with OE_ENCLAVE_FLAG_DEBUG_AUTO

### DIFF
--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -860,6 +860,10 @@ oe_result_t oe_sgx_build_enclave(
     if (!enclave->debug && oe_sgx_is_debug_auto_load_context(context))
         enclave->debug = props.config.attributes & OE_SGX_FLAGS_DEBUG;
 
+    /* Update the flag in the context to ensure the flag will be set in SECS */
+    if (enclave->debug)
+        context->attributes.flags |= OE_ENCLAVE_FLAG_DEBUG;
+
     /* Consolidate enclave-debug-flag with create-debug-flag */
     if (props.config.attributes & OE_SGX_FLAGS_DEBUG)
     {

--- a/tests/debug-mode/enc/enc.c
+++ b/tests/debug-mode/enc/enc.c
@@ -5,7 +5,9 @@
 #include <openenclave/enclave.h>
 #include "debug_mode_t.h"
 
+int is_enclave_debug_allowed();
+
 int test(void)
 {
-    return 0;
+    return is_enclave_debug_allowed();
 }


### PR DESCRIPTION
This PR fixes the bug with the OE_ENCLAVE_FLAG_DEBUG_AUTO, ensuring the debug flag will be reflected in the SECS.

Fixes #4021 

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>