### PR TITLE
TLS crash repro

### DIFF
--- a/tests/thread_local/enc/enc.cpp
+++ b/tests/thread_local/enc/enc.cpp
@@ -17,6 +17,9 @@
 VISIBILITY_SPEC __thread volatile int __thread_int = 1;
 VISIBILITY_SPEC __thread volatile int g_x[10] = {8};
 
+// Will be put in .tbss
+__thread void* ptr;
+
 struct thread_local_struct
 {
     bool initialized;
@@ -173,6 +176,8 @@ void enclave_thread(int thread_num, int iters, int step)
     OE_TEST(total == (2 * step * iters) + start_value1 + start_value2);
 
     wait_for_test_completion();
+    // Avoid being optimised out
+    ptr = nullptr;
 }
 
 #define NUM_TCS 16


### PR DESCRIPTION
This is a minimal change to the thread_local test to show the consequences of using a thread_local amount that results in an amount of `.tbss` unaligned on 16 byte boundaries. The crash disappears when declaring an even number of `void *` `thread_local `, and happens for all odd numbers of `void *` `thread_local `.

```
amchamay@amchamay:~/openenclave/build$ ninja
[3/8] Performing build step for 'ptraceLib'
ninja: no work to do.
[4/6] Generating oeutil_enc.signed
Created /home/amchamay/openenclave/build/output/bin/oeutil_enc.signed
[5/6] cd /home/amchamay/openenclave/build/tests/tools/oeapkman/zlib/enc && /home/amchamay/openenclave/tools/oeapkman/oeapkman add zlib-dev zlib-static
OK: 11 MiB in 24 packages
[6/6] cd /home/amchamay/openenclave/build/tests/tools/oeapkman/sqlite/enc && /home/amchamay/openenclave/tools/oeapkman/oeapkman add sqlite-dev sqlite-static
OK: 11 MiB in 24 packages
amchamay@amchamay:~/openenclave/build$ /home/amchamay/openenclave/build/tests/thread_local/host/thread_local_host "/home/amchamay/openenclave/build/tests/thread_local/enc/thread_local_enc_exported"
thread_local_struct initialized with value = 5thread_local_struct initialized with value = 78
thread_local_struct initialized with value = 5thread_local_struct initialized with value = 78thread_local_struct initialized with value = 25thread_local_struct initialized with value = 41thread_local_struct initialized with value = 2thread_local_struct initialized with value = 14thread_local_struct initialized with value = 28
thread_local_struct initialized with value = 5thread_local_struct initialized with value = 78thread_local_struct initialized with value = 25thread_local_struct initialized with value = 41thread_local_struct initialized with value = 2
thread_local_struct initialized with value = 5thread_local_struct initialized with value = 78thread_local_struct initialized with value = 25thread_local_struct initialized with value = 41thread_local_struct initialized with value = 2thread_local_struct initialized with value = 14thread_local_struct initialized with value = 28thread_local_struct initialized with value = 82
thread_local_struct initialized with value = 5thread_local_struct initialized with value = 78thread_local_struct initialized with value = 25
thread_local_struct initialized with value = 5thread_local_struct initialized with value = 78thread_local_struct initialized with value = 25thread_local_struct initialized with value = 41thread_local_struct initialized with value = 2thread_local_struct initialized with value = 14thread_local_struct initialized with value = 28
thread_local_struct initialized with value = 5thread_local_struct initialized with value = 78thread_local_struct initialized with value = 25thread_local_struct initialized with value = 41thread_local_struct initialized with value = 2thread_local_struct initialized with value = 14
Test failed: ../tests/thread_local/enc/enc.cpp(151): enclave_thread thread_local_value1 == 1
thread_local_struct initialized with value = 41
thread_local_struct initialized with value = 5thread_local_struct initialized with value = 78thread_local_struct initialized with value = 25thread_local_struct initialized with value = 41
thread_local_struct initialized with value = 41thread_local_struct initialized with value = 29thread_local_struct initialized with value = 70
thread_local_struct initialized with value = 41thread_local_struct initialized with value = 29
thread_local_struct initialized with value = 57
2021-11-19T13:55:42+0000.259547Z [(H)ERROR] tid(0x7f3bd8fff700) | :OE_ENCLAVE_ABORTING [../host/calls.c:_call_enclave_function_impl:56]
Test failed: ../tests/thread_local/host/host.cpp(27): run_enclave_thread enclave_thread(enclave, thread_num, iters, step) == OE_OK
2021-11-19T13:55:42+0000.259584Z [(H)ERROR] tid(0x7f3bd4ff7700) | :OE_ENCLAVE_ABORTING [../host/calls.c:_call_enclave_function_impl:56]
2021-11-19T13:55:42+0000.259711Z [(H)ERROR] tid(0x7f3bd87fe700) | :OE_ENCLAVE_ABORTING [../host/calls.c:_call_enclave_function_impl:56]
2021-11-19T13:55:42+0000.259652Z [(H)ERROR] tid(0x7f3bcdff9700) | :OE_ENCLAVE_ABORTING [../host/calls.c:_call_enclave_function_impl:56]
2021-11-19T13:55:42+0000.259746Z [(H)ERROR] tid(0x7f3bcf7fc700) | :OE_ENCLAVE_ABORTING [../host/calls.c:_call_enclave_function_impl:56]
2021-11-19T13:55:42+0000.259594Z [(H)ERROR] tid(0x7f3bd57f8700) | :OE_ENCLAVE_ABORTING [../host/calls.c:_call_enclave_function_impl:56]
2021-11-19T13:55:42+0000.259812Z [(H)ERROR] tid(0x7f3bceffb700) | :OE_ENCLAVE_ABORTING [../host/calls.c:_call_enclave_function_impl:56]
Test failed: ../tests/thread_local/enc/enc.cpp(151): enclave_thread thread_local_value1 == 1
Test failed: ../tests/thread_local/host/host.cpp(27): run_enclave_thread enclave_thread(enclave, thread_num, iters, step) == OE_OK
2021-11-19T13:55:42+0000.259839Z [(H)ERROR] tid(0x7f3bce7fa700) | :OE_ENCLAVE_ABORTING [../host/calls.c:_call_enclave_function_impl:56]
Test failed: ../tests/thread_local/host/host.cpp(27): run_enclave_thread enclave_thread(enclave, thread_num, iters, step) == OE_OK
Aborted (core dumped)
```

@mjp41