### PR TITLE
Fix eeid_plugin test failure with USE_SNMALLOC=on

### DIFF
--- a/tests/eeid_plugin/test_helpers.c
+++ b/tests/eeid_plugin/test_helpers.c
@@ -24,7 +24,8 @@ oe_result_t make_test_eeid(oe_eeid_t** eeid, size_t data_size)
     for (size_t i = 0; i < data_size; i++)
         (*eeid)->data[i] = (uint8_t)('a' + (i % 26));
     (*eeid)->data[data_size - 1] = 0;
-    (*eeid)->size_settings.num_heap_pages = 120 + (data_size / OE_PAGE_SIZE);
+    // snmalloc needs atleast 512 pages for this test.
+    (*eeid)->size_settings.num_heap_pages = 512 + (data_size / OE_PAGE_SIZE);
     (*eeid)->size_settings.num_stack_pages = 50;
     (*eeid)->size_settings.num_tcs = 2;
     (*eeid)->tls_page_count = 1;


### PR DESCRIPTION
Bump up the number of heap pages to 512.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>