### PR TITLE
Do not update td state in the case of direct return

### DIFF
--- a/enclave/core/sgx/exit.S
+++ b/enclave/core/sgx/exit.S
@@ -58,8 +58,9 @@ oe_asm_exit:
     mov %rdx, %r11
 
 .determine_exit_type:
-    // Check if the argument direct_return is set
-    cmp $1, %rcx
+    // Save the direct_return argument in r13 and check if it is set
+    mov %rcx, %r13
+    cmp $1, %r13
     je .return
 
     // Check the depth of the ECALL stack (zero for clean exit)
@@ -117,23 +118,33 @@ oe_asm_exit:
     mov SGX_SSA_URSP_OFFSET(%r12), %rsp
     mov SGX_SSA_URBP_OFFSET(%r12), %rbp
 
+    // Bypass update_td_state if direct_return is set
+    cmp $1, %r13
+    je .execute_eexit
+
+.update_td_state:
+    lfence
+
     // Do not update the state if the enclave exits in the middle
     // the exception handling (e.g., exiting from the first-level
-    // exception handler) or exits after an illegal instruction
-    // emulation
+    // exception handler), exits after an illegal instruction
+    // emulation, or the enclave is aborted
     cmpq $TD_STATE_SECOND_LEVEL_EXCEPTION_HANDLING, td_state(%r11)
     je .execute_eexit
     cmpq $TD_STATE_FIRST_LEVEL_EXCEPTION_HANDLING, td_previous_state(%r11)
     je .execute_eexit
+    cmpq $TD_STATE_ABORTED, td_state(%r11)
+    je .execute_eexit
+
+    lfence
 
     // Update the state to indicate that the enclave is returning
     // to the host
     movq $TD_STATE_EXITED, td_state(%r11)
 
+.execute_eexit:
     oe_cleanup_registers
 
-.execute_eexit:
-    lfence
     // Check oe_sgx_td_t.simulate flag
     // simulate-flag-check.
     mov td_simulate(%r11), %rax

--- a/host/sgx/enclavemanager.c
+++ b/host/sgx/enclavemanager.c
@@ -201,7 +201,7 @@ cleanup:
     }
 
     if (!ret)
-        OE_TRACE_ERROR("tcs=0x%x\n", tcs);
+        OE_TRACE_ERROR("tcs=0x%lx\n", tcs);
 
     return ret;
 }

--- a/tests/sgx/thread_interrupt/host/host.c
+++ b/tests/sgx/thread_interrupt/host/host.c
@@ -98,11 +98,12 @@ int main(int argc, const char* argv[])
     }
     else if (!strcmp(argv[2], "blocking"))
     {
-        result = enc_thread_interrupt_blocking(enclave);
-        OE_TEST(result == OE_ENCLAVE_ABORTING);
-        /* Expcet a non-OE_OK result. The error code may be different
-         * between debug and release build. */
-        OE_TEST(oe_terminate_enclave(enclave) != OE_OK);
+        int ret = 0;
+        result = enc_thread_interrupt_blocking(enclave, &ret);
+        OE_TEST(ret == 1);
+        if (result != OE_OK)
+            oe_put_err("oe_call_enclave() failed: result=%u", result);
+        OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
     }
     else
     {

--- a/tests/sgx/thread_interrupt/thread_interrupt.edl
+++ b/tests/sgx/thread_interrupt/thread_interrupt.edl
@@ -8,7 +8,7 @@ enclave {
 
     trusted {
         public void enc_thread_interrupt_nonblocking();
-        public void enc_thread_interrupt_blocking();
+        public void enc_thread_interrupt_blocking([in, out] int* ret);
         public void enc_run_thread_nonblocking(int tid);
         public void enc_run_thread_blocking(int tid);
     };


### PR DESCRIPTION
We didn't bypass the td state update in the case of direct return in the enclave exit logic, which could mess up the state machine.
This PR fixes the behavior.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>