### PR TITLE
Revise thread_interrupt test

### DIFF
--- a/include/openenclave/internal/tests.h
+++ b/include/openenclave/internal/tests.h
@@ -66,6 +66,30 @@ OE_EXTERNC_BEGIN
 
 #define OE_TEST_IGNORE(COND) OE_TEST_IF(COND, false)
 
+#define OE_EXPECT_IF(VALUE, EXPECTED, OE_TEST_ABORT)                 \
+    do                                                               \
+    {                                                                \
+        uint64_t value = (uint64_t)(VALUE);                          \
+        uint64_t expected = (uint64_t)(EXPECTED);                    \
+        if (value != expected)                                       \
+        {                                                            \
+            OE_PRINT(                                                \
+                STDERR,                                              \
+                "Test failed: %s(%u): %s expected: %lu, got: %lu\n", \
+                __FILE__,                                            \
+                __LINE__,                                            \
+                __FUNCTION__,                                        \
+                expected,                                            \
+                value);                                              \
+            if (OE_TEST_ABORT)                                       \
+                OE_ABORT();                                          \
+        }                                                            \
+    } while (0)
+
+#define OE_EXPECT(VALUE, EXPECTED) OE_EXPECT_IF(VALUE, EXPECTED, true)
+
+#define OE_EXPECT_IGNORE(VALUE, EXPECTED) OE_EXPECT_IF(VALUE, EXPECTED, false)
+
 /* Multi-threaded test cases may need a specific base allocation
  * when using allocators that make use of thread-local storage, such
  * as tcmalloc or snmalloc.

--- a/tests/sgx/td_state/enc/enc.c
+++ b/tests/sgx/td_state/enc/enc.c
@@ -14,24 +14,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define OE_EXPECT(a, b)                                              \
-    do                                                               \
-    {                                                                \
-        uint64_t value = (uint64_t)(a);                              \
-        uint64_t expected = (uint64_t)(b);                           \
-        if (value != expected)                                       \
-        {                                                            \
-            printf(                                                  \
-                "Test failed: %s(%u): %s expected: %lu, got: %lu\n", \
-                __FILE__,                                            \
-                __LINE__,                                            \
-                __FUNCTION__,                                        \
-                expected,                                            \
-                value);                                              \
-            oe_abort();                                              \
-        }                                                            \
-    } while (0)
-
 typedef struct _thread_info_t
 {
     int tid;

--- a/tests/sgx/thread_interrupt/host/host.c
+++ b/tests/sgx/thread_interrupt/host/host.c
@@ -98,9 +98,7 @@ int main(int argc, const char* argv[])
     }
     else if (!strcmp(argv[2], "blocking"))
     {
-        int ret = 0;
-        result = enc_thread_interrupt_blocking(enclave, &ret);
-        OE_TEST(ret == 1);
+        result = enc_thread_interrupt_blocking(enclave);
         if (result != OE_OK)
             oe_put_err("oe_call_enclave() failed: result=%u", result);
         OE_TEST(oe_terminate_enclave(enclave) == OE_OK);

--- a/tests/sgx/thread_interrupt/thread_interrupt.edl
+++ b/tests/sgx/thread_interrupt/thread_interrupt.edl
@@ -8,7 +8,7 @@ enclave {
 
     trusted {
         public void enc_thread_interrupt_nonblocking();
-        public void enc_thread_interrupt_blocking([in, out] int* ret);
+        public void enc_thread_interrupt_blocking();
         public void enc_run_thread_nonblocking(int tid);
         public void enc_run_thread_blocking(int tid);
     };


### PR DESCRIPTION
The PR revises the thread_interrupt test and avoids the flakiness in the blocking test by ensuring the SIGUSR1 is unregistered after the test with registered signal.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>