### PR TITLE
Skip sgx-zerobasetest on non-dcap (LLC platforms)

### DIFF
--- a/tests/sgx_zerobase/CMakeLists.txt
+++ b/tests/sgx_zerobase/CMakeLists.txt
@@ -9,19 +9,29 @@ endif ()
 
 add_enclave_test(tests/sgx_zerobase_macro_only sgx_zerobase_host
                  sgx_zerobase_macro_only_enc)
+set_enclave_tests_properties(tests/sgx_zerobase_macro_only 
+                               PROPERTIES SKIP_RETURN_CODE 2)
+                             
 
 # Tests 0-base enclave creation when OE_SET_ENCLAVE_SGX*() macro is not
 # used and only oesign configuration file is used to set properties.
 add_enclave_test(tests/sgx_zerobase_conf_only sgx_zerobase_host
                  sgx_zerobase_conf_only_enc_signed)
-
+set_enclave_tests_properties(tests/sgx_zerobase_conf_only 
+                               PROPERTIES SKIP_RETURN_CODE 2)
+                               
 # Tests 0-base enclave creation when OE_SET_ENCLAVE_SGX*() macro disables
 # 0-base enclave creation and oesign configuration file enables 0-base enclave creation.
 add_enclave_test(
   tests/sgx_zerobase_prop_macro_disable_conf_enable sgx_zerobase_host
   sgx_zerobase_macro_disable_conf_enable_enc_signed)
-
+set_enclave_tests_properties(tests/sgx_zerobase_prop_macro_disable_conf_enable
+                               PROPERTIES SKIP_RETURN_CODE 2)
+                               
 # Tests 0-base enclave creation when OE_SET_ENCLAVE_SGX*() macro enables
 # 0-base enclave creation but oesign configuration file disables 0-base enclave creation.
 add_enclave_test(tests/sgx_zerobase_macro_enable_conf_disable sgx_zerobase_host
                  sgx_zerobase_macro_enable_conf_disable_enc_signed)
+set_enclave_tests_properties(tests/sgx_zerobase_macro_enable_conf_disable
+                               PROPERTIES SKIP_RETURN_CODE 2)
+                               

--- a/tests/sgx_zerobase/host/host.cpp
+++ b/tests/sgx_zerobase/host/host.cpp
@@ -4,12 +4,16 @@
 #include <openenclave/bits/exception.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <sys/mman.h>
 #include <iostream>
 
 #include "../host/sgx/cpuid.h"
 #include "sgx_zerobase_u.h"
+
+#define SKIP_RETURN_CODE 2
 
 const char* message = "Hello world from Host\n\0";
 
@@ -44,6 +48,13 @@ int main(int argc, const char* argv[])
     {
         fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
         return 1;
+    }
+
+    if (!oe_has_sgx_quote_provider())
+    {
+        // this test should not run on any platforms where FLC is not supported
+        OE_TRACE_INFO("=== tests skipped when DCAP libraries are not found.\n");
+        return SKIP_RETURN_CODE;
     }
 
     if (strstr(argv[1], "_conf_") == NULL)


### PR DESCRIPTION
Skipping SGX zerobase tests on LLC platforms, because this feature is not supported there.

+ @MWShan 
