### PR TITLE
Add repository links for Azure DCAP Client

### DIFF
--- a/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md
@@ -107,14 +107,14 @@ sudo ln -s libdcap_quoteprov.so.1.8.100.2 libdcap_quoteprov.so
 
 NOTES TO USERS WHO HAVE ALREADY INSTALLED AZURE DCAP CLIENT:
 
-If you have Azure DCAP client installed before trying these instructions, please make sure the Azure one is renamed to something else.
+If you have [Azure DCAP Client](https://github.com/microsoft/Azure-DCAP-Client) installed before trying these instructions, please make sure the Azure one is renamed to something else.
 
 To check if you have it installed, run the following command.
 ```bash
 dpkg --list | grep az-dcap-client
 ```
 
-If you don't have the Azure DCAP client installed previously, please skip the content below.
+If you don't have the Azure DCAP Client installed previously, please skip the content below.
 
 In most cases the Azure version of libdcap_quoteprov.so is located in /usr/lib. Check your path before changing. Here we use /usr/lib as an example.
 

--- a/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/WindowsSGX1FLCGettingStarted.md
@@ -62,7 +62,7 @@ updating the PSW and DCAP software components:
 ./scripts/install-windows-prereqs.ps1 -LaunchConfiguration SGX1FLC-NoIntelDrivers
 ```
 
-To install the prerequisites along with the Azure DCAP Client, use the below
+To install the prerequisites along with the [Azure DCAP Client](https://github.com/microsoft/Azure-DCAP-Client), use the below
 command. The Azure DCAP Client is necessary to perform attestation on an Azure
 Confidential Computing VM. This command assumes that you would like the
 prerequisites to be installed to `C:/oe_prereqs`.


### PR DESCRIPTION
Add a couple links to the "Azure DCAP Client" repository to the `GettingStartedDocs` documents.

Fix #4119.

Signed-off-by: Ryan Hsu <ryhsu@microsoft.com>