### PR TITLE
Internal support of an alternative exception handler stack

### DIFF
--- a/enclave/core/sgx/asmdefs.h
+++ b/enclave/core/sgx/asmdefs.h
@@ -37,6 +37,8 @@
 #define td_simulate (td_callsites + 8)
 #define td_host_ecall_context (td_simulate + 8)
 #define td_host_previous_ecall_context (td_host_ecall_context + 8)
+#define td_exception_handler_stack (td_host_previous_ecall_context + 8)
+#define td_exception_handler_stack_size (td_exception_handler_stack + 8)
 
 #define oe_exit_enclave __morestack
 #ifndef __ASSEMBLER__

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -105,15 +105,44 @@ oe_enter:
 
     // Abort if SSA[0].GPRSGX.URSP is within the enclave memory range
     cmp %r12, %r9
-    jb .exception_check_pass
+    jb .exception_handler_stack_check
     cmp %r13, %r9
-    jae .exception_check_pass
+    jae .exception_handler_stack_check
     jmp .abort
 
     // Reaching this point implies SSA[0].GPRSGX.RSP is within the enclave
     // memory range so we do not need additional checks.
 
-.exception_check_pass:
+.exception_handler_stack_check:
+    // Stop speculative execution at target of conditional jump
+    lfence
+
+    // Get the exception_handler_stack_check range
+    mov td_exception_handler_stack(%r11), %r14
+    mov td_exception_handler_stack_size(%r11), %r15
+    test %r15, %r15
+    jz .exception_stack_setup // check if size is zero
+    add %r14, %r15
+    jc .exception_stack_setup // check for overflow
+
+    // Check if the stack range is within the enclave memory range
+    // If the check fails, fallback to the default behavior (i.e.,
+    // re-using the stack pointer saved in the SSA)
+    cmp %r12, %r14
+    jb .exception_stack_setup
+    cmp %r13, %r15
+    ja .exception_stack_setup
+
+    // Check passes, use the exception handler stack
+    mov %r15, %r8
+
+    // Align the stack
+    and $-16, %r8
+
+    // Proceed without the red zone
+    jmp .call_function
+
+.exception_stack_setup:
     // Stop speculative execution at target of conditional jump
     lfence
 
@@ -149,6 +178,9 @@ oe_enter:
     sub $PAGE_SIZE, %r8
 
 .call_function:
+    // Stop speculative execution for the fallthrough cases
+    lfence
+
     // Set the rsp to the in-enclave stack
     mov %r8, %rsp
 

--- a/enclave/core/sgx/td.c
+++ b/enclave/core/sgx/td.c
@@ -171,6 +171,30 @@ oe_sgx_td_t* oe_sgx_get_td()
 /*
 **==============================================================================
 **
+** oe_sgx_set_td_exception_handler_stack()
+**
+**     Internal API that allows an enclave to setup stack area for
+**     exception handlers to use.
+**
+**==============================================================================
+*/
+bool oe_sgx_set_td_exception_handler_stack(void* stack, uint64_t size)
+{
+    oe_sgx_td_t* td = oe_sgx_get_td();
+
+    /* ensure stack + size is 16-byte aligned */
+    if (((uint64_t)stack + size) % 16)
+        return false;
+
+    td->exception_handler_stack_size = size;
+    td->exception_handler_stack = (uint64_t)stack;
+
+    return true;
+}
+
+/*
+**==============================================================================
+**
 ** td_initialized()
 **
 **     Returns TRUE if this thread data structure (oe_sgx_td_t) is initialized.

--- a/include/openenclave/bits/exception.h
+++ b/include/openenclave/bits/exception.h
@@ -24,6 +24,10 @@ OE_EXTERNC_BEGIN
  *  to the dispatcher that it should stop searching and continue execution. */
 #define OE_EXCEPTION_CONTINUE_EXECUTION 0xFFFFFFFF
 
+/** Return value used by an enclave vectored exception handler to indicate
+ *  to the dispatcher that it should stop searching and abort the execution. */
+#define OE_EXCEPTION_ABORT_EXECUTION 0xFFFFFFF0
+
 /**
  * Divider exception code, used by vectored exception handler.
  */

