### PR TITLE
Change exception_handler_stack to page_fault_handler_stack

### DIFF
--- a/enclave/core/sgx/asmdefs.h
+++ b/enclave/core/sgx/asmdefs.h
@@ -37,8 +37,8 @@
 #define td_simulate (td_callsites + 8)
 #define td_host_ecall_context (td_simulate + 8)
 #define td_host_previous_ecall_context (td_host_ecall_context + 8)
-#define td_exception_handler_stack (td_host_previous_ecall_context + 8)
-#define td_exception_handler_stack_size (td_exception_handler_stack + 8)
+#define td_page_fault_handler_stack (td_host_previous_ecall_context + 8)
+#define td_page_fault_handler_stack_size (td_page_fault_handler_stack + 8)
 
 #define oe_exit_enclave __morestack
 #ifndef __ASSEMBLER__

--- a/enclave/core/sgx/enter.S
+++ b/enclave/core/sgx/enter.S
@@ -105,21 +105,21 @@ oe_enter:
 
     // Abort if SSA[0].GPRSGX.URSP is within the enclave memory range
     cmp %r12, %r9
-    jb .exception_handler_stack_check
+    jb .page_fault_handler_stack_check
     cmp %r13, %r9
-    jae .exception_handler_stack_check
+    jae .page_fault_handler_stack_check
     jmp .abort
 
     // Reaching this point implies SSA[0].GPRSGX.RSP is within the enclave
     // memory range so we do not need additional checks.
 
-.exception_handler_stack_check:
+.page_fault_handler_stack_check:
     // Stop speculative execution at target of conditional jump
     lfence
 
-    // Get the exception_handler_stack_check range
-    mov td_exception_handler_stack(%r11), %r14
-    mov td_exception_handler_stack_size(%r11), %r15
+    // Get the page_fault_handler_stack_check range
+    mov td_page_fault_handler_stack(%r11), %r14
+    mov td_page_fault_handler_stack_size(%r11), %r15
     test %r15, %r15
     jz .exception_stack_setup // check if size is zero
     add %r14, %r15

--- a/enclave/core/sgx/td.c
+++ b/enclave/core/sgx/td.c
@@ -171,14 +171,14 @@ oe_sgx_td_t* oe_sgx_get_td()
 /*
 **==============================================================================
 **
-** oe_sgx_set_td_exception_handler_stack()
+** oe_sgx_td_set_page_fault_handler_stack()
 **
 **     Internal API that allows an enclave to setup stack area for
-**     exception handlers to use.
+**     page fault handlers to use.
 **
 **==============================================================================
 */
-bool oe_sgx_set_td_exception_handler_stack(void* stack, uint64_t size)
+bool oe_sgx_td_set_page_fault_handler_stack(void* stack, uint64_t size)
 {
     oe_sgx_td_t* td = oe_sgx_get_td();
 
@@ -186,8 +186,8 @@ bool oe_sgx_set_td_exception_handler_stack(void* stack, uint64_t size)
     if (((uint64_t)stack + size) % 16)
         return false;
 
-    td->exception_handler_stack_size = size;
-    td->exception_handler_stack = (uint64_t)stack;
+    td->page_fault_handler_stack_size = size;
+    td->page_fault_handler_stack = (uint64_t)stack;
 
     return true;
 }

--- a/include/openenclave/internal/sgx/td.h
+++ b/include/openenclave/internal/sgx/td.h
@@ -136,9 +136,10 @@ typedef struct _td
     struct _oe_ecall_context* host_ecall_context;
     struct _oe_ecall_context* host_previous_ecall_context;
 
-    /* The optional stack area setup by the runtime to handle the exceptions */
-    uint64_t exception_handler_stack;
-    uint64_t exception_handler_stack_size;
+    /* The alternative stack area setup by the runtime to handle the page faults
+     */
+    uint64_t page_fault_handler_stack;
+    uint64_t page_fault_handler_stack_size;
 
     /* Save the rsp and rbp values in the SSA when the exception handler
      * stack is set */
