### PR TITLE
Fix build if build dir is outside source dir

### DIFF
--- a/tests/debugger/host/contract.c
+++ b/tests/debugger/host/contract.c
@@ -6,7 +6,7 @@
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/tests.h>
 #include <string.h>
-#include "../../../../host/sgx/enclave.h"
+#include "../../../host/sgx/enclave.h"
 
 // The following variables are initialized so that the assertions below will
 // fail by default. The test expects the debugger to update the values


### PR DESCRIPTION
tests/debugger/host/host.c was moved from tests/debugger/oegdb/host/host.c.
The relative #include must be adapted to this.