### PR TITLE
Update Linux_using_oe_sdk.md

### DIFF
--- a/docs/GettingStartedDocs/Linux_using_oe_sdk.md
+++ b/docs/GettingStartedDocs/Linux_using_oe_sdk.md
@@ -28,7 +28,7 @@ On Linux, the Open Enclave SDK installation also contains the following folder:
 ## Configure environment variables for Open Enclave SDK for Linux
 For ease of development, we recommend adding:
 - Open Enclave SDK `bin` folder to `PATH`, for use of our tools (such as `oegdb` and `oeedger8r`).
-- Open Enclave SDK `install` folder to `CMAKE_PREFIX_PATH`, for use of the [CMake package](/cmake/sdk_cmake_targets_readme.md).
+- Open Enclave SDK `cmake` folder to `CMAKE_PREFIX_PATH`, for use of the [CMake package](/cmake/sdk_cmake_targets_readme.md).
 - Open Enclave SDK `pkgconfig` folder to `PKG_CONFIG_PATH`, for use of `pkg-config`.
 
 You can do this by sourcing the `openenclaverc` file that is distributed with the SDK:


### PR DESCRIPTION
I guess there was a minor typo. There is no install folder. Instead cmake folder should be added to CMAKE_PREFIX_PATH. Complete path of cmake folder is /opt/openenclave/lib/openenclave/cmake