### PR TITLE
Support compiler-rt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ graphviz/
 build/
 winbuild/
 
+3rdparty/compiler-rt/compiler-rt
 3rdparty/libcxx/libcxx
 
 devex/cross-nuget/linux/build

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -7,6 +7,7 @@
 # details.
 set(LIBCXX_INCLUDES ${OE_INCDIR}/openenclave/libcxx)
 
+add_subdirectory(compiler-rt)
 add_subdirectory(dlmalloc)
 add_subdirectory(libcxx)
 add_subdirectory(libcxxrt)

--- a/3rdparty/compiler-rt/CMakeLists.txt
+++ b/3rdparty/compiler-rt/CMakeLists.txt
@@ -1,0 +1,248 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+include(FetchContent)
+FetchContent_Declare(
+  compiler-rt-sources
+  SOURCE_DIR
+  ${CMAKE_CURRENT_SOURCE_DIR}/compiler-rt
+  URL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/compiler-rt-10.0.1.src.tar.xz
+  URL_HASH
+    SHA256=d90dc8e121ca0271f0fd3d639d135bfaa4b6ed41e67bd6eb77808f72629658fa)
+
+FetchContent_GetProperties(compiler-rt-sources)
+if (NOT compiler-rt-sources_POPULATED)
+  FetchContent_Populate(compiler-rt-sources)
+endif ()
+
+set(COMPILER_RT_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/compiler-rt/lib/builtins/")
+
+# List based on compiler-rt/lib/builtins/CMakeLists.txt
+set(GENERIC_SOURCES
+    absvdi2.c
+    absvsi2.c
+    absvti2.c
+    adddf3.c
+    addsf3.c
+    addtf3.c
+    addvdi3.c
+    addvsi3.c
+    addvti3.c
+    ashldi3.c
+    ashlti3.c
+    ashrdi3.c
+    ashrti3.c
+    bswapdi2.c
+    bswapsi2.c
+    clzdi2.c
+    clzsi2.c
+    clzti2.c
+    cmpdi2.c
+    cmpti2.c
+    comparedf2.c
+    comparesf2.c
+    ctzdi2.c
+    ctzsi2.c
+    ctzti2.c
+    divdc3.c
+    divdf3.c
+    divdi3.c
+    divmoddi4.c
+    divmodsi4.c
+    divsc3.c
+    divsf3.c
+    divsi3.c
+    divtc3.c
+    divti3.c
+    divtf3.c
+    extendsfdf2.c
+    extendhfsf2.c
+    ffsdi2.c
+    ffssi2.c
+    ffsti2.c
+    fixdfdi.c
+    fixdfsi.c
+    fixdfti.c
+    fixsfdi.c
+    fixsfsi.c
+    fixsfti.c
+    fixunsdfdi.c
+    fixunsdfsi.c
+    fixunsdfti.c
+    fixunssfdi.c
+    fixunssfsi.c
+    fixunssfti.c
+    floatdidf.c
+    floatdisf.c
+    floatsidf.c
+    floatsisf.c
+    floattidf.c
+    floattisf.c
+    floatundidf.c
+    floatundisf.c
+    floatunsidf.c
+    floatunsisf.c
+    floatuntidf.c
+    floatuntisf.c
+    fp_mode.c
+    int_util.c
+    lshrdi3.c
+    lshrti3.c
+    moddi3.c
+    modsi3.c
+    modti3.c
+    muldc3.c
+    muldf3.c
+    muldi3.c
+    mulodi4.c
+    mulosi4.c
+    muloti4.c
+    mulsc3.c
+    mulsf3.c
+    multi3.c
+    multf3.c
+    mulvdi3.c
+    mulvsi3.c
+    mulvti3.c
+    negdf2.c
+    negdi2.c
+    negsf2.c
+    negti2.c
+    negvdi2.c
+    negvsi2.c
+    negvti2.c
+    os_version_check.c
+    paritydi2.c
+    paritysi2.c
+    parityti2.c
+    popcountdi2.c
+    popcountsi2.c
+    popcountti2.c
+    powidf2.c
+    powisf2.c
+    powitf2.c
+    subdf3.c
+    subsf3.c
+    subvdi3.c
+    subvsi3.c
+    subvti3.c
+    subtf3.c
+    trampoline_setup.c
+    truncdfhf2.c
+    truncdfsf2.c
+    truncsfhf2.c
+    ucmpdi2.c
+    ucmpti2.c
+    udivdi3.c
+    udivmoddi4.c
+    udivmodsi4.c
+    udivmodti4.c
+    udivsi3.c
+    udivti3.c
+    umoddi3.c
+    umodsi3.c
+    umodti3.c)
+
+set(GENERIC_TF_SOURCES
+    comparetf2.c
+    extenddftf2.c
+    extendsftf2.c
+    fixtfdi.c
+    fixtfsi.c
+    fixtfti.c
+    fixunstfdi.c
+    fixunstfsi.c
+    fixunstfti.c
+    floatditf.c
+    floatsitf.c
+    floattitf.c
+    floatunditf.c
+    floatunsitf.c
+    floatuntitf.c
+    multc3.c
+    trunctfdf2.c
+    trunctfsf2.c)
+
+# The following is commented out since OE uses a different unwinder and defines
+# a void* personality.
+# set(GENERIC_SOURCES ${GENERIC_SOURCES} gcc_personality_v0.c)
+# Make unwind.h available.
+# set_source_files_properties(${COMPILER_RT_SRC_DIR}/gcc_personality_v0.c
+#  PROPERTIES
+#   COMPILE_FLAGS "-I ${PROJECT_SOURCE_DIR}/3rdparty/libunwind/libunwind/include")
+
+set(GENERIC_SOURCES ${GENERIC_SOURCES} clear_cache.c)
+
+set(x86_ARCH_SOURCES
+    cpu_model.c
+    divxc3.c
+    fixxfdi.c
+    fixxfti.c
+    fixunsxfdi.c
+    fixunsxfsi.c
+    fixunsxfti.c
+    floatdixf.c
+    floattixf.c
+    floatundixf.c
+    floatuntixf.c
+    mulxc3.c
+    powixf2.c)
+
+set(x86_64_SOURCES
+    x86_64/floatdidf.c x86_64/floatdisf.c x86_64/floatdixf.c
+    x86_64/floatundidf.S x86_64/floatundisf.S x86_64/floatundixf.S)
+
+set(x86_64_SOURCES ${GENERIC_TF_SOURCES} ${GENERIC_SOURCES} ${x86_64_SOURCES}
+                   ${x86_ARCH_SOURCES})
+
+set(aarch64_SOURCES ${GENERIC_TF_SOURCES} ${GENERIC_SOURCES} aarch64/fp_mode.c)
+
+if (OE_SGX)
+  set(SOURCES ${x86_64_SOURCES})
+else ()
+  set(SOURCES ${aarch64_SOURCES})
+endif ()
+
+list(TRANSFORM SOURCES PREPEND "${COMPILER_RT_SRC_DIR}")
+
+add_enclave_library(oecompiler-rt OBJECT ${SOURCES})
+
+maybe_build_using_clangw(oecompiler-rt)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR USE_CLANGW)
+  enclave_compile_options(
+    oecompiler-rt
+    PRIVATE
+    -Wno-sign-conversion
+    -Wno-unused-parameter
+    -Wno-implicit-int-float-conversion
+    -Wno-shorten-64-to-32
+    -Wno-float-conversion
+    -Wno-implicit-int-conversion
+    -fno-stack-protector
+    -std=c11
+    -nostdinc
+    -fpic)
+else ()
+  enclave_compile_options(
+    oecompiler-rt
+    PRIVATE
+    -Wno-conversion
+    -Wno-builtin-declaration-mismatch
+    -Wno-unused-parameter
+    -fno-stack-protector
+    -std=c11
+    -nostdinc
+    -fpic)
+endif ()
+
+enclave_link_libraries(oecompiler-rt PRIVATE oelibc_includes)
+
+install_enclaves(
+  TARGETS
+  oecompiler-rt
+  EXPORT
+  openenclave-targets
+  ARCHIVE
+  DESTINATION
+  ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This enables applications to adopt NullPointerException/ NullReferenceException in their program logic and/or use other application stacks that do (Example, .NET runtime).
   - Developers can create an 0-base enclave by setting the oesign tool configuration option 'CreateZeroBaseEnclave' to 1 or by passing in argument CREATE_ZERO_BASE_ENCLAVE=1 in OE_SET_ENCLAVE_SGX2().
   - If the 0-base enclave creation is chosen, enclave image start address should be provided by setting the oesign tool configuration option 'StartAddress' or pass in the argument ENCLAVE_START_ADDRESS in OE_SET_ENCLAVE_SGX2().
+- Support for `compiler-rt`. `oelibc` includes LLVM's `compiler-rt-10.0.1`.
 
 ## Changed
 - Updated libcxx to version 10.0.1

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -989,6 +989,7 @@ enclave_link_libraries(
   oesyscall
   oecore
   oelibc_includes
+  oecompiler-rt
   PRIVATE
   oelibasm)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -173,6 +173,7 @@ if (UNIX
   endif ()
 
   add_subdirectory(c99_compliant)
+  add_subdirectory(compiler_rt)
   add_subdirectory(create-errors)
   add_subdirectory(crypto)
   add_subdirectory(data_types)

--- a/tests/compiler_rt/CMakeLists.txt
+++ b/tests/compiler_rt/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/compiler_rt compiler_rt_host compiler_rt_enc)

--- a/tests/compiler_rt/compiler_rt.edl
+++ b/tests/compiler_rt/compiler_rt.edl
@@ -1,0 +1,17 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public int enc_test();
+    };
+
+};

