### PR TITLE
Fix build issues with latest Visual Studio 2019

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -122,7 +122,10 @@ elseif (MSVC)
   # so this behavior can be removed if/when cmake_minimum_required is raised to 3.15.
   # ======= Default compiler flags for cmake version 3.12 can be found here: =======
   # https://github.com/Kitware/CMake/blob/v3.12.0/Modules/Platform/Windows-MSVC.cmake
-  set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS")
+  # With std:c11, the preprocessor in latest MSVC is more standards compliant and emits
+  # warnings in winbase.h. As recommended by the warning, /Wv:18 is added to suppress
+  # it.
+  set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /Wv:18")
   set(CMAKE_C_FLAGS_DEBUG "/MDd /Zi /Ob0 /Od /RTC1")
   set(CMAKE_C_FLAGS_RELEASE "/MD /O2 /Ob2 /DNDEBUG")
 

--- a/scripts/clangw
+++ b/scripts/clangw
@@ -48,6 +48,7 @@ function call_clang {
         [ "$a" == "/W3" ]           && continue
         [ "$a" == "/W4" ]           && continue
         [ "$a" == "/WX" ]           && continue
+        [ "$a" == "/Wv:18" ]        && continue
 
         # Ignore warnings for specific error codes
         if [[ "$a" =~ /[wW][dD][0-9]* ]]; then

--- a/tests/abi/host/host.cpp
+++ b/tests/abi/host/host.cpp
@@ -3,12 +3,12 @@
 
 #include <host/ecall_ids.h>
 #include <host/hostthread.h>
+#include <math.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/tests.h>
-#include <cmath>
 #include "../abi_utils.h"
 #include "abi_u.h"
 
@@ -239,7 +239,7 @@ void test_mmx_abi_poison(oe_enclave_t* enclave)
     OE_TEST(enclave_add_float(enclave, &float_result) == OE_OK);
 
     printf("x87 FPU result = %f\n", float_result);
-    OE_TEST(!std::isnan(float_result));
+    OE_TEST(!isnan(float_result));
 }
 
 void test_fpu_stack_overflow(oe_enclave_t* enclave)
@@ -266,7 +266,7 @@ void test_fpu_stack_overflow(oe_enclave_t* enclave)
     OE_TEST(enclave_add_float(enclave, &float_result) == OE_OK);
 
     printf("x87 FPU result = %f\n", float_result);
-    OE_TEST(!std::isnan(float_result));
+    OE_TEST(!isnan(float_result));
 }
 
 int main(int argc, const char* argv[])


### PR DESCRIPTION
- clangw, compiler_settings.cmake
  When -std:11 is specified, MSVC's preprocessor
  generates a warning when winbase.h (via Windows.h) is included.
  This warning being treated as error results in build failure.
  Add /Wv:18 option to the compiler as recommended by the warning
  message.
- tests/abi/host/hotst.cpp
  This file is compiled using clang. Since cmath
  errors out saying clang 11 is needed, use math.h
  instead.

fixed #3734 

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>