### PR TITLE
Support oe_sgx_get_additional_host_entropy for the FIPS module

### DIFF
--- a/cmake/add_enclave.cmake
+++ b/cmake/add_enclave.cmake
@@ -351,23 +351,8 @@ macro (add_enclave_optee)
 
   target_link_libraries(${ENCLAVE_TARGET} oeenclave)
 
-  # If the CRYPTO_LIB argument to add_enclave() is not set, the following
-  # logic determines the default crypto library based on the value of the
-  # DEFAULT_TEST_ENCLAVE_CRYPTO_LIB global variable (e.g., either "MbedTLS" or "OpenSSL").
-  # If the CRYPTO_LIB argument is set, it overrides the DEFAULT_TEST_ENCLAVE_CRYPTO_LIB.
   # Note that the OpenSSL-based crypto library is currently not supported on OP-TEE.
-  if (NOT ENCLAVE_CRYPTO_LIB)
-    set(ENCLAVE_CRYPTO_LIB ${DEFAULT_TEST_ENCLAVE_CRYPTO_LIB})
-  endif ()
-
-  string(TOLOWER "${ENCLAVE_CRYPTO_LIB}" ENCLAVE_CRYPTO_LIB_LOWER)
-  if (ENCLAVE_CRYPTO_LIB_LOWER STREQUAL "mbedtls")
-    enclave_link_libraries(${ENCLAVE_TARGET} oecryptombedtls)
-  elseif (ENCLAVE_CRYPTO_LIB_LOWER STREQUAL "openssl")
-    enclave_link_libraries(${ENCLAVE_TARGET} oecryptoopenssl)
-  else ()
-    message(FATAL_ERROR "Unsupported crypto library ${ENCLAVE_CRYPTO_LIB}.")
-  endif ()
+  target_link_libraries(${ENCLAVE_TARGET} oecryptombedtls)
 
   if (ENCLAVE_CXX)
     target_link_libraries(${ENCLAVE_TARGET} oelibcxx)

--- a/docs/SystemEdls.md
+++ b/docs/SystemEdls.md
@@ -185,6 +185,11 @@ Ocall | Dependent Public APIs | Comments |
 :---|:---:|:---|
 oe_sgx_backtrace_symbols_ocall | backtrace, backtrace_symbols | Part of libc APIs. |
 
+## sgx/entropy.edl
+Ocall | Dependent Public APIs | Comments |
+:---|:---:|:---|
+oe_sgx_get_additional_host_entropy_ocall | N/A | Required by the SymCrypt FIPS module. |
+
 ## sgx/switchless/edl
 Ecall | Dependent Public APIs | Comments |
 :---|:---:|:---|

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -34,7 +34,7 @@ if (OE_SGX)
     OUTPUT platform_t.h platform_args.h
     DEPENDS ${SGX_EDL_FILE} edger8r
     COMMAND edger8r --header-only --search-path ${OE_INCLUDE_DIR} --trusted
-            ${SGX_EDL_FILE})
+            ${SGX_EDL_FILE} -DOE_SGX_ENTROPY)
 
   add_custom_target(platform_trusted_edl DEPENDS platform_t.h platform_args.h)
 endif ()

--- a/enclave/crypto/openssl/CMakeLists.txt
+++ b/enclave/crypto/openssl/CMakeLists.txt
@@ -18,6 +18,7 @@ add_enclave_library(
   ${PROJECT_SOURCE_DIR}/common/crypto/openssl/rsa.c
   ${PROJECT_SOURCE_DIR}/common/crypto/openssl/sha.c
   cert.c
+  entropy.c
   gcm.c
   init.c
   symcrypt_engine.c)
@@ -27,7 +28,7 @@ maybe_build_using_clangw(oecryptoopenssl)
 enclave_enable_code_coverage(oecryptoopenssl)
 
 enclave_include_directories(
-  oecryptoopenssl PRIVATE
+  oecryptoopenssl PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include>
   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/3rdparty/mbedtls>)
 