@@ -190,7 +191,7 @@ OE_STATIC_ASSERT(
 /* Get the thread data object for the current thread */
 oe_sgx_td_t* oe_sgx_get_td(void);
 
-bool oe_sgx_set_td_exception_handler_stack(void* stack, uint64_t size);
+bool oe_sgx_td_set_page_fault_handler_stack(void* stack, uint64_t size);
 
 OE_EXTERNC_END
 

--- a/tests/VectorException/VectorException.edl
+++ b/tests/VectorException/VectorException.edl
@@ -17,11 +17,11 @@ enclave {
     };
 
     trusted {
-        public int enc_test_vector_exception(int use_exception_handler_stack);
-        public int enc_test_ocall_in_handler(int use_exception_handler_stack);
+        public int enc_test_vector_exception(int use_page_fault_handler_stack);
+        public int enc_test_ocall_in_handler(int use_page_fault_handler_stack);
         public void enc_test_cpuid_in_global_constructors();
         public int enc_test_sigill_handling(
-            int use_exception_handler_stack,
+            int use_page_fault_handler_stack,
             [out] uint32_t cpuid_table[OE_CPUID_LEAF_COUNT][OE_CPUID_REG_COUNT]);
     };
 };

--- a/tests/VectorException/enc/init.cpp
+++ b/tests/VectorException/enc/init.cpp
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include "VectorException_t.h"
 
