### PR TITLE
Add missing MUSL search, string, stdlib functions.

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -274,9 +274,9 @@ add_enclave_library(
   ${MUSLSRC}/locale/uselocale.c
   ${MUSLSRC}/locale/wcscoll.c
   ${MUSLSRC}/locale/wcsxfrm.c
-  ${MUSLSRC}/linux/getrandom.c
   ${MUSLSRC}/linux/epoll.c
   ${MUSLSRC}/linux/flock.c
+  ${MUSLSRC}/linux/getrandom.c
   ${MUSLSRC}/linux/mount.c
   ${MUSLSRC}/linux/sysinfo.c
   ${MUSLSRC}/math/__math_divzero.c
@@ -600,15 +600,18 @@ add_enclave_library(
   ${MUSLSRC}/search/lsearch.c
   ${MUSLSRC}/select/select.c
   ${MUSLSRC}/select/poll.c
-  ${MUSLSRC}/stat/mkdir.c
+  ${MUSLSRC}/search/hsearch.c
+  ${MUSLSRC}/search/insque.c
+  ${MUSLSRC}/search/lsearch.c
   ${MUSLSRC}/search/tdelete.c
+  ${MUSLSRC}/search/tdestroy.c
   ${MUSLSRC}/search/tfind.c
   ${MUSLSRC}/search/tsearch.c
   ${MUSLSRC}/search/twalk.c
   ${MUSLSRC}/stat/fstat.c
   ${MUSLSRC}/stat/fstatat.c
+  ${MUSLSRC}/stat/mkdir.c
   ${MUSLSRC}/stat/stat.c
-  ${MUSLSRC}/stdio/asprintf.c
   ${MUSLSRC}/stdio/asprintf.c
   ${MUSLSRC}/stdio/clearerr.c
   ${MUSLSRC}/stdio/dprintf.c
@@ -690,7 +693,6 @@ add_enclave_library(
   ${MUSLSRC}/stdio/sscanf.c
   ${MUSLSRC}/stdio/stderr.c
   ${MUSLSRC}/stdio/stdin.c
-  ${MUSLSRC}/stdio/tmpfile.c
   ${MUSLSRC}/stdio/__stdio_close.c
   ${MUSLSRC}/stdio/__stdio_exit.c
   ${MUSLSRC}/stdio/__stdio_read.c
@@ -700,6 +702,8 @@ add_enclave_library(
   ${MUSLSRC}/stdio/__stdout_write.c
   ${MUSLSRC}/stdio/swprintf.c
   ${MUSLSRC}/stdio/swscanf.c
+  ${MUSLSRC}/stdio/tempnam.c
+  ${MUSLSRC}/stdio/tmpfile.c
   ${MUSLSRC}/stdio/__toread.c
   ${MUSLSRC}/stdio/__towrite.c
   ${MUSLSRC}/stdio/__uflow.c
@@ -729,6 +733,9 @@ add_enclave_library(
   ${MUSLSRC}/stdlib/atoll.c
   ${MUSLSRC}/stdlib/bsearch.c
   ${MUSLSRC}/stdlib/div.c
+  ${MUSLSRC}/stdlib/ecvt.c
+  ${MUSLSRC}/stdlib/fcvt.c
+  ${MUSLSRC}/stdlib/gcvt.c
   ${MUSLSRC}/stdlib/imaxabs.c
   ${MUSLSRC}/stdlib/imaxdiv.c
   ${MUSLSRC}/stdlib/labs.c
@@ -743,6 +750,7 @@ add_enclave_library(
   ${MUSLSRC}/string/bcmp.c
   ${MUSLSRC}/string/bcopy.c
   ${MUSLSRC}/string/bzero.c
+  ${MUSLSRC}/string/explicit_bzero.c
   ${MUSLSRC}/string/index.c
   ${MUSLSRC}/string/memccpy.c
   ${MUSLSRC}/string/memchr.c
@@ -775,6 +783,7 @@ add_enclave_library(
   ${MUSLSRC}/string/strpbrk.c
   ${MUSLSRC}/string/strrchr.c
   ${MUSLSRC}/string/strsep.c
+  ${MUSLSRC}/string/strsignal.c
   ${MUSLSRC}/string/strspn.c
   ${MUSLSRC}/string/strstr.c
   ${MUSLSRC}/string/strtok.c

--- a/tests/libc/tests.cmake
+++ b/tests/libc/tests.cmake
@@ -27,6 +27,7 @@ set(LIBC_TESTS
     3rdparty/musl/libc-test/src/functional/memstream.c
     3rdparty/musl/libc-test/src/functional/qsort.c
     3rdparty/musl/libc-test/src/functional/random.c
+    3rdparty/musl/libc-test/src/functional/search_hsearch.c
     3rdparty/musl/libc-test/src/functional/search_insque.c
     3rdparty/musl/libc-test/src/functional/search_lsearch.c
     3rdparty/musl/libc-test/src/functional/search_tsearch.c
@@ -315,7 +316,6 @@ if (FALSE)
     3rdparty/musl/libc-test/src/functional/pthread_mutex.c
     3rdparty/musl/libc-test/src/functional/pthread_robust.c
     3rdparty/musl/libc-test/src/functional/pthread_tsd.c
-    3rdparty/musl/libc-test/src/functional/search_hsearch.c
     3rdparty/musl/libc-test/src/functional/sem_init.c
     3rdparty/musl/libc-test/src/functional/sem_open.c
     3rdparty/musl/libc-test/src/functional/setjmp.c

--- a/tests/memory/enc/basic.c
+++ b/tests/memory/enc/basic.c
@@ -5,6 +5,7 @@
 #include <openenclave/internal/globals.h>
 #include <openenclave/internal/tests.h>
 
+#include <errno.h>
 #include <malloc.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -23,47 +24,62 @@ static void _check_buffer(int* buf, size_t start, size_t end)
         OE_TEST(buf[i] == (int)i);
 }
 
+#define LARGE_N (1L << 32)
+
 void test_malloc(void)
 {
     /* malloc(0) is implementation defined, but we can always free it. */
+    errno = -1;
     int* ptr = (int*)malloc(0);
+    OE_TEST(errno == 0);
     free(ptr);
 
     /* Basic malloc test. */
     ptr = (int*)malloc(256 * sizeof(int));
     OE_TEST(ptr != NULL);
+    OE_TEST(errno == 0);
     _set_buffer(ptr, 0, 256);
     _check_buffer(ptr, 0, 256);
     free(ptr);
 
     /* Ensure that malloc fails. */
-    ptr = (int*)malloc(~((size_t)0));
+    errno = 0;
+    ptr = (int*)malloc(LARGE_N);
     OE_TEST(ptr == NULL);
+    OE_TEST(errno == ENOMEM);
 }
 
 void test_calloc(void)
 {
     /* calloc with 0 is implementation defined, but we can always free it. */
+    errno = -1;
     int* ptr = (int*)calloc(0, 0);
+    OE_TEST(errno == 0);
     free(ptr);
 
     /* Basic calloc test. */
+    errno = -1;
     ptr = (int*)calloc(256, sizeof(int));
     OE_TEST(ptr != NULL);
+    OE_TEST(errno == 0);
     for (int i = 0; i < 256; i++)
         OE_TEST(ptr[i] == 0);
     free(ptr);
 
     /* Ensure that calloc fails. */
-    ptr = (int*)calloc(1, ~((size_t)0));
+    errno = 0;
+    ptr = (int*)calloc(1, LARGE_N);
     OE_TEST(ptr == NULL);
+    OE_TEST(errno == ENOMEM);
 }
 
 void test_realloc(void)
 {
     /* Realloc with null pointer works like malloc. */
+    errno = -1;
     int* ptr = (int*)realloc(NULL, 256 * sizeof(int));
     OE_TEST(ptr != NULL);
+    OE_TEST(errno == 0);
     _set_buffer(ptr, 0, 256);
     _check_buffer(ptr, 0, 256);
 
@@ -76,8 +92,10 @@ void test_realloc(void)
 
     /* Realloc to expand pointer. Ensure that the values up to the original
      * size are not changed. */
+    errno = -1;
     ptr = (int*)realloc(ptr, 1024 * sizeof(int));
     OE_TEST(ptr != NULL);
+    OE_TEST(errno == 0);
     _check_buffer(ptr, 0, 256);
     _set_buffer(ptr, 256, 1024);
     _check_buffer(ptr, 0, 1024);
@@ -98,11 +116,13 @@ void test_realloc(void)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Walloc-size-larger-than="
 #endif
-    void* ptr2 = realloc(ptr, ~((size_t)0));
+    errno = 0;
+    void* ptr2 = realloc(ptr, LARGE_N);
 #if __GNUC__ >= 7
 #pragma GCC diagnostic pop
 #endif
     OE_TEST(ptr2 == NULL);
+    OE_TEST(errno == ENOMEM);
 
     /* realloc(X, 0) is implementation defined, but we can always free it. */
     free(ptr);
@@ -113,27 +133,45 @@ void test_realloc(void)
 void test_memalign(void)
 {
     /* Get an aligned pointer below malloc's alignment. */
+    errno = -1;
     int* ptr = (int*)memalign(8, 256 * sizeof(int));
     OE_TEST(ptr != NULL);
+    OE_TEST(errno == 0);
     OE_TEST((uintptr_t)ptr % 8 == 0);
     _set_buffer(ptr, 0, 256);
     _check_buffer(ptr, 0, 256);
     free(ptr);
 
     /* Get an aligned pointer beyond malloc's alignment. */
+    errno = -1;
     ptr = (int*)memalign(64, 256 * sizeof(int));
     OE_TEST(ptr != NULL);
+    OE_TEST(errno == 0);
     OE_TEST((uintptr_t)ptr % 64 == 0);
     _set_buffer(ptr, 0, 256);
     _check_buffer(ptr, 0, 256);
     free(ptr);
 
     /* Should fail if out of memory. */
-    size_t max = ((size_t)1) << 63;
-    OE_TEST(memalign(64, max) == NULL);
+    errno = 0;
+    OE_TEST(memalign(64, LARGE_N) == NULL);
+    OE_TEST(errno == ENOMEM);
 
-    /* Should fail if alignment isn't possible. */
-    OE_TEST(memalign(max, 64) == NULL);
+    /* Should fail if alignment isn't a power of two. */
+    errno = 0;
+    OE_TEST(memalign(15, 64) == NULL);
+    OE_TEST(errno == EINVAL);
+
+    /* Should NOT fail if alignment isn't a multiple of sizeof(void*). */
+    errno = EINVAL;
+    OE_TEST((ptr = memalign(4, 64)) != NULL);
+    OE_TEST(errno == 0);
+    free(ptr);
+
+    /* Should NOT fail if size isn't a multiple of alignment. */
+    errno = EINVAL;
+    OE_TEST((ptr = memalign(16, 63)) != NULL);
+    OE_TEST(errno == 0);
 }
 
 void test_posix_memalign(void)
@@ -155,19 +193,17 @@ void test_posix_memalign(void)
     _set_buffer((int*)ptr, 0, 256);
     _check_buffer((int*)ptr, 0, 256);
     free(ptr);
+    ptr = 0;
 
     /* Should fail if alignment isn't a power of 2 or a multiple of
      * sizeof(void*). */
-    OE_TEST(posix_memalign(&ptr, 0, 256 * sizeof(int)) != 0);
-    OE_TEST(posix_memalign(&ptr, 2, 256 * sizeof(int)) != 0);
-    OE_TEST(posix_memalign(&ptr, 63, 256 * sizeof(int)) != 0);
+    OE_TEST(posix_memalign(&ptr, 0, 256 * sizeof(int)) == EINVAL);
+    OE_TEST(posix_memalign(&ptr, 2, 256 * sizeof(int)) == EINVAL);
+    OE_TEST(posix_memalign(&ptr, 63, 256 * sizeof(int)) == EINVAL);
 
     /* Should fail if out of memory. */
     size_t max = ((size_t)1) << 63;
-    OE_TEST(posix_memalign(&ptr, 64, max) != 0);
-
-    /* Should fail if alignment isn't possible. */
-    OE_TEST(posix_memalign(&ptr, max, 64) != 0);
+    OE_TEST(posix_memalign(&ptr, 64, max) == ENOMEM);
 }
 
 void test_malloc_usable_size(void)

--- a/tests/openssl/enc/CMakeLists.txt
+++ b/tests/openssl/enc/CMakeLists.txt
@@ -39,6 +39,7 @@ enclave_include_directories(openssl-support PRIVATE ${OPENSSL_DIR}/include
 # definition errors due to the way test_cleanup.c is written.
 add_enclave_library(openssl-common OBJECT enc.c
                     ${CMAKE_CURRENT_BINARY_DIR}/openssl_t.c)
+add_enclave_dependencies(openssl-common openssl_generated)
 
 enclave_link_libraries(openssl-common PRIVATE oelibc oe_includes)
 enclave_include_directories(

--- a/tests/report/enc/CMakeLists.txt
+++ b/tests/report/enc/CMakeLists.txt
@@ -24,4 +24,4 @@ add_enclave(
 enclave_include_directories(report_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                             ${CMAKE_CURRENT_SOURCE_DIR}/../common)
 
-enclave_link_libraries(report_enc oelibc)
+enclave_link_libraries(report_enc oelibcxx oelibc)


### PR DESCRIPTION
Also fix bugs in malloc/debug-malloc implementations
- errno was not being set correctly in all cases.
- oe_posix_memalign could end up making a recursive call to itself with debug malloc turned on.

Also fix missing dependencies of report_enc and openssl-common targets.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>