### PR TITLE
Jenkins Shared Library, and tests for releases and release candidates

### DIFF
--- a/.jenkins/library/vars/common.groovy
+++ b/.jenkins/library/vars/common.groovy
@@ -1,0 +1,235 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/************************************
+* Shared Library for common functions
+************************************/
+
+String dockerBuildArgs(String... args) {
+    String argumentString = ""
+    for(arg in args) {
+        argumentString += " --build-arg ${arg}"
+    }
+    return argumentString
+}
+
+String dockerImage(String tag, String dockerfile = ".jenkins/Dockerfile", String buildArgs = "") {
+    return docker.build(tag, "${buildArgs} -f ${dockerfile} .")
+}
+
+def ContainerRun(String imageName, String compiler, String task, String runArgs="", registryUrl="https://oejenkinscidockerregistry.azurecr.io", registryName="oejenkinscidockerregistry") {
+    exec_with_retry(10,300){
+        docker.withRegistry(registryUrl, registryName) {
+            def image = docker.image(imageName)
+            image.pull()
+            image.inside(runArgs) {
+                dir("${WORKSPACE}/build") {
+                    Run(compiler, task)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Runs tasks within a Docker container
+ *
+ * @param imageName     The name of the Docker image to run.
+ * @param compiler      The compiler to use, if applicable.
+ * @param tasks         List of tasks to run within the Docker container. Must be in Jenkins groovy syntax.
+ * @param runArgs       [Optional] Arguments to pass when calling Docker run
+ * @param registryUrl   [Optional] Url of the Docker registry to pull from. Defaults to "https://oejenkinscidockerregistry.azurecr.io"
+ * @param registryName  [Optional] Name of the Docker registry to pull from. Defaults to "oejenkinscidockerregistry"
+ */
+def ContainerTasks(String imageName, String compiler, List tasks, String runArgs="", registryUrl="https://oejenkinscidockerregistry.azurecr.io", registryName="oejenkinscidockerregistry") {
+    exec_with_retry(3,300){
+        docker.withRegistry(registryUrl, registryName) {
+            def image = docker.image(imageName)
+            image.pull()
+            image.inside(runArgs) {
+                for (task in tasks) {
+                    task
+                }
+            }
+        }
+    }
+}
+
+def azureEnvironment(String task, String imageName = "oetools-deploy:latest") {
+    withCredentials([usernamePassword(credentialsId: 'SERVICE_PRINCIPAL_OSTCLAB',
+                                      passwordVariable: 'SERVICE_PRINCIPAL_PASSWORD',
+                                      usernameVariable: 'SERVICE_PRINCIPAL_ID'),
+                     string(credentialsId: 'OSCTLabSubID', variable: 'SUBSCRIPTION_ID'),
+                     string(credentialsId: 'TenantID', variable: 'TENANT_ID')]) {
+        docker.withRegistry("https://oejenkinscidockerregistry.azurecr.io", "oejenkinscidockerregistry") {
+            def image = docker.image("oetools-deploy:latest")
+            image.pull()
+            image.inside {
+                sh """#!/usr/bin/env bash
+                      set -o errexit
+                      set -o pipefail
+                      source /etc/profile
+                      ${task}
+                   """
+            }
+        }
+    }
+}
+
+def runTask(String task) {
+    dir("${WORKSPACE}/build") {
+        sh """#!/usr/bin/env bash
+                set -o errexit
+                set -o pipefail
+                source /etc/profile
+                ${task}
+            """
+    }
+}
+
+def Run(String compiler, String task, String compiler_version = "") {
+    def c_compiler
+    def cpp_compiler
+
+    compiler_components = compiler.split("-")
+    if (compiler_components[0] == "clang" && compiler_components.size() > 1) {
+        compiler = "clang"
+        compiler_version = compiler_components[1]
+    }
+
+    switch(compiler) {
+        case "cross":
+            // In this case, the compiler is set by the CMake toolchain file. As
+            // such, it is not necessary to specify anything in the environment.
+            runTask(task)
+            return
+        case "clang":
+            c_compiler = "clang"
+            cpp_compiler = "clang++"
+            break
+        case "clang-7":
+            c_compiler = "clang"
+            cpp_compiler = "clang++"
+            compiler_version = "7"
+            break
+        case "gcc":
+            c_compiler = "gcc"
+            cpp_compiler = "g++"
+            break
+        default:
+            // This is needed for backwards compatibility with the old
+            // implementation of the method.
+            c_compiler = "clang"
+            cpp_compiler = "clang++"
+            compiler_version = "8"
+    }
+    if (compiler_version) {
+        c_compiler += "-${compiler_version}"
+        cpp_compiler += "-${compiler_version}"
+    }
+    withEnv(["CC=${c_compiler}","CXX=${cpp_compiler}"]) {
+        runTask(task);
+    }
+}
+
+def deleteRG(List resourceGroups, String imageName = "oetools-deploy:latest") {
+    stage("Delete ${resourceGroups.toString()} resource groups") {
+        resourceGroups.each { rg ->
+            withEnv(["RESOURCE_GROUP=${rg}"]) {
+                dir("${WORKSPACE}/.jenkins/provision") {
+                    azureEnvironment("./cleanup.sh", imageName)
+                }
+            }
+        }
+    }
+}
+
+def emailJobStatus(String status) {
+    emailext (
+      to: '$DEFAULT_RECIPIENTS',      
+      subject: "[Jenkins Job ${status}] ${env.JOB_NAME} - ${env.BUILD_NUMBER}",
+      body: """            
+            <p>               
+            For additional logging details for this job please check: 
+            <a href="${env.BUILD_URL}">${env.JOB_NAME} - ${env.BUILD_NUMBER}</a>
+            </p>
+            """,
+      recipientProviders: [[$class: 'DevelopersRecipientProvider'], [$class: 'RequesterRecipientProvider']],
+      mimeType: 'text/html'     
+    )
+}
+
+/**
+ * Compile open-enclave on Windows platform, generate NuGet package out of it, 
+ * install the generated NuGet package, and run samples tests against the installation.
+ */
+def WinCompilePackageTest(String dirName, String buildType, String hasQuoteProvider, Integer timeoutSeconds, String lviMitigation = 'None', String lviMitigationSkipTests = 'ON', List extra_cmake_args = []) {
+    cleanWs()
+    checkout scm
+    dir(dirName) {
+        /*
+        In simulation mode, some samples should not be ran or should run simulation mode. 
+        For items that should be skipped, see items appended to SAMPLES_LIST under the IF statement with OE_SIMULATION in:
+        https://github.com/openenclave/openenclave/blob/master/samples/test-samples.cmake#L54
+        For items that should run in simulation mode, check sample Makefiles for target `simulate`
+        SIMULATION_SKIP is a "list" of samples to skip in simulation mode.
+        SIMULATION_TEST is a "list" of samples to run in simulation mode.
+        */
+        bat(
+            returnStdout: false,
+            returnStatus: false,
+            script: """
+                call vcvars64.bat x64
+                setlocal EnableDelayedExpansion
+                cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${buildType} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=${hasQuoteProvider} -DLVI_MITIGATION=${lviMitigation} -DLVI_MITIGATION_SKIP_TESTS=${lviMitigationSkipTests} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -DCPACK_GENERATOR=NuGet -Wdev ${extra_cmake_args.join(' ')} || exit !ERRORLEVEL!
+                ninja.exe || exit !ERRORLEVEL!
+                ctest.exe -V -C ${buildType} --timeout ${timeoutSeconds} || exit !ERRORLEVEL!
+                cpack.exe -D CPACK_NUGET_COMPONENT_INSTALL=ON -DCPACK_COMPONENTS_ALL=OEHOSTVERIFY || exit !ERRORLEVEL!
+                cpack.exe || exit !ERRORLEVEL!
+                if exist C:\\oe rmdir /s/q C:\\oe
+                nuget.exe install open-enclave -Source %cd% -OutputDirectory C:\\oe -ExcludeVersion
+                set CMAKE_PREFIX_PATH=C:\\oe\\open-enclave\\openenclave\\lib\\openenclave\\cmake
+                set SIMULATION_SKIP="\\attested_tls\\attestation\\"
+                set SIMULATION_TEST="\\debugmalloc\\helloworld\\switchless\\log_callback\\file-encryptor\\pluggable_allocator\\"
+                cd C:\\oe\\open-enclave\\openenclave\\share\\openenclave\\samples
+                for /d %%i in (*) do (
+                    set BUILD=1
+                    if ${OE_SIMULATION} equ 1 if "!SIMULATION_SKIP:%%~nxi=!" neq "%SIMULATION_SKIP%" set BUILD=
+                    if !BUILD! equ 1 (
+                        cd C:\\oe\\open-enclave\\openenclave\\share\\openenclave\\samples\\"%%i"
+                        mkdir build
+                        cd build
+                        cmake .. -G Ninja -DNUGET_PACKAGE_PATH=C:\\oe_prereqs -DLVI_MITIGATION=${lviMitigation} || exit !ERRORLEVEL!
+                        ninja || exit !ERRORLEVEL!
+                        if ${OE_SIMULATION} equ 1 if "!SIMULATION_TEST:%%~nxi=!" neq "%SIMULATION_TEST%" (
+                            echo "Running %%i with --simulation flag" 
+                            ninja simulate || exit !ERRORLEVEL!
+                        ) else (
+                            ninja run || exit !ERRORLEVEL!
+                        )
+                    ) else (
+                        echo "Skipping %%i as we are in simulation mode."
+                    )
+                )
+            """
+        )
+    }
+}
+
+def exec_with_retry(int max_retries = 10, int retry_timeout = 30, Closure body) {
+    int retry_count = 1
+    while (retry_count <= max_retries) {
+        try {
+            body.call()
+            break
+        } catch (Exception e) {
+            if (retry_count == max_retries) {
+                throw e
+            }
+            println("Command failed. Retry count ${retry_count}/${max_retries}. Retrying in ${retry_timeout} seconds")
+            sleep(retry_timeout)
+            retry_count += 1
+            continue
+        }
+    }
+}

--- a/.jenkins/library/vars/globalvars.groovy
+++ b/.jenkins/library/vars/globalvars.groovy
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/************************************
+* Shared Library for Global Variables
+************************************/
+
+import groovy.transform.Field
+
+@Field GLOBAL_TIMEOUT_MINUTES = 120
+@Field CTEST_TIMEOUT_SECONDS = 480
+@Field GLOBAL_ERROR = null
+@Field AGENTS_LABELS = [
+    "acc-ubuntu-20.04":         env.UBUNTU_2004_CUSTOM_LABEL ?: "ACC-2004",
+    "acc-ubuntu-18.04":         env.UBUNTU_1804_CUSTOM_LABEL ?: "ACC-1804",
+    "ubuntu-nonsgx":            env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004",
+    "windows-nonsgx":           env.WINDOWS_NONSGX_CUSTOM_LABEL ?: "nonSGX-Windows",
+    "acc-ubuntu-20.04-vanilla": env.UBUNTU_VANILLA_2004_CUSTOM_LABEL ?: "vanilla-ubuntu-2004",
+    "acc-ubuntu-18.04-vanilla": env.UBUNTU_VANILLA_1804_CUSTOM_LABEL ?: "vanilla-ubuntu-1804",
+    "acc-win2019-dcap":         env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP"
+]
+@Field COMPILER = "clang-10"

--- a/.jenkins/library/vars/helpers.groovy
+++ b/.jenkins/library/vars/helpers.groovy
@@ -1,0 +1,425 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/****************************************
+* Shared Library for Helpers and Commands
+****************************************/
+
+def CmakeArgs(String build_type = "RelWithDebInfo", String code_coverage = "OFF", String debug_malloc = "ON", String lvi_args="", String cmake_args = "") {
+    def args = "-G Ninja -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave' -DCPACK_GENERATOR=DEB -DCODE_COVERAGE=${code_coverage} -DUSE_DEBUG_MALLOC=${debug_malloc} -DCMAKE_BUILD_TYPE=${build_type} ${lvi_args} ${cmake_args} -Wdev"
+    return args
+}
+
+def WaitForAptLock() {
+    def aptWait = """
+        i=0
+        echo "Checking for locks..."
+        # Check for locks
+        while fuser /var/lib/dpkg/lock > /dev/null 2>&1 ||
+              fuser /var/lib/dpkg/lock-frontend > /dev/null 2>&1 ||
+              fuser /var/lib/apt/lists/lock > /dev/null 2>&1; do
+            # Wait up to 600 seconds to lock to be released
+            if (( i > 600 )); then
+                echo "Timeout waiting for lock."
+                exit 1
+            fi
+            echo "Waiting for apt/dpkg locks..."
+            i=\${i++}
+            sleep 1
+        done
+    """
+    return aptWait
+}
+
+def TestCommand() {
+    def testCommand = """
+        echo "Running Test Command"
+        ctest --output-on-failure --timeout ${globalvars.CTEST_TIMEOUT_SECONDS}
+    """
+    return testCommand
+}
+
+def InstallBuildCommand() {
+    def installCommand = """
+        echo "Running Install Build Command"
+        cpack -G DEB
+        ${WaitForAptLock()}
+        sudo ninja -v install
+    """
+    return installCommand
+}
+
+def InstallReleaseCommand() {
+    def installCommand = """
+        echo "Running Install Release Command"
+        echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+        wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+
+        echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
+        wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+
+        echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
+        wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+
+        ${WaitForAptLock()}
+        sudo apt update
+
+        ${WaitForAptLock()}
+        sudo apt install -y open-enclave
+
+        echo "Open Enclave SDK version installed"
+        apt list --installed | grep open-enclave
+    """
+    return installCommand
+}
+
+/**
+ * Returns Windows current working directory path
+*/
+def getWindowsCwd() {
+    return powershell(
+            script: "(Get-Location).path",
+            returnStdout: true
+        ).trim()
+}
+/**
+ * Tests Open Enclave samples on *nix systems
+ *
+ * @param lvi_mitigation  Determines whether tests should be ran with LVI mitigation
+ * @param oe_package      Open Enclave package to install
+ *                         - "open-enclave" [Default]
+ *                         - "open-enclave-hostverify"
+ */
+def testSamplesLinux(boolean lvi_mitigation, String oe_package) {
+    def lvi_args = ""
+    if(oe_package == "open-enclave-hostverify") {
+        // No host verification tests available during this migration
+        return
+    }
+    if(lvi_mitigation) {
+        sh "printf \'%s\\n\' no /usr/local/lvi-mitigation  | sudo /opt/openenclave/bin/scripts/lvi-mitigation/install_lvi_mitigation_bindir"
+        lvi_args += "-DLVI_MITIGATION=ControlFlow -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/lvi_mitigation_bin .."
+    }
+    sh """#!/bin/bash
+        echo "Running Test Samples Command"
+        cp -r /opt/openenclave/share/openenclave/samples ~/
+        cd ~/samples
+        . /opt/openenclave/share/openenclave/openenclaverc
+        for i in *; do
+            if [[ -d \${i} ]] && [[ -f \${i}/CMakeLists.txt ]]; then
+                cd \${i}
+                mkdir build
+                cd build
+                cmake .. ${lvi_args}
+                make
+                make run
+                cd ~/samples
+            fi
+        done
+        cd ~
+        rm -rf ~/samples
+    """   
+}
+
+/**
+ * Tests Open Enclave samples on Windows systems
+ *
+ * @param lvi_mitigation  Determines whether tests should be ran with LVI mitigation
+ * @param oe_package      Open Enclave package to install
+ *                         - "open-enclave" [Default]
+ *                         - "open-enclave.OEHOSTVERIFY"
+ */
+def testSamplesWindows(boolean lvi_mitigation, String oe_package) {
+    // Set flags for LVI mitigation
+    def lvi_args = ""
+    if(lvi_mitigation) {
+        lvi_args += "-DLVI_MITIGATION=ControlFlow -DLVI_MITIGATION_SKIP_TESTS=OFF"
+    }
+    def cmakeArgs = "-G Ninja \
+                    -DNUGET_PACKAGE_PATH=C:\\oe_prereqs \
+                    -DCMAKE_PREFIX_PATH=C:\\oe\\${oe_package}\\openenclave\\lib\\openenclave\\cmake ${lvi_args}"
+    bat(
+        returnStdout: false,
+        returnStatus: false,
+        script: """
+            call vcvars64.bat x64
+            @echo on
+            cd C:\\oe\\${oe_package}\\openenclave\\share\\openenclave\\samples
+            for /d %%i in (*) do (
+                cd "C:\\oe\\${oe_package}\\openenclave\\share\\openenclave\\samples\\%%i"
+                mkdir build
+                cd build
+                ${ninjaBuildCommand(cmakeArgs, "..")}
+                ninja run || exit !ERRORLEVEL!
+            )
+        """
+    )
+}
+/**
+ * Tests Open Enclave samples on Unix and Windows systems
+ *
+ * @param lvi_mitigation  Determines whether tests should be ran with LVI mitigation
+ * @param oe_package      Open Enclave package to install
+ *                         - "open-enclave" [Default]
+ *                         - "open-enclave-hostverify"
+ */
+def TestSamplesCommand(boolean lvi_mitigation = false, String oe_package = "open-enclave") {
+    if(isUnix()) {
+        testSamplesLinux(lvi_mitigation, oe_package)
+    }
+    else {
+        if(oe_package == "open-enclave-hostverify") {
+            oe_package = "open-enclave.OEHOSTVERIFY"
+        }
+        testSamplesWindows(lvi_mitigation, oe_package)
+    }
+}
+
+/**
+ * Builds Open Enclave using cmake and Ninja.
+ *
+ * @param cmake_arguments String of arguments to be passed to cmake
+ * @param build_dir       String that is a path to the directory that contains CMakeList.txt
+ *                        Can be relative to current working directory or an absolute path
+ */
+def ninjaBuildCommand(String cmake_arguments = "", String build_directory = "${WORKSPACE}") {
+    if(isUnix()) {
+        return """
+            set -x
+            cmake ${build_directory} ${cmake_arguments}
+            ninja -v
+        """
+    } else {
+        return """
+            @echo on
+            setlocal EnableDelayedExpansion
+            cmake ${build_directory} ${cmake_arguments} || exit !ERRORLEVEL!
+            ninja -v || exit !ERRORLEVEL!
+        """
+    }
+}
+
+/**
+ * Download from an Azure Storage Container
+ * From https://plugins.jenkins.io/windows-azure-storage/
+ *
+ * @param container_name          Name of the Azure Storage Container to download from
+ * @param file_pattern            File pattern to match (Ant glob syntax)
+ * @param storage_credentials_id  Jenkins credentials id to use to authenticate with Azure Storage
+*/
+def azureContainerDownload(String container_name, String file_pattern, String storage_credentials_id) {
+    azureDownload(
+        containerName: container_name,
+        downloadType: 'container',
+        includeArchiveZips: true,
+        includeFilesPattern: file_pattern,
+        storageCredentialId: storage_credentials_id
+    )
+}
+
+/**
+ * Downloads an Ubuntu Open Enclave release version from GitHub
+ *
+ * @param release_version  The version of the Open Enclave release to install
+ * @param oe_package       Open Enclave package to install
+ *                          - "open-enclave" [Default]
+ *                          - "open-enclave-hostverify"
+ * @param os_id            The distribution name (e.g. Ubuntu)
+ * @param os_release       The distribution version without "." (e.g. 1804)
+ */
+def releaseDownloadLinuxGitHub(String release_version, String oe_package, String os_id, String os_release) {
+    sh """#!/bin/bash -x
+        CHANGED=0
+        valid_url_regex='^https?://[-A-Za-z0-9\\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\\+&@#/%=~_|]\$'
+        ${WaitForAptLock()}
+        sudo apt-get install -y jq
+        urls=\$(curl -sS https://api.github.com/repos/openenclave/openenclave/releases/tags/v${release_version} | jq --raw-output --compact-output '.assets | map(.browser_download_url) | .[]')
+        for url in \${urls}; do
+            # Check if url is valid
+            if echo "\${url}" | grep -E '^https?://[-A-Za-z0-9\\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\\+&@#/%=~_|]\$'; then
+                # Filter packages specific to current distribution and version
+                if echo "\${url}" | grep "${os_id}_${os_release}_${oe_package}"; then
+                    wget --no-verbose --directory-prefix="${release_version}/${os_id} ${os_release}" \${url}
+                    if [[ -f "${release_version}/${os_id} ${os_release}/\$(basename \${url})" ]]; then
+                        CHANGED=1
+                    else
+                        echo "[Error] Failed to download from \${url}"
+                        exit 1
+                    fi
+                fi
+            else
+                echo "[Error] Encountered invalid URL: \${url}"
+                exit 1
+            fi
+        done
+        if [[ \${CHANGED} -eq 0 ]]; then
+            echo "[Error] No files were downloaded!"
+            exit 1
+        fi
+    """
+}
+
+/**
+ * Downloads an Ubuntu Open Enclave release version from a pre-defined Azure Blob container or GitHub
+ *
+ * @param release_version  The version of the Open Enclave release to install
+ * @param oe_package       Open Enclave package to install
+ *                          - "open-enclave" [Default]
+ *                          - "open-enclave-hostverify"
+ * @param source           Which source to download Open Enclave from
+ *                          - "Azure" to download from the Azure blob storage [Default]
+ *                          - "GitHub" to download from the Open Enclave Repository
+ * @param os_id            The distribution name (e.g. Ubuntu)
+ * @param os_release       The distribution version without "." (e.g. 1804)
+ */
+def releaseDownloadLinux(String release_version, String oe_package, String source, String os_id, String os_release) {
+    // Determine distribution and version
+    // Note: lsb_release is only available on Ubuntu.
+    if(source == "Azure") {
+        // Download from Open Enclave storage container
+        azureContainerDownload('releasecandidates', "${release_version}/${os_id} ${os_release}/*", 'openenclavereleaseblobcontainer')
+    } else if(source == "GitHub") {
+        // Download packages from Open Enclave GitHub repository releaases
+        releaseDownloadLinuxGitHub(release_version, oe_package, os_id, os_release)
+    } else {
+        error("[Error] Invalid Open Enclave source defined!")
+    }
+}
+
+/**
+ * Downloads a Windows Open Enclave release version from GitHub
+ *
+ * @param release_version  The version of the Open Enclave release to install
+ * @param oe_package       Open Enclave package to install
+ *                         - "open-enclave" [Default]
+ *                         - "open-enclave.OEHOSTVERIFY"
+ */
+def releaseDownloadWindowsGitHub(String release_version, String oe_package) {
+    def cwd = getWindowsCwd()
+    powershell """
+        \$changed = \$false
+        # Initialize IE so subsequent Invoke-RestMethod and Invoke-WebRequest do not fail
+        Set-ItemProperty -Path "HKLM:\\SOFTWARE\\Microsoft\\Internet Explorer\\Main" -Name "DisableFirstRunCustomize" -Value 1
+        \$json = Invoke-RestMethod https://api.github.com/repos/openenclave/openenclave/releases/tags/v${release_version}
+        Foreach (\$asset in \$json.assets) {
+            # Download release assets that are nuget packages
+            if (\$asset.browser_download_url -match "https?://.*/${oe_package}\\.${release_version}\\.nupkg") {
+                Write-Output "Downloading ${cwd}\\\$(\$asset.name) from \$(\$asset.browser_download_url)"
+                Invoke-WebRequest \$asset.browser_download_url -outFile \$asset.name -passThru
+                if (Test-Path "${cwd}\\\$(\$asset.name)" -PathType leaf) {
+                    Write-Output "Downloaded ${cwd}\\\$(\$asset.name)"
+                    \$changed = \$true
+                } else {
+                    Throw "[Error] Failed to download from \$(\$asset.browser_download_url)"
+                }
+            } else {
+                Write-Output "Skipping \$(\$asset.browser_download_url)"
+            }
+        }
+        if (!\$changed) {
+            Throw "[Error] No files were downloaded!"
+        }
+    """
+}
+
+/**
+ * Downloads a Windows Open Enclave release version from a pre-defined Azure Blob container or GitHub
+ *
+ * @param release_version  The version of the Open Enclave release to install
+ * @param oe_package       Open Enclave package to install
+ *                         - "open-enclave" [Default]
+ *                         - "open-enclave.OEHOSTVERIFY"
+ * @param source           Which source to download Open Enclave from
+ *                         - "Azure" to download from the Azure blob storage [Default]
+ *                         - "GitHub" to download from the Open Enclave Repository
+ * @param windows_version  The Windows version caption (output of "wmic os get caption")
+ */
+def releaseDownloadWindows(String release_version, String oe_package, String source, String windows_version) {
+    if(source == "Azure") {
+        // Download from Azure storage container
+        azureContainerDownload('releasecandidates', "${release_version}/${windows_version}/*", 'openenclavereleaseblobcontainer')
+    } else if(source == "GitHub") {
+        // Download nuget packages from Open Enclave GitHub repository releaases
+        releaseDownloadWindowsGitHub(release_version, oe_package)
+    } else {
+        error("[Error] Invalid Open Enclave source defined!")
+    }
+}
+
+/**
+ * Downloads and installs an Open Enclave release version for either Windows or Ubuntu
+ * Warning: this function must not be called within a shell otherwise a null command would be ran after this function completes.
+ *
+ * @param release_version  The version of the Open Enclave release to install
+ * @param oe_package       Open Enclave package to install
+ *                         - "open-enclave" [Default]
+ *                         - "open-enclave-hostverify"
+ * @param source           Which source to download Open Enclave from
+ *                         - "Azure" to download from the Azure blob storage [Default]
+ *                         - "GitHub" to download from the Open Enclave Repository
+ */
+def releaseInstall(String release_version = null, String oe_package = "open-enclave", String source = "Azure") {
+    // Check parameters are valid
+    if(!release_version) {
+        error("[Error] Invalid Open Enclave release version defined!")
+    }
+    if(!["open-enclave", "open-enclave-hostverify"].contains(oe_package)) {
+        error("[Error] Invalid Open Enclave package defined!")
+    }
+    if(!["Azure", "GitHub"].contains(source)) {
+        error("[Error] Invalid Open Enclave source defined!")
+    }
+    // For *nix
+    if(isUnix()) {
+        // Get distribution name
+        def os_id = sh(
+                script: "lsb_release --id --short",
+                returnStdout: true
+            ).trim()
+        // Get distribution version
+        def os_release = sh(
+                script: "lsb_release --release --short | sed 's/\\.//'",
+                returnStdout: true
+            ).trim()
+        // Download Open Enclave package
+        releaseDownloadLinux(release_version, oe_package, source, os_id, os_release)
+        // Install Open Enclave package
+        sh """
+            ${WaitForAptLock()}
+            sudo dpkg -i "${release_version}/${os_id} ${os_release}/${os_id}_${os_release}_${oe_package}_${release_version}_amd64.deb"
+        """
+    // For Windows
+    } else {
+        // Determine Windows installation type
+        def windows_version = bat(
+            script: """
+                @echo off
+                wmic os get caption | find /v "Caption"
+                """,
+            returnStdout: true
+        ).trim()
+        // Get current working directory path
+        def cwd = getWindowsCwd()
+        // Override oe_package name scheme for Host Verify
+        if(oe_package == "open-enclave-hostverify") {
+            oe_package = "open-enclave.OEHOSTVERIFY"
+        }
+        // Download Open Enclave package
+        releaseDownloadWindows(release_version, oe_package, source, windows_version)     
+        // Set nuget flags
+        def nuget_flags = "-OutputDirectory C:\\oe -ExcludeVersion"
+        if(source == "Azure") {
+            nuget_flags += " -Source \"${cwd}\\${release_version}\\${windows_version}\""
+        } else if(source == "GitHub") {
+            nuget_flags += " -Source \"${cwd}\""
+        }
+        // Add additional prerelease flag for release candidates if applicable
+        if(release_version.contains('-rc')) {
+            nuget_flags += " -prerelease"
+        }
+        // Install Open Enclave package
+        powershell """
+            nuget.exe install \"${oe_package}\" ${nuget_flags}
+        """
+    }
+}

--- a/.jenkins/library/vars/tests.groovy
+++ b/.jenkins/library/vars/tests.groovy
@@ -1,0 +1,610 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+/*************************************
+* Shared Library for OpenEnclave Tests
+*************************************/
+
+// Azure Linux
+
+def ACCCodeCoverageTest(String label, String compiler, String build_type) {
+    stage("${label} ${compiler} ${build_type} Code Coverage") {
+        node("${label}") {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def cmakeArgs = helpers.CmakeArgs(build_type)
+                def task = """
+                           ${helpers.ninjaBuildCommand(cmakeArgs)}
+                           ${helpers.TestCommand()}
+                           ninja code_coverage
+                           """
+                common.Run(compiler, task)
+
+                // Publish the report via Cobertura Plugin.
+                cobertura coberturaReportFile: 'build/coverage/coverage.xml'
+
+                // Publish the result to the PR(s) via GitHub Coverage reporter Plugin.
+                // Workaround to obtain the PR id(s) as Bors does not us to grab them reliably.
+                def log = sh (script: "git log -1 | grep -Po '(Try #\\K|Merge #\\K)[^:]*'", returnStdout: true).trim()
+                def id_list = log.split(' #')
+                id_list.each {
+                    echo "PR ID: ${it}, REPOSITORY_NAME: ${REPOSITORY_NAME}"
+                    withEnv(["CHANGE_URL=https://github.com/${REPOSITORY_NAME}/pull/${it}"]) {
+                        publishCoverageGithub(filepath:'build/coverage/coverage.xml',
+                                              coverageXmlType: 'cobertura',
+                                              comparisonOption: [ value: 'optionFixedCoverage', fixedCoverage: '0.60' ],
+                                              coverageRateType: 'Line')
+                    }
+                }
+            }
+        }
+    }
+}
+
+def ACCTest(String label, String compiler, String build_type, List extra_cmake_args = [], List test_env = [], boolean fresh_install = false) {
+    stage("${label} ${compiler} ${build_type}, extra_cmake_args: ${extra_cmake_args}, test_env: ${test_env}${fresh_install ? ", e2e" : ""}") {
+        node(label) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                if (fresh_install) {
+                    sh  """
+                        sudo bash scripts/ansible/install-ansible.sh
+                        # Run ACC Playbook
+                        for i in 1 2 3 4 5
+                        do
+                            sudo \$(which ansible-playbook) scripts/ansible/oe-contributors-acc-setup.yml && break
+                            sleep 60
+                        done
+                        """
+                }
+                def cmakeArgs = helpers.CmakeArgs(build_type,"OFF","ON","-DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin",extra_cmake_args.join(' '))
+                def task = """
+                           ${helpers.ninjaBuildCommand(cmakeArgs)}
+                           ${helpers.TestCommand()}
+                           """
+                withEnv(test_env) {
+                    common.Run(compiler, task)
+                }
+            }
+        }
+    }
+}
+
+def ACCUpgradeTest(String label, String compiler, String version, List extra_cmake_args = [], List test_env = []) {
+    stage("${label} Container ${version} RelWithDebInfo, extra_cmake_args: ${extra_cmake_args}") {
+        node("${label}") {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def cmakeArgs = helpers.CmakeArgs("RelWithDebInfo","OFF","ON","-DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin",extra_cmake_args.join(' '))
+                withEnv(test_env) {
+                    common.Run(compiler, helpers.InstallReleaseCommand())
+                    helpers.TestSamplesCommand()
+                    common.Run(compiler, helpers.ninjaBuildCommand(cmakeArgs))
+                    common.Run(compiler, helpers.InstallBuildCommand())
+                    helpers.TestSamplesCommand()
+                }
+            }
+        }
+    }
+}
+
+def ACCContainerTest(String label, String version, List extra_cmake_args = []) {
+    stage("${label} Container ${version} RelWithDebInfo, extra_cmake_args: ${extra_cmake_args}") {
+        node("${label}") {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def cmakeArgs = helpers.CmakeArgs("RelWithDebInfo","OFF","ON","-DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin",extra_cmake_args.join(' '))
+                def task = """
+                           ${helpers.ninjaBuildCommand(cmakeArgs)}
+                           ${helpers.TestCommand()}
+                           """
+                common.ContainerRun("oetools-${version}:${params.DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
+            }
+        }
+    }
+}
+
+def ACCPackageTest(String label, String version, List extra_cmake_args = []) {
+    stage("${label} PackageTest ${version} RelWithDebInfo, extra_cmake_args: ${extra_cmake_args}") {
+        node("${label}") {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def cmakeArgs = helpers.CmakeArgs("RelWithDebInfo","OFF","ON","-DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin",extra_cmake_args.join(' '))
+                common.ContainerTasks(
+                    "oetools-${version}:${params.DOCKER_TAG}",
+                    globalvars.COMPILER,
+                    [
+                    common.Run(
+                        globalvars.COMPILER,
+                        """
+                        ${helpers.ninjaBuildCommand(cmakeArgs)}
+                        ${helpers.InstallBuildCommand()}
+                        """
+                    ),
+                    helpers.TestSamplesCommand()
+                    ],
+                    "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket"
+                )
+            }
+        }
+    }
+}
+
+def ACCHostVerificationTest(String version, String build_type) {
+    /* Compile tests in SGX machine.  This will generate the necessary certs for the
+    * host_verify test.
+    */
+    stage("ACC-1804 Generate Quote") {
+        node(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def cmakeArgs = "-G Ninja -DCMAKE_BUILD_TYPE=${build_type} -Wdev"
+                println("Generating certificates and reports ...")
+                def task = """
+                           ${helpers.ninjaBuildCommand(cmakeArgs)}
+                           pushd tests/host_verify/host
+                           openssl ecparam -name prime256v1 -genkey -noout -out keyec.pem
+                           openssl ec -in keyec.pem -pubout -out publicec.pem
+                           openssl genrsa -out keyrsa.pem 2048
+                           openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
+                           ../../../output/bin/oeutil gen --format cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
+                           ../../../output/bin/oeutil gen --format cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
+                           ../../../output/bin/oeutil gen --format legacy_report_remote --out sgx_report.bin --verify
+                           ../../../output/bin/oeutil gen --format sgx_ecdsa --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
+                           ../../../output/bin/oeutil gen --format sgx_ecdsa --quote-proc in --verify
+                           ../../../output/bin/oeutil gen --format sgx_ecdsa --quote-proc out --verify
+                           popd
+                           """
+                common.ContainerRun("oetools-${version}:${params.DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
+
+                def ec_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_ec.der'
+                def rsa_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_rsa.der'
+                def report_created = fileExists 'build/tests/host_verify/host/sgx_report.bin'
+                def evidence_created = fileExists 'build/tests/host_verify/host/sgx_evidence.bin'
+                if (ec_cert_created) {
+                    println("EC cert file created successfully!")
+                } else {
+                    error("Failed to create EC cert file.")
+                }
+                if (rsa_cert_created) {
+                    println("RSA cert file created successfully!")
+                } else {
+                    error("Failed to create RSA cert file.")
+                }
+                if (report_created) {
+                    println("SGX report file created successfully!")
+                } else {
+                    error("Failed to create SGX report file.")
+                }
+                if (evidence_created) {
+                    println("SGX evidence file created successfully!")
+                } else {
+                    error("Failed to create SGX evidence file.")
+                }
+
+                stash includes: 'build/tests/host_verify/host/*.der,build/tests/host_verify/host/*.bin', name: "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+            }
+        }
+    }
+
+    /* Compile the tests and unstash the certs over for verification.  */
+    stage("Linux nonSGX Verify Quote") {
+        node(globalvars.AGENTS_LABELS["ubuntu-nonsgx"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+                def cmakeArgs = "-G Ninja -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -Wdev"
+                def task = """
+                           ${helpers.ninjaBuildCommand(cmakeArgs)}
+                           ctest -R host_verify --output-on-failure --timeout ${globalvars.CTEST_TIMEOUT_SECONDS}
+                           """
+                // Note: Include the commands to build and run the quote verification test above
+                common.ContainerRun("oetools-${version}:${params.DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE")
+            }
+        }
+    }
+
+    /* Windows nonSGX stage. */
+    stage("Windows nonSGX Verify Quote") {
+        node(globalvars.AGENTS_LABELS["windows-nonsgx"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+                def cmakeArgs = "-G Ninja -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev"
+                dir('build') {
+                    bat(
+                        returnStdout: false,
+                        returnStatus: false,
+                        script: """
+                            call vcvars64.bat x64
+                            ${helpers.ninjaBuildCommand(cmakeArgs)}
+                            ctest.exe -V -C ${build_type} -R host_verify --output-on-failure --timeout ${globalvars.CTEST_TIMEOUT_SECONDS} || exit !ERRORLEVEL!
+                        """
+                    )
+                }
+            }
+        }
+    }
+}
+
+def ACCHostVerificationPackageTest(String version, String build_type) {
+    /* Generate an SGX report and two SGX certificates for the host_verify sample.
+    * Also generate and install the host_verify package. Then run the host_verify sample.
+    */
+    stage("ACC-1804 Generate Quote") {
+        node(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def cmakeArgs = "-G Ninja -DCMAKE_BUILD_TYPE=${build_type} -Wdev"
+                println("Generating certificates and reports ...")
+                def task = """
+                           ${helpers.ninjaBuildCommand(cmakeArgs)}
+                           pushd tests/host_verify/host
+                           openssl ecparam -name prime256v1 -genkey -noout -out keyec.pem
+                           openssl ec -in keyec.pem -pubout -out publicec.pem
+                           openssl genrsa -out keyrsa.pem 2048
+                           openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
+                           ../../../output/bin/oeutil gen --format cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
+                           ../../../output/bin/oeutil gen --format cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
+                           ../../../output/bin/oeutil gen --format legacy_report_remote --out sgx_report.bin --verify
+                           ../../../output/bin/oeutil gen --format sgx_ecdsa --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
+                           ../../../output/bin/oeutil gen --format sgx_ecdsa --quote-proc in --verify
+                           ../../../output/bin/oeutil gen --format sgx_ecdsa --quote-proc out --verify
+                           popd
+                           """
+                common.ContainerRun("oetools-${version}:${params.DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
+
+                def ec_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_ec.der'
+                def rsa_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_rsa.der'
+                def report_created = fileExists 'build/tests/host_verify/host/sgx_report.bin'
+                def evidence_created = fileExists 'build/tests/host_verify/host/sgx_evidence.bin'
+                if (ec_cert_created) {
+                    println("EC cert file created successfully!")
+                } else {
+                    error("Failed to create EC cert file.")
+                }
+                if (rsa_cert_created) {
+                    println("RSA cert file created successfully!")
+                } else {
+                    error("Failed to create RSA cert file.")
+                }
+                if (report_created) {
+                    println("SGX report file created successfully!")
+                } else {
+                    error("Failed to create SGX report file.")
+                }
+                if (evidence_created) {
+                    println("SGX evidence file created successfully!")
+                } else {
+                    error("Failed to create SGX evidence file.")
+                }
+
+                stash includes: 'build/tests/host_verify/host/*.der,build/tests/host_verify/host/*.bin', name: "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+            }
+        }
+    }
+
+    /* Linux nonSGX stage. */
+    stage("Linux nonSGX Verify Quote") {
+        node(globalvars.AGENTS_LABELS["ubuntu-nonsgx"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+                cmakeArgs = "-G Ninja \
+                             -DBUILD_ENCLAVES=OFF \
+                             -DCMAKE_BUILD_TYPE=${build_type} \
+                             -DCMAKE_INSTALL_PREFIX=/opt/openenclave \
+                             -DCOMPONENT=OEHOSTVERIFY \
+                             -Wdev"
+                cmakeArgsHostVerify = "-G Ninja \
+                                       -DBUILD_ENCLAVES=OFF \
+                                       -DCMAKE_BUILD_TYPE=${build_type} \
+                                       -Wdev"
+                def task = """
+                           ${helpers.ninjaBuildCommand(cmakeArgs)}
+                           cpack -G DEB -D CPACK_DEB_COMPONENT_INSTALL=ON -D CPACK_COMPONENTS_ALL=OEHOSTVERIFY
+                           if [ -d /opt/openenclave ]; then sudo rm -r /opt/openenclave; fi
+                           sudo dpkg -i open-enclave-hostverify*.deb
+                           cp tests/host_verify/host/*.der ${WORKSPACE}/samples/host_verify
+                           cp tests/host_verify/host/*.bin ${WORKSPACE}/samples/host_verify
+                           pushd ${WORKSPACE}/samples/host_verify
+                           if [ ! -d build ]; then mkdir build; fi
+                           cd build
+                           ${helpers.ninjaBuildCommand(cmakeArgs, "..")}
+                           ./host_verify -r ../sgx_report.bin
+                           ./host_verify -c ../sgx_cert_ec.der
+                           ./host_verify -c ../sgx_cert_rsa.der
+                           popd
+                           """
+                // Note: Include the commands to build and run the quote verification test above
+                common.ContainerRun("oetools-${version}:${params.DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE")
+            }
+        }
+    }
+
+    /* Windows nonSGX stage. */
+    stage("Windows nonSGX Verify Quote") {
+        node(globalvars.AGENTS_LABELS["windows-nonsgx"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
+                cmakeArgs = "-G Ninja \
+                             -DBUILD_ENCLAVES=OFF \
+                             -DCMAKE_BUILD_TYPE=${build_type} \
+                             -DCOMPONENT=OEHOSTVERIFY \
+                             -DCPACK_GENERATOR=NuGet \
+                             -DNUGET_PACKAGE_PATH=C:/oe_prereqs \
+                             -Wdev"
+                cmakeArgsHostVerify = "-G Ninja \
+                                       -DBUILD_ENCLAVES=OFF \
+                                       -DCMAKE_BUILD_TYPE=${build_type} \
+                                       -DCMAKE_PREFIX_PATH=C:/openenclave/lib/openenclave/cmake \
+                                       -DNUGET_PACKAGE_PATH=C:/oe_prereqs \
+                                       -Wdev"
+                dir('build') {
+                    bat(
+                        returnStdout: false,
+                        returnStatus: false,
+                        script: """
+                            call vcvars64.bat x64
+                            ${helpers.ninjaBuildCommand(cmakeArgs)}
+                            cpack -D CPACK_NUGET_COMPONENT_INSTALL=ON -DCPACK_COMPONENTS_ALL=OEHOSTVERIFY
+                            copy tests\\host_verify\\host\\*.der ${WORKSPACE}\\samples\\host_verify
+                            copy tests\\host_verify\\host\\*.bin ${WORKSPACE}\\samples\\host_verify
+                            if exist C:\\oe (rmdir C:\\oe)
+                            nuget.exe install open-enclave.OEHOSTVERIFY -Source ${WORKSPACE}\\build -OutputDirectory C:\\oe -ExcludeVersion
+                            xcopy /E C:\\oe\\open-enclave.OEHOSTVERIFY\\openenclave C:\\openenclave\\
+                            pushd ${WORKSPACE}\\samples\\host_verify
+                            if not exist build\\ (mkdir build)
+                            cd build
+                            ${helpers.ninjaBuildCommand(cmakeArgsHostVerify, "..")}
+                            host_verify.exe -r ../sgx_report.bin
+                            host_verify.exe -c ../sgx_cert_ec.der
+                            host_verify.exe -c ../sgx_cert_rsa.der
+                            popd
+                            """
+                    )
+                }
+            }
+        }
+    }
+}
+
+def OEReleaseTest(String label, String release_version, String oe_package = "open-enclave", String source = "Azure", boolean lvi_mitigation = false) {
+    stage("OE Release Test ${label}") {
+        node(label) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                helpers.releaseInstall(release_version, oe_package, source)
+                helpers.TestSamplesCommand(lvi_mitigation, oe_package)
+            }
+        }
+    }
+}
+
+// Azure Windows
+
+def windowsPrereqsVerify(String label) {
+    stage("Windows ${label} Install Prereqs Verification") {
+        node(globalvars.AGENTS_LABELS[label]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                dir('scripts') {
+                    bat(
+                        returnStdout: false,
+                        returnStatus: false,
+                        script: """
+                            powershell.exe -ExecutionPolicy Unrestricted -NoLogo -NonInteractive -NoProfile -WindowStyle Hidden -File install-windows-prereqs.ps1 -InstallPath C:\\oe_prereqs -LaunchConfiguration SGX1FLC-NoIntelDrivers -DCAPClientType Azure -VerificationOnly
+                        """
+                    )
+                }
+            }
+        }
+    }
+}
+
+def windowsLinuxElfBuild(String label, String version, String compiler, String build_type, String lvi_mitigation = 'None', String lvi_mitigation_skip_tests = 'OFF', List extra_cmake_args = []) {
+    stage("Ubuntu ${version} SGX1 ${compiler} ${build_type} LVI_MITIGATION=${lvi_mitigation}") {
+        node(globalvars.AGENTS_LABELS["ubuntu-nonsgx"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def task = """
+                           cmake ${WORKSPACE}                                           \
+                               -G Ninja                                                 \
+                               -DCMAKE_BUILD_TYPE=${build_type}                         \
+                               -DLVI_MITIGATION=${lvi_mitigation}                       \
+                               -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
+                               -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} \
+                               -Wdev                                                    \
+                               ${extra_cmake_args.join(' ')}
+                           ninja -v
+                           """
+                common.ContainerRun("oetools-${version}:${DOCKER_TAG}", compiler, task, "--cap-add=SYS_PTRACE")
+                stash includes: 'build/tests/**', name: "linux-${label}-${compiler}-${build_type}-lvi_mitigation=${lvi_mitigation}-${version}-${BUILD_NUMBER}"
+            }
+        }
+    }
+    stage("Windows ${label} ${build_type} LVI_MITIGATION=${lvi_mitigation}") {
+        node(globalvars.AGENTS_LABELS[label]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                unstash "linux-${label}-${compiler}-${build_type}-lvi_mitigation=${lvi_mitigation}-${version}-${BUILD_NUMBER}"
+                bat 'move build linuxbin'
+                dir('build') {
+                    bat(
+                        returnStdout: false,
+                        returnStatus: false,
+                        script: """
+                            call vcvars64.bat x64
+                            setlocal EnableDelayedExpansion
+                            cmake.exe ${WORKSPACE} -G Ninja -DADD_WINDOWS_ENCLAVE_TESTS=ON -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -DLINUX_BIN_DIR=${WORKSPACE}\\linuxbin\\tests -DLVI_MITIGATION=${lvi_mitigation} -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev || exit !ERRORLEVEL!
+                            ninja -v || exit !ERRORLEVEL!
+                            ctest.exe -V -C ${build_type} --timeout ${globalvars.CTEST_TIMEOUT_SECONDS} || exit !ERRORLEVEL!
+                        """
+                    )
+                }
+            }
+        }
+    }
+}
+
+def windowsCrossCompile(String label, String build_type, String lvi_mitigation = 'None', String OE_SIMULATION = "0", String lvi_mitigation_skip_tests = 'OFF', List extra_cmake_args = []) {
+    def node_label = globalvars.AGENTS_LABELS["${label}-dcap"]
+
+    stage("Windows ${label} ${build_type} with SGX LVI_MITIGATION=${lvi_mitigation}") {
+        node(node_label) {
+            withEnv(["OE_SIMULATION=${OE_SIMULATION}"]) {
+                timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                    // OFF value of quote provider until https://github.com/openenclave/openenclave-ci/pull/29 is merged
+                    common.WinCompilePackageTest("build/X64-${build_type}", build_type, 'OFF', globalvars.CTEST_TIMEOUT_SECONDS, lvi_mitigation, lvi_mitigation_skip_tests, extra_cmake_args)
+                }
+            }
+        }
+    }
+}
+
+def windowsCrossPlatform(String label) {
+    def node_label = globalvars.AGENTS_LABELS[label]
+    stage("Windows ${node_label} Cross Plaform Build") {
+        node(node_label) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+
+                dir("devex/cross-nuget/standalone-builds/windows") {
+                    bat(
+                        returnStdout: false,
+                        returnStatus: false,
+                        script: """
+                            vcvars64.bat x64 && powershell -c "Set-ExecutionPolicy Bypass -Scope Process; .\\build.ps1 -SDK_PATH ${WORKSPACE}"
+                            vcvars64.bat x64 && powershell -c "Set-ExecutionPolicy Bypass -Scope Process; .\\pack.ps1"
+                        """
+                    )
+                }
+            }
+        }
+    }
+}
+
+
+// Agnostic Linux
+
+def simulationContainerTest(String version, String build_type, List extra_cmake_args = []) {
+    stage("Simulation Ubuntu ${version} clang-10 ${build_type}, extra_cmake_args: ${extra_cmake_args}") {
+        node(globalvars.AGENTS_LABELS["ubuntu-nonsgx"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def task = """
+                           cmake ${WORKSPACE}                                           \
+                               -G Ninja                                                 \
+                               -DCMAKE_BUILD_TYPE=${build_type}                         \
+                               -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
+                               ${extra_cmake_args.join(' ')}                            \
+                               -Wdev
+                           ninja -v
+                           ctest --output-on-failure --timeout ${globalvars.CTEST_TIMEOUT_SECONDS}
+                           """
+                withEnv(["OE_SIMULATION=1"]) {
+                    common.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE")
+                }
+            }
+        }
+    }
+}
+
+def buildCrossPlatform(String version) {
+    stage("Ubuntu ${version} OP-TEE Build") {
+        node(globalvars.AGENTS_LABELS["ubuntu-nonsgx"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def os = version == "20.04" ? "focal" : "bionic"
+                def task = """
+                           cd ${WORKSPACE}
+
+                           sdk_path=\$(pwd)
+                           export OE_SDK_PATH=\${sdk_path}
+                           export BUILD_PATH=\${sdk_path}/build
+                           export OPTEE_BUILD_PATH=\${sdk_path}/build/optee
+                           export PACK_PATH=\${sdk_path}/path
+                           export OS_CODENAME=${os}
+
+                           sudo ansible-playbook scripts/ansible/oe-contributors-setup-cross-arm.yml
+                           sudo apt install python python3-pyelftools p7zip-full -y
+
+                           bash devex/cross-nuget/standalone-builds/linux/build-optee.sh
+                           bash devex/cross-nuget/standalone-builds/linux/runner.sh
+                           """
+
+                common.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE")
+            }
+        }
+    }
+}
+
+def AArch64GNUTest(String version, String build_type) {
+    stage("AArch64 GNU gcc Ubuntu${version} ${build_type}") {
+        node(globalvars.AGENTS_LABELS["ubuntu-nonsgx"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def task = """
+                            cmake ${WORKSPACE}                                                     \
+                                -G Ninja                                                           \
+                                -DCMAKE_BUILD_TYPE=${build_type}                                   \
+                                -DCMAKE_TOOLCHAIN_FILE=${WORKSPACE}/cmake/arm-cross.cmake          \
+                                -DOE_TA_DEV_KIT_DIR=/devkits/vexpress-qemu_armv8a/export-ta_arm64  \
+                                -DHAS_QUOTE_PROVIDER=OFF                                           \
+                                -Wdev
+                            ninja -v
+                            """
+                common.ContainerRun("oetools-${version}:${DOCKER_TAG}", "cross", task, "--cap-add=SYS_PTRACE")
+            }
+        }
+    }
+}
+
+def checkDevFlows(String version) {
+    stage('Default compiler') {
+        node(globalvars.AGENTS_LABELS["ubuntu-nonsgx"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                def task = """
+                           cmake ${WORKSPACE} -G Ninja -DHAS_QUOTE_PROVIDER=OFF -Wdev --warn-uninitialized -Werror=dev
+                           ninja -v
+                           """
+                common.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE")
+            }
+        }
+    }
+}
+
+def checkCI() {
+    stage('Check CI') {
+        node(globalvars.AGENTS_LABELS["ubuntu-nonsgx"]) {
+            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
+                cleanWs()
+                checkout scm
+                // At the moment, the check-ci script assumes that it's executed from the
+                // root source code directory.
+                common.ContainerRun("oetools-18.04:${DOCKER_TAG}", "clang-10", "cd ${WORKSPACE} && ./scripts/check-ci", "--cap-add=SYS_PTRACE")
+            }
+        }
+    }
+}

