### PR TITLE
mmap and munmap implementations

### DIFF
--- a/include/openenclave/internal/safemath.h
+++ b/include/openenclave/internal/safemath.h
@@ -254,6 +254,17 @@ OE_INLINE oe_result_t oe_safe_mul_sizet(size_t a, size_t b, size_t* c)
     SAFE_MULTIPLY(a, b, c, 0, OE_SIZE_MAX);
 }
 
+OE_INLINE oe_result_t oe_safe_round_up_u64(uint64_t a, uint64_t b, uint64_t* c)
+{
+    if (!b)
+        return OE_INVALID_PARAMETER;
+    uint64_t value = 0;
+    oe_result_t result = oe_safe_add_u64(a, b - 1, &value);
+    if (result != OE_OK)
+        return result;
+    return oe_safe_mul_u64(value / b, b, c);
+}
+
 /* Re-enable GCC warnings for -Wtype-limits. */
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -96,6 +96,7 @@ add_enclave_library(
   libunwind_stubs.c
   link.c
   malloc.c
+  mman.c
   pthread.c
   sched_yield.c
   sigaction.c
@@ -510,8 +511,6 @@ add_enclave_library(
   ${MUSLSRC}/misc/ioctl.c
   ${MUSLSRC}/misc/nftw.c
   ${MUSLSRC}/misc/uname.c
-  ${MUSLSRC}/mman/mmap.c
-  ${MUSLSRC}/mman/munmap.c
   ${MUSLSRC}/multibyte/btowc.c
   ${MUSLSRC}/multibyte/c16rtomb.c
   ${MUSLSRC}/multibyte/c32rtomb.c

--- a/libc/mman.c
+++ b/libc/mman.c
@@ -1,0 +1,362 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/corelibc/errno.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/safemath.h>
+#include <openenclave/internal/thread.h>
+#include <openenclave/internal/utils.h>
+#include <stdlib.h>
+
+#include "mman.h"
+#include "openenclave/bits/defs.h"
+#include "openenclave/bits/result.h"
+#include "syscall.h"
+
+static oe_mapping_t* _mappings;
+static oe_spinlock_t _lock;
+
+static void _clear_mappings(void)
+{
+    oe_mapping_t* m = _mappings;
+    _mappings = 0;
+    while (m)
+    {
+        oe_mapping_t* next = m->next;
+        free((void*)m->start);
+        m->start = 0;
+        free(m->status_vector);
+        m->status_vector = NULL;
+        free(m);
+        m = next;
+    }
+}
+
+static void _call_atexit(void)
+{
+    atexit(_clear_mappings);
+}
+
+static void _register_atexit_callback(void)
+{
+    static oe_once_t once = OE_ONCE_INITIALIZER;
+    oe_once(&once, _call_atexit);
+}
+
+static oe_result_t _validate_mmap_parameters(
+    void* addr,
+    size_t length,
+    int prot,
+    int flags,
+    int fd,
+    off_t offset)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    int flags_copy = flags;
+
+    // If addr is not NULL, then the kernel takes it as a hint about where to
+    // place the mapping; on Linux, the kernel will pick a nearby page boundary
+    // (but always above or equal to the value specified by
+    // /proc/sys/vm/mmap_min_addr) and attempt to create the mapping there.
+    // OE currently does not support this usage.
+    if (addr != NULL)
+        OE_RAISE_MSG(
+            OE_UNSUPPORTED, "non-zero `addr` parameter is not supported.");
+
+    // PROT_NONE and PROT_EXEC are not supported.
+    if (prot == PROT_NONE || (prot & PROT_EXEC))
+        OE_RAISE_MSG(OE_UNSUPPORTED, "unsupported `prot` value %d", prot);
+
+    if (length == 0)
+        OE_RAISE_MSG(OE_INVALID_PARAMETER, "length must be non zero");
+
+    enum
+    {
+        UNSUPPORTED,
+        IGNORED,
+        SUPPORTED
+    };
+    static struct support
+    {
+        int flag;
+        int support;
+    } flags_table[] = {
+        {MAP_SHARED, SUPPORTED},
+        {MAP_SHARED_VALIDATE, SUPPORTED},
+        {MAP_PRIVATE, SUPPORTED},
+#ifdef MAP_32BIT
+        {MAP_32BIT, UNSUPPORTED},
+#endif
+        {MAP_ANON, SUPPORTED},
+        {MAP_ANONYMOUS, SUPPORTED},
+        {MAP_DENYWRITE, IGNORED /* by spec */},
+        {MAP_EXECUTABLE, IGNORED /* by spec */},
+        {MAP_FILE, IGNORED /* by spec */},
+        {MAP_FIXED, UNSUPPORTED},
+        {MAP_FIXED_NOREPLACE, UNSUPPORTED},
+        {MAP_GROWSDOWN, UNSUPPORTED},
+        {MAP_HUGETLB, UNSUPPORTED},
+        {MAP_HUGE_2MB, UNSUPPORTED},
+        {MAP_HUGE_1GB, UNSUPPORTED},
+        {MAP_LOCKED, UNSUPPORTED},
+        {MAP_NONBLOCK, IGNORED /* no special handling by OE */},
+        {MAP_NORESERVE, IGNORED /* no special handling by OE */},
+        {MAP_POPULATE, IGNORED /* no special handling by OE */},
+        {MAP_STACK, IGNORED /* currently no-op on Linux */},
+        {MAP_SYNC, IGNORED /* no special handling needed for OE */},
+        // MUSL doesn't defined MAP_UNINITIALIZED
+        // { MAP_UNINITIALIZED, SUPPORTED }
+    };
+
+    // Of the above flags, only MAP_FIXED is specified in POSIX.1-2001 and
+    // POSIX.1-2008.  However, most systems also support MAP_ANONYMOUS.
+
+    for (int i = 0; i < OE_COUNTOF(flags_table); ++i)
+    {
+        if (flags_copy & flags_table[i].flag)
+        {
+            if (flags_table[i].support == UNSUPPORTED)
+                OE_RAISE_MSG(
+                    OE_UNSUPPORTED,
+                    "unsupported `flag` value %d",
+                    flags_table[i].flag);
+
+            // Remove flag.
+            flags_copy &= ~flags_table[i].flag;
+        }
+    }
+
+    if (flags_copy)
+        OE_RAISE_MSG(OE_INVALID_PARAMETER, "invalid flag supplied");
+
+    // MAP_SHARED, MAP_SHARED_VALIDATE, MAP_PRIVATE are all treated the same
+    // since an enclave is a single process. Exactly one of them must be
+    // specified. They occupy the lower two bits of flags.
+    OE_STATIC_ASSERT(MAP_SHARED == 0x01);
+    OE_STATIC_ASSERT(MAP_PRIVATE == 0x02);
+    OE_STATIC_ASSERT(MAP_SHARED_VALIDATE == 0x03);
+
+    if (!(flags & 0x03))
+        OE_RAISE_MSG(
+            OE_INVALID_PARAMETER,
+            "`flags` must specify exactly one of MAP_SHARED or "
+            "MAP_SHARED_VALIDATE or MAP_PRIVATE");
+
+    if (flags & MAP_ANON || flags & MAP_ANONYMOUS)
+    {
+        // The fd argument is ignored; however, some implementations require fd
+        // to be -1 if MAP_ANONYMOUS (or MAP_ANON) is specified. The offset
+        // argument should be zero.
+        if (offset != 0)
+            OE_RAISE_MSG(
+                OE_INVALID_PARAMETER,
+                "offset` must be zero for anonymous mapping.");
+    }
+
+    result = OE_OK;
+done:
+    if (result != OE_OK)
+        oe_errno = OE_EINVAL;
+
+    return result;
+}
+
+// See https://www.man7.org/linux/man-pages/man2/mmap.2.html for
+// semantics of mmap and munmap.
+void* oe_mmap(
+    void* addr,
+    size_t length,
+    int prot,
+    int flags,
+    int fd,
+    off_t offset)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    void* ptr = NULL;
+    void* vector = NULL;
+    oe_mapping_t* m = NULL;
+    size_t vector_length = 0;
+    int ret = 0;
+
+    OE_CHECK(_validate_mmap_parameters(addr, length, prot, flags, fd, offset));
+
+    _register_atexit_callback();
+
+    // length is rounded up to nearest page size.
+    OE_CHECK(oe_safe_round_up_u64(length, OE_PAGE_SIZE, &length));
+    OE_CHECK(oe_safe_round_up_u64(length / 8, 8, &vector_length));
+
+    // Allocate objects.
+    vector = (uint8_t*)calloc(vector_length, 1);
+    m = (oe_mapping_t*)malloc(sizeof(*m));
+    if (!vector || !m)
+    {
+        oe_errno = OE_ENOMEM;
+        OE_RAISE(OE_OUT_OF_MEMORY);
+    }
+
+    if (((ret = posix_memalign(&ptr, OE_PAGE_SIZE, length)) != 0) || !m)
+    {
+        // posix_memalign does not set errno (by spec).
+        // Set it ourselves.
+        oe_errno = ret;
+        OE_RAISE_MSG(
+            OE_OUT_OF_MEMORY, "posix_memalign failed with code %d", ret);
+    }
+
+    // Set up mapping.
+    m->start = (uint64_t)ptr;
+    OE_CHECK(oe_safe_add_u64((uint64_t)m->start, length, (uint64_t*)&m->end));
+    m->status_vector = vector;
+    memset(ptr, 0, length);
+
+    // Set relevant bits of status vector to 1.
+    {
+        int bv_idx = 0;
+        uint8_t bit_mask = 0x01;
+        // Since m->end has been rounded to OE_PAGE_SIZE and been validated via
+        // oe_safe_add_u64, it is safe to add OE_PAGE_SIZE to `a` since it won't
+        // overflow.
+        for (uint64_t a = m->start; a < m->end; a += OE_PAGE_SIZE)
+        {
+            m->status_vector[bv_idx] |= bit_mask;
+            bit_mask <<= 1;
+            if (!bit_mask)
+            {
+                // Move to next byte in status vector.
+                ++bv_idx;
+                bit_mask = 0x01;
+            }
+        }
+    }
+
+    // Update mappings list.
+    oe_spin_lock(&_lock);
+    m->next = _mappings;
+    _mappings = m;
+    oe_spin_unlock(&_lock);
+
+    result = OE_OK;
+
+done:
+    if (result != OE_OK)
+    {
+        free(vector);
+        free(ptr);
+        free(m);
+        return MAP_FAILED;
+    }
+    return ptr;
+}
+
+static void _munmap(
+    oe_mapping_t* prev,
+    oe_mapping_t* m,
+    uint64_t start,
+    uint64_t end)
+{
+    while (m)
+    {
+        if (end <= m->start || start >= m->end)
+        {
+            // Specified address range does not intersect with current mapping.
+            prev = m;
+            m = m->next;
+            continue;
+        }
+
+        // Specified address range intersects with current mapping.
+
+        // Unmap part of address range that lies to the left of current mapping.
+        if (start < m->start)
+            _munmap(m, m->next, start, m->start);
+
+        // Unmap part of address range that lies to the right of current
+        // mapping.
+        if (end > m->end)
+            _munmap(m, m->next, m->end, end);
+
+        bool delete = true;
+        if (start > m->start || end < m->end)
+        {
+            // Partial unmapping.
+            uint8_t bit_mask = 1;
+            int bv_idx = 0;
+
+            // Mark all pages in given address range as unmapped.
+            for (uint64_t a = m->start; a < m->end; a += OE_PAGE_SIZE)
+            {
+                // If pages lies in the specified range, unset its status.
+                if (start <= a && a < end)
+                    m->status_vector[bv_idx] &= ~bit_mask;
+
+                bit_mask <<= 1;
+                if (!bit_mask)
+                {
+                    // Retain the mapping if any bit in the vector is set.
+                    delete = delete &&!m->status_vector[bv_idx];
+                    bit_mask = 1;
+                    bv_idx++;
+                }
+            }
+            delete = delete &&!m->status_vector[bv_idx];
+        }
+
+        if (delete)
+        {
+            if (prev)
+                prev->next = m->next;
+            else
+                _mappings = m->next;
+            free(m->status_vector);
+            free((void*)m->start);
+            free(m);
+        }
+
+        break;
+    }
+}
+
+int oe_munmap(void* addr, uint64_t length)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    uint64_t start = (uint64_t)addr;
+    uint64_t end = 0;
+    OE_CHECK(oe_safe_add_u64(start, length, &end));
+    OE_CHECK(oe_safe_round_up_u64(end, OE_PAGE_SIZE, &end));
+
+    if ((start % OE_PAGE_SIZE) != 0)
+    {
+        oe_errno = OE_EINVAL;
+        goto done;
+    }
+
+    oe_spin_lock(&_lock);
+    _munmap(NULL, _mappings, start, end);
+    oe_spin_unlock(&_lock);
+    oe_errno = 0;
+    result = OE_OK;
+done:
+    return (result == OE_OK) ? 0 : -1;
+}
+
+void* mmap(void* start, size_t len, int prot, int flags, int fd, off_t off)
+{
+    return (void*)__syscall(SYS_mmap, start, len, prot, flags, fd, off);
+}
+
+int munmap(void* start, size_t len)
+{
+    return (int)syscall(SYS_munmap, start, len);
+}
+
+// Needed for MUSL
+OE_WEAK_ALIAS(mmap, __mmap);
+OE_WEAK_ALIAS(mmap, mmap64);
+OE_WEAK_ALIAS(munmap, __munmap);
+
+// Utility function for tests.
+oe_mapping_t* oe_test_get_mappings(void)
+{
+    return _mappings;
+}

