### PR TITLE
Update the driver link to the most recent version for Ubuntu 20.04

### DIFF
--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_20.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_20.04.md
@@ -37,7 +37,7 @@ If the output of the above is blank, you should proceed with installing the driv
 ```bash
 sudo apt update
 sudo apt -y install dkms
-wget https://download.01.org/intel-sgx/sgx-dcap/1.9/linux/distro/ubuntu20.04-server/sgx_linux_x64_driver_1.36.2.bin -O sgx_linux_x64_driver.bin
+wget https://download.01.org/intel-sgx/sgx-linux/2.13.3/linux/distro/ubuntu20.04-server/sgx_linux_x64_driver_1.41.bin -O sgx_linux_x64_driver.bin
 chmod +x sgx_linux_x64_driver.bin
 sudo ./sgx_linux_x64_driver.bin
 ```


### PR DESCRIPTION
Update the driver link to the most recent version (1.41). This is required for kernel 5.8 or later on Ubuntu 20.04.
Signed-off-by: Carlos Bilbao <bilbao@vt.edu>