--- a/include/openenclave/internal/sgx/td.h
+++ b/include/openenclave/internal/sgx/td.h
@@ -81,7 +81,7 @@ oe_thread_data_t* oe_get_thread_data(void);
  * Due to the inability to use OE_OFFSETOF on a struct while defining its
  * members, this value is computed and hard-coded.
  */
-#define OE_THREAD_SPECIFIC_DATA_SIZE (3756)
+#define OE_THREAD_SPECIFIC_DATA_SIZE (3724)
 
 typedef struct _oe_callsite oe_callsite_t;
 
@@ -136,14 +136,23 @@ typedef struct _td
     struct _oe_ecall_context* host_ecall_context;
     struct _oe_ecall_context* host_previous_ecall_context;
 
+    /* The optional stack area setup by the runtime to handle the exceptions */
+    uint64_t exception_handler_stack;
+    uint64_t exception_handler_stack_size;
+
+    /* Save the rsp and rbp values in the SSA when the exception handler
+     * stack is set */
+    uint64_t last_ssa_rsp;
+    uint64_t last_ssa_rbp;
+
     /* The last stack pointer (set by enclave when making an OCALL) */
     uint64_t last_sp;
 
-    // The exception code.
+    /* The exception code */
     uint32_t exception_code;
-    // The exception flags.
+    /* The exception flags */
     uint32_t exception_flags;
-    // The rip when exception happened.
+    /* The rip when exception happened */
     uint64_t exception_address;
 
     /* The threads implementations uses this to put threads on queues */