--- a/libc/mman.h
+++ b/libc/mman.h
@@ -1,0 +1,25 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <sys/mman.h>
+
+void* oe_mmap(
+    void* addr,
+    size_t length,
+    int prot,
+    int flags,
+    int fd,
+    off_t offset);
+
+int oe_munmap(void* addr, uint64_t length);
+
+typedef struct _mapping
+{
+    uint64_t start;
+    uint64_t end;
+    uint8_t* status_vector;
+    struct _mapping* next;
+} oe_mapping_t;
+
+oe_mapping_t* oe_test_get_mappings(void);

--- a/libc/syscalls.c
+++ b/libc/syscalls.c
@@ -23,6 +23,8 @@
 #include <sys/time.h>
 #include <time.h>
 
+#include "mman.h"
+
 static oe_syscall_hook_t _hook;
 static oe_spinlock_t _lock;
 
@@ -32,14 +34,20 @@ static const uint64_t _MSEC_TO_NSEC = 1000000UL;
 
 OE_WEAK OE_DEFINE_SYSCALL6(SYS_mmap)
 {
-    /* Always fail */
-    return EPERM;
+    void* addr = (void*)arg1;
+    size_t length = (size_t)arg2;
+    int prot = (int)arg3;
+    int flags = (int)arg4;
+    int fd = (int)arg5;
+    off_t offset = (off_t)arg6;
+    return (long)oe_mmap(addr, length, prot, flags, fd, offset);
 }
 
 OE_WEAK OE_DEFINE_SYSCALL2(SYS_munmap)
 {
-    /* Always fail */
-    return EPERM;
+    void* addr = (void*)arg1;
+    size_t length = (size_t)arg2;
+    return (long)oe_munmap(addr, length);
 }
 
 OE_WEAK OE_DEFINE_SYSCALL2(SYS_clock_gettime)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,6 +130,7 @@ if (UNIX
     add_subdirectory(libcxxrt)
     add_subdirectory(libunwind)
     add_subdirectory(mbed)
+    add_subdirectory(mman)
     add_subdirectory(module_loading)
     add_subdirectory(ocall-create)
     add_subdirectory(oeedger8r)

--- a/tests/mman/CMakeLists.txt
+++ b/tests/mman/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/mman mman_host mman_enc)

