### PR TITLE
Disable optimizations for testcase

### DIFF
--- a/3rdparty/compiler-rt/CMakeLists.txt
+++ b/3rdparty/compiler-rt/CMakeLists.txt
@@ -222,7 +222,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR USE_CLANGW)
     -fno-stack-protector
     -std=c11
     -nostdinc
-    -fpic)
+    -fno-omit-frame-pointer
+    -fno-builtin
+    -fpic
+    -ffreestanding)
 else ()
   enclave_compile_options(
     oecompiler-rt
@@ -233,7 +236,10 @@ else ()
     -fno-stack-protector
     -std=c11
     -nostdinc
-    -fpic)
+    -fno-omit-frame-pointer
+    -fno-builtin
+    -fpic
+    -ffreestanding)
 endif ()
 
 enclave_link_libraries(oecompiler-rt PRIVATE oelibc_includes)

--- a/tests/compiler_rt/enc/CMakeLists.txt
+++ b/tests/compiler_rt/enc/CMakeLists.txt
@@ -47,15 +47,26 @@ foreach (TEST IN LISTS TEST_FILES)
   #   - rename main to ${NAME}_main. This function will be called from
   #     generated test.c.
   #   - Prefix ${NAME} to identifiers that are also used in other test files.
-  set_source_files_properties(
-    ${TEST}
-    PROPERTIES
-      COMPILE_FLAGS
+  set(COMPILE_FLAGS
       "-Dmain=${NAME}_main -Dassumption_1=${NAME}_assumption_1 \
     -Dassumption_2=${NAME}_assumption_2 -Dassumption_3=${NAME}_assumption_3 \
     -Dclassify=${NAME}_classify -Dx=${NAME}_x -Dcases=${NAME}_cases \
     -Dtests=${NAME}_tests -Dnaive_popcount=${NAME}_naive_popcount \
     -Dnaive_parity=${NAME}_naive_parity")
+
+  if (${NAME} MATCHES "extendhfsf2")
+    # This testcase fails when compiled with optimizations.
+    # The same failure can be reproduced outside OE by doing:
+    #    clang-10 ../../../lib/builtins/extendhfsf2.c extendhfsf2_test.c
+    #          -fpic -O2 -fno-builtin -ffreestanding
+    #    ./a.out
+    # Therefore disable optimizations for this testcase.
+    # due to compiler optimizations.
+    string(APPEND COMPILE_FLAGS " -O0")
+  endif ()
+
+  set_source_files_properties(${TEST} PROPERTIES COMPILE_FLAGS
+                                                 "${COMPILE_FLAGS}")
 
   # Add test to list of supported tests.
   list(APPEND SUPPORTED_TESTS ${TEST})


### PR DESCRIPTION
The particular testcase is sensitive to compiler optimization.
It fails in a similar manner outside OE/enclaves.

Also add more enclave conformant flags to compiler-rt sources.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>