### PR TITLE
Fix pf_gp_exceptions test to use the signed enclave properly

### DIFF
--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -100,10 +100,7 @@ static bool _is_kss_supported()
     oe_get_cpuid(CPUID_SGX_LEAF, 0x1, &eax, &ebx, &ecx, &edx);
 
     // Check if KSS (bit 7) is supported by the processor
-    if (!(eax & CPUID_SGX_KSS_MASK))
-        return false;
-    else
-        return true;
+    return (eax & CPUID_SGX_KSS_MASK);
 }
 
 static bool _is_misc_region_supported()
@@ -115,10 +112,7 @@ static bool _is_misc_region_supported()
     oe_get_cpuid(CPUID_SGX_LEAF, 0x0, &eax, &ebx, &ecx, &edx);
 
     // Check if EXINFO is supported by the processor
-    if (!(ebx & CPUID_SGX_MISC_EXINFO_MASK))
-        return false;
-    else
-        return true;
+    return (ebx & CPUID_SGX_MISC_EXINFO_MASK);
 }
 
 static oe_result_t _add_filled_pages(

--- a/tests/pf_gp_exceptions/CMakeLists.txt
+++ b/tests/pf_gp_exceptions/CMakeLists.txt
@@ -8,7 +8,7 @@ if (BUILD_ENCLAVES)
 endif ()
 
 add_enclave_test(tests/pf_gp_exceptions pf_gp_exceptions_host
-                 sgx_pf_gp_exceptions_enc)
+                 sgx_pf_gp_exceptions_enc_signed)
 
 add_enclave_test(tests/pf_gp_exceptions_unsigned pf_gp_exceptions_host
                  sgx_pf_gp_exceptions_enc_unsigned)

--- a/tests/pf_gp_exceptions/host/host.c
+++ b/tests/pf_gp_exceptions/host/host.c
@@ -19,10 +19,7 @@ static bool _is_misc_region_supported()
     oe_get_cpuid(CPUID_SGX_LEAF, 0x0, &eax, &ebx, &ecx, &edx);
 
     // Check if EXINFO is supported by the processor
-    if (!(ebx & CPUID_SGX_MISC_EXINFO_MASK))
-        return false;
-    else
-        return true;
+    return (ebx & CPUID_SGX_MISC_EXINFO_MASK);
 }
 
 int main(int argc, const char* argv[])


### PR DESCRIPTION
This PR fixes the test to use the signed enclave correctly.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>