--- a/enclave/crypto/openssl/entropy.c
+++ b/enclave/crypto/openssl/entropy.c
@@ -1,0 +1,55 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/raise.h>
+#include "../../core/platform_t.h"
+
+/**
+ * Declare the prototype of the following function to avoid the
+ * missing-prototypes warning.
+ */
+oe_result_t _oe_sgx_get_additional_host_entropy_ocall(
+    oe_result_t* result,
+    uint8_t* data,
+    size_t size);
+
+oe_result_t _oe_sgx_get_additional_host_entropy_ocall(
+    oe_result_t* result,
+    uint8_t* data,
+    size_t size)
+{
+    OE_UNUSED(result);
+    OE_UNUSED(data);
+    OE_UNUSED(size);
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(
+    _oe_sgx_get_additional_host_entropy_ocall,
+    oe_sgx_get_additional_host_entropy_ocall);
+
+OE_EXPORT
+int oe_sgx_get_additional_host_entropy(uint8_t* data, size_t size)
+{
+    oe_result_t result = OE_FAILURE;
+
+    if (!data || !size)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    OE_CHECK(oe_sgx_get_additional_host_entropy_ocall(&result, data, size));
+    OE_CHECK(result);
+
+    result = OE_OK;
+
+done:
+    if (result == OE_UNSUPPORTED)
+    {
+        OE_TRACE_ERROR(
+            "oe_sgx_get_additional_host_entropy is not available. To "
+            "enable, please add \n\n"
+            "from \"openenclave/edl/sgx/entropy.edl\" import *;\n\n"
+            "in the edl file.\n");
+        oe_abort();
+    }
+
+    return result == OE_OK ? 1 : 0;
+}

--- a/enclave/crypto/openssl/init.c
+++ b/enclave/crypto/openssl/init.c
@@ -9,8 +9,11 @@ static oe_once_t _openssl_initialize_once;
 static ENGINE* _rdrand_engine;
 int _is_symcrypt_engine_available = 0;
 
-/* Forward declaration */
+#define HOST_ENTROPY_TEST_SIZE 16
+
+/* Forward declarations */
 int SC_OSSL_ENGINE_Initialize();
+int oe_sgx_get_additional_host_entropy(uint8_t*, size_t);
 
 static void _finalize(void)
 {
@@ -85,6 +88,14 @@ static void _initialize(void)
         /* Explicitly register the RDRAND engine if the SymCrypt engine
          * is not available, which provides its own RAND implementation. */
         _initialize_rdrand_engine();
+    }
+    else
+    {
+        uint8_t data[HOST_ENTROPY_TEST_SIZE];
+        /* Enforce the invocation of oe_sgx_get_additional_host_entropy,
+         * which will cause an enclave abort if the entropy.edl has not been
+         * included properly */
+        oe_sgx_get_additional_host_entropy(data, HOST_ENTROPY_TEST_SIZE);
     }
 }
 

--- a/enclave/sgx/verifier.c
+++ b/enclave/sgx/verifier.c
@@ -51,7 +51,6 @@ static void dump_info(
     }
 }
 
-#if !defined(OE_USE_BUILTIN_EDL)
 /**
  * Declare the prototype of the following function to avoid the
  * missing-prototypes warning.
@@ -154,7 +153,6 @@ oe_result_t _oe_verify_quote_ocall(
     return OE_UNSUPPORTED;
 }
 OE_WEAK_ALIAS(_oe_verify_quote_ocall, oe_verify_quote_ocall);
-#endif
 
 oe_result_t oe_verify_qve_report_and_identity(
     const uint8_t* p_quote,

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -88,7 +88,7 @@ if (OE_SGX)
     OUTPUT platform_u.h platform_args.h
     DEPENDS ${SGX_EDL_FILE} edger8r
     COMMAND edger8r --header-only --search-path ${OE_INCLUDE_DIR} --untrusted
-            ${SGX_EDL_FILE})
+            ${SGX_EDL_FILE} -DOE_SGX_ENTROPY)
 
   add_custom_target(platform_untrusted_edl DEPENDS platform_u.h platform_args.h)
 endif ()

--- a/include/openenclave/edl/sgx/entropy.edl
+++ b/include/openenclave/edl/sgx/entropy.edl
@@ -1,0 +1,25 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/*
+**==============================================================================
+**
+** sgx/entropy.edl:
+**
+**     Internal OCALL to be used by SymCrypt FIPS module to obtain extra entropy
+**     from the host.
+**
+**==============================================================================
+*/
+
+enclave
+{
+    include "openenclave/bits/types.h"
+
+    untrusted
+    {
+        oe_result_t oe_sgx_get_additional_host_entropy_ocall(
+            [out, size=size] uint8_t* data,
+            size_t size);
+    };
+};

