### PR TITLE
Fix thread local section alignment issue.

### DIFF
--- a/tests/thread_local/enc/enc.cpp
+++ b/tests/thread_local/enc/enc.cpp
@@ -17,6 +17,9 @@
 VISIBILITY_SPEC __thread volatile int __thread_int = 1;
 VISIBILITY_SPEC __thread volatile int g_x[10] = {8};
 
+// Will be put in .tbss
+__thread char tbss_var[18];
+
 struct thread_local_struct
 {
     bool initialized;
@@ -173,6 +176,9 @@ void enclave_thread(int thread_num, int iters, int step)
     OE_TEST(total == (2 * step * iters) + start_value1 + start_value2);
 
     wait_for_test_completion();
+
+    // Avoid being optimised out
+    memset(tbss_var, 0, sizeof(tbss_var));
 }
 
 #define NUM_TCS 16


### PR DESCRIPTION
Earlier, we used to choose the larger of the two alignments to align both the sections.
This is incorrect. For example, if tbss has a smaller alignment than tdata, then using
the larger alignment value will increase the size of the tdata section. This will inturn
cause a shift in the start of the tdata section which immediately precedes tbss section.
The tdata template will be copied to the region starting at the incorrect tdata start.

The fix is to
- First compute the aligned start of the tbss section.
- Then subract the tdata size from tbss start and then align it to data alignment to obtain tdata start.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>