### PR TITLE
Update the SymCrypt engine initializer naming

### DIFF
--- a/cmake/add_enclave.cmake
+++ b/cmake/add_enclave.cmake
@@ -203,8 +203,6 @@ function (add_enclave_sgx)
     enclave_link_libraries(${ENCLAVE_TARGET} oecryptombedtls)
   elseif (ENCLAVE_CRYPTO_LIB_LOWER STREQUAL "openssl")
     enclave_link_libraries(${ENCLAVE_TARGET} oecryptoopenssl)
-  else ()
-    message(WARNING "Unsupported crypto library ${ENCLAVE_CRYPTO_LIB}.")
   endif ()
 
   if (ENCLAVE_CXX)

--- a/enclave/crypto/mbedtls/init.c
+++ b/enclave/crypto/mbedtls/init.c
@@ -4,13 +4,13 @@
 #include <openenclave/internal/crypto/init.h>
 
 /* Forward declaration */
-int SYMCRYPT_ENGINE_Initialize();
+int SC_OSSL_ENGINE_Initialize();
 
 /* Add the implementation of the function (only available for OpenSSL)
  * to fulfill the linker requirement */
-int SYMCRYPT_ENGINE_Initialize()
+int SC_OSSL_ENGINE_Initialize()
 {
-    return 0;
+    return OE_SYMCRYPT_ENGINE_INVALID;
 }
 
 /* oe_crypto_initialize will be invoked during the enclave initialization.

--- a/enclave/crypto/openssl/init.c
+++ b/enclave/crypto/openssl/init.c
@@ -6,48 +6,48 @@
 #include <openenclave/internal/trace.h>
 #include <openssl/engine.h>
 static oe_once_t _openssl_initialize_once;
-static ENGINE* eng;
-int is_symcrypt_engine_available = 0;
+static ENGINE* _rdrand_engine;
+int _is_symcrypt_engine_available = 0;
 
 /* Forward declaration */
