### PR TITLE
Enable error debug log during the enclave initialization

### DIFF
--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -624,20 +624,14 @@ OE_NO_RETURN
 static void _exit_enclave(uint64_t arg1, uint64_t arg2)
 {
     static bool _initialized = false;
-    static bool _stitch_ocall_stack = false;
     oe_sgx_td_t* td = oe_sgx_get_td();
 
     // Since determining whether an enclave supports debugging is a stateless
-    // idempotent operation, there is no need to lock. The result is cached
-    // for performance since is_enclave_debug_allowed uses local report to
-    // securely determine if an enclave supports debugging or not.
+    // idempotent operation, there is no need to lock.
     if (!_initialized)
-    {
-        _stitch_ocall_stack = is_enclave_debug_allowed();
         _initialized = true;
-    }
 
-    if (_stitch_ocall_stack)
+    if (is_enclave_debug_allowed())
     {
         oe_ecall_context_t* host_ecall_context = td->host_ecall_context;
 

--- a/enclave/core/sgx/tracee.c
+++ b/enclave/core/sgx/tracee.c
@@ -9,28 +9,36 @@
 #include "../tracee.h"
 #include "report.h"
 
+static volatile int _is_enclave_debug_allowed = -1;
+
 // Read an enclave's identity attribute to see to if it was signed as an debug
 // enclave
 bool is_enclave_debug_allowed()
 {
-    bool ret = false;
-    oe_sgx_td_t* td = oe_sgx_get_td();
+    if (_is_enclave_debug_allowed != -1)
+        goto done;
 
+    oe_sgx_td_t* td = oe_sgx_get_td();
     if (td->simulate)
     {
-        // enclave in simulate mode is treated as debug_allowed
-        ret = true;
+        // Enclave in simulate mode is treated as debug_allowed
+        _is_enclave_debug_allowed = 1;
     }
     else
     {
-        // get a report on the enclave itself for enclave identity information
+        // Get a report on the enclave itself for enclave identity information
         sgx_report_t sgx_report;
         oe_result_t result = sgx_create_report(NULL, 0, NULL, 0, &sgx_report);
         if (result != OE_OK)
+        {
+            _is_enclave_debug_allowed = 0;
             goto done;
+        }
 
-        ret = (sgx_report.body.attributes.flags & SGX_FLAGS_DEBUG) != 0;
+        _is_enclave_debug_allowed =
+            (sgx_report.body.attributes.flags & SGX_FLAGS_DEBUG) != 0;
     }
+
 done:
-    return ret;
+    return _is_enclave_debug_allowed == 1 ? true : false;
 }

--- a/enclave/core/tracee.c
+++ b/enclave/core/tracee.c
@@ -19,7 +19,6 @@
 
 static oe_log_level_t _active_log_level = OE_LOG_LEVEL_ERROR;
 static char _enclave_filename[OE_MAX_FILENAME_LEN];
-static bool _debug_allowed_enclave = false;
 
 const char* get_filename_from_path(const char* path)
 {
@@ -68,8 +67,6 @@ void oe_log_init_ecall(const char* enclave_path, uint32_t log_level)
     {
         memset(_enclave_filename, 0, sizeof(_enclave_filename));
     }
-
-    _debug_allowed_enclave = is_enclave_debug_allowed();
 }
 
 oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...)
@@ -80,8 +77,8 @@ oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...)
     int bytes_written = 0;
     char* message = NULL;
 
-    // skip logging for non-debug-allowed enclaves
-    if (!_debug_allowed_enclave)
+    // Skip logging for non-debug-allowed enclaves
+    if (!is_enclave_debug_allowed())
     {
         result = OE_OK;
         goto done;
@@ -93,6 +90,7 @@ oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...)
         result = OE_OK;
         goto done;
     }
+
     // Validate input
     if (!fmt)
     {

--- a/enclave/crypto/openssl/init.c
+++ b/enclave/crypto/openssl/init.c
@@ -63,8 +63,6 @@ static int _initialize_symcrypt_engine()
     if (result != OE_SYMCRYPT_ENGINE_SUCCESS)
         goto done;
 
-    OE_TRACE_INFO("SymCrypt engine is registered");
-
 done:
     if (result == OE_SYMCRYPT_ENGINE_FAIL)
         OE_TRACE_ERROR("SymCrypt engine initialization failed");


### PR DESCRIPTION
This PR enables the in-enclave, `DEBUG` level log traces during the enclave initialization when logging.edl is included.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>