### PR TITLE
Gracefully error out upon libsgx_enclave_common.so.1 load failure.

### DIFF
--- a/host/sgx/sgx_enclave_common_wrapper.c
+++ b/host/sgx/sgx_enclave_common_wrapper.c
@@ -150,18 +150,15 @@ static void _load_sgx_enclave_common_impl(void)
     }
     else
     {
-        OE_TRACE_ERROR("Failed to load %s\n", LIBRARY_NAME);
+        OE_TRACE_ERROR(
+            "Failed to load %s. Cannot create SGX enclaves. Try simulation "
+            "mode instead.\n",
+            LIBRARY_NAME);
         goto done;
     }
 
 done:
-    if (result != OE_OK)
-    {
-        // It is a catastrophic error if sgx_enclave_common library cannot be
-        // successfully loaded.
-        OE_TRACE_ERROR("Terminating host application.");
-        abort();
-    }
+    return;
 }
 
 static bool _load_sgx_enclave_common(void)
@@ -169,6 +166,11 @@ static bool _load_sgx_enclave_common(void)
     static oe_once_type _once;
     oe_once(&_once, _load_sgx_enclave_common_impl);
     return (_module != NULL);
+}
+
+oe_result_t oe_sgx_load_sgx_enclave_common(void)
+{
+    return _load_sgx_enclave_common() ? OE_OK : OE_FAILURE;
 }
 
 void* oe_sgx_enclave_create(

--- a/host/sgx/sgx_enclave_common_wrapper.h
+++ b/host/sgx/sgx_enclave_common_wrapper.h
@@ -76,4 +76,6 @@ bool oe_sgx_enclave_set_information(
     size_t input_info_size,
     uint32_t* enclave_error);
 
+oe_result_t oe_sgx_load_sgx_enclave_common(void);
+
 #endif //  _OE_HOST_SGX_ENCLAVE_COMMON_WRAPPER_H

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -427,6 +427,8 @@ oe_result_t oe_sgx_create_enclave(
     }
     else
     {
+        OE_CHECK(oe_sgx_load_sgx_enclave_common());
+
         uint32_t enclave_error = 0;
         image_base = oe_sgx_enclave_create_ex(
             start_address,


### PR DESCRIPTION
This can happen if the user fails to specify SIMULATE flag when
creating enclaves on a non-sgx machine.

fixes #4174 

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>