--- a/include/openenclave/edl/sgx/platform.edl
+++ b/include/openenclave/edl/sgx/platform.edl
@@ -19,4 +19,7 @@ enclave
     from "openenclave/edl/sgx/debug.edl" import *;
     from "openenclave/edl/sgx/thread.edl" import *;
     from "openenclave/edl/sgx/switchless.edl" import *;
+#ifdef OE_SGX_ENTROPY
+    from "openenclave/edl/sgx/entropy.edl" import *;
+#endif
 };

--- a/tests/edl_opt_out/edl/header.edl
+++ b/tests/edl_opt_out/edl/header.edl
@@ -3,6 +3,7 @@
 
 enclave {
 #ifdef OE_SGX
+    from "openenclave/edl/sgx/entropy.edl" import *;
     from "openenclave/edl/sgx/platform.edl" import *;
 #else
     from "openenclave/edl/optee/platform.edl" import *;

--- a/tests/edl_opt_out/enc/CMakeLists.txt
+++ b/tests/edl_opt_out/enc/CMakeLists.txt
@@ -25,6 +25,8 @@ add_enclave(
   edl_opt_out_enc
   UUID
   892e7f65-5da1-45d0-8209-53795ce5be8f
+  CRYPTO_LIB
+  OpenSSL
   SOURCES
   enc.c
   ${CMAKE_CURRENT_BINARY_DIR}/edl_opt_out_t.c)

--- a/tests/edl_opt_out/enc/enc.c
+++ b/tests/edl_opt_out/enc/enc.c
@@ -122,7 +122,7 @@ void enc_edl_opt_out()
         oe_sgx_backtrace_symbols_ocall(NULL, NULL, NULL, 0, NULL, 0, NULL) ==
         OE_UNSUPPORTED);
 
-    /* sgx/switchless.edl*/
+    /* sgx/switchless.edl */
     OE_TEST(oe_sgx_sleep_switchless_worker_ocall(NULL) == OE_UNSUPPORTED);
     OE_TEST(oe_sgx_wake_switchless_worker_ocall(NULL) == OE_UNSUPPORTED);
 
@@ -168,6 +168,12 @@ void enc_edl_opt_out()
             OE_UNSUPPORTED);
         OE_TEST(result == OE_UNSUPPORTED);
     }
+
+    /* sgx/entropy.edl */
+    /* Only available with oecryptoopenssl */
+    OE_TEST(
+        oe_sgx_get_additional_host_entropy_ocall(NULL, NULL, 0) ==
+        OE_UNSUPPORTED);
 #endif
 }
 

--- a/tests/module_loading/commands.gdb
+++ b/tests/module_loading/commands.gdb
@@ -39,7 +39,7 @@ commands 3
 end
 
 # Set a breakpoint by line number
-b module.c:17
+b module.c:19
 commands 4
     # Check that value has been set.
     if is_module_init != 1
@@ -58,7 +58,7 @@ commands 5
 end
 
 # Set breakpoint in square function
-b module.c:30
+b module.c:32
 commands 6
     # Evaluate expression
     set var r = a * a
@@ -66,7 +66,7 @@ commands 6
 end
 
 # Set conditional breakpoint
-b module.c:42
+b module.c:44
 commands 7
     p t
     set var t = a + b + k

--- a/tests/module_loading/commands.py
+++ b/tests/module_loading/commands.py
@@ -46,7 +46,7 @@ def bp_init_module(frame, bp_loc, dict):
     return False
 
 # Breakpoint by line number in module
