### PR TITLE
[0-base] use LOOKUP_FUNCTION instead of _lookup_function() for enclave_create_ex

### DIFF
--- a/host/sgx/sgx_enclave_common_wrapper.c
+++ b/host/sgx/sgx_enclave_common_wrapper.c
@@ -125,11 +125,17 @@ static void _load_sgx_enclave_common_impl(void)
     {
         OE_CHECK(_lookup_function("enclave_create", (void**)&_enclave_create));
         /*
-         * NOTE: _enclave_create_ex is available only in newer PSW. Hence, it
-         * should not check for valid function pointer until all systems upgrade
-         * PSW.
+         * NOTE: enclave_create_ex() is available only in newer PSW. We should
+         * not check for valid function pointer until all systems upgrade to
+         * PSW version 2.14.1 or higher.
+         * Hence, directly use LOOKUP_FUNCTION() and not _lookup_function().
          */
-        _lookup_function("enclave_create_ex", (void**)&_enclave_create_ex);
+        _enclave_create_ex = LOOKUP_FUNCTION("enclave_create_ex");
+        if (!_enclave_create_ex)
+            OE_TRACE_INFO(
+                "enclave_create_ex not found in %s. "
+                "Need PSW version 2.14.1 or higher.\n",
+                LIBRARY_NAME);
         OE_CHECK(
             _lookup_function("enclave_load_data", (void**)&_enclave_load_data));
         OE_CHECK(_lookup_function(


### PR DESCRIPTION
This avoids a error trace logged by _lookup_function() when using older PSW and enclave_create_ex() is not found in sgx_enclave_common.so.

>>$ host/echo_host enc/echo_enc
**2021-07-06T20:29:13+0530.529720Z [(H)ERROR] tid(0x7fdd0fceab80) | enclave_create_ex function not found.**
[/home/anakrish/oe2/host/sgx/sgx_enclave_common_wrapper.c:_lookup_function:110]
Hello from Echo function!
=== passed all tests (echo)

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>