### PR TITLE
Runtime option to switch SGX DCAP QPL path

### DIFF
--- a/3rdparty/sgxsdk/include/sgx_dcap_ql_wrapper.h
+++ b/3rdparty/sgxsdk/include/sgx_dcap_ql_wrapper.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/**
+ * File: sgx_dcap_ql_wrapper.h
+ *
+ * Description: Definitions and prototypes for SGX's quote library for
+ * use in the DCAP SDK.
+ *
+ */
+#ifndef _SGX_DCAP_QL_WRAPPER_H_
+#define _SGX_DCAP_QL_WRAPPER_H_
+
+#include "sgx_pce.h"
+#include "sgx_ql_lib_common.h"
+#include "sgx_report.h"
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+    quote3_error_t sgx_qe_set_enclave_load_policy(
+        sgx_ql_request_policy_t policy);
+
+    quote3_error_t sgx_qe_get_target_info(sgx_target_info_t* p_qe_target_info);
+
+    quote3_error_t sgx_qe_get_quote_size(uint32_t* p_quote_size);
+
+    quote3_error_t sgx_qe_get_quote(
+        const sgx_report_t* p_app_report,
+        uint32_t quote_size,
+        uint8_t* p_quote);
+
+    quote3_error_t sgx_qe_cleanup_by_policy();
+
+#ifndef _MSC_VER
+    typedef enum
+    {
+        SGX_QL_QE3_PATH,
+        SGX_QL_PCE_PATH,
+        SGX_QL_QPL_PATH
+    } sgx_ql_path_type_t;
+    quote3_error_t sgx_ql_set_path(
+        sgx_ql_path_type_t path_type,
+        const char* p_path);
+#endif
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !_SGX_DCAP_QL_WRAPPER_H_ */

--- a/3rdparty/sgxsdk/update.make
+++ b/3rdparty/sgxsdk/update.make
@@ -25,5 +25,6 @@ update-sgxsdk-headers:
 	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteGeneration/quote_wrapper/common/inc/sgx_ql_lib_common.h )
 	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteGeneration/pce_wrapper/inc/sgx_pce.h )
 	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteGeneration/quote_wrapper/common/inc/sgx_ql_quote.h )
+	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteGeneration/quote_wrapper/ql/inc/sgx_dcap_ql_wrapper.h )
 	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteVerification/QvE/Include/sgx_qve_header.h )
 	( cd include; wget https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/$(DCAP_VERSION)/QuoteVerification/dcap_quoteverify/inc/sgx_dcap_quoteverify.h )

--- a/docs/DesignDocs/SGX_QuoteEx_Integration.md
+++ b/docs/DesignDocs/SGX_QuoteEx_Integration.md
@@ -232,6 +232,26 @@ The proposal is to implement option 1. With runtime detection and loading of
 both the SGX DCAP and quote-ex libraries, it's possible for the OE SDK to be
 built on a non-SGX platform.
 
+### Locating the SGX DCAP and quote-ex Libraries
+
+* To load QL (`libsgx-dcap-ql`), the dynamic loader must be able to locate
+  `libsgx_dcap_ql.so` or `sgx_dcap_ql.dll`.
+
+* To load quote-ex library (`libsgx-quote-ex`), the dynamic loader must be able
+  to locate `libsgx_quote_ex.so.1` or `sgx_quote_ex.dll`.
+
+* To load QPL, the dynamic loader must be able to locate at least one QPL.
+  * There can be several QPL implementations. For instance in Ubuntu 18.04,
+    * Azure QPL (`az-dcap-client`) can be installed at
+      `/usr/lib/libdcap_quoteprov.so`
+    * Intel QPL (`libsgx-dcap-default-qpl`) can be installed at
+      `/usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1`
+  * QPL loading path depends on the environment variable `OE_SGX_DCAP_QPL`.
+    * If `OE_SGX_DCAP_QPL` is not defined, the dynamic loader must be able to
+      locate `libdcap_quoteprov.so` or `dcap_quoteprov.dll`.
+    * If `OE_SGX_DCAP_QPL` is defined, the value is used as absolute path to
+      the QPL library.
+
 ### Support of SGX Evidence Formats Enumeration
 
 The SGX plugin code file `enclave/sgx/attester.c` implements the OE SDK API