-int SYMCRYPT_ENGINE_Initialize();
+int SC_OSSL_ENGINE_Initialize();
 
 static void _finalize(void)
 {
-    if (eng)
+    if (_rdrand_engine)
     {
-        ENGINE_finish(eng);
-        ENGINE_free(eng);
+        ENGINE_finish(_rdrand_engine);
+        ENGINE_free(_rdrand_engine);
         ENGINE_cleanup();
-        eng = NULL;
+        _rdrand_engine = NULL;
     }
 }
 
 static void _initialize_rdrand_engine()
 {
-    int rc = 0;
+    int result = 0;
 
     /* Initialize rdrand engine. */
     ENGINE_load_rdrand();
-    eng = ENGINE_by_id("rdrand");
-    if (eng == NULL)
+    _rdrand_engine = ENGINE_by_id("rdrand");
+    if (_rdrand_engine == NULL)
         goto done;
 
-    rc = ENGINE_init(eng);
-    if (rc == 0)
+    result = ENGINE_init(_rdrand_engine);
+    if (result == 0)
         goto done;
 
-    rc = ENGINE_set_default(eng, ENGINE_METHOD_RAND);
-    if (rc == 0)
+    result = ENGINE_set_default(_rdrand_engine, ENGINE_METHOD_RAND);
+    if (result == 0)
         goto done;
 
     if (!atexit(_finalize))
         goto done;
 
-    rc = 1;
+    result = 1;
 
 done:
-    if (rc == 0)
+    if (result == 0)
     {
         OE_TRACE_ERROR("OpenSSL initialization failed");
         _finalize();
@@ -57,19 +57,19 @@ done:
 
 static int _initialize_symcrypt_engine()
 {
-    int rc = 0;
+    int result;
 
-    /* The actual implementation of SYMCRYPT_ENGINE_Initialize
-     * always returns 1. */
-    if (SYMCRYPT_ENGINE_Initialize() != 1)
+    result = SC_OSSL_ENGINE_Initialize();
+    if (result != OE_SYMCRYPT_ENGINE_SUCCESS)
         goto done;
-
-    rc = 1;
 
     OE_TRACE_INFO("SymCrypt engine is registered");
 
 done:
-    return rc;
+    if (result == OE_SYMCRYPT_ENGINE_FAIL)
+        OE_TRACE_ERROR("SymCrypt engine initialization failed");
+
+    return (result == OE_SYMCRYPT_ENGINE_SUCCESS) ? 1 : 0;
 }
 
 static void _initialize(void)
@@ -78,9 +78,9 @@ static void _initialize(void)
      * returns 1 if the enclave opts into the engine at link-time. Otherwise,
      * the weak implementation of the function is used, which always returns 0.
      */
-    is_symcrypt_engine_available = _initialize_symcrypt_engine();
+    _is_symcrypt_engine_available = _initialize_symcrypt_engine();
 
-    if (!is_symcrypt_engine_available)
+    if (!_is_symcrypt_engine_available)
     {
         /* Explicitly register the RDRAND engine if the SymCrypt engine
          * is not available, which provides its own RAND implementation. */
@@ -95,5 +95,5 @@ void oe_crypto_initialize(void)
 
 int oe_is_symcrypt_engine_available()
 {
-    return is_symcrypt_engine_available;
+    return _is_symcrypt_engine_available;
 }

--- a/enclave/crypto/openssl/symcrypt_engine.c
+++ b/enclave/crypto/openssl/symcrypt_engine.c
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 
 #include <openenclave/bits/defs.h>
+#include <openenclave/internal/crypto/init.h>
 
 /* When the enclave does not opt into the SymCrypt engine at link time,
  * the following implementation (weak) will be picked by the linker.
  * Note that we have to put the function in a separated source file from
  * init.c to prevent the linker pulls in the symbol along with the
  * oe_crypto_initialize function. */
-int _SYMCRYPT_ENGINE_Initialize()
+int _oe_sc_ossl_engine_initialize()
 {
-    return 0;
+    return OE_SYMCRYPT_ENGINE_NOT_LINKED;
 }
-OE_WEAK_ALIAS(_SYMCRYPT_ENGINE_Initialize, SYMCRYPT_ENGINE_Initialize);
+OE_WEAK_ALIAS(_oe_sc_ossl_engine_initialize, SC_OSSL_ENGINE_Initialize);

--- a/enclave/link.c
+++ b/enclave/link.c
@@ -8,8 +8,8 @@
 #include <openenclave/internal/malloc.h>
 #include "core_t.h"
 
-/* Forward declarartion */
-int SYMCRYPT_ENGINE_Initialize();
+/* Forward declarartion for the symcrypt engine initializer */
+int SC_OSSL_ENGINE_Initialize();
 
 //
 // start.S (the compilation unit containing the entry point) contains a
@@ -34,7 +34,7 @@ const void* oe_link_enclave(void)
         oe_allocator_malloc,
         oe_debug_malloc_tracking_start,
         oe_crypto_initialize,
-        SYMCRYPT_ENGINE_Initialize,
+        SC_OSSL_ENGINE_Initialize,
 #if defined(OE_USE_DEBUG_MALLOC)
         oe_debug_malloc_check,
 #endif /* defined(OE_USE_DEBUG_MALLOC) */

--- a/include/openenclave/internal/crypto/init.h
+++ b/include/openenclave/internal/crypto/init.h
@@ -7,6 +7,13 @@
 /* Initialize OE crypto. */
 void oe_crypto_initialize(void);
 
+/* Value 0 and 1 are defined by the SymCrypt
+ * engine implementation. */
+#define OE_SYMCRYPT_ENGINE_FAIL 0
+#define OE_SYMCRYPT_ENGINE_SUCCESS 1
+#define OE_SYMCRYPT_ENGINE_NOT_LINKED 2
+#define OE_SYMCRYPT_ENGINE_INVALID 3
+
 int oe_is_symcrypt_engine_available();
 
 #endif /* _OE_INTERNAL_CRYPTO_INIT_H */

--- a/tests/symcrypt_engine/enc/symcrypt_engine_test.c
+++ b/tests/symcrypt_engine/enc/symcrypt_engine_test.c
@@ -1,10 +1,12 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
+#include <openenclave/internal/crypto/init.h>
+
 /* We do not have the SymCrypt engine available yet, defining a mock initializer
- * with the same function prototype and returns 1, mimicking the expected
- * behavior. */
-int SYMCRYPT_ENGINE_Initialize()
+ * with the same function prototype and returns OE_SYMCRYPT_ENGINE_SUCCESS,
+ * mimicking the expected behavior. */
+int SC_OSSL_ENGINE_Initialize()
 {
-    return 1;
+    return OE_SYMCRYPT_ENGINE_SUCCESS;
 }


### PR DESCRIPTION
Update the naming of the initialization function of SymCrypt Engine (will soon be open-sourced on github) that OE depends on.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>