### PR TITLE
[Mystikos] 0-base enclaves need to use the desired start address for measurements

### DIFF
--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -415,8 +415,14 @@ oe_result_t oe_sgx_create_enclave(
 
     if (context->type == OE_SGX_LOAD_TYPE_MEASURE)
     {
-        /* Use this phony base address when signing enclaves */
-        image_base = (void*)0x0000ffff00000000;
+        /*
+         * Use the phony base address 0x0000ffff00000000 when signing enclaves.
+         * In case of zerobase enclaves, this value needs to be the desired
+         * start address.
+         */
+        image_base = context->create_zero_base_enclave
+                         ? start_address
+                         : (void*)0x0000ffff00000000;
     }
 #if !defined(OEHOSTMR)
     else if (oe_sgx_is_simulation_load_context(context))


### PR DESCRIPTION
Fixes the bug where oesign (and config file) was unable to create 0-base enclave without macro setting the properties accordingly.

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>