### PR TITLE
Never set errno to zero in malloc and related functions

### DIFF
--- a/enclave/core/debugmalloc.c
+++ b/enclave/core/debugmalloc.c
@@ -496,8 +496,6 @@ void* oe_malloc(size_t size)
         if (_failure_callback)
             _failure_callback(__FILE__, __LINE__, __FUNCTION__, size);
     }
-    else
-        oe_errno = 0;
 
     return p;
 }
@@ -537,8 +535,6 @@ done:
         if (_failure_callback)
             _failure_callback(__FILE__, __LINE__, __FUNCTION__, nmemb * size);
     }
-    else
-        oe_errno = 0;
 
     return p;
 }
@@ -561,8 +557,6 @@ void* oe_realloc(void* ptr, size_t size)
         if (_failure_callback)
             _failure_callback(__FILE__, __LINE__, __FUNCTION__, size);
     }
-    else
-        oe_errno = 0;
 
     return p;
 }
@@ -577,7 +571,9 @@ void* oe_memalign(size_t alignment, size_t size)
     {
         if (alignment < sizeof(void*))
             alignment = sizeof(void*);
-        oe_errno = oe_posix_memalign(&ptr, alignment, size);
+        int r = oe_posix_memalign(&ptr, alignment, size);
+        if (r)
+            oe_errno = r;
     }
 
     return ptr;

--- a/enclave/core/malloc.c
+++ b/enclave/core/malloc.c
@@ -29,8 +29,6 @@ void* oe_malloc(size_t size)
         if (_failure_callback)
             _failure_callback(__FILE__, __LINE__, __FUNCTION__, size);
     }
-    else
-        oe_errno = 0;
 
     return p;
 }
@@ -50,8 +48,6 @@ void* oe_calloc(size_t nmemb, size_t size)
         if (_failure_callback)
             _failure_callback(__FILE__, __LINE__, __FUNCTION__, nmemb * size);
     }
-    else
-        oe_errno = 0;
 
     return p;
 }
@@ -66,8 +62,6 @@ void* oe_realloc(void* ptr, size_t size)
         if (_failure_callback)
             _failure_callback(__FILE__, __LINE__, __FUNCTION__, size);
     }
-    else
-        oe_errno = 0;
 
     return p;
 }
@@ -82,7 +76,9 @@ void* oe_memalign(size_t alignment, size_t size)
     {
         if (alignment < sizeof(void*))
             alignment = sizeof(void*);
-        oe_errno = oe_posix_memalign(&ptr, alignment, size);
+        int r = oe_posix_memalign(&ptr, alignment, size);
+        if (r)
+            oe_errno = r;
     }
 
     return ptr;

--- a/tests/memory/enc/basic.c
+++ b/tests/memory/enc/basic.c
@@ -29,7 +29,7 @@ static void _check_buffer(int* buf, size_t start, size_t end)
 void test_malloc(void)
 {
     /* malloc(0) is implementation defined, but we can always free it. */
-    errno = -1;
+    errno = 0;
     int* ptr = (int*)malloc(0);
     OE_TEST(errno == 0);
     free(ptr);
@@ -43,7 +43,6 @@ void test_malloc(void)
     free(ptr);
 
     /* Ensure that malloc fails. */
-    errno = 0;
     ptr = (int*)malloc(LARGE_N);
     OE_TEST(ptr == NULL);
     OE_TEST(errno == ENOMEM);
@@ -52,13 +51,12 @@ void test_malloc(void)
 void test_calloc(void)
 {
     /* calloc with 0 is implementation defined, but we can always free it. */
-    errno = -1;
+    errno = 0;
     int* ptr = (int*)calloc(0, 0);
     OE_TEST(errno == 0);
     free(ptr);
 
     /* Basic calloc test. */
-    errno = -1;
     ptr = (int*)calloc(256, sizeof(int));
     OE_TEST(ptr != NULL);
     OE_TEST(errno == 0);
@@ -67,7 +65,6 @@ void test_calloc(void)
     free(ptr);
 
     /* Ensure that calloc fails. */
-    errno = 0;
     ptr = (int*)calloc(1, LARGE_N);
     OE_TEST(ptr == NULL);
     OE_TEST(errno == ENOMEM);
@@ -76,7 +73,7 @@ void test_calloc(void)
 void test_realloc(void)
 {
     /* Realloc with null pointer works like malloc. */
-    errno = -1;
+    errno = 0;
     int* ptr = (int*)realloc(NULL, 256 * sizeof(int));
     OE_TEST(ptr != NULL);
     OE_TEST(errno == 0);
@@ -92,7 +89,6 @@ void test_realloc(void)
 
     /* Realloc to expand pointer. Ensure that the values up to the original
      * size are not changed. */
-    errno = -1;
     ptr = (int*)realloc(ptr, 1024 * sizeof(int));
     OE_TEST(ptr != NULL);
     OE_TEST(errno == 0);
@@ -133,7 +129,7 @@ void test_realloc(void)
 void test_memalign(void)
 {
     /* Get an aligned pointer below malloc's alignment. */
-    errno = -1;
+    errno = 0;
     int* ptr = (int*)memalign(8, 256 * sizeof(int));
     OE_TEST(ptr != NULL);
     OE_TEST(errno == 0);
@@ -143,7 +139,6 @@ void test_memalign(void)
     free(ptr);
 
     /* Get an aligned pointer beyond malloc's alignment. */
-    errno = -1;
     ptr = (int*)memalign(64, 256 * sizeof(int));
     OE_TEST(ptr != NULL);
     OE_TEST(errno == 0);
@@ -163,13 +158,13 @@ void test_memalign(void)
     OE_TEST(errno == EINVAL);
 
     /* Should NOT fail if alignment isn't a multiple of sizeof(void*). */
-    errno = EINVAL;
+    errno = 0;
     OE_TEST((ptr = memalign(4, 64)) != NULL);
     OE_TEST(errno == 0);
     free(ptr);
 
     /* Should NOT fail if size isn't a multiple of alignment. */
-    errno = EINVAL;
+    errno = 0;
     OE_TEST((ptr = memalign(16, 63)) != NULL);
     OE_TEST(errno == 0);
 }


### PR DESCRIPTION
According to Linux man pages,
"The value of errno is never set to zero by any system call or library function"

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>