### PR TITLE
Fix broken link in host_verify sample README.

### DIFF
--- a/samples/host_verify/README.md
+++ b/samples/host_verify/README.md
@@ -18,7 +18,7 @@ The sample does remote host-side enclave attestation by taking one of the follow
 
 The sample also accepts an endorsement file as input. See the end of the file for usage.
 
-A user can generate a report, an endorsement file or a certificate with `oeutil generate-evidence`. See the [oeutil README file](https://github.com/openenclave/openenclave/blob/master/tests/tools/oeutil/README.md) for more details.
+A user can generate a report, an endorsement file or a certificate with `oeutil generate-evidence`. See the [oeutil README file](https://github.com/openenclave/openenclave/blob/master/tools/oeutil/README.md) for more details.
 
 In the main function, if it sees the attribute `-r`, then it will continue to read the next argument to get the report and call `verify_report()` to verify the report.
 Likewise, if it sees the attribute `-c`, then it will continue to read the next argument to get the certificate and call `verify_cert()` to verify the certificate.


### PR DESCRIPTION
While reading through the host_verify sample I noticed a useful link was broken. I found the correct link and have replaced it with this simple patch.