### PR TITLE
Rename SymCrypt-OpenSSL symbols

### DIFF
--- a/enclave/crypto/mbedtls/init.c
+++ b/enclave/crypto/mbedtls/init.c
@@ -4,11 +4,11 @@
 #include <openenclave/internal/crypto/init.h>
 
 /* Forward declaration */
-int SC_OSSL_ENGINE_Initialize();
+int SCOSSL_ENGINE_Initialize();
 
 /* Add the implementation of the function (only available for OpenSSL)
  * to fulfill the linker requirement */
-int SC_OSSL_ENGINE_Initialize()
+int SCOSSL_ENGINE_Initialize()
 {
     return OE_SYMCRYPT_ENGINE_INVALID;
 }

--- a/enclave/crypto/openssl/init.c
+++ b/enclave/crypto/openssl/init.c
@@ -12,7 +12,7 @@ int _is_symcrypt_engine_available = 0;
 #define HOST_ENTROPY_TEST_SIZE 16
 
 /* Forward declarations */
-int SC_OSSL_ENGINE_Initialize();
+int SCOSSL_ENGINE_Initialize();
 int oe_sgx_get_additional_host_entropy(uint8_t*, size_t);
 
 static void _finalize(void)
@@ -62,7 +62,7 @@ static int _initialize_symcrypt_engine()
 {
     int result;
 
-    result = SC_OSSL_ENGINE_Initialize();
+    result = SCOSSL_ENGINE_Initialize();
     if (result != OE_SYMCRYPT_ENGINE_SUCCESS)
         goto done;
 

--- a/enclave/crypto/openssl/symcrypt_engine.c
+++ b/enclave/crypto/openssl/symcrypt_engine.c
@@ -9,8 +9,8 @@
  * Note that we have to put the function in a separated source file from
  * init.c to prevent the linker pulls in the symbol along with the
  * oe_crypto_initialize function. */
-int _oe_sc_ossl_engine_initialize()
+int _oe_scossl_engine_initialize()
 {
     return OE_SYMCRYPT_ENGINE_NOT_LINKED;
 }
-OE_WEAK_ALIAS(_oe_sc_ossl_engine_initialize, SC_OSSL_ENGINE_Initialize);
+OE_WEAK_ALIAS(_oe_scossl_engine_initialize, SCOSSL_ENGINE_Initialize);

--- a/enclave/link.c
+++ b/enclave/link.c
@@ -10,7 +10,7 @@
 #include "core_t.h"
 
 /* Forward declarartion for the symcrypt engine initializer */
-int SC_OSSL_ENGINE_Initialize();
+int SCOSSL_ENGINE_Initialize();
 
 //
 // start.S (the compilation unit containing the entry point) contains a
@@ -36,7 +36,7 @@ const void* oe_link_enclave(void)
         oe_debug_malloc_tracking_start,
         oe_crypto_initialize,
         oe_libc_initialize,
-        SC_OSSL_ENGINE_Initialize,
+        SCOSSL_ENGINE_Initialize,
 #if defined(OE_USE_DEBUG_MALLOC)
         oe_debug_malloc_check,
 #endif /* defined(OE_USE_DEBUG_MALLOC) */

--- a/tests/symcrypt_engine/enc/symcrypt_engine_test.c
+++ b/tests/symcrypt_engine/enc/symcrypt_engine_test.c
@@ -6,7 +6,7 @@
 /* We do not have the SymCrypt engine available yet, defining a mock initializer
  * with the same function prototype and returns OE_SYMCRYPT_ENGINE_SUCCESS,
  * mimicking the expected behavior. */
-int SC_OSSL_ENGINE_Initialize()
+int SCOSSL_ENGINE_Initialize()
 {
     return OE_SYMCRYPT_ENGINE_SUCCESS;
 }


### PR DESCRIPTION
+ Since SymCrypt-OpenSSL has renamed symbols to have scossl_ or SCOSSL_
  prefix across the board (https://github.com/microsoft/SymCrypt-OpenSSL/pull/31), callers need to be updated