### PR TITLE
Use default Intel SGX drivers when present

### DIFF
--- a/scripts/ansible/roles/linux/intel/tasks/driver-validation.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/driver-validation.yml
@@ -10,9 +10,7 @@
   include_vars:
     file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
 
-- name: Check for existing required directories
-  stat:
-    path: "{{ item }}"
-  with_items: "{{ driver_validation_directories }}"
-  register: directory
-  failed_when: directory.stat.isdir == False
+- name: Load default driver
+  modprobe:
+    name: intel_sgx
+    state: present

--- a/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
@@ -5,51 +5,77 @@
 - name: Gather Ansible facts
   setup:
 
-- name: Include distribution vars
-  include_vars:
-    file: "{{ ansible_distribution | lower }}/main.yml"
-
-- name: Include distribution release specific vars
-  include_vars:
-    file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
-
-- name: Install the SGX driver requirements
-  include_tasks: "{{ ansible_distribution | lower }}/sgx-driver-requirements.yml"
-
 - name: Populate service facts
   service_facts:
 
-- name: Ensure aesmd service stopped
-  service:
-    name: aesmd
-    state: stopped
-  when: "'aesmd.service' in ansible_facts.services"
+- name: Load default driver
+  modprobe:
+    name: intel_sgx
+    state: present
+  ignore_errors: yes
+  register: intel_sgx_module
 
-- name: Download Intel SGX DCAP Driver
-  get_url:
-    url: "{{intel_sgx_w_flc_driver_url}}"
-    dest: /tmp/sgx_linux_x64_driver.bin
-    mode: 0755
-    timeout: 120
-  retries: 3
-  when: flc_enabled|bool
+- name: install driver
+  block:
 
-- name: Download Intel SGX1 Driver
-  get_url:
-    url: "{{intel_sgx1_driver_url}}"
-    dest: /tmp/sgx_linux_x64_driver.bin
-    mode: 0755
-    timeout: 120
-  retries: 3
-  when: not flc_enabled|bool
+  - name: Include distribution vars
+    include_vars:
+      file: "{{ ansible_distribution | lower }}/main.yml"
 
-- name: Install the Intel SGX Driver
-  command: /tmp/sgx_linux_x64_driver.bin
+  - name: Include distribution release specific vars
+    include_vars:
+      file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
 
-- name: Remove the Intel SGX driver installer
-  file:
-    path: /tmp/sgx_linux_x64_driver.bin
-    state: absent
+  - name: Install the SGX driver requirements
+    include_tasks: "{{ ansible_distribution | lower }}/sgx-driver-requirements.yml"
+
+  - name: Ensure aesmd service stopped
+    service:
+      name: aesmd
+      state: stopped
+    when: "'aesmd.service' in ansible_facts.services"
+
+  - name: Download Intel SGX DCAP Driver
+    get_url:
+      url: "{{intel_sgx_w_flc_driver_url}}"
+      dest: /tmp/sgx_linux_x64_driver.bin
+      mode: 0755
+      timeout: 120
+    retries: 3
+    when: flc_enabled|bool
+
+  - name: Download Intel SGX1 Driver
+    get_url:
+      url: "{{intel_sgx1_driver_url}}"
+      dest: /tmp/sgx_linux_x64_driver.bin
+      mode: 0755
+      timeout: 120
+    retries: 3
+    when: not flc_enabled|bool
+
+  - name: Install the Intel SGX Driver
+    command: /tmp/sgx_linux_x64_driver.bin
+
+  - name: Remove the Intel SGX driver installer
+    file:
+      path: /tmp/sgx_linux_x64_driver.bin
+      state: absent
+
+  - name: Add user to sgx_prv group
+    user:
+      name: "{{ lookup('env', 'USER') }}"
+      group: sgx_prv
+    when:
+     - intel_sgx_prv_permissions is defined
+     - intel_sgx_prv_permissions | bool
+
+  - name: Set out-of-proc attestation by default
+    lineinfile:
+      path: /etc/environment
+      state: present
+      line: SGX_AESM_ADDR=1
+
+  when: intel_sgx_module is failed
 
 - name: Ensure aesmd service running
   service:
@@ -57,9 +83,3 @@
     state: started
     enabled: yes
   when: "'aesmd.service' in ansible_facts.services"
-
-- name: Set out-of-proc attestation by default
-  lineinfile:
-    path: /etc/environment
-    state: present
-    line: SGX_AESM_ADDR=1

--- a/scripts/ansible/roles/linux/intel/vars/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/main.yml
@@ -1,8 +1,0 @@
-# Copyright (c) Open Enclave SDK contributors.
-# Licensed under the MIT License.
-
----
-intel_sgx_directory: "/opt/intel"
-
-driver_validation_directories:
-  - "{{ intel_sgx_directory }}/sgxdriver"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/focal.yml
@@ -2,7 +2,9 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.9/linux/distro/ubuntu20.04-server/sgx_linux_x64_driver_1.36.2.bin"
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.10.3/linux/distro/ubuntu20.04-server/sgx_linux_x64_driver_1.41.bin"
+# For Intel SGX driver 1.41 and above, intel_sgx_prv_permissions needs to be set to yes
+intel_sgx_prv_permissions: yes
 intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.13.3/distro/ubuntu20.04-server/sgx_linux_x64_driver_2.11.0_2d2b795.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf17"


### PR DESCRIPTION
This change will add the following behaviour to the Ansible setups:
* If an Intel SGX driver is already present, then it will not install a new driver
* If an Intel SGX driver is not present on Ubuntu 20.04 then it will install Intel SGX driver 1.41. This is necessary as 1.36 will not work on Linux kernel 5.7+
* Changed the method to validate the presence of the driver. It will now use `modprobe` to load the intel_sgx driver, rather than rely on specific files to be present. As such, the variables `intel_sgx_directory` and `driver_validation_directories` are no longer needed, and were the only two variables present in `roles/linux/intel/vars/main.yml `