### PR TITLE
Optimize oe_cert_find_extension

### DIFF
--- a/common/attest_plugin.c
+++ b/common/attest_plugin.c
@@ -516,26 +516,22 @@ oe_result_t oe_verify_attestation_certificate_with_evidence_v2(
     // determine the size of the extension
     while (oid_array_index < oid_array_count)
     {
-        if (oe_cert_find_extension(
-                &cert,
-                (const char*)oid_array[oid_array_index],
-                NULL,
-                &report_size) == OE_BUFFER_TOO_SMALL)
+        oe_result_t find_result = oe_cert_find_extension(
+            &cert,
+            (const char*)oid_array[oid_array_index],
+            &report,
+            &report_size);
+
+        if (find_result == OE_NOT_FOUND)
         {
-            report = (uint8_t*)oe_malloc(report_size);
-            if (!report)
-                OE_RAISE(OE_OUT_OF_MEMORY);
-
-            OE_CHECK(oe_cert_find_extension(
-                &cert,
-                (const char*)oid_array[oid_array_index],
-                report,
-                &report_size));
-
-            break;
+            oid_array_index++;
+            continue;
         }
 
-        oid_array_index++;
+        if (find_result == OE_OK)
+            break;
+
+        OE_RAISE_MSG(find_result, "oe_cert_find_extension failed", NULL);
     }
 
     // if there is no match

--- a/common/cert.c
+++ b/common/cert.c
@@ -124,21 +124,13 @@ oe_result_t oe_get_crl_distribution_points(
     if (oe_align_pointer(buffer, sizeof(void*)) != buffer)
         OE_RAISE(OE_BAD_ALIGNMENT);
 
-    /* Determine the size of the extension */
-    if (oe_cert_find_extension(cert, _OID, NULL, &size) != OE_BUFFER_TOO_SMALL)
-        OE_RAISE(OE_FAILURE);
-
     /* Find all the CRL distribution points in this extension */
     {
         oe_asn1_t asn1;
         size_t urls_bytes;
 
         /* Find the extension */
-        data = (uint8_t*)oe_malloc(size);
-        if (!data)
-            OE_RAISE(OE_OUT_OF_MEMORY);
-
-        OE_CHECK(oe_cert_find_extension(cert, _OID, data, &size));
+        OE_CHECK(oe_cert_find_extension(cert, _OID, &data, &size));
 
         /* Determine the number of URLs */
         {

--- a/common/sgx/sgxcertextensions.c
+++ b/common/sgx/sgxcertextensions.c
@@ -393,23 +393,20 @@ done:
  */
 static oe_result_t _get_sgx_extension(
     oe_cert_t* cert,
-    uint8_t* data,
+    uint8_t** data,
     size_t* data_size)
 {
     oe_result_t result = OE_INVALID_SGX_CERTIFICATE_EXTENSIONS;
-    size_t size = *data_size;
-    OE_CHECK(oe_cert_find_extension(cert, SGX_EXTENSION_OID_STR, data, &size));
+    OE_CHECK(
+        oe_cert_find_extension(cert, SGX_EXTENSION_OID_STR, data, data_size));
 
     result = OE_OK;
 done:
-    *data_size = size;
     return result;
 }
 
-oe_result_t ParseSGXExtensions(
+oe_result_t oe_parse_sgx_extensions(
     oe_cert_t* cert,
-    uint8_t* buffer,
-    size_t* buffer_size,
     ParsedExtensionInfo* parsed_info)
 {
     oe_result_t result = OE_INVALID_SGX_CERTIFICATE_EXTENSIONS;
@@ -422,15 +419,16 @@ oe_result_t ParseSGXExtensions(
     uint8_t* config_itr = NULL;
     size_t config_length = 0;
     uint8_t* config_end = NULL;
+    uint8_t* extension_data = NULL;
+    size_t extension_size = 0;
 
-    if (cert == NULL || buffer == NULL || buffer_size == NULL ||
-        parsed_info == NULL)
+    if (cert == NULL || parsed_info == NULL)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    OE_CHECK(_get_sgx_extension(cert, buffer, buffer_size));
+    OE_CHECK(_get_sgx_extension(cert, &extension_data, &extension_size));
 
-    itr = buffer;
-    end = itr + *buffer_size;
+    itr = extension_data;
+    end = itr + extension_size;
     if (end <= itr)
         OE_RAISE(OE_INVALID_SGX_CERTIFICATE_EXTENSIONS);
 
@@ -560,5 +558,8 @@ oe_result_t ParseSGXExtensions(
 
     result = OE_OK;
 done:
+    oe_free(extension_data);
+    extension_data = NULL;
+
     return result;
 }

--- a/common/sgx/tlsverifier.c
+++ b/common/sgx/tlsverifier.c
@@ -112,35 +112,13 @@ oe_result_t oe_verify_attestation_certificate(
     // set enclave to NULL because we are dealing only with remote report now
     //------------------------------------------------------------------------
 
-    // determine the size of the extension
-    if (oe_cert_find_extension(
-            &cert, (const char*)oid_oe_report, NULL, &report_size) ==
-        OE_BUFFER_TOO_SMALL)
-    {
-        report = (uint8_t*)oe_malloc(report_size);
-        if (!report)
-            OE_RAISE(OE_OUT_OF_MEMORY);
-
-        OE_CHECK(oe_cert_find_extension(
-            &cert, (const char*)oid_oe_report, report, &report_size));
-    }
-    else if (
-        oe_cert_find_extension(
-            &cert, (const char*)oid_new_oe_report, NULL, &report_size) ==
-        OE_BUFFER_TOO_SMALL)
-    {
-        report = (uint8_t*)oe_malloc(report_size);
-        if (!report)
-            OE_RAISE(OE_OUT_OF_MEMORY);
-
-        OE_CHECK(oe_cert_find_extension(
-            &cert, (const char*)oid_new_oe_report, report, &report_size));
-    }
-    else
-    {
-        OE_RAISE_MSG(
-            OE_FAILURE, "No expected certificate extension matched", NULL);
-    }
+    result = oe_cert_find_extension(
+        &cert, (const char*)oid_oe_report, &report, &report_size);
+    if (result == OE_NOT_FOUND)
+        result = oe_cert_find_extension(
+            &cert, (const char*)oid_new_oe_report, &report, &report_size);
+    if (result != OE_OK)
+        OE_RAISE_MSG(result, "No expected certificate extension matched", NULL);
 
     OE_TRACE_VERBOSE("extract_x509_report_extension() succeeded");
 

--- a/host/crypto/bcrypt/cert.c
+++ b/host/crypto/bcrypt/cert.c
@@ -1264,11 +1264,13 @@ done:
 oe_result_t oe_cert_find_extension(
     const oe_cert_t* cert,
     const char* oid,
-    uint8_t* data,
+    uint8_t** data,
     size_t* data_size)
 {
     oe_result_t result = OE_UNEXPECTED;
     cert_t* impl = (cert_t*)cert;
+    size_t extension_size = 0;
+    uint8_t* extension_data = NULL;
 
     /* Reject invalid parameters */
     if (!_cert_is_valid(impl) || !oid || !data_size)
@@ -1283,32 +1285,27 @@ oe_result_t oe_cert_find_extension(
     if (!extension)
         OE_RAISE(OE_NOT_FOUND);
 
-    /* If the caller's buffer is too small, raise error */
-    if (extension->Value.cbData > *data_size)
-    {
-        *data_size = extension->Value.cbData;
+    extension_size = extension->Value.cbData;
+    extension_data = (uint8_t*)malloc(extension_size);
+    if (!extension_data)
+        OE_RAISE(OE_OUT_OF_MEMORY);
 
-        if (data)
-            OE_RAISE(OE_BUFFER_TOO_SMALL);
-        /* If data is null, this call is intented to get the correct
-         * data_size so no need to trace OE_BUFFER_TOO_SMALL */
-        else
-            OE_RAISE_NO_TRACE(OE_BUFFER_TOO_SMALL);
-    }
-
-    if (data)
-    {
-        OE_CHECK(oe_memcpy_s(
-            data,
-            *data_size,
-            extension->Value.pbData,
-            extension->Value.cbData));
-        *data_size = extension->Value.cbData;
-    }
+    OE_CHECK(oe_memcpy_s(
+        extension_data,
+        extension_size,
+        extension->Value.pbData,
+        extension->Value.cbData));
+    *data_size = extension_size;
+    *data = extension_data;
 
     result = OE_OK;
 
 done:
+    if (result != OE_OK)
+    {
+        free(extension_data);
+        extension_data = NULL;
+    }
     return result;
 }
 

--- a/include/openenclave/internal/crypto/cert.h
+++ b/include/openenclave/internal/crypto/cert.h
@@ -304,14 +304,12 @@ oe_result_t oe_cert_chain_get_leaf_cert(
  * @return OE_OK success.
  * @return OE_INVALID_PARAMETER a parameter is invalid.
  * @return OE_NOT_FOUND an extension with the given OID was not found.
- * @return OE_BUFFER_TOO_SMALL the data buffer is too small and the **size**
- *         parameter contains the required size.
  * @return OE_FAILURE general failure.
  */
 oe_result_t oe_cert_find_extension(
     const oe_cert_t* cert,
     const char* oid,
-    uint8_t* data,
+    uint8_t** data,
     size_t* size);
 
 /**

--- a/include/openenclave/internal/sgxcertextensions.h
+++ b/include/openenclave/internal/sgxcertextensions.h
@@ -26,10 +26,8 @@ typedef struct _parsed_extension_info
     bool opt_smt_enabled;
 } ParsedExtensionInfo;
 
-oe_result_t ParseSGXExtensions(
+oe_result_t oe_parse_sgx_extensions(
     oe_cert_t* cert,
-    uint8_t* buffer,
-    size_t* buffer_size,
     ParsedExtensionInfo* parsed_info);
 
 OE_EXTERNC_END

--- a/tests/crypto/asn1_tests.c
+++ b/tests/crypto/asn1_tests.c
@@ -330,8 +330,8 @@ done:
 static void _test_asn1_parsing(void)
 {
     oe_cert_t cert;
-    uint8_t data[4096];
-    size_t size = sizeof(data);
+    uint8_t* data = NULL;
+    size_t size = 0;
     const char OID[] = "1.2.840.113741.1.13.1";
     oe_result_t r;
 
@@ -340,7 +340,7 @@ static void _test_asn1_parsing(void)
     OE_TEST(oe_cert_read_pem(&cert, _CERT, strlen(_CERT) + 1) == OE_OK);
 
     /* Find the SGX_EXTENSION */
-    r = oe_cert_find_extension(&cert, OID, data, &size);
+    r = oe_cert_find_extension(&cert, OID, &data, &size);
     OE_TEST(r == OE_OK);
 
     oe_hex_dump(data, size);
@@ -362,6 +362,7 @@ static void _test_asn1_parsing(void)
     OE_TEST(strcmp(str, _PARSE_OUTPUT) == 0);
 
     free(str);
+    free(data);
 
     printf("=== passed %s()\n", __FUNCTION__);
 }

--- a/tests/crypto/ec_tests.c
+++ b/tests/crypto/ec_tests.c
@@ -808,13 +808,15 @@ static void _test_cert_extensions(
         {
             const Extension* ext = &extensions[i];
             const char* oid = ext->oid;
-            uint8_t data[4096];
-            size_t size = sizeof(data);
+            uint8_t* data = NULL;
+            size_t size = 0;
 
-            OE_TEST(oe_cert_find_extension(&cert, oid, data, &size) == OE_OK);
+            OE_TEST(oe_cert_find_extension(&cert, oid, &data, &size) == OE_OK);
             OE_TEST(strcmp(oid, ext->oid) == 0);
             OE_TEST(size == ext->size);
             OE_TEST(memcmp(data, ext->data, size) == 0);
+
+            free(data);
         }
     }
 
@@ -822,26 +824,29 @@ static void _test_cert_extensions(
     if (!extensions)
     {
         oe_result_t r;
-        uint8_t data[4096];
-        size_t size = sizeof(data);
+        uint8_t* data = NULL;
+        size_t size = 0;
 
-        r = oe_cert_find_extension(&cert, "1.2.3.4", data, &size);
+        r = oe_cert_find_extension(&cert, "1.2.3.4", &data, &size);
         OE_TEST(r == OE_NOT_FOUND);
+        OE_TEST(data == NULL);
     }
 
     /* Find the extension with the given OID and check for OE_NOT_FOUND */
     if (!extensions)
     {
         oe_result_t r;
-        uint8_t data[4096];
-        size_t size = sizeof(data);
+        uint8_t* data = NULL;
+        size_t size = 0;
 
-        r = oe_cert_find_extension(&cert, test_oid, data, &size);
+        r = oe_cert_find_extension(&cert, test_oid, &data, &size);
 
         if (extensions)
             OE_TEST(r == OE_OK);
         else
             OE_TEST(r == OE_NOT_FOUND);
+
+        free(data);
     }
 
     oe_cert_free(&cert);

--- a/tools/oeutil/host/generate_evidence.cpp
+++ b/tools/oeutil/host/generate_evidence.cpp
@@ -340,29 +340,15 @@ void parse_certificate_extension(const uint8_t* data, size_t data_len)
     oe_cert_chain_t cert_chain = {0};
     oe_cert_t leaf_cert = {0};
     ParsedExtensionInfo extension_info = {{0}};
-    size_t buffer_size = 1024;
-    uint8_t* buffer = NULL;
 
     // get leaf cert to parse sgx extension
     oe_cert_chain_read_pem(&cert_chain, data, data_len);
     oe_cert_chain_get_leaf_cert(&cert_chain, &leaf_cert);
 
-    // Try parsing the extensions.
-    buffer = (uint8_t*)malloc(buffer_size);
-    if (buffer == NULL)
-        OE_RAISE(OE_OUT_OF_MEMORY);
-    result =
-        ParseSGXExtensions(&leaf_cert, buffer, &buffer_size, &extension_info);
+    result = oe_parse_sgx_extensions(&leaf_cert, &extension_info);
+    if (result != OE_OK)
+        goto done;
 
-    if (result == OE_BUFFER_TOO_SMALL)
-    {
-        free(buffer);
-        buffer = (uint8_t*)malloc(buffer_size);
-        if (buffer == NULL)
-            OE_RAISE(OE_OUT_OF_MEMORY);
-        result = ParseSGXExtensions(
-            &leaf_cert, buffer, &buffer_size, &extension_info);
-    }
     printf(
         "\n    parsed qe certificate extension (%s) {\n",
         SGX_EXTENSION_OID_STR);
@@ -393,7 +379,6 @@ void parse_certificate_extension(const uint8_t* data, size_t data_len)
         extension_info.opt_smt_enabled ? "true" : "false");
     printf("    } qe cert extension \n");
 done:
-    free(buffer);
     oe_cert_chain_free(&cert_chain);
     oe_cert_free(&leaf_cert);
 }
@@ -853,7 +838,7 @@ oe_result_t get_oe_report_from_certificate(
 {
     oe_result_t result = OE_UNEXPECTED;
     uint8_t* report_buffer = nullptr;
-    size_t report_buffer_size = certificate_in_der_length;
+    size_t report_buffer_size = 0;
     oe_cert_t certificate = {0};
 
     result = oe_cert_read_der(
@@ -861,15 +846,11 @@ oe_result_t get_oe_report_from_certificate(
     if (result != OE_OK)
         return result;
 
-    report_buffer = (uint8_t*)malloc(report_buffer_size);
-    if (!report_buffer)
-        return OE_OUT_OF_MEMORY;
-
     // find the extension
     result = oe_cert_find_extension(
         &certificate,
         X509_OID_FOR_NEW_QUOTE_STRING,
-        report_buffer,
+        &report_buffer,
         &report_buffer_size);
 
     if (result == OE_OK)


### PR DESCRIPTION
This PR refactors the internal `oe_cert_find_extension` API, mainly for eliminating the double call pattern.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>