### PR TITLE
Add tests on ICX VMs

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,20 +1,28 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-if ( params.OECI_LIB_VERSION ) {
-    library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
-} else {
-    library "OpenEnclaveJenkinsLibrary@master"
-    OECI_LIB_VERSION = "master"
-}
-GLOBAL_ERROR = null
-
+// Global variables
 REPOSITORY_NAME = env.REPOSITORY_NAME ?: "openenclave/openenclave"
 BRANCH_NAME = env.BRANCH_NAME ?: "master"
 DOCKER_TAG = env.DOCKER_TAG ?: "latest"
 FULL_TEST_SUITE = env.FULL_TEST_SUITE ?: false
 // Regex that includes directory you want to ignore for CI builds.
 String IGNORED_DIRS = "^(docs|\\.jenkins/infrastructure)|\\.md\$"
+GLOBAL_ERROR = null
+
+// Load OpenEnclaveJenkinsLibrary version to use in this priority:
+//     1. If this is a bors run, use the bors branch
+//     2. Use params.OECI_LIB_VERSION if it is specified
+//     3. If none of the above, default to master
+if ( REPOSITORY_NAME == 'openenclave/openenclave' && BRANCH_NAME ==~ /^(trying|staging)$/ ) {
+    OECI_LIB_VERSION = BRANCH_NAME
+} else if ( params.OECI_LIB_VERSION ) {
+    // Use regex to match bors branches to include any changes to OpenEnclaveJenkinsLibrary
+    OECI_LIB_VERSION = params.OECI_LIB_VERSION
+} else {
+    OECI_LIB_VERSION = "master"
+}
+library "OpenEnclaveJenkinsLibrary@${OECI_LIB_VERSION}"
 
 properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
                                       artifactNumToKeepStr: '180',

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -65,7 +65,7 @@ try {
                                  string(name: 'DOCKER_TAG', value: DOCKER_TAG),
                                  string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx"]),
                                  string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
-                                 booleanParam(name: 'FULL_TEST_SUITE',value: FULL_TEST_SUITE)]
+                                 booleanParam(name: 'FULL_TEST_SUITE', value: FULL_TEST_SUITE)]
            },
            "Azure Linux" : {
                build job: '/pipelines/Azure-Linux',
@@ -77,11 +77,11 @@ try {
                                   string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx"]),
                                   string(name: 'WINDOWS_NONSGX_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["windows-nonsgx"]),
                                   string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
-                                  booleanParam(name: 'FULL_TEST_SUITE',value: FULL_TEST_SUITE)]
+                                  booleanParam(name: 'FULL_TEST_SUITE', value: FULL_TEST_SUITE)]
            },
            "Intel Linux" : {
                build job: '/pipelines/Intel-Agnostic',
-                     parameters: [booleanParam(name: 'FULL_TEST_SUITE',value: FULL_TEST_SUITE)]
+                     parameters: [booleanParam(name: 'FULL_TEST_SUITE', value: FULL_TEST_SUITE)]
            },
            "Azure Windows" : {
                build job: '/pipelines/Azure-Windows',
@@ -92,7 +92,7 @@ try {
                                   string(name: 'WINDOWS_2019_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["acc-win2019"]),
                                   string(name: 'WINDOWS_2019_DCAP_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["acc-win2019-dcap"]),
                                   string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
-                                  booleanParam(name: 'FULL_TEST_SUITE',value: FULL_TEST_SUITE)]
+                                  booleanParam(name: 'FULL_TEST_SUITE', value: FULL_TEST_SUITE)]
            }
         )
     }

