### PR TITLE
Support for Intel PCCS API v3

### DIFF
--- a/common/sgx/collateral.c
+++ b/common/sgx/collateral.c
@@ -3,6 +3,7 @@
 
 #include "collateral.h"
 #include <openenclave/bits/attestation.h>
+#include <openenclave/corelibc/ctype.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/crypto/cert.h>
 #include <openenclave/internal/crypto/crl.h>
@@ -309,8 +310,7 @@ oe_result_t oe_validate_revocation_list(
             for (size_t l = 0; l < der_data_size; ++l)
             {
                 const uint8_t c = sgx_endorsements->items[i].data[l];
-                if (!((c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f') ||
-                      (c >= '0' && c <= '9')))
+                if (!oe_isxdigit(c))
                 {
                     ishex = false;
                     break;
@@ -319,7 +319,7 @@ oe_result_t oe_validate_revocation_list(
             if (ishex)
             {
                 OE_CHECK_MSG(
-                    oe_hex_to_buf(
+                    oe_hex_to_buffer(
                         (const char*)sgx_endorsements->items[i].data,
                         der_data_size,
                         sgx_endorsements->items[i].data,

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -208,6 +208,7 @@ if (OE_SGX)
     ${PROJECT_SOURCE_DIR}/common/sgx/tcbinfo.c
     ${PROJECT_SOURCE_DIR}/common/sgx/tlsverifier.c
     ${PROJECT_SOURCE_DIR}/common/sgx/verifier.c
+    ${PROJECT_SOURCE_DIR}/enclave/core/ctype.c
     sgx/hostverify_report.c
     sgx/report_common.c
     sgx/sgxquoteprovider.c

--- a/include/openenclave/internal/utils.h
+++ b/include/openenclave/internal/utils.h
@@ -228,6 +228,33 @@ OE_INLINE void oe_mem_reverse_inplace(void* mem, size_t n)
     }
 }
 
+OE_INLINE unsigned char oe_hex_digit_to_num(char c)
+{
+    if (c >= '0' && c <= '9')
+        return (unsigned char)(c - '0');
+
+    if (c >= 'A' && c <= 'F')
+        return (unsigned char)(10 + (c - 'A'));
+
+    return (unsigned char)(10 + (c - 'a'));
+}
+
+OE_INLINE oe_result_t
+oe_hex_to_buf(const char* str, size_t strsize, uint8_t* buf, size_t bufsize)
+{
+    if (bufsize * 2 < strsize)
+    {
+        return OE_BUFFER_TOO_SMALL;
+    }
+    for (size_t i = 0; i < strsize; i += 2)
+    {
+        unsigned char v =
+            (unsigned char)(16 * oe_hex_digit_to_num(str[i]) + oe_hex_digit_to_num(str[i + 1]));
+        buf[i / 2] = v;
+    }
+    return OE_OK;
+}
+
 OE_EXTERNC_END
 
 #endif /* _OE_UTILS_H */

--- a/include/openenclave/internal/utils.h
+++ b/include/openenclave/internal/utils.h
@@ -5,6 +5,7 @@
 #define _OE_UTILS_H
 
 #include <openenclave/bits/types.h>
+#include <openenclave/corelibc/ctype.h>
 #include <openenclave/internal/defs.h>
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -230,7 +231,7 @@ OE_INLINE void oe_mem_reverse_inplace(void* mem, size_t n)
 
 OE_INLINE unsigned char oe_hex_digit_to_num(char c)
 {
-    if (c >= '0' && c <= '9')
+    if (oe_isdigit(c))
         return (unsigned char)(c - '0');
 
     if (c >= 'A' && c <= 'F')
@@ -239,18 +240,21 @@ OE_INLINE unsigned char oe_hex_digit_to_num(char c)
     return (unsigned char)(10 + (c - 'a'));
 }
 
-OE_INLINE oe_result_t
-oe_hex_to_buf(const char* str, size_t strsize, uint8_t* buf, size_t bufsize)
+OE_INLINE oe_result_t oe_hex_to_buffer(
+    const char* hex_string,
+    size_t hex_string_size,
+    uint8_t* buffer,
+    size_t buffer_size)
 {
-    if (bufsize * 2 < strsize)
+    if (buffer_size * 2 < hex_string_size)
     {
         return OE_BUFFER_TOO_SMALL;
     }
-    for (size_t i = 0; i < strsize; i += 2)
+    for (size_t i = 0; i < hex_string_size; i += 2)
     {
         unsigned char v =
-            (unsigned char)(16 * oe_hex_digit_to_num(str[i]) + oe_hex_digit_to_num(str[i + 1]));
-        buf[i / 2] = v;
+            (unsigned char)(16 * oe_hex_digit_to_num(hex_string[i]) + oe_hex_digit_to_num(hex_string[i + 1]));
+        buffer[i / 2] = v;
     }
     return OE_OK;
 }


### PR DESCRIPTION
From the [documentation for Intel's PCCS v.12](https://download.01.org/intel-sgx/sgx-dcap/1.12/linux/docs/SGX_DCAP_Caching_Service_Design_Guide.pdf#%5B%7B%22num%22%3A22%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C69%2C309%2C0%5D) and as mentioned [here](https://github.com/openenclave/openenclave/issues/4139#issuecomment-930442740), hex encoded DER is now the official way for returning the root CA CRL.

This PR aims to fix compatibility by adding a check in `oe_validata_revocation_list()` for hex encoded DER v3 CRLs.
If a hex encoded CRL is encountered it is converted to DER, using `oe_hex_to_buf()` and `oe_hex_digit_to_num()`.
These functions have been adopted from a [test file](https://github.com/openenclave/openenclave/blob/master/tests/crypto/utils.c) and were added to ` include/openenclave/internal/utils.h`.

Signed-off-by: Daniel Weiße <dw@edgeless.systems>