### PR TITLE
Update the header config.h with new name

### DIFF
--- a/samples/file-encryptor/enclave/mbedtls_src/keys.cpp
+++ b/samples/file-encryptor/enclave/mbedtls_src/keys.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include <mbedtls/aes.h>
-#include <mbedtls/config.h>
+#include <mbedtls/mbedtls_config.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/error.h>


### PR DESCRIPTION
The header config.h has a new name, so fixing this is imperative to allow compilation of the sample with the mbedTLS library. See their commit to mbedtls [here](https://github.com/ARMmbed/mbedtls/commit/bb0cfeb2d4b34eb3ec932ca8b8e215f49b703153#diff-0279e5915ac49daea5fd9ed14934a074d1a88e9b35c674d7d1a0d0e0688f60bb).

Signed-off-by: Carlos Bilbao <bilbao@vt.edu>