-def bp_module_c_17(frame, bp_loc, dict):
+def bp_module_c_19(frame, bp_loc, dict):
     # Check that value has been set
     is_module_init = lldb_eval("is_module_init")
     if int(is_module_init.value) != 1:
@@ -63,12 +63,12 @@ def bp_fini_module(frame, bp_loc, dict):
     return False
 
 # Breakpoint in square function
-def bp_module_c_30(frame, bp_loc, dict):
+def bp_module_c_32(frame, bp_loc, dict):
     lldb_expr("r = a * a")
     return False
 
 # Another breakpoint to test variable lookup
-def bp_module_c_42(frame, bp_loc, dict):
+def bp_module_c_44(frame, bp_loc, dict):
     lldb_expr(" t = a + b + k")
     t = lldb_eval("t")
     print("t = %s" % t.value)
@@ -87,17 +87,17 @@ def run_test():
     bp = target.BreakpointCreateByName("init_module")
     bp.SetScriptCallbackFunction('commands.bp_init_module')
 
-    bp = target.BreakpointCreateByLocation("module.c", 17)
-    bp.SetScriptCallbackFunction('commands.bp_module_c_17')
+    bp = target.BreakpointCreateByLocation("module.c", 19)
+    bp.SetScriptCallbackFunction('commands.bp_module_c_19')
 
     bp = target.BreakpointCreateByName("fini_module")
     bp.SetScriptCallbackFunction('commands.bp_fini_module')
 
-    bp = target.BreakpointCreateByLocation("module.c", 30)
-    bp.SetScriptCallbackFunction('commands.bp_module_c_30')
+    bp = target.BreakpointCreateByLocation("module.c", 32)
+    bp.SetScriptCallbackFunction('commands.bp_module_c_32')
 
-    bp = target.BreakpointCreateByLocation("module.c", 42)
-    bp.SetScriptCallbackFunction('commands.bp_module_c_42')
+    bp = target.BreakpointCreateByLocation("module.c", 44)
+    bp.SetScriptCallbackFunction('commands.bp_module_c_44')
 
     # The `personality` syscall is used by lldb to turn off ASLR.
     # This syscall may not be permitted within containers.

--- a/tests/module_loading/enc/CMakeLists.txt
+++ b/tests/module_loading/enc/CMakeLists.txt
@@ -14,12 +14,12 @@ add_enclave_library(module_loading_common OBJECT enc.c
                     ${CMAKE_CURRENT_BINARY_DIR}/module_loading_t.c)
 enclave_include_directories(module_loading_common PRIVATE
                             ${CMAKE_CURRENT_BINARY_DIR})
-enclave_link_libraries(module_loading_common oelibc oe_includes)
+enclave_link_libraries(module_loading_common oeenclave oecryptoopenssl oelibc
+                       oe_includes)
 maybe_build_using_clangw(module_loading_common)
 
 # Add the enclave for postive tests
 add_enclave(TARGET module_loading_enc)
-maybe_build_using_clangw(module_loading_enc)
 add_enclave_dependencies(module_loading_enc module_loading_common module)
 if (UNIX)
   enclave_link_libraries(module_loading_enc module_loading_common module)
@@ -43,7 +43,6 @@ endif ()
 
 # Add the enclave for the negative test of linking more than one modules
 add_enclave(TARGET module_loading_negative_extra_enc)
-maybe_build_using_clangw(module_loading_negative_extra_enc)
 add_enclave_dependencies(module_loading_negative_extra_enc module
                          module_negative_extra)
 if (UNIX)
@@ -71,7 +70,6 @@ endif ()
 
 # Add the enclave for the negative test of loading module from a wrong path
 add_enclave(TARGET module_loading_negative_path_enc)