--- a/.jenkins/library/vars/globalvars.groovy
+++ b/.jenkins/library/vars/globalvars.groovy
@@ -12,11 +12,14 @@ import groovy.transform.Field
 @Field GLOBAL_ERROR = null
 @Field AGENTS_LABELS = [
     "acc-ubuntu-20.04":         env.UBUNTU_2004_CUSTOM_LABEL ?: "ACC-2004",
+    "acc-v3-ubuntu-20.04":      env.UBUNTU_2004_ICX_CUSTOM_LABEL ?: "ACC-v3-2004",
     "acc-ubuntu-18.04":         env.UBUNTU_1804_CUSTOM_LABEL ?: "ACC-1804",
+    "acc-v3-ubuntu-18.04":      env.UBUNTU_1804_ICX_CUSTOM_LABEL ?: "ACC-v3-1804",
     "ubuntu-nonsgx":            env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004",
     "windows-nonsgx":           env.WINDOWS_NONSGX_CUSTOM_LABEL ?: "nonSGX-Windows",
     "acc-ubuntu-20.04-vanilla": env.UBUNTU_VANILLA_2004_CUSTOM_LABEL ?: "vanilla-ubuntu-2004",
     "acc-ubuntu-18.04-vanilla": env.UBUNTU_VANILLA_1804_CUSTOM_LABEL ?: "vanilla-ubuntu-1804",
-    "acc-win2019-dcap":         env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP"
+    "acc-win2019-dcap":         env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP",
+    "acc-v3-win2019-dcap":      env.WINDOWS_2019_DCAP_ICX_CUSTOM_LABEL ?: "ACC-v3-SGXFLC-Windows-2019-DCAP"
 ]
 @Field COMPILER = "clang-10"

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -1,7 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-library "OpenEnclaveJenkinsLibraryCyan@${params.OECI_LIB_VERSION}"
+library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 GLOBAL_ERROR = globalvars.GLOBAL_ERROR
 
 properties(

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -1,7 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
+library "OpenEnclaveJenkinsLibraryCyan@${params.OECI_LIB_VERSION}"
 GLOBAL_ERROR = globalvars.GLOBAL_ERROR
 
 properties(
@@ -83,7 +83,10 @@ try{
                 "ACC2004 clang-10 RelWithDebInfo LVI e2e snmalloc": { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04-vanilla"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
                 "ACC1804 clang-10 Debug LVI e2e snmalloc":          { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-10', 'Debug',          ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
                 "ACC1804 clang-10 RelWithDebInfo LVI e2e snmalloc": { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04-vanilla"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], [], true) },
-                "ACC2004 clang-10 RelWithDebInfo LVI snmalloc":     { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) }
+                "ACC2004 clang-10 RelWithDebInfo LVI snmalloc":     { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"],         'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
+
+                "ACC2004ICX clang-10 RelWithDebInfo LVI":           { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-20.04"],   'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=OFF']) },
+                "ACC1804ICX clang-10 RelWithDebInfo LVI snmalloc":  { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-18.04"],   'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) }
             ]
             parallel testing_stages
         }

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -1,7 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
+library "OpenEnclaveJenkinsLibraryCyan@${params.OECI_LIB_VERSION}"
 GLOBAL_ERROR = globalvars.GLOBAL_ERROR
 globalvars.CTEST_TIMEOUT_SECONDS = 1200
 
@@ -53,7 +53,7 @@ try{
                 "Win2019 RelWithDebInfo Cross Compile with DCAP libs":            { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo') },
                 "Win2019 Debug Cross Compile DCAP LVI":                           { tests.windowsCrossCompile('acc-win2019', 'Debug',          'ControlFlow') },
                 "Win2019 RelWithDebInfo Cross Compile DCAP LVI":                  { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow') },
-
+                "Win2019ICX RelWithDebInfo Cross Compile DCAP LVI":               { tests.windowsCrossCompile('acc-v3-win2019', 'RelWithDebInfo', 'ControlFlow') },
                 "Win2019 Sim Debug Cross Compile LVI snmalloc":                   { tests.windowsCrossCompile('acc-win2019', 'Debug',          'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
                 "Win2019 RelWithDebInfo Cross Compile DCAP LVI snmalloc":         { tests.windowsCrossCompile('acc-win2019', 'RelWithDebInfo', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) },
                 "Win2019 Cross Platform":                                         { tests.windowsCrossPlatform('acc-win2019-dcap') }

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -1,7 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-library "OpenEnclaveJenkinsLibraryCyan@${params.OECI_LIB_VERSION}"
+library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 GLOBAL_ERROR = globalvars.GLOBAL_ERROR
 globalvars.CTEST_TIMEOUT_SECONDS = 1200
 


### PR DESCRIPTION
This adds 3 tests to run on the new ICX ACC VMs for the _full test suite_:
  1. 1x Ubuntu 20.04 with LVI and dlmalloc
  2. 1x Ubuntu 18.04 with LVI and snmalloc
  3. 1x Windows Server 2019 with LVI

Signed-off-by: Chris Yan <chrisyan@microsoft.com>