--- a/tests/mman/enc/CMakeLists.txt
+++ b/tests/mman/enc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../mman.edl)
+
+add_custom_command(
+  OUTPUT mman_t.h mman_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(
+  TARGET
+  mman_enc
+  UUID
+  71b0822f-42a3-4543-a97c-ca491f76b82c
+  SOURCES
+  enc.c
+  ${CMAKE_CURRENT_BINARY_DIR}/mman_t.c)
+
+enclave_include_directories(mman_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+enclave_link_libraries(mman_enc oelibc)

--- a/tests/mman/enc/enc.c
+++ b/tests/mman/enc/enc.c
@@ -1,0 +1,357 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <errno.h>
+#include <openenclave/internal/tests.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include "../../../libc/mman.h"
+#include "mman_t.h"
+#include "openenclave/bits/defs.h"
+
+const uint64_t chunk_size = 1024;
+
+static void _test_basic()
+{
+    // Test whether memory can be mmaped and unmapped.
+    uint8_t* ptr = (uint8_t*)mmap(
+        NULL,
+        chunk_size,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE,
+        -1,
+        0);
+    OE_TEST(ptr != MAP_FAILED);
+    OE_TEST(errno == 0);
+
+    // Test that memory is zeroed out.
+    for (uint64_t i = 0; i < chunk_size; ++i)
+        OE_TEST(ptr[i] == 0);
+
+    OE_TEST(munmap(ptr, chunk_size) == 0);
+    OE_TEST(errno == 0);
+    OE_TEST(oe_test_get_mappings() == NULL);
+}
+
+static void _test_partial_unmapping(void)
+{
+    uint64_t p1_length = 5 * OE_PAGE_SIZE;
+    uint64_t p1_start = (uint64_t)mmap(
+        NULL,
+        p1_length - 477,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE,
+        -1,
+        0);
+    uint64_t p1_end = p1_start + p1_length;
+
+    oe_mapping_t* m = oe_test_get_mappings();
+    OE_TEST(m->start == p1_start);
+    OE_TEST(m->end == p1_end);
+
+    uint64_t p2_length = 3 * OE_PAGE_SIZE;
+    uint64_t p2_start = (uint64_t)mmap(
+        NULL,
+        p2_length - 2048,
+        PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_PRIVATE,
+        -1,
+        0);
+    uint64_t p2_end = p2_start + p2_length;
+    m = oe_test_get_mappings();
+    OE_TEST(m->start == p2_start);
+    OE_TEST(m->end == p2_end);
+
+    // Swap p1 and p2 if p2 lies before p1.
+    if (p2_start < p1_start)
+    {
+        uint64_t t = p1_start;
+        p1_start = p2_start;
+        p2_start = t;
+
+        t = p1_end;
+        p1_end = p2_end;
+        p2_end = t;
+    }
+
+    // Do an unmap that starts within p1 and ends within p2.
+    uint64_t start = p1_end - OE_PAGE_SIZE;
+    uint64_t end = p2_end - OE_PAGE_SIZE;
+    OE_TEST(munmap((void*)start, end - start) == 0);
+    OE_TEST(errno == 0);
+
+    // Partial unmapping only changes the status vectors and not the bounds.
+    m = oe_test_get_mappings();
+    OE_TEST(m->start == p2_start);
+    OE_TEST(m->end == p2_end);
+    m = m->next;
+    OE_TEST(m->start == p1_start);
+    OE_TEST(m->end == p1_end);
+
+    // Do another partial unmap.
+    start -= OE_PAGE_SIZE;
+    OE_TEST(munmap((void*)start, end - start) == 0);
+    OE_TEST(errno == 0);
+    m = oe_test_get_mappings();
+    OE_TEST(m->start == p2_start);
+    OE_TEST(m->end == p2_end);
+    m = m->next;
+    OE_TEST(m->start == p1_start);
+    OE_TEST(m->end == p1_end);
+
+    // Do an unmap till the start.
+    // This ought to delete one mapping completely.
+    OE_TEST(munmap((void*)OE_PAGE_SIZE, start - OE_PAGE_SIZE) == 0);
+    OE_TEST(errno == 0);
+    m = oe_test_get_mappings();
+    OE_TEST(m->next == NULL);
+
+    // Do another unmapping that spans entire enclave memory.
+    // This ought to get rid of all mappings.
+    for (size_t i = 1; i < 20; ++i)
+    {
+        OE_TEST(
+            mmap(NULL, i * 1, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0) !=
+            MAP_FAILED);
+        OE_TEST(errno == 0);
+    }
+    OE_TEST(munmap(0, (1L << 62)) == 0);
+    OE_TEST(errno == 0);
+    OE_TEST(oe_test_get_mappings() == NULL);
+
+    // Test unmapping a mapping in small chunks.
+    start = (uint64_t)mmap(
+        NULL, 3 * OE_PAGE_SIZE, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    OE_TEST(oe_test_get_mappings() != NULL);
+
+    OE_TEST(munmap((void*)(start + OE_PAGE_SIZE), 1) == 0);
+    OE_TEST(oe_test_get_mappings() != NULL);
+    OE_TEST(munmap((void*)(start + 2 * OE_PAGE_SIZE), 1) == 0);
+    OE_TEST(oe_test_get_mappings() != NULL);
+    OE_TEST(munmap((void*)start, 1) == 0);
+    OE_TEST(oe_test_get_mappings() == NULL);
+}
+
+static void _test_mmap_params(void)
+{
+    // Non zero addr should fail.
+    OE_TEST(
+        mmap(
+            (void*)1,
+            chunk_size,
+            PROT_READ,
+            MAP_ANONYMOUS | MAP_PRIVATE,
+            -1,
+            0) == MAP_FAILED);
+    OE_TEST(errno == EINVAL);
+
+    // Zero length should fail.
+    OE_TEST(
+        mmap(NULL, 0, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0) ==
+        MAP_FAILED);
+    OE_TEST(errno == EINVAL);
+
+    // Large mmap should fail.
+    // Note: snmalloc crashes with a shift greater than 49.
+    OE_TEST(
+        mmap(NULL, (1L << 49), PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0) ==
+        MAP_FAILED);
+    OE_TEST(errno == ENOMEM);
+
+    OE_TEST(
+        mmap(NULL, (1L << 32), PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0) ==
+        MAP_FAILED);
+    OE_TEST(errno == ENOMEM);
+
+    // Test various prots.
+    OE_TEST(
+        mmap(NULL, chunk_size, 0, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0) ==
+        MAP_FAILED);
+    OE_TEST(errno == EINVAL);
+
+    OE_TEST(
+        mmap(NULL, chunk_size, PROT_EXEC, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0) ==
+        MAP_FAILED);
+    OE_TEST(errno == EINVAL);
+
+    errno = 0;
+    OE_TEST(
+        mmap(NULL, chunk_size, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0) !=
+        MAP_FAILED);
+    OE_TEST(errno == 0);
+
+    // Check that mmap of multiple of chunk size works.
+    OE_TEST(
+        mmap(
+            NULL,
+            5 * chunk_size,
+            PROT_WRITE,
+            MAP_ANONYMOUS | MAP_PRIVATE,
+            -1,
+            0) != MAP_FAILED);
+    OE_TEST(errno == 0);
+
+    OE_TEST(
+        mmap(
+            NULL,
+            chunk_size,
+            PROT_READ | PROT_WRITE,
+            MAP_ANONYMOUS | MAP_PRIVATE,
+            -1,
+            0) != MAP_FAILED);
+    OE_TEST(errno == 0);
+
+    // Test various flags.
+    OE_TEST(
+        mmap(NULL, chunk_size, PROT_READ | PROT_WRITE, 0, -1, 0) == MAP_FAILED);
+    OE_TEST(errno == EINVAL);
+
+    errno = 0;
+    // One of MAP_SHARED, MAP_SHARED_VALIDATE, MAP_PRIVATE must be used.
+    OE_TEST(
+        mmap(NULL, chunk_size, PROT_READ | PROT_WRITE, MAP_SHARED, -1, 0) !=
+        MAP_FAILED);
+    OE_TEST(errno == 0);
+
+    OE_TEST(
+        mmap(
+            NULL,
+            chunk_size,
+            PROT_READ | PROT_WRITE,
+            MAP_SHARED_VALIDATE,
+            -1,
+            0) != MAP_FAILED);
+    OE_TEST(errno == 0);
+
+    OE_TEST(
+        mmap(NULL, chunk_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, -1, 0) !=
+        MAP_FAILED);
+    OE_TEST(errno == 0);
+
+    OE_TEST(
+        mmap(NULL, chunk_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0) ==
+        MAP_FAILED);
+    OE_TEST(errno == EINVAL);
+
+    errno = 0;
+    // Test unsupported flags.
+    OE_TEST(
+        mmap(NULL, chunk_size, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0) !=
+        MAP_FAILED);
+    OE_TEST(errno == 0);
+
+    int unsupported[] = {
+#ifdef MAP_32BIT
+        MAP_32BIT,
+#endif
+        MAP_FIXED,
+        MAP_FIXED_NOREPLACE,
+        MAP_GROWSDOWN,
+        MAP_HUGETLB,
+        MAP_HUGE_2MB,
+        MAP_HUGE_1GB,
+        MAP_LOCKED};
+    for (size_t i = 0; i < OE_COUNTOF(unsupported); ++i)
+    {
+        errno = 0;
+        OE_TEST(
+            mmap(
+                NULL,
+                chunk_size,
+                PROT_READ,
+                unsupported[i] | MAP_PRIVATE,
+                0,
+                0) == MAP_FAILED);
+        OE_TEST(errno == EINVAL);
+    }
+
+    int ignored[] = {
+        MAP_DENYWRITE,
+        MAP_EXECUTABLE,
+        MAP_FILE,
+        MAP_NONBLOCK,
+        MAP_NORESERVE,
+        MAP_POPULATE,
+        MAP_STACK,
+        MAP_SYNC};
+    for (size_t i = 0; i < OE_COUNTOF(ignored); ++i)
+    {
+        errno = 0;
+        OE_TEST(
+            mmap(NULL, chunk_size, PROT_READ, ignored[i] | MAP_PRIVATE, 0, 0) !=
+            MAP_FAILED);
+        OE_TEST(errno == 0);
+    }
+
+    // fd is ignored.
+    OE_TEST(
+        mmap(NULL, chunk_size, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0) !=
+        MAP_FAILED);
+    OE_TEST(errno == 0);
+
+    OE_TEST(
+        mmap(
+            NULL,
+            chunk_size,
+            PROT_READ,
+            MAP_ANONYMOUS | MAP_PRIVATE,
+            1234,
+            0) != MAP_FAILED);
+    OE_TEST(errno == 0);
+
+    // offset must be zero.
+    OE_TEST(
+        mmap(NULL, chunk_size, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, 0, -1) ==
+        MAP_FAILED);
+    OE_TEST(errno == EINVAL);
+
+    OE_TEST(
+        mmap(NULL, chunk_size, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, 0, 1) ==
+        MAP_FAILED);
+    OE_TEST(errno == EINVAL);
+
+    // All the mapping ought to be autoamatically cleared during atexit.
+    // If that doens't happen, the test will fail due to memory leak.
+}
+
+static void _test_unmap_params(void)
+{
+    // Test various parameters for unmap.
+    void* ptrs[] = {
+        0,
+        (void*)OE_PAGE_SIZE, // It is valid to unmap pages that are not mapped.
+    };
+
+    uint64_t lengths[] = {0, 47, OE_PAGE_SIZE, 12345, (1L << 56)};
+
+    for (size_t i = 0; i < OE_COUNTOF(ptrs); ++i)
+    {
+        for (size_t j = 0; j < OE_COUNTOF(lengths); ++j)
+        {
+            errno = -1;
+            OE_TEST(munmap(ptrs[i], lengths[j]) == 0);
+            OE_TEST(errno == 0);
+        }
+    }
+
+    // addr must be multiple of page size.
+    OE_TEST(munmap((void*)chunk_size, OE_PAGE_SIZE) != 0);
+    OE_TEST(errno == EINVAL);
+}
+
+int enc_main()
+{
+    _test_basic();
+    _test_partial_unmapping();
+    _test_mmap_params();
+    _test_unmap_params();
+    return 0;
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/mman/host/CMakeLists.txt
+++ b/tests/mman/host/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../mman.edl)
+
+add_custom_command(
+  OUTPUT mman_u.h mman_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(mman_host host.c mman_u.c)
+
+target_include_directories(mman_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(mman_host oehost)

--- a/tests/mman/host/host.c
+++ b/tests/mman/host/host.c
@@ -1,0 +1,41 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include "mman_u.h"
+
+int main(int argc, char** argv)
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+    int return_val = 0;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    if ((result = oe_create_mman_enclave(
+             argv[1], OE_ENCLAVE_TYPE_AUTO, flags, NULL, 0, &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    result = enc_main(enclave, &return_val);
+
+    if (result != OE_OK)
+        oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+    if (return_val != 0)
+        oe_put_err("ECALL failed args.result=%d", return_val);
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (mman)\n");
+
+    return 0;
+}

--- a/tests/mman/mman.edl
+++ b/tests/mman/mman.edl
@@ -1,0 +1,16 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public int enc_main();
+    };
+};


### PR DESCRIPTION
mmap and munmap are implemented to support their most common
use: to allocate and deallocate memory.

mmap works atop OE's memory allocator (dlmalloc/snmalloc) and
thus can leverage the allocator's performance.

A future PR will implement MAP_FIXED which supports mapping files.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>