### PR TITLE
update oesign README.md; removed -z, -s options from oesign sign

### DIFF
--- a/tools/oesign/README.md
+++ b/tools/oesign/README.md
@@ -9,35 +9,52 @@ All enclave images should be signed before they are used in production.
 To understand the full CLI of this tool, please refer to the `usage` printout below:
 
 ```
-Usage: ./output/bin/oesign sign {--enclave-image | -e} ENCLAVE_IMAGE {--config-file | -c} CONFIG_FILE {--key-file | -k} KEY_FILE
-
+Usage: output/bin/oesign sign -e ENCLAVE_IMAGE [-c CONFIG_FILE] [SIGN_OPTIONS...]
 Where:
     ENCLAVE_IMAGE -- path of an enclave image file
     CONFIG_FILE -- configuration file containing enclave properties
-    KEY_FILE -- private key file used to digitally sign the image
 
 Description:
-    This utility (1) injects runtime properties into an enclave image and
-    (2) digitally signs that image.
+    This command (1) injects runtime properties into an enclave image
+    and (2) digitally signs that image.
 
     The properties are read from the CONFIG_FILE. They override any
-    properties that were already defined inside the enclave image through
-    use of the OE_SET_ENCLAVE_SGX macro. These properties include:
+    properties that were already defined inside the enclave image
+    through use of OE_SET_ENCLAVE_SGX or OE_SET_ENCLAVE_SGX2 macros.
+    If a property is not explicitly set, the default values override
+    the definitions set by SET_OE_ENCLAVE_SGX(2) macros.
+    These properties include:
 
-        Debug - whether enclave debug mode should be enabled (1) or not (0)
+        Debug - whether debug mode should be enabled (1) or not (0) in enclave
+        (default: 0)
         ProductID - the product identified number
         SecurityVersion - the security version number
         NumHeapPages - the number of heap pages for this enclave
         NumStackPages - the number of stack pages for this enclave
         NumTCS - the number of thread control structures for this enclave
+        ExtendedProductID - a 128-bit globally unique identifier for the
+        enclave if the 16-bit ProductID proves too restrictive  (SGX2 feature)
+        FamilyID - product family identity to group different enclaves
+        under a common identity (SGX2 feature)
+        CapturePFGPExceptions - whether in-enclave exception handler should
+        be enabled (1) or not (0) to capture #PF and #GP exceptions
+        (SGX2 feature, default: 0)
+        CreateZeroBaseEnclave - whether the enclave creation should be
+        enabled (1) or not (0) with base address 0x0 (default: 0).
+        StartAddress -  the enclave image address when CreateZeroBaseEnclave=1.
+        The value should be a power of two and greater than
+        /proc/sys/vm/mmap_min_addr
+
+    NOTE: If neither ExtendedProductID nor FamilyID is set, Key Separation
+    and Sharing (KSS) is disabled by default.
 
     The configuration file contains simple NAME=VALUE entries. For example:
 
         Debug=1
         NumHeapPages=1024
 
-    The key is read from KEY_FILE and contains a private RSA key in PEM
-    format. The keyfile must contain the following header.
+    If specified, the key read from KEY_FILE and contains a private RSA key in PEM
+    format. The keyfile must contain the following header:
 
         -----BEGIN RSA PRIVATE KEY-----
 


### PR DESCRIPTION
Updated oesign tool's README and usage text to include new additions. Listed defaults for the fields.
Removed the --zero-base/-z and --start-address/-s command line options - seemed unnecessary.

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>