### PR TITLE
Expand arena as needed.

### DIFF
--- a/tests/switchless/enc/enc.c
+++ b/tests/switchless/enc/enc.c
@@ -105,6 +105,21 @@ int enc_echo_regular(
     return 0;
 }
 
+static uint8_t buffer[1024 * 1024 * 10];
+void enc_test_large_switchless_ocall()
+{
+    // First make a smaller call.
+    OE_TEST(host_large_ocall_switchless(buffer, 1024) == OE_OK);
+
+    // Then make a call equal to default capacity.
+    OE_TEST(host_large_ocall_switchless(buffer, 1024 * 1024) == OE_OK);
+
+    // Then make a larger call.
+    OE_TEST(host_large_ocall_switchless(buffer, sizeof(buffer)) == OE_OK);
+
+    oe_host_printf("large_switchless_ocall passed.\n");
+}
+
 OE_SET_ENCLAVE_SGX(
     1,                             /* ProductID */
     1,                             /* SecurityVersion */

--- a/tests/switchless/host/host.c
+++ b/tests/switchless/host/host.c
@@ -322,6 +322,12 @@ void* launch_host_thread(void* a)
     return NULL;
 }
 
+void host_large_ocall_switchless(uint8_t* buffer, uint64_t count)
+{
+    OE_UNUSED(buffer);
+    OE_UNUSED(count);
+}
+
 void test_switchless_ecalls(
     oe_enclave_t* enclave_switchless,
     oe_enclave_t* enclave_normal,
@@ -502,6 +508,8 @@ int main(int argc, const char* argv[])
     else
         test_switchless_ocalls(
             enclave_switchless, enclave_normal, num_enclave_threads);
+
+    OE_TEST(enc_test_large_switchless_ocall(enclave_switchless) == OE_OK);
 
     result = oe_terminate_enclave(enclave_switchless);
     OE_TEST(result == OE_OK);

--- a/tests/switchless/switchless_test.edl
+++ b/tests/switchless/switchless_test.edl
@@ -41,6 +41,8 @@ enclave {
             [out] char out[100],
             [string, in] const char* str1,
             [in] char str2[100]);
+
+	public void enc_test_large_switchless_ocall();
     };
 
     untrusted {
@@ -58,5 +60,10 @@ enclave {
             [out] char out[100],
             [string, in] const char* str1,
             [in] char str2[100]);
+
+        void host_large_ocall_switchless(
+	    [count=count, in] uint8_t* buffer,
+	    size_t count)
+	    transition_using_threads;
     };
 };


### PR DESCRIPTION
Currently, switchless calls will fail if a call requies memory
more than the configured arena capacity (1MB by default).

This causes failures in some Mystikos tests.

With this PR, if no objects exist in the arena, then the arena
is expanded so that a failing allocation would subsequently
succeed.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>