### PR TITLE
Check existence of built-in SGX driver

### DIFF
--- a/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
@@ -8,19 +8,27 @@
 - name: Populate service facts
   service_facts:
 
-- name: Load default driver
-  modprobe:
-    name: intel_sgx
-    state: present
+- name: Include distribution vars
+  include_vars:
+    file: "{{ ansible_distribution | lower }}/main.yml"
+
+- name: Check default driver files
+  stat:
+    path: "{{ item }}"
+  loop: "{{ intel_dcap_driver_files }}"
   ignore_errors: yes
-  register: intel_sgx_module
+  register: intel_sgx_driver
+
+- name: Trigger driver installation based on file existence
+  set_fact:
+    intel_sgx_driver_exists: yes
+  loop: "{{ intel_sgx_driver.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: item.stat.exists
 
 - name: install driver
   block:
-
-  - name: Include distribution vars
-    include_vars:
-      file: "{{ ansible_distribution | lower }}/main.yml"
 
   - name: Include distribution release specific vars
     include_vars:
@@ -75,7 +83,8 @@
       state: present
       line: SGX_AESM_ADDR=1
 
-  when: intel_sgx_module is failed
+  when: intel_sgx_driver_exists is undefined or
+        not intel_sgx_driver_exists
 
 - name: Ensure aesmd service running
   service:

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
@@ -2,6 +2,12 @@
 # Licensed under the MIT License.
 
 ---
+intel_dcap_driver_files:
+  - "/dev/sgx/provision"
+  - "/dev/sgx/enclave"
+  - "/dev/sgx_provision"
+  - "/dev/sgx_enclave"
+
 intel_sgx_packages:
   - "libsgx-enclave-common"
   - "libsgx-ae-qve"


### PR DESCRIPTION
Kernel 5.11 of Ubuntu 20.04 will have Intel SGX driver built-in instead of a kernel module. This change is to preserve functionality of the Ansible role in the new kernel version.

This new method is not as reliable as a check as calling modprobe, since if any of the driver files exist in their expected paths, then it will consider the driver already installed. However, as far as I know, there is no straightforward way of checking for driver functionality/version when the SGX driver is built into the kernel.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>