### PR TITLE
Clear the td states on ECALL return

### DIFF
--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -1223,7 +1223,9 @@ void oe_abort(void)
 {
     oe_sgx_td_t* td = oe_sgx_get_td();
 
-    td->state = OE_TD_STATE_ABORTED;
+    /* only update the state if td is initialized */
+    if (td)
+        td->state = OE_TD_STATE_ABORTED;
 
     // Once it starts to crash, the state can only transit forward, not
     // backward.

--- a/enclave/core/sgx/td_basic.c
+++ b/enclave/core/sgx/td_basic.c
@@ -110,6 +110,9 @@ void td_init(oe_sgx_td_t* td)
         /* List of callsites is initially empty */
         td->callsites = NULL;
 
+        /* Set the exception handler stack to NULL */
+        oe_sgx_td_set_exception_handler_stack(td, NULL, 0);
+
         oe_thread_local_init(td);
     }
 }
@@ -151,6 +154,9 @@ void td_clear(oe_sgx_td_t* td)
 
     /* Clear the magic number */
     td->magic = 0;
+
+    /* Clear td states */
+    oe_sgx_td_clear_states(td);
 
     /* Never clear oe_sgx_td_t.initialized nor host registers */
 }

--- a/include/openenclave/internal/sgx/td.h
+++ b/include/openenclave/internal/sgx/td.h
@@ -227,20 +227,20 @@ OE_STATIC_ASSERT(
 /* Get the thread data object for the current thread */
 oe_sgx_td_t* oe_sgx_get_td(void);
 
-/* The following APIs are expected to be used only by the thread itself. */
+void oe_sgx_td_clear_states(oe_sgx_td_t* td);
 
-bool oe_sgx_set_td_exception_handler_stack(void* stack, uint64_t size);
+bool oe_sgx_td_set_exception_handler_stack(
+    oe_sgx_td_t* td,
+    void* stack,
+    uint64_t size);
 
-void oe_sgx_td_mask_host_signal();
+void oe_sgx_td_mask_host_signal(oe_sgx_td_t* td);
 
-void oe_sgx_td_unmask_host_signal();
+void oe_sgx_td_unmask_host_signal(oe_sgx_td_t* td);
 
-/* The following APIs are expected to be used by both the thread itself
- * and other threads. */
+bool oe_sgx_td_register_host_signal(oe_sgx_td_t* td, int signal_number);
 
-bool oe_sgx_register_td_host_signal(oe_sgx_td_t* td, int signal_number);
-
-bool oe_sgx_unregister_td_host_signal(oe_sgx_td_t* td, int signal_number);
+bool oe_sgx_td_unregister_host_signal(oe_sgx_td_t* td, int signal_number);
 
 bool oe_sgx_td_host_signal_registered(oe_sgx_td_t* td, int signal_number);
 

--- a/tests/VectorException/enc/enc.c
+++ b/tests/VectorException/enc/enc.c
@@ -23,18 +23,19 @@ int initialize_exception_handler_stack(
     uint64_t* stack_size,
     int use_exception_handler_stack)
 {
+    oe_sgx_td_t* td = oe_sgx_get_td();
+
     if (use_exception_handler_stack)
     {
         *stack_size = EXCEPTION_HANDLER_STACK_SIZE;
         *stack = malloc(*stack_size);
         if (!*stack)
             return -1;
-        if (!oe_sgx_set_td_exception_handler_stack(*stack, *stack_size))
+        if (!oe_sgx_td_set_exception_handler_stack(td, *stack, *stack_size))
             return -1;
     }
     else
     {
-        oe_sgx_td_t* td = oe_sgx_get_td();
         void* tcs = td_to_tcs(td);
         *stack_size = STACK_SIZE;
         *stack = (void*)((uint64_t)tcs - PAGE_SIZE - STACK_SIZE);
@@ -48,9 +49,11 @@ void cleaup_exception_handler_stack(
     uint64_t* stack_size,
     int use_exception_handler_stack)
 {
+    oe_sgx_td_t* td = oe_sgx_get_td();
+
     if (use_exception_handler_stack)
     {
-        oe_sgx_set_td_exception_handler_stack(NULL, 0);
+        oe_sgx_td_set_exception_handler_stack(td, NULL, 0);
         free(*stack);
     }
 

--- a/tests/VectorException/enc/init.cpp
+++ b/tests/VectorException/enc/init.cpp
@@ -58,12 +58,14 @@ __attribute__((constructor)) void test_cpuid_constructor()
     void* stack = malloc(EXCEPTION_HANDLER_STACK_SIZE);
     if (!stack)
         return;
-    oe_sgx_set_td_exception_handler_stack(stack, EXCEPTION_HANDLER_STACK_SIZE);
+    oe_sgx_td_t* td = oe_sgx_get_td();
+    oe_sgx_td_set_exception_handler_stack(
+        td, stack, EXCEPTION_HANDLER_STACK_SIZE);
     test_cpuid_instruction(500, 1);
     test_cpuid_instruction(600, 1);
     test_cpuid_instruction(AESNI_INSTRUCTIONS, 1);
 
-    oe_sgx_set_td_exception_handler_stack(NULL, 0);
+    oe_sgx_td_set_exception_handler_stack(td, NULL, 0);
     free(stack);
 }
 

--- a/tests/sgx/td_state/td_state.edl
+++ b/tests/sgx/td_state/td_state.edl
@@ -9,11 +9,16 @@ enclave {
     trusted {
         public void enc_td_state(uint64_t lock_state);
         public void enc_run_thread(int tid);
+        public void enc_td_state_handler_no_return();
+        public void enc_run_thread_handler_no_return(int tid);
+        public void enc_run_thread_reuse_tcs(int tid);
     };
 
     untrusted {
         void host_send_interrupt(int tid, int signal_number);
         void host_create_thread();
+        void host_create_thread_handler_no_return();
+        void host_create_thread_reuse_tcs();
         void host_join_thread();
         void host_spin();
         int host_get_tid();

--- a/tests/stack_overflow_exception/host/host.c
+++ b/tests/stack_overflow_exception/host/host.c
@@ -53,11 +53,6 @@ int main(int argc, const char* argv[])
                "ECALL.\n");
     else if (_is_misc_region_supported())
     {
-        if (enc_initialize_exception_handler(enclave, &result) != OE_OK)
-            oe_put_err(
-                "enc_initialize_exception_handler() failed: result=%u", result);
-        OE_TEST(result == OE_OK);
-
         OE_TEST(enc_stack_overflow_exception(enclave) == OE_ENCLAVE_ABORTING);
         OE_TEST(enclave_stack_overflowed == true);
 

--- a/tests/stack_overflow_exception/stack_overflow_exception.edl
+++ b/tests/stack_overflow_exception/stack_overflow_exception.edl
@@ -7,7 +7,6 @@ enclave {
     from "openenclave/edl/sgx/platform.edl" import *;
 
     trusted {
-        public oe_result_t enc_initialize_exception_handler();
         public void enc_stack_overflow_exception();
     };
 


### PR DESCRIPTION
Ensure the td states are cleared on ECALL return so the the following ECALL using the same tcs will not inherit the states.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>