### PR TITLE
Increase stack size for stack overflow test with snmalloc

### DIFF
--- a/tests/stack_overflow_exception/enc/enc.c
+++ b/tests/stack_overflow_exception/enc/enc.c
@@ -12,7 +12,7 @@
 
 #define PAGE_SIZE 4096
 #define EXCEPTION_HANDLER_STACK_SIZE 8192
-#define STACK_PAGE_NUMBER 2
+#define STACK_PAGE_NUMBER 4
 #define STACK_SIZE (STACK_PAGE_NUMER * PAGE_SIZE)
 void* td_to_tcs(const oe_sgx_td_t* td);
 

--- a/tests/stack_overflow_exception/enc/sign.conf
+++ b/tests/stack_overflow_exception/enc/sign.conf
@@ -5,7 +5,7 @@
 Debug=1
 CapturePFGPExceptions=1
 NumHeapPages=1024
-NumStackPages=2
+NumStackPages=4
 NumTCS=1
 ProductID=1
 SecurityVersion=1


### PR DESCRIPTION
The existing stack size (2 pages) is too small for snmalloc. Increase the size to 4 pages so that the test works with snmalloc.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>