@@ -180,6 +189,8 @@ OE_STATIC_ASSERT(
 
 /* Get the thread data object for the current thread */
 oe_sgx_td_t* oe_sgx_get_td(void);
+
+bool oe_sgx_set_td_exception_handler_stack(void* stack, uint64_t size);
 
 OE_EXTERNC_END
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,6 +152,7 @@ if (UNIX
     add_subdirectory(thread_local_large)
     add_subdirectory(thread_local_no_tdata)
     add_subdirectory(VectorException)
+    add_subdirectory(stack_overflow_exception)
     add_subdirectory(stack_smashing_protector)
     add_subdirectory(stress)
 

--- a/tests/VectorException/VectorException.edl
+++ b/tests/VectorException/VectorException.edl
@@ -17,10 +17,11 @@ enclave {
     };
 
     trusted {
-        public int enc_test_vector_exception();
-        public int enc_test_ocall_in_handler();
+        public int enc_test_vector_exception(int use_exception_handler_stack);
+        public int enc_test_ocall_in_handler(int use_exception_handler_stack);
         public void enc_test_cpuid_in_global_constructors();
         public int enc_test_sigill_handling(
+            int use_exception_handler_stack,
             [out] uint32_t cpuid_table[OE_CPUID_LEAF_COUNT][OE_CPUID_REG_COUNT]);
     };
 };

--- a/tests/VectorException/enc/exception_handler_stack.h
+++ b/tests/VectorException/enc/exception_handler_stack.h
@@ -1,0 +1,26 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/defs.h>
+#include <openenclave/internal/sgx/td.h>
+#include <openenclave/internal/types.h>
+
+#define EXCEPTION_HANDLER_STACK_SIZE 8192
+#define PAGE_SIZE 4096
+#define STACK_PAGE_NUMBER 1024
+#define STACK_SIZE (STACK_PAGE_NUMBER * PAGE_SIZE)
+
+OE_EXTERNC_BEGIN
+
+bool oe_sgx_set_td_exception_handler_stack(void* stack, uint64_t size);
+void* td_to_tcs(const oe_sgx_td_t* td);
+int initialize_exception_handler_stack(
+    void** stack,
+    uint64_t* stack_size,
+    int use_exception_handler_stack);
+void cleaup_exception_handler_stack(
+    void** stack,
+    uint64_t* stack_size,
+    int use_exception_handler_stack);
+
+OE_EXTERNC_END

--- a/tests/VectorException/enc/init.cpp
+++ b/tests/VectorException/enc/init.cpp
@@ -3,8 +3,12 @@
 
 #include <openenclave/enclave.h>
 #include <openenclave/internal/cpuid.h>
+#include <openenclave/internal/print.h>
 #include <openenclave/internal/tests.h>
+#include <stdlib.h>
 #include "VectorException_t.h"
+
+#include "exception_handler_stack.h"
 
 // Defined in sigill_handling.c
 extern "C" void get_cpuid(
@@ -15,19 +19,20 @@ extern "C" void get_cpuid(
     unsigned int* ecx,
     unsigned int* edx);
 
-static int done = 0;
-static unsigned int c = 0;
-static int hits1 = 0;
-static int hits2 = 0;
+static int done[2];
+static unsigned int c[2];
+static int hits1[2];
+static int hits2[2];
 
 #define AESNI_INSTRUCTIONS 0x02000000u
 
-int test_cpuid_instruction(unsigned int what)
+int test_cpuid_instruction(unsigned int what, int use_exception_handler_stack)
 {
-    if (!done)
+    int index = (use_exception_handler_stack) ? 1 : 0;
+    if (!done[index])
     {
         unsigned int a, b, d;
-        get_cpuid(1, 0, &a, &b, &c, &d);
+        get_cpuid(1, 0, &a, &b, &c[index], &d);
         // Do something with out param so call to cpuid is not optimized out.
         if (a == 0)
         {
@@ -35,27 +40,44 @@ int test_cpuid_instruction(unsigned int what)
         }
 
         // This should be executed only once.
-        ++hits1;
-        done = 1;
+        ++hits1[index];
+        done[index] = 1;
     }
 
     // This should be executed 3 times.
-    ++hits2;
-    return ((c & what) != 0) ? 1 : 0;
+    ++hits2[index];
+    return ((c[index] & what) != 0) ? 1 : 0;
 }
 
-static int init =
-    (test_cpuid_instruction(500),
-     test_cpuid_instruction(600),
-     test_cpuid_instruction(AESNI_INSTRUCTIONS));
+__attribute__((constructor)) void test_cpuid_constructor()
+{
+    test_cpuid_instruction(500, 0);
+    test_cpuid_instruction(600, 0);
+    test_cpuid_instruction(AESNI_INSTRUCTIONS, 0);
+
+    void* stack = malloc(EXCEPTION_HANDLER_STACK_SIZE);
+    if (!stack)
+        return;
+    oe_sgx_set_td_exception_handler_stack(stack, EXCEPTION_HANDLER_STACK_SIZE);
+    test_cpuid_instruction(500, 1);
+    test_cpuid_instruction(600, 1);
+    test_cpuid_instruction(AESNI_INSTRUCTIONS, 1);
+
+    oe_sgx_set_td_exception_handler_stack(NULL, 0);
+    free(stack);
+}
 
 void enc_test_cpuid_in_global_constructors()
 {
-    OE_TEST(init == 1);
-    OE_TEST(done == 1);
-    OE_TEST(c != 0);
-    OE_TEST(hits1 == 1);
-    OE_TEST(hits2 == 3);
+    OE_TEST(done[0] == 1);
+    OE_TEST(c[0] != 0);
+    OE_TEST(hits1[0] == 1);
+    OE_TEST(hits2[0] == 3);
+
+    OE_TEST(done[1] == 1);
+    OE_TEST(c[1] != 0);
+    OE_TEST(hits1[1] == 1);
+    OE_TEST(hits2[1] == 3);
     oe_host_printf(
         "enc_test_cpuid_in_global_constructors: completed successfully.\n");
 }

--- a/tests/stack_overflow_exception/CMakeLists.txt
+++ b/tests/stack_overflow_exception/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/stack_overflow_exception stack_overflow_exception_host
+                 sgx_stack_overflow_exception_enc_signed)
+
+add_enclave_test(
+  tests/stack_overflow_exception_unsigned stack_overflow_exception_host
+  sgx_stack_overflow_exception_enc_unsigned)

--- a/tests/stack_overflow_exception/enc/CMakeLists.txt
+++ b/tests/stack_overflow_exception/enc/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../stack_overflow_exception.edl)
+
+add_custom_command(
+  OUTPUT stack_overflow_exception_t.h stack_overflow_exception_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(
+  TARGET
+  sgx_stack_overflow_exception_enc
+  CONFIG
+  sign.conf
+  SOURCES
+  enc.c
+  ${CMAKE_CURRENT_BINARY_DIR}/stack_overflow_exception_t.c)
+
+add_enclave(TARGET sgx_stack_overflow_exception_enc_unsigned SOURCES enc.c
+            ${CMAKE_CURRENT_BINARY_DIR}/stack_overflow_exception_t.c)
+
+enclave_include_directories(sgx_stack_overflow_exception_enc PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})
+
+enclave_include_directories(sgx_stack_overflow_exception_enc_unsigned PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/stack_overflow_exception/enc/enc.c
+++ b/tests/stack_overflow_exception/enc/enc.c
@@ -1,0 +1,77 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/calls.h>
+#include <openenclave/internal/print.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/sgx/td.h>
+#include <openenclave/internal/tests.h>
+#include <stdlib.h>
+#include "stack_overflow_exception_t.h"
+
+#define PAGE_SIZE 4096
+#define EXCEPTION_HANDLER_STACK_SIZE 8192
+#define STACK_PAGE_NUMBER 2
+#define STACK_SIZE (STACK_PAGE_NUMER * PAGE_SIZE)
+bool oe_sgx_set_td_exception_handler_stack(void* stack, uint64_t size);
+void* td_to_tcs(const oe_sgx_td_t* td);
+
+uint8_t exception_handler_stack[EXCEPTION_HANDLER_STACK_SIZE];
+
+uint64_t test_stack_overflow_handler(oe_exception_record_t* exception_record)
+{
+    OE_TEST(exception_record->code == OE_EXCEPTION_PAGE_FAULT);
+
+    /* Calculate the stack boundary based on OE enclave memory layout */
+    oe_sgx_td_t* td = oe_sgx_get_td();
+    void* tcs = td_to_tcs(td);
+    uint64_t stack_base = (uint64_t)tcs - PAGE_SIZE;
+    OE_TEST(exception_record->context->rsp < (stack_base - STACK_PAGE_NUMBER));
+
+    host_notify_stack_overflowed();
+
+    return OE_EXCEPTION_ABORT_EXECUTION;
+}
+
+oe_result_t enc_initialize_exception_handler()
+{
+    oe_result_t result = OE_FAILURE;
+
+    if (!oe_sgx_set_td_exception_handler_stack(
+            exception_handler_stack, EXCEPTION_HANDLER_STACK_SIZE))
+        goto done;
+
+    OE_CHECK(
+        oe_add_vectored_exception_handler(false, test_stack_overflow_handler));
+
+    result = OE_OK;
+
+done:
+    return result;
+}
+
+void enc_stack_overflow_exception()
+{
+    uint8_t data[8192]; // Over-allocate stack
+
+    asm volatile("leaq %0, %%r8\n\t"
+                 "movw $0, 8191(%%r8)\n\t"
+                 :
+                 : "m"(data)
+                 : "r8");
+}
+
+OE_SET_ENCLAVE_SGX2(
+    1,                 /* ProductID */
+    1,                 /* SecurityVersion */
+    ({0}),             /* ExtendedProductID */
+    ({0}),             /* FamilyID */
+    true,              /* Debug */
+    true,              /* CapturePFGPExceptions */
+    false,             /* RequireKSS */
+    false,             /* CreateZeroBaseEnclave */
+    0,                 /* StartAddress */
+    1024,              /* NumHeapPages */
+    STACK_PAGE_NUMBER, /* NumStackPages */
+    1);                /* NumTCS */

--- a/tests/stack_overflow_exception/enc/sign.conf
+++ b/tests/stack_overflow_exception/enc/sign.conf
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# Enclave settings:
+Debug=1
+CapturePFGPExceptions=1
+NumHeapPages=1024
+NumStackPages=2
+NumTCS=1
+ProductID=1
+SecurityVersion=1

--- a/tests/stack_overflow_exception/host/CMakeLists.txt
+++ b/tests/stack_overflow_exception/host/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../stack_overflow_exception.edl)
+
+add_custom_command(
+  OUTPUT stack_overflow_exception_u.h stack_overflow_exception_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(stack_overflow_exception_host host.c
+                                             stack_overflow_exception_u.c)
+
+string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
+if (BUILD_TYPE_UPPER STREQUAL "DEBUG")
+  target_compile_definitions(stack_overflow_exception_host PRIVATE DEBUG_BUILD)
+endif ()
+
+target_include_directories(stack_overflow_exception_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(stack_overflow_exception_host oehost)

--- a/tests/stack_overflow_exception/host/host.c
+++ b/tests/stack_overflow_exception/host/host.c
@@ -1,0 +1,85 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <limits.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "../host/sgx/cpuid.h"
+#include "stack_overflow_exception_u.h"
+
+static bool enclave_stack_overflowed = false;
+
+static bool _is_misc_region_supported()
+{
+    uint32_t eax, ebx, ecx, edx;
+    eax = ebx = ecx = edx = 0;
+
+    // Obtain feature information using CPUID
+    oe_get_cpuid(CPUID_SGX_LEAF, 0x0, &eax, &ebx, &ecx, &edx);
+
+    // Check if EXINFO is supported by the processor
+    return (ebx & CPUID_SGX_MISC_EXINFO_MASK);
+}
+
+void host_notify_stack_overflowed()
+{
+    enclave_stack_overflowed = true;
+}
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    result = oe_create_stack_overflow_exception_enclave(
+        argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);
+    /* The enclave creation should succeed on both SGX1 and SGX2 machines. */
+    if (result != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    if (flags & OE_ENCLAVE_FLAG_SIMULATE)
+        printf("Simulation mode does not support exceptions. Skip the test "
+               "ECALL.\n");
+    else if (_is_misc_region_supported())
+    {
+        if (enc_initialize_exception_handler(enclave, &result) != OE_OK)
+            oe_put_err(
+                "enc_initialize_exception_handler() failed: result=%u", result);
+        OE_TEST(result == OE_OK);
+
+        OE_TEST(enc_stack_overflow_exception(enclave) == OE_ENCLAVE_ABORTING);
+        OE_TEST(enclave_stack_overflowed == true);
+
+        result = oe_terminate_enclave(enclave);
+#ifdef DEBUG_BUILD
+        /* Expect OE_MEMORY_LEAK in the debug build (the debugmalloc is enabled)
+         * because the oe_handle_call_enclave_function does not return and
+         * therefore an internal buffer on the heap is not freed  */
+        OE_TEST(result == OE_MEMORY_LEAK);
+#else
+        OE_TEST(result == OE_OK);
+#endif
+    }
+    else
+    {
+        printf("CPU does not support the CapturePFGPExceptions=1 "
+               "configuration. Skip the test ECALL.\n");
+
+        OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+    }
+
+    printf("=== passed all tests (stack_overflow_exception)\n");
+
+    return 0;
+}

--- a/tests/stack_overflow_exception/stack_overflow_exception.edl
+++ b/tests/stack_overflow_exception/stack_overflow_exception.edl
@@ -1,0 +1,17 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/fcntl.edl" import *;
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/sgx/platform.edl" import *;
+
+    trusted {
+        public oe_result_t enc_initialize_exception_handler();
+        public void enc_stack_overflow_exception();
+    };
+
+    untrusted {
+        void host_notify_stack_overflowed();
+    };
+};


### PR DESCRIPTION
This PR introduces an internal mechanism that allows the OE runtime to set up a temporary, alternative stack for exception handlers. Such use cases include creating a pthread (see #4230 for example) with a small stack. The alternative stack allows the thread to handle a stack overflow exception, which is not supported by the default behavior where the exception handler directly uses the stack pointer saved on the SSA (in this case, pointing to invalid memory).  This PR also adds a new test that demonstrates how the stack overflow exception can be captured (required SGX2 hardware with in-enclave #PF/#GP delivery).

To use the API, OE runtime needs to be responsible to maintain the temporary stack by itself, and carefully set/unset the exception handler stack at proper time. The logic implemented by this PR always validates the stack pointer before using it. If the stack pointer is invalid, the logic will fallback to default behavior.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>