--- a/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
@@ -1,170 +1,72 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-OECI_LIB_VERSION = env.OECI_LIB_VERSION ?: "master"
-oe = library("OpenEnclaveCommon@${OECI_LIB_VERSION}").jenkins.common.Openenclave.new()
+library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
+GLOBAL_ERROR = globalvars.GLOBAL_ERROR
 
-GLOBAL_TIMEOUT_MINUTES = 120
-CTEST_TIMEOUT_SECONDS = 480
-GLOBAL_ERROR = null
-
-DOCKER_TAG = env.DOCKER_TAG ?: "latest"
-AGENTS_LABELS = [
-    "ubuntu-nonsgx": env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004"
-]
-
-
-def simulationContainerTest(String version, String build_type, List extra_cmake_args = []) {
-    stage("Simulation Ubuntu ${version} clang-10 ${build_type}, extra_cmake_args: ${extra_cmake_args}") {
-        node(AGENTS_LABELS["ubuntu-nonsgx"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def task = """
-                           cmake ${WORKSPACE}                                           \
-                               -G Ninja                                                 \
-                               -DCMAKE_BUILD_TYPE=${build_type}                         \
-                               -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
-                               ${extra_cmake_args.join(' ')}                            \
-                               -Wdev
-                           ninja -v
-                           ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
-                           """
-                withEnv(["OE_SIMULATION=1"]) {
-                    oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE")
-                }
-            }
-        }
-    }
-}
-
-def buildCrossPlatform(String version) {
-    stage("Ubuntu ${version} OP-TEE Build") {
-        node(AGENTS_LABELS["ubuntu-nonsgx"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def os = version == "20.04" ? "focal" : "bionic"
-                def task = """
-                           cd ${WORKSPACE}
-
-                           sdk_path=\$(pwd)
-                           export OE_SDK_PATH=\${sdk_path}
-                           export BUILD_PATH=\${sdk_path}/build
-                           export OPTEE_BUILD_PATH=\${sdk_path}/build/optee
-                           export PACK_PATH=\${sdk_path}/path
-                           export OS_CODENAME=${os}
-
-                           sudo ansible-playbook scripts/ansible/oe-contributors-setup-cross-arm.yml
-                           sudo apt install python python3-pyelftools p7zip-full -y
-
-                           bash devex/cross-nuget/standalone-builds/linux/build-optee.sh
-                           bash devex/cross-nuget/standalone-builds/linux/runner.sh
-                           """
-
-                oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE")
-            }
-        }
-    }
-}
-
-def AArch64GNUTest(String version, String build_type) {
-    stage("AArch64 GNU gcc Ubuntu${version} ${build_type}") {
-        node(AGENTS_LABELS["ubuntu-nonsgx"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def task = """
-                            cmake ${WORKSPACE}                                                     \
-                                -G Ninja                                                           \
-                                -DCMAKE_BUILD_TYPE=${build_type}                                   \
-                                -DCMAKE_TOOLCHAIN_FILE=${WORKSPACE}/cmake/arm-cross.cmake          \
-                                -DOE_TA_DEV_KIT_DIR=/devkits/vexpress-qemu_armv8a/export-ta_arm64  \
-                                -DHAS_QUOTE_PROVIDER=OFF                                           \
-                                -Wdev
-                            ninja -v
-                            """
-                oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "cross", task, "--cap-add=SYS_PTRACE")
-            }
-        }
-    }
-}
-
-def checkDevFlows(String version) {
-    stage('Default compiler') {
-        node(AGENTS_LABELS["ubuntu-nonsgx"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def task = """
-                           cmake ${WORKSPACE} -G Ninja -DHAS_QUOTE_PROVIDER=OFF -Wdev --warn-uninitialized -Werror=dev
-                           ninja -v
-                           """
-                oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE")
-            }
-        }
-    }
-}
-
-def checkCI() {
-    stage('Check CI') {
-        node(AGENTS_LABELS["ubuntu-nonsgx"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                // At the moment, the check-ci script assumes that it's executed from the
-                // root source code directory.
-                oe.ContainerRun("oetools-18.04:${DOCKER_TAG}", "clang-10", "cd ${WORKSPACE} && ./scripts/check-ci", "--cap-add=SYS_PTRACE")
-            }
-        }
-    }
-}
-
-properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
-                                      artifactNumToKeepStr: '180',
-                                      daysToKeepStr: '90',
-                                      numToKeepStr: '180')),
-            [$class: 'JobRestrictionProperty']])
+properties(
+    [
+        buildDiscarder(
+            logRotator(
+                artifactDaysToKeepStr: '90',
+                artifactNumToKeepStr: '180',
+                daysToKeepStr: '90',
+                numToKeepStr: '180'
+            )
+        ),
+        [$class: 'JobRestrictionProperty'],
+        parameters(
+            [
+                string(name: 'REPOSITORY_NAME',             defaultValue: 'openenclave/openenclave', description: 'GitHub repository to build.'),
+                string(name: 'BRANCH_NAME',                 defaultValue: 'master',                  description: 'Git branch to build.'),
+                string(name: 'DOCKER_TAG',                  defaultValue: 'latest',                  description: 'Tag used to pull oetools docker image.'),
+                string(name: 'OECI_LIB_VERSION',            defaultValue: 'master',                  description: 'Version of OE Libraries to use'),
+                string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL',  defaultValue: '',                        description: '[Optional] Jenkins agent label to use for Ubuntu 20.04 without SGX.'),
+                booleanParam(name: 'FULL_TEST_SUITE',       defaultValue: false,                     description: 'Run all additional tests available in the test suite.')
+            ]
+        )
+    ]
+)
 
 try{
-    oe.emailJobStatus('STARTED')
+    common.emailJobStatus('STARTED')
     def testing_stages = [
-        "Check CI":                                { checkCI() },
-        "Check Developer Experience Ubuntu 20.04": { checkDevFlows('20.04') },
-        "Check Developer Experience Ubuntu 18.04": { checkDevFlows('18.04') },
-        "AArch64 2004 GNU gcc Debug":              { AArch64GNUTest('20.04', 'Debug') },
-        "AArch64 2004 GNU gcc RelWithDebInfo":     { AArch64GNUTest('20.04', 'RelWithDebInfo') },
-        "AArch64 1804 GNU gcc Debug":              { AArch64GNUTest('18.04', 'Debug') },
-        "AArch64 1804 GNU gcc RelWithDebInfo":     { AArch64GNUTest('18.04', 'RelWithDebInfo') }
+        "Check CI":                                { tests.checkCI() },
+        "Check Developer Experience Ubuntu 20.04": { tests.checkDevFlows('20.04') },
+        "Check Developer Experience Ubuntu 18.04": { tests.checkDevFlows('18.04') },
+        "AArch64 2004 GNU gcc Debug":              { tests.AArch64GNUTest('20.04', 'Debug') },
+        "AArch64 2004 GNU gcc RelWithDebInfo":     { tests.AArch64GNUTest('20.04', 'RelWithDebInfo') },
+        "AArch64 1804 GNU gcc Debug":              { tests.AArch64GNUTest('18.04', 'Debug') },
+        "AArch64 1804 GNU gcc RelWithDebInfo":     { tests.AArch64GNUTest('18.04', 'RelWithDebInfo') }
     ]
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
-                "Sim 1804 clang-10 SGX1 Debug":                      { simulationContainerTest('18.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 1804 clang-10 SGX1 RelWithDebInfo":             { simulationContainerTest('18.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 1804 clang-10 SGX1FLC Debug":                   { simulationContainerTest('18.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 1804 clang-10 SGX1FLC RelWithDebInfo":          { simulationContainerTest('18.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 1804 clang-10 SGX1FLC Debug snmalloc":          { simulationContainerTest('18.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
-                "Sim 1804 clang-10 SGX1FLC RelWithDebInfo snmalloc": { simulationContainerTest('18.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
-                "Sim 2004 clang-10 SGX1 Debug":                      { simulationContainerTest('20.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 2004 clang-10 SGX1 RelWithDebInfo":             { simulationContainerTest('20.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 2004 clang-10 SGX1FLC Debug":                   { simulationContainerTest('20.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 2004 clang-10 SGX1FLC RelWithDebInfo":          { simulationContainerTest('20.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "Sim 2004 clang-10 SGX1FLC Debug snmalloc":          { simulationContainerTest('20.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
-                "Sim 2004 clang-10 SGX1FLC RelWithDebInfo snmalloc": { simulationContainerTest('20.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
-                "Ubuntu 1804 Cross Platform Build":                  { buildCrossPlatform("18.04") },
-                "Ubuntu 2004 Cross Platform Build":                  { buildCrossPlatform("20.04") }
+                "Sim 1804 clang-10 SGX1 Debug":                      { tests.simulationContainerTest('18.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-10 SGX1 RelWithDebInfo":             { tests.simulationContainerTest('18.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-10 SGX1FLC Debug":                   { tests.simulationContainerTest('18.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-10 SGX1FLC RelWithDebInfo":          { tests.simulationContainerTest('18.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 1804 clang-10 SGX1FLC Debug snmalloc":          { tests.simulationContainerTest('18.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+                "Sim 1804 clang-10 SGX1FLC RelWithDebInfo snmalloc": { tests.simulationContainerTest('18.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+                "Sim 2004 clang-10 SGX1 Debug":                      { tests.simulationContainerTest('20.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 2004 clang-10 SGX1 RelWithDebInfo":             { tests.simulationContainerTest('20.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 2004 clang-10 SGX1FLC Debug":                   { tests.simulationContainerTest('20.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 2004 clang-10 SGX1FLC RelWithDebInfo":          { tests.simulationContainerTest('20.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "Sim 2004 clang-10 SGX1FLC Debug snmalloc":          { tests.simulationContainerTest('20.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+                "Sim 2004 clang-10 SGX1FLC RelWithDebInfo snmalloc": { tests.simulationContainerTest('20.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+                "Ubuntu 1804 Cross Platform Build":                  { tests.buildCrossPlatform("18.04") },
+                "Ubuntu 2004 Cross Platform Build":                  { tests.buildCrossPlatform("20.04") }
             ]
             parallel testing_stages
         }
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "Sim 1804 clang-10 SGX1 RelWithDebInfo":             { simulationContainerTest('18.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "Sim 1804 clang-10 SGX1FLC Debug":                   { simulationContainerTest('18.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "Sim 2004 clang-10 SGX1FLC RelWithDebInfo":          { simulationContainerTest('20.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "Sim 2004 clang-10 SGX1FLC RelWithDebInfo snmalloc": { simulationContainerTest('20.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON', '-DUSE_SNMALLOC=ON']) },
-                "Ubuntu 1804 Cross Platform Build":                  { buildCrossPlatform("18.04") }
+                "Sim 1804 clang-10 SGX1 RelWithDebInfo":             { tests.simulationContainerTest('18.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=OFF', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "Sim 1804 clang-10 SGX1FLC Debug":                   { tests.simulationContainerTest('18.04', 'Debug',          ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "Sim 2004 clang-10 SGX1FLC RelWithDebInfo":          { tests.simulationContainerTest('20.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "Sim 2004 clang-10 SGX1FLC RelWithDebInfo snmalloc": { tests.simulationContainerTest('20.04', 'RelWithDebInfo', ['-DHAS_QUOTE_PROVIDER=ON',  '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON', '-DUSE_SNMALLOC=ON']) },
+                "Ubuntu 1804 Cross Platform Build":                  { tests.buildCrossPlatform("18.04") }
             ]
             parallel testing_stages
         }
@@ -175,5 +77,5 @@ try{
     throw e
 } finally {
     currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"
-    oe.emailJobStatus(currentBuild.result)
+    common.emailJobStatus(currentBuild.result)
 }

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -1,565 +1,114 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-OECI_LIB_VERSION = env.OECI_LIB_VERSION ?: "master"
-oe = library("OpenEnclaveCommon@${OECI_LIB_VERSION}").jenkins.common.Openenclave.new()
+library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
+GLOBAL_ERROR = globalvars.GLOBAL_ERROR
 
-GLOBAL_TIMEOUT_MINUTES = 120
-CTEST_TIMEOUT_SECONDS = 480
-GLOBAL_ERROR = null
-
-DOCKER_TAG = env.DOCKER_TAG ?: "latest"
-AGENTS_LABELS = [
-    "acc-ubuntu-20.04":         env.UBUNTU_2004_CUSTOM_LABEL ?: "ACC-2004",
-    "acc-ubuntu-18.04":         env.UBUNTU_1804_CUSTOM_LABEL ?: "ACC-1804",
-    "ubuntu-nonsgx":            env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004",
-    "windows-nonsgx":           env.WINDOWS_NONSGX_CUSTOM_LABEL ?: "nonSGX-Windows",
-    "acc-ubuntu-20.04-vanilla": env.UBUNTU_VANILLA_2004_CUSTOM_LABEL ?: "vanilla-ubuntu-2004",
-    "acc-ubuntu-18.04-vanilla": env.UBUNTU_VANILLA_1804_CUSTOM_LABEL ?: "vanilla-ubuntu-1804"
-]
-
-def CmakeArgs(String build_type = "RelWithDebInfo", String code_coverage = "OFF", String debug_malloc = "ON", String lvi_args="", String cmake_args = "") {
-    def args = "-G Ninja -DCMAKE_INSTALL_PREFIX:PATH='/opt/openenclave' -DCPACK_GENERATOR=DEB -DCODE_COVERAGE=${code_coverage} -DUSE_DEBUG_MALLOC=${debug_malloc} -DCMAKE_BUILD_TYPE=${build_type} ${lvi_args} ${cmake_args} -Wdev"
-    return args
-}
-
-def WaitForAptLock() {
-    def aptWait = """
-        i=0
-        echo "Checking for locks..."
-        # Check for locks
-        while fuser /var/lib/dpkg/lock > /dev/null 2>&1 ||
-              fuser /var/lib/dpkg/lock-frontend > /dev/null 2>&1 ||
-              fuser /var/lib/apt/lists/lock > /dev/null 2>&1; do
-            # Wait up to 600 seconds to lock to be released
-            if (( i > 600 )); then
-                echo "Timeout waiting for lock."
-                exit 1
-            fi
-            echo "Waiting for apt/dpkg locks..."
-            i=\${i++}
-            sleep 1
-        done
-    """
-    return aptWait
-}
-
-def TestCommand() {
-    def testCommand = """
-        echo "Running Test Command"
-        ctest --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
-    """
-    return testCommand
-}
-
-def InstallBuildCommand() {
-    def installCommand = """
-        echo "Running Install Build Command"
-        cpack -G DEB
-        ${WaitForAptLock()}
-        sudo ninja -v install
-    """
-    return installCommand
-}
-
-def InstallReleaseCommand() {
-    def installCommand = """
-        echo "Running Install Release Command"
-        echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-        wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-
-        echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
-        wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-
-        echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
-        wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-
-        ${WaitForAptLock()}
-        sudo apt update
-
-        ${WaitForAptLock()}
-        sudo apt install -y open-enclave
-
-        echo "Open Enclave SDK version installed"
-        apt list --installed | grep open-enclave
-    """
-    return installCommand
-}
-
-def TestSamplesCommand() {
-    def testCommand = """
-        echo "Running Test Samples Command"
-        cp -r /opt/openenclave/share/openenclave/samples ~/
-        pushd ~/samples
-        source /opt/openenclave/share/openenclave/openenclaverc
-        for i in *; do
-            if [ -d \${i} ]; then
-                cd \${i}
-                mkdir build
-                cd build
-                cmake ..
-                make
-                make run
-                cd ../..
-            fi
-        done
-        popd
-        rm -rf ~/samples
-    """
-    return testCommand
-}
-
-def ACCCodeCoverageTest(String label, String compiler, String build_type) {
-    stage("${label} ${compiler} ${build_type} Code Coverage") {
-        node("${label}") {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def cmakeArgs = CmakeArgs(build_type)
-                def task = """
-                           cmake ${WORKSPACE} ${cmakeArgs}
-                           ninja -v
-                           ${TestCommand()}
-                           ninja code_coverage
-                           """
-                oe.Run(compiler, task)
-
-                // Publish the report via Cobertura Plugin.
-                cobertura coberturaReportFile: 'build/coverage/coverage.xml'
-
-                // Publish the result to the PR(s) via GitHub Coverage reporter Plugin.
-                // Workaround to obtain the PR id(s) as Bors does not us to grab them reliably.
-                def log = sh (script: "git log -1 | grep -Po '(Try #\\K|Merge #\\K)[^:]*'", returnStdout: true).trim()
-                def id_list = log.split(' #')
-                id_list.each {
-                    echo "PR ID: ${it}, REPOSITORY_NAME: ${REPOSITORY_NAME}"
-                    withEnv(["CHANGE_URL=https://github.com/${REPOSITORY_NAME}/pull/${it}"]) {
-                        publishCoverageGithub(filepath:'build/coverage/coverage.xml',
-                                              coverageXmlType: 'cobertura',
-                                              comparisonOption: [ value: 'optionFixedCoverage', fixedCoverage: '0.60' ],
-                                              coverageRateType: 'Line')
-                    }
-                }
-            }
-        }
-    }
-}
-
-def ACCTest(String label, String compiler, String build_type, List extra_cmake_args = [], List test_env = [], boolean fresh_install = false) {
-    stage("${label} ${compiler} ${build_type}, extra_cmake_args: ${extra_cmake_args}, test_env: ${test_env}${fresh_install ? ", e2e" : ""}") {
-        node(label) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                if (fresh_install) {
-                    sh  """
-                        sudo bash scripts/ansible/install-ansible.sh
-                        # Run ACC Playbook
-                        for i in 1 2 3 4 5
-                        do
-                            sudo \$(which ansible-playbook) scripts/ansible/oe-contributors-acc-setup.yml && break
-                            sleep 60
-                        done
-                        """
-                }
-                def cmakeArgs = CmakeArgs(build_type,"OFF","ON","-DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin",extra_cmake_args.join(' '))
-                def task = """
-                           cmake ${WORKSPACE} ${cmakeArgs}
-                           ninja -v
-                           ${TestCommand()}
-                           """
-                withEnv(test_env) {
-                    oe.Run(compiler, task)
-                }
-            }
-        }
-    }
-}
-
-def ACCUpgradeTest(String label, String compiler, String version, List extra_cmake_args = [], List test_env = []) {
-    stage("${label} Container ${version} RelWithDebInfo, extra_cmake_args: ${extra_cmake_args}") {
-        node("${label}") {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def cmakeArgs = CmakeArgs("RelWithDebInfo","OFF","ON","-DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin",extra_cmake_args.join(' '))
-                def task = """
-                           ${InstallReleaseCommand()}
-                           ${TestSamplesCommand()}
-                           cmake ${WORKSPACE} ${cmakeArgs}
-                           ninja -v
-                           ${InstallBuildCommand()}
-                           ${TestSamplesCommand()}
-                           """
-                withEnv(test_env) {
-                    oe.Run(compiler, task)
-                }
-            }
-        }
-    }
-}
-
-def ACCContainerTest(String label, String version, List extra_cmake_args = []) {
-    stage("${label} Container ${version} RelWithDebInfo, extra_cmake_args: ${extra_cmake_args}") {
-        node("${label}") {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def cmakeArgs = CmakeArgs("RelWithDebInfo","OFF","ON","-DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin",extra_cmake_args.join(' '))
-                def task = """
-                           cmake ${WORKSPACE} ${cmakeArgs}
-                           ninja -v
-                           ${TestCommand()}
-                           """
-                oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
-            }
-        }
-    }
-}
-
-def ACCPackageTest(String label, String version, List extra_cmake_args = []) {
-    stage("${label} PackageTest ${version} RelWithDebInfo, extra_cmake_args: ${extra_cmake_args}") {
-        node("${label}") {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def cmakeArgs = CmakeArgs("RelWithDebInfo","OFF","ON","-DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin",extra_cmake_args.join(' '))
-                def task = """
-                           cmake ${WORKSPACE} ${cmakeArgs}
-                           ninja -v
-                           ${InstallBuildCommand()}
-                           ${TestSamplesCommand()}
-                           """
-                oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
-            }
-        }
-    }
-}
-
-def ACCHostVerificationTest(String version, String build_type) {
-    /* Compile tests in SGX machine.  This will generate the necessary certs for the
-    * host_verify test.
-    */
-    stage("ACC-1804 Generate Quote") {
-        node(AGENTS_LABELS["acc-ubuntu-18.04"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-
-                println("Generating certificates and reports ...")
-                def task = """
-                           cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -Wdev
-                           ninja -v
-                           pushd tests/host_verify/host
-                           openssl ecparam -name prime256v1 -genkey -noout -out keyec.pem
-                           openssl ec -in keyec.pem -pubout -out publicec.pem
-                           openssl genrsa -out keyrsa.pem 2048
-                           openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
-                           ../../../output/bin/oeutil gen --format cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
-                           ../../../output/bin/oeutil gen --format cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
-                           ../../../output/bin/oeutil gen --format legacy_report_remote --out sgx_report.bin --verify
-                           ../../../output/bin/oeutil gen --format sgx_ecdsa --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
-                           ../../../output/bin/oeutil gen --format sgx_ecdsa --quote-proc in --verify
-                           ../../../output/bin/oeutil gen --format sgx_ecdsa --quote-proc out --verify
-                           popd
-                           """
-                oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
-
-                def ec_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_ec.der'
-                def rsa_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_rsa.der'
-                def report_created = fileExists 'build/tests/host_verify/host/sgx_report.bin'
-                def evidence_created = fileExists 'build/tests/host_verify/host/sgx_evidence.bin'
-                if (ec_cert_created) {
-                    println("EC cert file created successfully!")
-                } else {
-                    error("Failed to create EC cert file.")
-                }
-                if (rsa_cert_created) {
-                    println("RSA cert file created successfully!")
-                } else {
-                    error("Failed to create RSA cert file.")
-                }
-                if (report_created) {
-                    println("SGX report file created successfully!")
-                } else {
-                    error("Failed to create SGX report file.")
-                }
-                if (evidence_created) {
-                    println("SGX evidence file created successfully!")
-                } else {
-                    error("Failed to create SGX evidence file.")
-                }
-
-                stash includes: 'build/tests/host_verify/host/*.der,build/tests/host_verify/host/*.bin', name: "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
-            }
-        }
-    }
-
-    /* Compile the tests and unstash the certs over for verification.  */
-    stage("Linux nonSGX Verify Quote") {
-        node(AGENTS_LABELS["ubuntu-nonsgx"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
-                def task = """
-                           cmake ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -Wdev
-                           ninja -v
-                           ctest -R host_verify --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
-                           """
-                // Note: Include the commands to build and run the quote verification test above
-                oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE")
-            }
-        }
-    }
-
-    /* Windows nonSGX stage. */
-    stage("Windows nonSGX Verify Quote") {
-        node(AGENTS_LABELS["windows-nonsgx"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
-                dir('build') {
-                    bat """
-                        vcvars64.bat x64 && \
-                        cmake.exe ${WORKSPACE} -G Ninja -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev && \
-                        ninja -v && \
-                        ctest.exe -V -C ${build_type} -R host_verify --output-on-failure --timeout ${CTEST_TIMEOUT_SECONDS}
-                        """
-                }
-            }
-        }
-    }
-}
-
-def ACCHostVerificationPackageTest(String version, String build_type) {
-    /* Generate an SGX report and two SGX certificates for the host_verify sample.
-    * Also generate and install the host_verify package. Then run the host_verify sample.
-    */
-    stage("ACC-1804 Generate Quote") {
-        node(AGENTS_LABELS["acc-ubuntu-18.04"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-
-                println("Generating certificates and reports ...")
-                def task = """
-                           cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -Wdev
-                           ninja -v
-                           pushd tests/host_verify/host
-                           openssl ecparam -name prime256v1 -genkey -noout -out keyec.pem
-                           openssl ec -in keyec.pem -pubout -out publicec.pem
-                           openssl genrsa -out keyrsa.pem 2048
-                           openssl rsa -in keyrsa.pem -outform PEM -pubout -out publicrsa.pem
-                           ../../../output/bin/oeutil gen --format cert keyec.pem publicec.pem --out sgx_cert_ec.der --verify
-                           ../../../output/bin/oeutil gen --format cert keyrsa.pem publicrsa.pem --out sgx_cert_rsa.der --verify
-                           ../../../output/bin/oeutil gen --format legacy_report_remote --out sgx_report.bin --verify
-                           ../../../output/bin/oeutil gen --format sgx_ecdsa --out sgx_evidence.bin --endorsements sgx_endorsements.bin --verify
-                           ../../../output/bin/oeutil gen --format sgx_ecdsa --quote-proc in --verify
-                           ../../../output/bin/oeutil gen --format sgx_ecdsa --quote-proc out --verify
-                           popd
-                           """
-                oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
-
-                def ec_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_ec.der'
-                def rsa_cert_created = fileExists 'build/tests/host_verify/host/sgx_cert_rsa.der'
-                def report_created = fileExists 'build/tests/host_verify/host/sgx_report.bin'
-                def evidence_created = fileExists 'build/tests/host_verify/host/sgx_evidence.bin'
-                if (ec_cert_created) {
-                    println("EC cert file created successfully!")
-                } else {
-                    error("Failed to create EC cert file.")
-                }
-                if (rsa_cert_created) {
-                    println("RSA cert file created successfully!")
-                } else {
-                    error("Failed to create RSA cert file.")
-                }
-                if (report_created) {
-                    println("SGX report file created successfully!")
-                } else {
-                    error("Failed to create SGX report file.")
-                }
-                if (evidence_created) {
-                    println("SGX evidence file created successfully!")
-                } else {
-                    error("Failed to create SGX evidence file.")
-                }
-
-                stash includes: 'build/tests/host_verify/host/*.der,build/tests/host_verify/host/*.bin', name: "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
-            }
-        }
-    }
-
-    /* Linux nonSGX stage. */
-    stage("Linux nonSGX Verify Quote") {
-        node(AGENTS_LABELS["ubuntu-nonsgx"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
-                def task = """
-                           cmake ${WORKSPACE} \
-                             -DBUILD_ENCLAVES=OFF \
-                             -DCMAKE_BUILD_TYPE=${build_type} \
-                             -DCMAKE_INSTALL_PREFIX=/opt/openenclave \
-                             -DCOMPONENT=OEHOSTVERIFY \
-                             -Wdev
-                           make VERBOSE=1
-                           cpack -G DEB -D CPACK_DEB_COMPONENT_INSTALL=ON -D CPACK_COMPONENTS_ALL=OEHOSTVERIFY
-                           if [ -d /opt/openenclave ]; then sudo rm -r /opt/openenclave; fi
-                           sudo dpkg -i open-enclave-hostverify*.deb
-                           cp tests/host_verify/host/*.der ${WORKSPACE}/samples/host_verify
-                           cp tests/host_verify/host/*.bin ${WORKSPACE}/samples/host_verify
-                           pushd ${WORKSPACE}/samples/host_verify
-                           if [ ! -d build ]; then mkdir build; fi
-                           cd build
-                           cmake ..  -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -Wdev
-                           make VERBOSE=1
-                           ./host_verify -r ../sgx_report.bin
-                           ./host_verify -c ../sgx_cert_ec.der
-                           ./host_verify -c ../sgx_cert_rsa.der
-                           popd
-                           """
-                // Note: Include the commands to build and run the quote verification test above
-                oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", "clang-10", task, "--cap-add=SYS_PTRACE")
-            }
-        }
-    }
-
-    /* Windows nonSGX stage. */
-    stage("Windows nonSGX Verify Quote") {
-        node(AGENTS_LABELS["windows-nonsgx"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                unstash "linux_host_verify-${version}-${build_type}-${BUILD_NUMBER}"
-                dir('build') {
-                    bat """
-                        vcvars64.bat x64 && \
-                        cmake.exe ${WORKSPACE} \
-                          -G Ninja \
-                          -DBUILD_ENCLAVES=OFF \
-                          -DCMAKE_BUILD_TYPE=${build_type} \
-                          -DCOMPONENT=OEHOSTVERIFY \
-                          -DCPACK_GENERATOR=NuGet \
-                          -DNUGET_PACKAGE_PATH=C:/oe_prereqs \
-                          -Wdev && \
-                        ninja -v && \
-                        cpack -D CPACK_NUGET_COMPONENT_INSTALL=ON -DCPACK_COMPONENTS_ALL=OEHOSTVERIFY && \
-                        copy tests\\host_verify\\host\\*.der ${WORKSPACE}\\samples\\host_verify && \
-                        copy tests\\host_verify\\host\\*.bin ${WORKSPACE}\\samples\\host_verify && \
-                        if exist C:\\oe (rmdir C:\\oe) && \
-                        nuget.exe install open-enclave.OEHOSTVERIFY -Source ${WORKSPACE}\\build -OutputDirectory C:\\oe -ExcludeVersion && \
-                        xcopy /E C:\\oe\\open-enclave.OEHOSTVERIFY\\openenclave C:\\openenclave\\ && \
-                        pushd ${WORKSPACE}\\samples\\host_verify && \
-                        if not exist build\\ (mkdir build) && \
-                        cd build && \
-                        cmake.exe .. \
-                          -G Ninja \
-                          -DBUILD_ENCLAVES=OFF \
-                          -DCMAKE_BUILD_TYPE=${build_type} \
-                          -DCMAKE_PREFIX_PATH=C:/openenclave/lib/openenclave/cmake \
-                          -DNUGET_PACKAGE_PATH=C:/oe_prereqs \
-                          -Wdev && \
-                        ninja -v && \
-                        host_verify.exe -r ../sgx_report.bin && \
-                        host_verify.exe -c ../sgx_cert_ec.der && \
-                        host_verify.exe -c ../sgx_cert_rsa.der && \
-                        popd
-                        """
-                }
-            }
-        }
-    }
-}
-
-properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
-                                      artifactNumToKeepStr: '180',
-                                      daysToKeepStr: '90',
-                                      numToKeepStr: '180')),
-            [$class: 'JobRestrictionProperty']])
+properties(
+    [
+        buildDiscarder(
+            logRotator(
+                artifactDaysToKeepStr: '90',
+                artifactNumToKeepStr: '180',
+                daysToKeepStr: '90',
+                numToKeepStr: '180'
+            )
+        ),
+        [$class: 'JobRestrictionProperty'],
+        parameters(
+            [
+                string(name: 'REPOSITORY_NAME',             defaultValue: 'openenclave/openenclave', description: 'GitHub repository to build.'),
+                string(name: 'BRANCH_NAME',                 defaultValue: 'master',                  description: 'Git branch to build.'),
+                string(name: 'DOCKER_TAG',                  defaultValue: 'latest',                  description: 'Tag used to pull oetools docker image.'),
+                string(name: 'OECI_LIB_VERSION',            defaultValue: 'master',                  description: 'Version of OE Libraries to use'),
+                string(name: 'UBUNTU_1804_CUSTOM_LABEL',    defaultValue: '',                        description: '[Optional] Jenkins agent label to use for Ubuntu 18.04 with SGX.'),
+                string(name: 'UBUNTU_2004_CUSTOM_LABEL',    defaultValue: '',                        description: '[Optional] Jenkins agent label to use for Ubuntu 20.04 with SGX.'),
+                string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL',  defaultValue: '',                        description: '[Optional] Jenkins agent label to use for Ubuntu 20.04 without SGX.'),
+                string(name: 'WINDOWS_NONSGX_CUSTOM_LABEL', defaultValue: '',                        description: '[Optional] Jenkins agent label to use for WS 2019 without SGX.'),
+                booleanParam(name: 'FULL_TEST_SUITE',       defaultValue: false,                     description: 'Run all additional tests available in the test suite.')
+            ]
+        )
+    ]
+)
 
 try{
-    oe.emailJobStatus('STARTED')
+    common.emailJobStatus('STARTED')
     def testing_stages = [
-        "Host verification 2004 RelWithDebInfo":            { ACCHostVerificationTest('20.04', 'RelWithDebInfo') },
-        "Host verification 1804 RelWithDebInfo":            { ACCHostVerificationTest('18.04', 'RelWithDebInfo') },
+        "Host verification 2004 RelWithDebInfo":            { tests.ACCHostVerificationTest('20.04', 'RelWithDebInfo') },
+        "Host verification 1804 RelWithDebInfo":            { tests.ACCHostVerificationTest('18.04', 'RelWithDebInfo') },
+        "ACC1804 clang-10 RelWithDebInfo":                  { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
 
-        "Host verification package 2004 RelWithDebInfo":    { ACCHostVerificationPackageTest('20.04', 'RelWithDebInfo') },
-        "Host verification package 1804 RelWithDebInfo":    { ACCHostVerificationPackageTest('18.04', 'RelWithDebInfo') },
+        "Host verification package 2004 RelWithDebInfo":    { tests.ACCHostVerificationPackageTest('20.04', 'RelWithDebInfo') },
+        "Host verification package 1804 RelWithDebInfo":    { tests.ACCHostVerificationPackageTest('18.04', 'RelWithDebInfo') },
 
-        "ACC1804 clang-10 RelWithDebInfo EEID Experimental LVI FULL Tests": { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DWITH_EEID=ON']) },
+        "ACC1804 clang-10 RelWithDebInfo EEID Experimental LVI FULL Tests": { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DWITH_EEID=ON']) },
 
-        "ACC2004 clang-10 Debug LVI e2e":                   { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04-vanilla"], 'clang-10', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) }
+        "ACC2004 clang-10 Debug LVI e2e":                   { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04-vanilla"], 'clang-10', 'Debug',   ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON'], [], true) }
     ]
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
-                "Host verification 2004 Debug": { ACCHostVerificationTest('20.04', 'Debug') },
-                "Host verification 1804 Debug": { ACCHostVerificationTest('18.04', 'Debug') },
+                "Host verification 2004 Debug": { tests.ACCHostVerificationTest('20.04', 'Debug') },
+                "Host verification 1804 Debug": { tests.ACCHostVerificationTest('18.04', 'Debug') },
 
-                "Host verification package 2004 Debug": { ACCHostVerificationPackageTest('20.04', 'Debug') },
-                "Host verification package 1804 Debug": { ACCHostVerificationPackageTest('18.04', 'Debug') },
+                "Host verification package 2004 Debug": { tests.ACCHostVerificationPackageTest('20.04', 'Debug') },
+                "Host verification package 1804 Debug": { tests.ACCHostVerificationPackageTest('18.04', 'Debug') },
 
-                "ACC2004 Package RelWithDebInfo":              { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC2004 Package RelWithDebInfo LVI":          { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC1804 Package RelWithDebInfo":              { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC1804 Package RelWithDebInfo LVI":          { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC2004 Package RelWithDebInfo":              { tests.ACCPackageTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC2004 Package RelWithDebInfo LVI":          { tests.ACCPackageTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 Package RelWithDebInfo":              { tests.ACCPackageTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 Package RelWithDebInfo LVI":          { tests.ACCPackageTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
 
-                "ACC2004 Container RelWithDebInfo":     { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC2004 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC1804 Container RelWithDebInfo":     { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC1804 Container RelWithDebInfo LVI": { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC2004 Container RelWithDebInfo":     { tests.ACCContainerTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC2004 Container RelWithDebInfo LVI": { tests.ACCContainerTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 Container RelWithDebInfo":     { tests.ACCContainerTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 Container RelWithDebInfo LVI": { tests.ACCContainerTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
 
-                "ACC2004 clang-10 Debug":                           { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'Debug',                  ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC2004 clang-10 RelWithDebInfo":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'RelWithDebInfo',         ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC2004 clang-10 Debug LVI":                       { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'Debug',                  ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC2004 clang-10 RelWithDebInfo LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'RelWithDebInfo',         ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC1804 clang-10 Debug":                           { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"],         'clang-10', 'Debug',                  ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC1804 clang-10 RelWithDebInfo":                  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"],         'clang-10', 'RelWithDebInfo',         ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC1804 clang-10 Debug LVI":                       { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"],         'clang-10', 'Debug',                  ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
-                "ACC1804 clang-10 RelWithDebInfo LVI":              { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"],         'clang-10', 'RelWithDebInfo',         ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC2004 clang-10 Debug":                           { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'Debug',                  ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC2004 clang-10 RelWithDebInfo":                  { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'RelWithDebInfo',         ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC2004 clang-10 Debug LVI":                       { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'Debug',                  ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC2004 clang-10 RelWithDebInfo LVI":              { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'RelWithDebInfo',         ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 clang-10 Debug":                           { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"],         'clang-10', 'Debug',                  ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 clang-10 RelWithDebInfo":                  { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"],         'clang-10', 'RelWithDebInfo',         ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 clang-10 Debug LVI":                       { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"],         'clang-10', 'Debug',                  ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 clang-10 RelWithDebInfo LVI":              { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"],         'clang-10', 'RelWithDebInfo',         ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
 
-                "ACC2004 clang-10 RelWithDebInfo LVI e2e":          { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04-vanilla"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) },
-                "ACC1804 clang-10 Debug LVI e2e":                   { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) },
-                "ACC1804 clang-10 RelWithDebInfo LVI e2e":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) },
+                "ACC2004 clang-10 RelWithDebInfo LVI e2e":          { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04-vanilla"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) },
+                "ACC1804 clang-10 Debug LVI e2e":                   { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) },
+                "ACC1804 clang-10 RelWithDebInfo LVI e2e":          { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF'], [], true) },
 
-                "ACC2004 Package RelWithDebInfo LVI snmalloc": { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
-                "ACC1804 Package RelWithDebInfo LVI snmalloc": { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+                "ACC2004 Package RelWithDebInfo LVI snmalloc": { tests.ACCPackageTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+                "ACC1804 Package RelWithDebInfo LVI snmalloc": { tests.ACCPackageTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
 
-                "ACC2004 clang-10 RelWithDebInfo LVI e2e snmalloc": { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04-vanilla"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
-                "ACC1804 clang-10 Debug LVI e2e snmalloc":          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
-                "ACC1804 clang-10 RelWithDebInfo LVI e2e snmalloc": { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
-                "ACC2004 clang-10 RelWithDebInfo LVI snmalloc":     { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) }
+                "ACC2004 clang-10 RelWithDebInfo LVI e2e snmalloc": { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04-vanilla"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
+                "ACC1804 clang-10 Debug LVI e2e snmalloc":          { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
+                "ACC1804 clang-10 RelWithDebInfo LVI e2e snmalloc": { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
+                "ACC2004 clang-10 RelWithDebInfo LVI snmalloc":     { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) }
             ]
             parallel testing_stages
         }
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "ACC2004 Package RelWithDebInfo LVI":              { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 Package RelWithDebInfo LVI":              { ACCPackageTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC2004 Package RelWithDebInfo LVI":              { tests.ACCPackageTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 Package RelWithDebInfo LVI":              { tests.ACCPackageTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
 
-                "ACC2004 Container RelWithDebInfo LVI":            { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 Container RelWithDebInfo LVI":            { ACCContainerTest(AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC2004 Container RelWithDebInfo LVI":            { tests.ACCContainerTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], '20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 Container RelWithDebInfo LVI":            { tests.ACCContainerTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], '18.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
 
-                "ACC2004 clang-10 Debug LVI":                      { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC2004 clang-10 RelWithDebInfo LVI":             { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 clang-10 Debug LVI":                      { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC1804 clang-10 RelWithDebInfo LVI FULL Tests":  { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC2004 clang-10 Debug LVI":                      { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC2004 clang-10 RelWithDebInfo LVI":             { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 clang-10 Debug LVI":                      { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC1804 clang-10 RelWithDebInfo LVI FULL Tests":  { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
 
-                "ACC1804 clang-10 Debug":                          { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                "ACC1804 clang-10 Debug":                          { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
 
-                "ACC1804 clang-10 RelWithDebInfo":                 { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=None',        '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
+                //"ACC1804 Code Coverage Test" :                     { ACCCodeCoverageTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'Debug') },
 
-                 //"ACC1804 Code Coverage Test" :                     { ACCCodeCoverageTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'Debug') },
-
-                "ACC2004 clang-10 RelWithDebInfo LVI snmalloc":            { ACCTest(AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON',  '-DUSE_SNMALLOC=ON']) },
-                "ACC1804 clang-10 RelWithDebInfo LVI FULL Tests snmalloc": { ACCTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
-                "ACC1804 Upgrade Package RelWithDebInfo LVI":              { ACCUpgradeTest(AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', '18.04', ['-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
-                "ACC2004 Upgrade Package RelWithDebInfo LVI":              { ACCUpgradeTest(AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-10', '20.04', ['-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) }
+                "ACC2004 clang-10 RelWithDebInfo LVI snmalloc":            { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=ON',  '-DUSE_SNMALLOC=ON']) },
+                "ACC1804 clang-10 RelWithDebInfo LVI FULL Tests snmalloc": { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+                "ACC1804 Upgrade Package RelWithDebInfo LVI":              { tests.ACCUpgradeTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], 'clang-10', '18.04', ['-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) },
+                "ACC2004 Upgrade Package RelWithDebInfo LVI":              { tests.ACCUpgradeTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-10', '20.04', ['-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=ON']) }
                 ]
             parallel testing_stages
         }
@@ -570,5 +119,5 @@ try{
     throw e
 } finally {
     currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"
-    oe.emailJobStatus(currentBuild.result)
+    common.emailJobStatus(currentBuild.result)
 }

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -1,168 +1,73 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-OECI_LIB_VERSION = env.OECI_LIB_VERSION ?: "master"
-oe = library("OpenEnclaveCommon@${OECI_LIB_VERSION}").jenkins.common.Openenclave.new()
+library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
+GLOBAL_ERROR = globalvars.GLOBAL_ERROR
+globalvars.CTEST_TIMEOUT_SECONDS = 1200
 
-GLOBAL_TIMEOUT_MINUTES = 120
-CTEST_TIMEOUT_SECONDS = 1200
-GLOBAL_ERROR = null
-
-DOCKER_TAG = env.DOCKER_TAG ?: "latest"
-AGENTS_LABELS = [
-    "ubuntu-nonsgx":    env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004",
-    "acc-win2019":      env.WINDOWS_2019_CUSTOM_LABEL ?: "SGX-Windows-2019",
-    "acc-win2019-dcap": env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP"
-]
-
-def windowsPrereqsVerify(String label) {
-    stage("Windows ${label} Install Prereqs Verification") {
-        node(AGENTS_LABELS[label]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                dir('scripts') {
-                    bat(
-                        returnStdout: false,
-                        returnStatus: false,
-                        script: """
-                            powershell.exe -ExecutionPolicy Unrestricted -NoLogo -NonInteractive -NoProfile -WindowStyle Hidden -File install-windows-prereqs.ps1 -InstallPath C:\\oe_prereqs -LaunchConfiguration SGX1FLC-NoIntelDrivers -DCAPClientType Azure -VerificationOnly
-                        """
-                    )
-                }
-            }
-        }
-    }
-}
-
-def windowsLinuxElfBuild(String label, String version, String compiler, String build_type, String lvi_mitigation = 'None', String lvi_mitigation_skip_tests = 'OFF', List extra_cmake_args = []) {
-    stage("Ubuntu ${version} SGX1 ${compiler} ${build_type} LVI_MITIGATION=${lvi_mitigation}") {
-        node(AGENTS_LABELS["ubuntu-nonsgx"]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                def task = """
-                           cmake ${WORKSPACE}                                           \
-                               -G Ninja                                                 \
-                               -DCMAKE_BUILD_TYPE=${build_type}                         \
-                               -DLVI_MITIGATION=${lvi_mitigation}                       \
-                               -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
-                               -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} \
-                               -Wdev                                                    \
-                               ${extra_cmake_args.join(' ')}
-                           ninja -v
-                           """
-                oe.ContainerRun("oetools-${version}:${DOCKER_TAG}", compiler, task, "--cap-add=SYS_PTRACE")
-                stash includes: 'build/tests/**', name: "linux-${label}-${compiler}-${build_type}-lvi_mitigation=${lvi_mitigation}-${version}-${BUILD_NUMBER}"
-            }
-        }
-    }
-    stage("Windows ${label} ${build_type} LVI_MITIGATION=${lvi_mitigation}") {
-        node(AGENTS_LABELS[label]) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-                unstash "linux-${label}-${compiler}-${build_type}-lvi_mitigation=${lvi_mitigation}-${version}-${BUILD_NUMBER}"
-                bat 'move build linuxbin'
-                dir('build') {
-                    bat(
-                        returnStdout: false,
-                        returnStatus: false,
-                        script: """
-                            call vcvars64.bat x64
-                            setlocal EnableDelayedExpansion
-                            cmake.exe ${WORKSPACE} -G Ninja -DADD_WINDOWS_ENCLAVE_TESTS=ON -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -DLINUX_BIN_DIR=${WORKSPACE}\\linuxbin\\tests -DLVI_MITIGATION=${lvi_mitigation} -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev || exit !ERRORLEVEL!
-                            ninja -v || exit !ERRORLEVEL!
-                            ctest.exe -V -C ${build_type} --timeout ${CTEST_TIMEOUT_SECONDS} || exit !ERRORLEVEL!
-                        """
-                    )
-                }
-            }
-        }
-    }
-}
-
-def windowsCrossCompile(String label, String build_type, String lvi_mitigation = 'None', String OE_SIMULATION = "0", String lvi_mitigation_skip_tests = 'OFF', List extra_cmake_args = []) {
-    def node_label = AGENTS_LABELS["${label}-dcap"]
-
-    stage("Windows ${label} ${build_type} with SGX LVI_MITIGATION=${lvi_mitigation}") {
-        node(node_label) {
-            withEnv(["OE_SIMULATION=${OE_SIMULATION}"]) {
-                timeout(GLOBAL_TIMEOUT_MINUTES) {
-                    // OFF value of quote provider until https://github.com/openenclave/openenclave-ci/pull/29 is merged
-                    oe.WinCompilePackageTest("build/X64-${build_type}", build_type, 'OFF', CTEST_TIMEOUT_SECONDS, lvi_mitigation, lvi_mitigation_skip_tests, extra_cmake_args)
-                }
-            }
-        }
-    }
-}
-
-def windowsCrossPlatform(String label) {
-    def node_label = AGENTS_LABELS[label]
-    stage("Windows ${node_label} Cross Plaform Build") {
-        node(node_label) {
-            timeout(GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                checkout scm
-
-                dir("devex/cross-nuget/standalone-builds/windows") {
-                    bat(
-                        returnStdout: false,
-                        returnStatus: false,
-                        script: """
-                            vcvars64.bat x64 && powershell -c "Set-ExecutionPolicy Bypass -Scope Process; .\\build.ps1 -SDK_PATH ${WORKSPACE}"
-                            vcvars64.bat x64 && powershell -c "Set-ExecutionPolicy Bypass -Scope Process; .\\pack.ps1"
-                        """
-                    )
-                }
-            }
-        }
-    }
-}
-
-properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
-                                      artifactNumToKeepStr: '180',
-                                      daysToKeepStr: '90',
-                                      numToKeepStr: '180')),
-            [$class: 'JobRestrictionProperty']])
+properties(
+    [
+        buildDiscarder(
+            logRotator(
+                artifactDaysToKeepStr: '90',
+                artifactNumToKeepStr: '180',
+                daysToKeepStr: '90',
+                numToKeepStr: '180'
+            )
+        ),
+        [$class: 'JobRestrictionProperty'],
+        parameters(
+            [
+                string(name: 'REPOSITORY_NAME',                defaultValue: 'openenclave/openenclave', description: 'GitHub repository to build.'),
+                string(name: 'BRANCH_NAME',                    defaultValue: 'master',                  description: 'Git branch to build.'),
+                string(name: 'DOCKER_TAG',                     defaultValue: 'latest',                  description: 'Tag used to pull oetools docker image.'),
+                string(name: 'OECI_LIB_VERSION',               defaultValue: 'master',                  description: 'Version of OE Libraries to use'),
+                string(name: 'WINDOWS_2019_CUSTOM_LABEL',      defaultValue: '',                        description: '[Optional] Jenkins agent label to use for Windows Server 2019'),
+                string(name: 'WINDOWS_2019_DCAP_CUSTOM_LABEL', defaultValue: '',                        description: '[Optional] Jenkins agent label to use for Windows Server 2019 with DCAP'),
+                string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL',     defaultValue: '',                        description: '[Optional] Jenkins agent label to use for Ubuntu 20.04 without SGX.'),
+                booleanParam(name: 'FULL_TEST_SUITE',          defaultValue: false,                     description: 'Run all additional tests available in the test suite.')
+            ]
+        )
+    ]
+)
 
 try{
-    oe.emailJobStatus('STARTED')
-    def testing_stages = [ "Windows 2019 Install Prerequisites Verification" : { windowsPrereqsVerify("acc-win2019-dcap") }]
+    common.emailJobStatus('STARTED')
+    def testing_stages = [ "Windows 2019 Install Prerequisites Verification" : { tests.windowsPrereqsVerify("acc-win2019-dcap") }]
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
-                "Win2019 Ubuntu2004 clang-10 Debug Linux-Elf-build":              { windowsLinuxElfBuild('acc-win2019-dcap', '20.04', 'clang-10', 'Debug') },
-                "Win2019 Ubuntu2004 clang-10 RelWithDebInfo Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2019-dcap', '20.04', 'clang-10', 'RelWithDebInfo') },
-                "Win2019 Ubuntu2004 clang-10 Debug Linux-Elf-build LVI":          { windowsLinuxElfBuild('acc-win2019-dcap', '20.04', 'clang-10', 'Debug', 'ControlFlow') },
-                "Win2019 Ubuntu2004 clang-10 RelWithDebInfo Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2019-dcap', '20.04', 'clang-10', 'RelWithDebInfo', 'ControlFlow') },
-                "Win2019 Ubuntu1804 clang-10 Debug Linux-Elf-build":              { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-10', 'Debug') },
-                "Win2019 Ubuntu1804 clang-10 RelWithDebInfo Linux-Elf-build":     { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-10', 'RelWithDebInfo') },
-                "Win2019 Ubuntu1804 clang-10 Debug Linux-Elf-build LVI":          { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-10', 'Debug', 'ControlFlow') },
-                "Win2019 Ubuntu1804 clang-10 RelWithDebInfo Linux-Elf-build LVI": { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-10', 'RelWithDebInfo', 'ControlFlow') },
-                "Win2019 Sim Debug Cross Compile":                                { windowsCrossCompile('acc-win2019', 'Debug',          'None',        '1') },
-                "Win2019 Sim RelWithDebInfo Cross Compile":                       { windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'None',        '1') },
-                "Win2019 Sim Debug Cross Compile LVI ":                           { windowsCrossCompile('acc-win2019', 'Debug',          'ControlFlow', '1') },
-                "Win2019 Sim RelWithDebInfo Cross Compile LVI ":                  { windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow', '1') },
-                "Win2019 Debug Cross Compile with DCAP libs":                     { windowsCrossCompile('acc-win2019', 'Debug') },
-                "Win2019 RelWithDebInfo Cross Compile with DCAP libs":            { windowsCrossCompile('acc-win2019', 'RelWithDebInfo') },
-                "Win2019 Debug Cross Compile DCAP LVI":                           { windowsCrossCompile('acc-win2019', 'Debug',          'ControlFlow') },
-                "Win2019 RelWithDebInfo Cross Compile DCAP LVI":                  { windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow') },
+                "Win2019 Ubuntu2004 clang-10 Debug Linux-Elf-build":              { tests.windowsLinuxElfBuild('acc-win2019-dcap', '20.04', 'clang-10', 'Debug') },
+                "Win2019 Ubuntu2004 clang-10 RelWithDebInfo Linux-Elf-build":     { tests.windowsLinuxElfBuild('acc-win2019-dcap', '20.04', 'clang-10', 'RelWithDebInfo') },
+                "Win2019 Ubuntu2004 clang-10 Debug Linux-Elf-build LVI":          { tests.windowsLinuxElfBuild('acc-win2019-dcap', '20.04', 'clang-10', 'Debug', 'ControlFlow') },
+                "Win2019 Ubuntu2004 clang-10 RelWithDebInfo Linux-Elf-build LVI": { tests.windowsLinuxElfBuild('acc-win2019-dcap', '20.04', 'clang-10', 'RelWithDebInfo', 'ControlFlow') },
+                "Win2019 Ubuntu1804 clang-10 Debug Linux-Elf-build":              { tests.windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-10', 'Debug') },
+                "Win2019 Ubuntu1804 clang-10 RelWithDebInfo Linux-Elf-build":     { tests.windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-10', 'RelWithDebInfo') },
+                "Win2019 Ubuntu1804 clang-10 Debug Linux-Elf-build LVI":          { tests.windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-10', 'Debug', 'ControlFlow') },
+                "Win2019 Ubuntu1804 clang-10 RelWithDebInfo Linux-Elf-build LVI": { tests.windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-10', 'RelWithDebInfo', 'ControlFlow') },
+                "Win2019 Sim Debug Cross Compile":                                { tests.windowsCrossCompile('acc-win2019', 'Debug',          'None',        '1') },
+                "Win2019 Sim RelWithDebInfo Cross Compile":                       { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'None',        '1') },
+                "Win2019 Sim Debug Cross Compile LVI ":                           { tests.windowsCrossCompile('acc-win2019', 'Debug',          'ControlFlow', '1') },
+                "Win2019 Sim RelWithDebInfo Cross Compile LVI ":                  { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow', '1') },
+                "Win2019 Debug Cross Compile with DCAP libs":                     { tests.windowsCrossCompile('acc-win2019', 'Debug') },
+                "Win2019 RelWithDebInfo Cross Compile with DCAP libs":            { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo') },
+                "Win2019 Debug Cross Compile DCAP LVI":                           { tests.windowsCrossCompile('acc-win2019', 'Debug',          'ControlFlow') },
+                "Win2019 RelWithDebInfo Cross Compile DCAP LVI":                  { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow') },
 
-                "Win2019 Sim Debug Cross Compile LVI snmalloc":                   { windowsCrossCompile('acc-win2019', 'Debug',          'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
-                "Win2019 RelWithDebInfo Cross Compile DCAP LVI snmalloc":         { windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) },
-                "Win2019 Cross Platform":                                         { windowsCrossPlatform('acc-win2019-dcap') }
+                "Win2019 Sim Debug Cross Compile LVI snmalloc":                   { tests.windowsCrossCompile('acc-win2019', 'Debug',          'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
+                "Win2019 RelWithDebInfo Cross Compile DCAP LVI snmalloc":         { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) },
+                "Win2019 Cross Platform":                                         { tests.windowsCrossPlatform('acc-win2019-dcap') }
             ]
             parallel testing_stages
         }
     } else {
         stage("PR Testing") {
             testing_stages += [
-                "Win2019 Ubuntu1804 clang-10 RelWithDebInfo Linux-Elf-build LVI":    { windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-10', 'RelWithDebInfo', 'ControlFlow', 'ON') },
-                "Win2019 Sim RelWithDebInfo Cross Compile LVI ":                     { windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow', '1', 'ON') },
-                "Win2019 Debug Cross Compile DCAP LVI":                              { windowsCrossCompile('acc-win2019', 'Debug',          'ControlFlow', '0', 'ON') },
-                "Win2019 RelWithDebInfo Cross Compile DCAP LVI FULL Tests":          { windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow') },
-                "Win2019 RelWithDebInfo Cross Compile DCAP LVI FULL Tests snmalloc": { windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) }
+                "Win2019 Ubuntu1804 clang-10 RelWithDebInfo Linux-Elf-build LVI":    { tests.windowsLinuxElfBuild('acc-win2019-dcap', '18.04', 'clang-10', 'RelWithDebInfo', 'ControlFlow', 'ON') },
+                "Win2019 Sim RelWithDebInfo Cross Compile LVI ":                     { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow', '1', 'ON') },
+                "Win2019 Debug Cross Compile DCAP LVI":                              { tests.windowsCrossCompile('acc-win2019', 'Debug',          'ControlFlow', '0', 'ON') },
+                "Win2019 RelWithDebInfo Cross Compile DCAP LVI FULL Tests":          { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow') },
+                "Win2019 RelWithDebInfo Cross Compile DCAP LVI FULL Tests snmalloc": { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) }
             ]
             parallel testing_stages
         }
@@ -173,5 +78,5 @@ try{
     throw e
 } finally {
     currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"
-    oe.emailJobStatus(currentBuild.result)
+    common.emailJobStatus(currentBuild.result)
 }

--- a/.jenkins/pipelines/OpenEnclave/releases/tests/Jenkinsfile
+++ b/.jenkins/pipelines/OpenEnclave/releases/tests/Jenkinsfile
@@ -1,0 +1,32 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+properties(
+    [
+        buildDiscarder(
+            logRotator(
+                artifactDaysToKeepStr: '90',
+                artifactNumToKeepStr: '180',
+                daysToKeepStr: '90',
+                numToKeepStr: '180'
+            )
+        ),
+        [$class: 'JobRestrictionProperty'],
+        parameters(
+            [
+                string(name: "OECI_LIB_VERSION", defaultValue: 'cyan/test-releases', description: 'Version of OE Libraries to use'),
+                string(name: "OE_RELEASE_VERSION", description: "Open Enclave Release Version"),
+                choice(name: "OE_PACKAGE", choices: ["open-enclave", "open-enclave-hostverify"], description: "Open Enclave package type to install"),
+                choice(name: "RELEASE_SOURCE", choices: ["Azure", "GitHub"], description: "Source to download the OE Release from")
+            ]
+        )
+    ]
+)
+
+library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
+
+parallel "Ubuntu 20.04":        { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, false) },
+         "Ubuntu 18.04":        { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, false) },
+         "Ubuntu 20.04 w/ LVI": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, true)  },
+         "Ubuntu 18.04 w/ LVI": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, true)  },
+         "Windows Server 2019": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-win2019-dcap"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, false) }


### PR DESCRIPTION
**### Do not run bors try on this!!**

This PR does the following changes:

* Added new Jenkinsfile for testing releases (from GitHub) or release candidates (from Azure container storage) on Linux and Windows
* Moved Jenkinsfile functions into a shared library in `.jenkins/library` to simplify Jenkinsfile designs
  - Global variables are in `.jenkins/library/vars/globalvars.groovy`
  - Helper functions are in `.jenkins/library/vars/helpers.groovy`
  - Test functions are in `.jenkins/library/vars/tests.groovy`
  - Deprecates [openenclave-ci library](https://github.com/openenclave/openenclave-ci/blob/master/src/jenkins/common/Openenclave.groovy) by moving it to `.jenkins/library/vars/common.groovy`
* New functions:
  - `common.ContainerTasks()` --> Similar to `common.ContainerRun` but is instead used to run groovy code within a Docker container
  - `tests.OEReleaseTest()` --> Installs a release version and runs samples
  - `helpers.ninjaBuildCommand()` --> Runs cmake and ninja build
  - `helpers.releaseInstallCommand()` --> Downloads an Open Enclave release version from a pre-defined Azure Blob container and installs it.
* New/changed parameters:
  - `OECI_LIB_VERSION` now determines the branch used to pull the library `.jenkins/library`
  - Jenkins parameters are now determined by the Jenkinsfile rather than manually changed in Jenkins UI.
 
Note: improvements have not been made to any of the code that were moved, except for required changes to function as a library, and to support release tests.

Future improvements
* Migrate other Jenkinsfiles to the new shared library (deliberately left out of review to minimize number of files changed and facilitate a more gradual transition)
* Clean up similar functions + minor improvements
* Reorganize helpers and common functions, as the two are similar in terms of use. It is likely better to split between test vs general use functions.

Discussion points:
* Preference to separate functions into a Linux version and a Windows version?
  - Pros: Smaller functions, and with more clearly defined separation Linux and Windows
  - Cons: More functions that may end up having extremely similar or duplicated code
* Preference to split longer sh, bash, powershell, or bat scripts into a separate file?
  - Pro: Removes a layer of complexity with escapes with groovy, so it is easier to maintain
  - Con: Adds an additional file to refer to when digging through code

Tests:
https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/Debug-Jobs/job/Test-Agnostic-Pipeline/
https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/Debug-Jobs/job/Test-Azure-Linux/
https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/Debug-Jobs/job/Test-Azure-Windows/
https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/Debug-Jobs/job/Release-Tests/