--- a/host/sgx/linux/sgxquoteproviderloader.c
+++ b/host/sgx/linux/sgxquoteproviderloader.c
@@ -22,9 +22,14 @@ void oe_load_quote_provider()
 {
     if (provider.handle == 0)
     {
-        OE_TRACE_INFO("oe_load_quote_provider libdcap_quoteprov.so\n");
-        provider.handle =
-            dlopen("libdcap_quoteprov.so", RTLD_LAZY | RTLD_LOCAL);
+        const char* qpl_path = getenv("OE_SGX_DCAP_QPL");
+        if (qpl_path == NULL)
+        {
+            qpl_path = "libdcap_quoteprov.so";
+        }
+
+        OE_TRACE_INFO("oe_load_quote_provider %s\n", qpl_path);
+        provider.handle = dlopen(qpl_path, RTLD_NOW | RTLD_LOCAL);
         if (provider.handle != 0)
         {
             sgx_ql_set_logging_function_t set_log_fcn =
@@ -77,8 +82,7 @@ void oe_load_quote_provider()
         }
         else
         {
-            OE_TRACE_ERROR(
-                "sgxquoteprovider: libdcap_quoteprov.so %s\n", dlerror());
+            OE_TRACE_ERROR("sgxquoteprovider: %s %s\n", qpl_path, dlerror());
         }
     }
 }


### PR DESCRIPTION
This patch provides a clean way to switch between multiple SGX DCAP QPL (Quote Provider Library) paths at runtime via environment variable. For example, following command will explicitly select `az-dcap-client` as the QPL.

```bash
OE_SGX_DCAP_QPL=/usr/lib/libdcap_quoteprov.so oeutil generate-evidence -f SGX_ECDSA 
```

With this feature, I can

- Build a docker image with both QPLs installed and allow user to choose one.
- Allow non-root user to switch QPL since there is no need to create symlinks under `/usr`.

This PR is related to [https://github.com/openenclave/openenclave/issues/3650](https://github.com/openenclave/openenclave/issues/3650) and [https://github.com/intel/SGXDataCenterAttestationPrimitives/issues/168](https://github.com/intel/SGXDataCenterAttestationPrimitives/issues/168)

## Why change

Dealing with multiple QPL installations in one machine involves error-prone symlink creation.

Suppose we installed two QPLs in an Ubuntu 18.04 machine:

- Azure QPL (`az-dcap-client`) at `/usr/lib/libdcap_quoteprov.so`
- Intel QPL (`libsgx-dcap-default-qpl`). at `/usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1`

Running `oeutil` reveals that in two places QPLs are loaded. Note that oeutil and libsgx_qe3_logic load different files.

```bash
$ ltrace -e dlopen oeutil generate-evidence -f SGX_ECDSA
NOTICE: oeutil generate-evidence is purely a debugging utility and not suitable for production use.

oeutil->dlopen("libdcap_quoteprov.so", 1)                                              = 0x25382e0
oeutil->dlopen("libsgx_enclave_common.so.1", 258)                                      = 0x257dae0
oeutil->dlopen("libsgx_dcap_ql.so", 258)                                               = 0x25787f0
libsgx_qe3_logic.so->dlopen("libdcap_quoteprov.so.1", 1)                               = 0x25382e0
libsgx_qe3_logic.so->dlopen("libdcap_quoteprov.so.1", 1)                               = 0x25382e0
....
```

- OE loads "libdcap_quoteprov.so" (https://github.com/openenclave/openenclave/blob/master/host/sgx/linux/sgxquoteproviderloader.c)
- libsgx_qe3_logic.so uses following loading order (https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/DCAP_1.11/QuoteGeneration/quote_wrapper/quote/qe_logic.cpp#L263)
    - path specified by `sgx_set_qpl_path()`
    - "libdcap_quoteprov.so.1"
    - "libdcap_quoteprov.so"

To choose one of them, we should resort to renaming existing files and creating symlinks. For instance, https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md describes a way to choosing Intel QPL when both are installed.

## What are changed

If `OE_SGX_DCAP_QPL` environment variable is nonempty,

1. `oe_load_quote_provider()` will load that path. This controls what OE loads.
2. `_load_sgx_dcap_ql_impl()` will call the QL's `sgx_ql_set_path()`, which in turn calls the QE3's `sgx_set_qpl_path()`. 

After patch, you can see that absolute QPL paths are used. 

```bash
$ OE_SGX_DCAP_QPL=/usr/lib/libdcap_quoteprov.so  ltrace -e dlopen oeutil generate-evidence -f SGX_ECDSA
NOTICE: oeutil generate-evidence is purely a debugging utility and not suitable for production use.

oeutil->dlopen("/usr/lib/libdcap_quoteprov.so", 2)            = 0xa462e0
oeutil->dlopen("libsgx_enclave_common.so.1", 258)             = 0xa96ab0
oeutil->dlopen("libsgx_dcap_ql.so", 258)                      = 0xa87050
libsgx_qe3_logic.so->dlopen("/usr/lib/libdcap_quoteprov.so", 1) = 0xa462e0
libsgx_qe3_logic.so->dlopen("/usr/lib/libdcap_quoteprov.so", 1) = 0xa462e0
```