--- a/tests/compiler_rt/enc/CMakeLists.txt
+++ b/tests/compiler_rt/enc/CMakeLists.txt
@@ -1,0 +1,104 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../compiler_rt.edl)
+
+add_custom_command(
+  OUTPUT compiler_rt_t.h compiler_rt_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Fetch all the unit test files from LLVM's test suite.
+# The list of files will rarely change during development. It will change when
+# compiler-rt is upgraded. Therefore, it is OK to use GLOB to gather the list.
+file(GLOB TEST_FILES
+     "../../../3rdparty/compiler-rt/compiler-rt/test/builtins/Unit/*.c"
+     "../../../3rdparty/compiler-rt/compiler-rt/test/builtins/Unit/*.cxx")
+
+# List of tests that work within enclaves. Most do.
+set(SUPPORTED_TESTS "")
+
+# The following tests don't work withn enclaves since they rely on
+# functionality that OE doesn't support. E.g: executable stack.
+set(IGNORE_LIST "clear_cache_test" "cpu_model_test" "gcc_personality_test"
+                "gcc_personality_test_helper" "enable_execute_stack_test")
+
+if (OE_TRUSTZONE)
+  # The following functions are not available in AARCH64.
+  list(APPEND IGNORE_LIST "divxc3_test" "mulxc3_test" "powixf2_test")
+endif ()
+
+set(PROTOTYPES "")
+set(CALLS "")
+
+foreach (TEST IN LISTS TEST_FILES)
+  get_filename_component(NAME "${TEST}" NAME_WE)
+  get_filename_component(EXT "${TEST}" EXT)
+
+  # Check whether the test needs to be ignored.
+  list(FIND IGNORE_LIST ${NAME} FOUND)
+  if (${FOUND} GREATER "-1")
+    continue()
+  endif ()
+
+  # When compiling each test file,
+  #   - rename main to ${NAME}_main. This function will be called from
+  #     generated test.c.
+  #   - Prefix ${NAME} to identifiers that are also used in other test files.
+  set_source_files_properties(
+    ${TEST}
+    PROPERTIES
+      COMPILE_FLAGS
+      "-Dmain=${NAME}_main -Dassumption_1=${NAME}_assumption_1 \
+    -Dassumption_2=${NAME}_assumption_2 -Dassumption_3=${NAME}_assumption_3 \
+    -Dclassify=${NAME}_classify -Dx=${NAME}_x -Dcases=${NAME}_cases \
+    -Dtests=${NAME}_tests -Dnaive_popcount=${NAME}_naive_popcount \
+    -Dnaive_parity=${NAME}_naive_parity")
+
+  # Add test to list of supported tests.
+  list(APPEND SUPPORTED_TESTS ${TEST})
+
+  string(APPEND CALLS "    OE_TEST(${NAME}_main() == 0);\n\n")
+  if (${EXT} STREQUAL ".c")
+    string(APPEND PROTOTYPES "extern \"C\" int ${NAME}_main(void);\n")
+  else ()
+    string(APPEND PROTOTYPES "int ${NAME}_main();\n")
+  endif ()
+endforeach ()
+
+# Emit a file test.c that calls each individual test.
+set(TEST_CPP "${CMAKE_CURRENT_BINARY_DIR}/test.cpp")
+file(WRITE "${TEST_CPP}" "#include <openenclave/enclave.h>\n")
+file(APPEND "${TEST_CPP}" "#include <openenclave/internal/tests.h>\n\n")
+
+# Emit prototypes
+file(APPEND "${TEST_CPP}" "${PROTOTYPES}")
+file(APPEND "${TEST_CPP}" "extern \"C\" void run_tests()\n{\n\n")
+file(APPEND "${TEST_CPP}" "${CALLS}")
+
+# Close test.cpp.
+file(APPEND "${TEST_CPP}" "}\n\n")
+file(APPEND "${TEST_CPP}"
+     "extern \"C\" int enc_test() { run_tests(); return 0; }")
+
+add_enclave(
+  TARGET
+  compiler_rt_enc
+  UUID
+  d0a1a92a-cfc5-4563-b9d4-57cf526a839d
+  SOURCES
+  enc.c
+  test.cpp
+  ${SUPPORTED_TESTS}
+  ${CMAKE_CURRENT_BINARY_DIR}/compiler_rt_t.c)
+
+enclave_include_directories(
+  compiler_rt_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+  "${PROJECT_SOURCE_DIR}/3rdparty/compiler-rt/compiler-rt/lib/builtins")
+
+maybe_build_using_clangw(compiler_rt_enc)
+
+enclave_compile_options(compiler_rt_enc PRIVATE -Wno-error)
+enclave_link_libraries(compiler_rt_enc oelibcxx oelibc)

--- a/tests/compiler_rt/enc/enc.c
+++ b/tests/compiler_rt/enc/enc.c
@@ -1,0 +1,51 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <math.h>
+#include "compiler_rt_t.h"
+
+#if __aarch64__
+
+/* Workaround: sqrtl is not implemented by MUSL for AARCH64. */
+long double sqrtl(long double v)
+{
+    return sqrt((double)v);
+}
+
+/* Workaround: 3rdparty/optee/optee_os/lib/libutee/tee_api_operations.c
+   defines rand. This causes multiple definition error since oelibc includes
+   3rdparty/musl/musl/src/prng/rand.c.
+   As a workaround, define a WEAK implementation of rand here which will be
+   picked up by the linker over oelibc implementation, and later overridden
+   by libutee implementation.
+ */
+OE_WEAK int rand(void)
+{
+    return 0;
+}
+
+#endif
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */
+
+#define TA_UUID                                            \
+    { /* d0a1a92a-cfc5-4563-b9d4-57cf526a839d */           \
+        0xd0a1a92a, 0xcfc5, 0x4563,                        \
+        {                                                  \
+            0xb9, 0xd4, 0x57, 0xcf, 0x52, 0x6a, 0x83, 0x9d \
+        }                                                  \
+    }
+
+OE_SET_ENCLAVE_OPTEE(
+    TA_UUID,
+    1 * 1024 * 1024,
+    12 * 1024,
+    0,
+    "1.0.0",
+    "compiler-rt test")

--- a/tests/compiler_rt/host/CMakeLists.txt
+++ b/tests/compiler_rt/host/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../compiler_rt.edl)
+
+add_custom_command(
+  OUTPUT compiler_rt_u.h compiler_rt_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(compiler_rt_host host.c compiler_rt_u.c)
+
+target_include_directories(compiler_rt_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(compiler_rt_host oehost)

--- a/tests/compiler_rt/host/host.c
+++ b/tests/compiler_rt/host/host.c
@@ -1,0 +1,43 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+
+#include "compiler_rt_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+    int return_val = -1;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    if ((result = oe_create_compiler_rt_enclave(
+             argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    result = enc_test(enclave, &return_val);
+
+    if (result != OE_OK)
+        oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+    if (return_val != 0)
+        oe_put_err("ECALL failed args.result=%d", return_val);
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (compiler_rt)\n");
+
+    return 0;
+}


### PR DESCRIPTION
The object library is included in oelibc.
Use the compiler-rt sources published in a separate archive as part of LLVM 10.0.1 release.

fixes #1766 

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>