-maybe_build_using_clangw(module_loading_negative_path_enc)
 add_enclave_dependencies(module_loading_negative_path_enc module)
 # Generate the enclave binary in the different directory from the module
 set_enclave_properties(
@@ -87,7 +85,6 @@ endif ()
 
 # Add the enclave for the negative test of using RPATH
 add_enclave(TARGET module_loading_negative_rpath_enc)
-maybe_build_using_clangw(module_loading_negative_rpath_enc)
 add_enclave_dependencies(module_loading_negative_rpath_enc module)
 if (UNIX)
   enclave_link_libraries(module_loading_negative_rpath_enc
@@ -102,7 +99,6 @@ enclave_link_libraries(
 
 # Add the enclave for the negative test of using RUNPATH
 add_enclave(TARGET module_loading_negative_runpath_enc)
-maybe_build_using_clangw(module_loading_negative_runpath_enc)
 add_enclave_dependencies(module_loading_negative_runpath_enc module)
 if (UNIX)
   enclave_link_libraries(module_loading_negative_runpath_enc

--- a/tests/module_loading/module/CMakeLists.txt
+++ b/tests/module_loading/module/CMakeLists.txt
@@ -20,7 +20,6 @@ enclave_compile_options(
   PUBLIC
   -fPIC
   -nostdinc
-  -fstack-protector-strong
   # Preserve frame-pointer in Release mode to enable oe_backtrace.
   -fno-omit-frame-pointer
   # Put each function or data in its own section.

--- a/tests/module_loading/module/module.c
+++ b/tests/module_loading/module/module.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <pthread.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -9,6 +10,7 @@ extern int debugger_test;
 extern int is_module_init;
 
 void notify_module_done_wrapper();
+int oe_sgx_get_additional_host_entropy(uint8_t* data, size_t size);
 
 __attribute__((constructor)) void init_module()
 {
@@ -55,6 +57,7 @@ int test_libc_symbols()
     TEST_SYMBOL(memcpy);
     TEST_SYMBOL(memmove);
     TEST_SYMBOL(memset);
+    TEST_SYMBOL(oe_sgx_get_additional_host_entropy);
     TEST_SYMBOL(pthread_mutex_destroy);
     TEST_SYMBOL(pthread_mutex_init);
     TEST_SYMBOL(pthread_mutex_lock);
@@ -65,7 +68,12 @@ int test_libc_symbols()
 
     /* The size of pthread_mutex_t is required to be 40 to be
      * compatible with musl and glibc. */
-    if (sizeof(pthread_mutex_t) == 40)
-        return 1;
-    return 0;
+    if (sizeof(pthread_mutex_t) != 40)
+        return 0;
+
+    uint8_t data[16];
+    if (!oe_sgx_get_additional_host_entropy(data, 16))
+        return 0;
+
+    return 1;
 }

--- a/tests/module_loading/module_loading.edl
+++ b/tests/module_loading/module_loading.edl
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 enclave {
-    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/fcntl.edl" import *;
 #ifdef OE_SGX
+    from "openenclave/edl/sgx/entropy.edl" import *;
     from "openenclave/edl/sgx/platform.edl" import *;
 #else
     from "openenclave/edl/optee/platform.edl" import *;

--- a/tests/symcrypt_engine/CMakeLists.txt
+++ b/tests/symcrypt_engine/CMakeLists.txt
@@ -9,3 +9,7 @@ endif ()
 
 add_enclave_test(tests/symcrypt_engine symcrypt_engine_host
                  sgx_symcrypt_engine_enc)
+
+add_enclave_test(
+  tests/symcrypt_engine_no_entropy symcrypt_engine_no_entropy_host
+  sgx_symcrypt_engine_no_entropy_enc)

--- a/tests/symcrypt_engine/enc/CMakeLists.txt
+++ b/tests/symcrypt_engine/enc/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 set(EDL_FILE ../symcrypt_engine.edl)
+set(NO_ENTROPY_EDL_FILE ../symcrypt_engine_no_entropy.edl)
 
 add_enclave_library(symcrypt_engine_test STATIC symcrypt_engine_test.c)
 enclave_link_libraries(symcrypt_engine_test oe_includes)
@@ -15,6 +16,14 @@ add_custom_command(
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
     ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_custom_command(
+  OUTPUT symcrypt_engine_no_entropy_t.h symcrypt_engine_no_entropy_t.c
+  DEPENDS ${NO_ENTROPY_EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${NO_ENTROPY_EDL_FILE} --search-path
+    ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_enclave(
   TARGET
   sgx_symcrypt_engine_enc
@@ -26,9 +35,27 @@ add_enclave(
   enc.c
   ${CMAKE_CURRENT_BINARY_DIR}/symcrypt_engine_t.c)
 
+add_enclave(
+  TARGET
+  sgx_symcrypt_engine_no_entropy_enc
+  CRYPTO_LIB
+  # Specify an unsupported option so that we can exercise the link-time
+  # symbol replacement
+  None
+  SOURCES
+  enc.c
+  ${CMAKE_CURRENT_BINARY_DIR}/symcrypt_engine_no_entropy_t.c)
+
+enclave_compile_definitions(sgx_symcrypt_engine_enc PRIVATE USE_ENTROPY_EDL)
+
 enclave_link_libraries(sgx_symcrypt_engine_enc symcrypt_engine_test
+                       oecryptoopenssl)
+enclave_link_libraries(sgx_symcrypt_engine_no_entropy_enc symcrypt_engine_test
                        oecryptoopenssl)
 
 # Add include paths
 enclave_include_directories(sgx_symcrypt_engine_enc PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})
+
+enclave_include_directories(sgx_symcrypt_engine_no_entropy_enc PRIVATE
                             ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/symcrypt_engine/enc/enc.c
+++ b/tests/symcrypt_engine/enc/enc.c
@@ -5,7 +5,11 @@
 #include <openenclave/internal/crypto/init.h>
 #include <openenclave/internal/print.h>
 #include <openenclave/internal/tests.h>
+#ifdef USE_ENTROPY_EDL
 #include "symcrypt_engine_t.h"
+#else
+#include "symcrypt_engine_no_entropy_t.h"
+#endif
 
 void ecall_test()
 {

--- a/tests/symcrypt_engine/host/CMakeLists.txt
+++ b/tests/symcrypt_engine/host/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 set(EDL_FILE ../symcrypt_engine.edl)
+set(NO_ENTROPY_EDL_FILE ../symcrypt_engine_no_entropy.edl)
 
 add_custom_command(
   OUTPUT symcrypt_engine_u.h symcrypt_engine_u.c
@@ -10,8 +11,24 @@ add_custom_command(
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
     ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_custom_command(
+  OUTPUT symcrypt_engine_no_entropy_u.h symcrypt_engine_no_entropy_u.c
+  DEPENDS ${NO_ENTROPY_EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${NO_ENTROPY_EDL_FILE} --search-path
+    ${PROJECT_SOURCE_DIR}/include ${DEFINE_OE_SGX} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_executable(symcrypt_engine_host host.c symcrypt_engine_u.c)
+add_executable(symcrypt_engine_no_entropy_host host.c
+                                               symcrypt_engine_no_entropy_u.c)
+
+target_compile_definitions(symcrypt_engine_host PRIVATE USE_ENTROPY_EDL)
 
 target_include_directories(symcrypt_engine_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(symcrypt_engine_no_entropy_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 target_link_libraries(symcrypt_engine_host oehost)
+target_link_libraries(symcrypt_engine_no_entropy_host oehost)

--- a/tests/symcrypt_engine/symcrypt_engine_no_entropy.edl
+++ b/tests/symcrypt_engine/symcrypt_engine_no_entropy.edl
@@ -4,7 +4,6 @@
 enclave {
     from "openenclave/edl/logging.edl" import *; // Support OE_TEST and oe_host_printf
     from "openenclave/edl/fcntl.edl" import *; // Support code coverage analysis
-    from "openenclave/edl/sgx/entropy.edl" import *;
     from "openenclave/edl/sgx/platform.edl" import *;
 
     trusted {


### PR DESCRIPTION
Add the internal `oe_sgx_get_additional_host_entropy` API, which is mandatory for the SymCrypt FIPS module to obtain extra entropy from the host. That is, the API is for SymCrypt FIPS module only instead of general use.

To enforce the hard requirement, the current design throws a runtime error if the `entropy.edl` is not imported.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>