-#include "exception_handler_stack.h"
+#include "page_fault_handler_stack.h"
 
 // Defined in sigill_handling.c
 extern "C" void get_cpuid(
@@ -26,9 +26,9 @@ static int hits2[2];
 
 #define AESNI_INSTRUCTIONS 0x02000000u
 
-int test_cpuid_instruction(unsigned int what, int use_exception_handler_stack)
+int test_cpuid_instruction(unsigned int what, int use_page_fault_handler_stack)
 {
-    int index = (use_exception_handler_stack) ? 1 : 0;
+    int index = (use_page_fault_handler_stack) ? 1 : 0;
     if (!done[index])
     {
         unsigned int a, b, d;
@@ -55,15 +55,16 @@ __attribute__((constructor)) void test_cpuid_constructor()
     test_cpuid_instruction(600, 0);
     test_cpuid_instruction(AESNI_INSTRUCTIONS, 0);
 
-    void* stack = malloc(EXCEPTION_HANDLER_STACK_SIZE);
+    void* stack = malloc(PAGE_FAULT_HANDLER_STACK_SIZE);
     if (!stack)
         return;
-    oe_sgx_set_td_exception_handler_stack(stack, EXCEPTION_HANDLER_STACK_SIZE);
+    oe_sgx_td_set_page_fault_handler_stack(
+        stack, PAGE_FAULT_HANDLER_STACK_SIZE);
     test_cpuid_instruction(500, 1);
     test_cpuid_instruction(600, 1);
     test_cpuid_instruction(AESNI_INSTRUCTIONS, 1);
 
-    oe_sgx_set_td_exception_handler_stack(NULL, 0);
+    oe_sgx_td_set_page_fault_handler_stack(NULL, 0);
     free(stack);
 }
 

--- a/tests/VectorException/enc/page_fault_handler_stack.h
+++ b/tests/VectorException/enc/page_fault_handler_stack.h
@@ -5,22 +5,16 @@
 #include <openenclave/internal/sgx/td.h>
 #include <openenclave/internal/types.h>
 
-#define EXCEPTION_HANDLER_STACK_SIZE 8192
+#define PAGE_FAULT_HANDLER_STACK_SIZE 8192
 #define PAGE_SIZE 4096
 #define STACK_PAGE_NUMBER 1024
 #define STACK_SIZE (STACK_PAGE_NUMBER * PAGE_SIZE)
 
 OE_EXTERNC_BEGIN
 
-bool oe_sgx_set_td_exception_handler_stack(void* stack, uint64_t size);
 void* td_to_tcs(const oe_sgx_td_t* td);
-int initialize_exception_handler_stack(
-    void** stack,
-    uint64_t* stack_size,
-    int use_exception_handler_stack);
-void cleaup_exception_handler_stack(
-    void** stack,
-    uint64_t* stack_size,
-    int use_exception_handler_stack);
+void get_stack(void** stack, uint64_t* stack_size);
+int initialize_page_fault_handler_stack(void** stack, uint64_t* stack_size);
+void cleaup_page_fault_handler_stack(void** stack, uint64_t* stack_size);
 
 OE_EXTERNC_END

--- a/tests/VectorException/host/host.c
+++ b/tests/VectorException/host/host.c
@@ -21,11 +21,11 @@ void host_set_was_ocall_called()
 
 void test_vector_exception(
     oe_enclave_t* enclave,
-    int use_exception_handler_stack)
+    int use_page_fault_handler_stack)
 {
     int ret = -1;
     oe_result_t result =
-        enc_test_vector_exception(enclave, &ret, use_exception_handler_stack);
+        enc_test_vector_exception(enclave, &ret, use_page_fault_handler_stack);
 
     if (result != OE_OK)
     {
@@ -42,11 +42,11 @@ void test_vector_exception(
 
 void test_ocall_in_handler(
     oe_enclave_t* enclave,
-    int use_exception_handler_stack)
+    int use_page_fault_handler_stack)
 {
     int ret = -1;
     oe_result_t result =
-        enc_test_ocall_in_handler(enclave, &ret, use_exception_handler_stack);
+        enc_test_ocall_in_handler(enclave, &ret, use_page_fault_handler_stack);
 
     if (result != OE_OK)
     {
@@ -60,14 +60,14 @@ void test_ocall_in_handler(
 
 void test_sigill_handling(
     oe_enclave_t* enclave,
-    int use_exception_handler_stack)
+    int use_page_fault_handler_stack)
 {
     uint32_t cpuid_table[OE_CPUID_LEAF_COUNT][OE_CPUID_REG_COUNT];
     memset(&cpuid_table, 0, sizeof(cpuid_table));
     int ret = -1;
 
     oe_result_t result = enc_test_sigill_handling(
-        enclave, &ret, use_exception_handler_stack, cpuid_table);
+        enclave, &ret, use_page_fault_handler_stack, cpuid_table);
     if (result != OE_OK)
     {
         oe_put_err("enc_test_sigill_handling() failed: result=%u", result);
@@ -178,7 +178,7 @@ int main(int argc, const char* argv[])
     test_sigill_handling(enclave, 0);
     test_ocall_in_handler(enclave, 0);
 
-    /* Test with setting an exception handler stack */
+    /* Test with setting page fault handler stack */
     test_vector_exception(enclave, 1);
     test_sigill_handling(enclave, 1);
     test_ocall_in_handler(enclave, 1);

--- a/tests/stack_overflow_exception/enc/enc.c
+++ b/tests/stack_overflow_exception/enc/enc.c
@@ -11,13 +11,12 @@
 #include "stack_overflow_exception_t.h"
 
 #define PAGE_SIZE 4096
-#define EXCEPTION_HANDLER_STACK_SIZE 8192
+#define PAGE_FAULT_HANDLER_STACK_SIZE 8192
 #define STACK_PAGE_NUMBER 2
 #define STACK_SIZE (STACK_PAGE_NUMER * PAGE_SIZE)
-bool oe_sgx_set_td_exception_handler_stack(void* stack, uint64_t size);
 void* td_to_tcs(const oe_sgx_td_t* td);
 
-uint8_t exception_handler_stack[EXCEPTION_HANDLER_STACK_SIZE];
+uint8_t page_fault_handler_stack[PAGE_FAULT_HANDLER_STACK_SIZE];
 
 uint64_t test_stack_overflow_handler(oe_exception_record_t* exception_record)
 {
@@ -38,8 +37,8 @@ oe_result_t enc_initialize_exception_handler()
 {
     oe_result_t result = OE_FAILURE;
 
-    if (!oe_sgx_set_td_exception_handler_stack(
-            exception_handler_stack, EXCEPTION_HANDLER_STACK_SIZE))
+    if (!oe_sgx_td_set_page_fault_handler_stack(
+            page_fault_handler_stack, PAGE_FAULT_HANDLER_STACK_SIZE))
         goto done;
 
     OE_CHECK(


### PR DESCRIPTION
The PR changes the internal support of exception handler stack to page fault handler. As a result, the stack will only be used when page fault occurs. For other types of exception, the handler will continue use the original stack. The reason for the change is that the alternative stack only makes sense when a page fault occurs (e.g., stack overflowed and the existing stack is no longer usable).

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>