### PR TITLE
Modify the state machine update logic for exception handling code

### DIFF
--- a/enclave/core/sgx/exception.c
+++ b/enclave/core/sgx/exception.c
@@ -241,7 +241,7 @@ void oe_real_exception_dispatcher(oe_context_t* oe_context)
 
     /* Validate the td state, which ensures the function
      * is only invoked after oe_virtual_exception_dispatcher */
-    if (td->state != OE_TD_STATE_SECOND_LEVEL_EXCEPTION_HANDLING)
+    if (td->state != OE_TD_STATE_FIRST_LEVEL_EXCEPTION_HANDLING)
     {
         oe_abort();
         return;
@@ -288,6 +288,17 @@ void oe_real_exception_dispatcher(oe_context_t* oe_context)
         oe_exception_record.context->rbp = td->last_ssa_rbp;
     }
 
+    /* Compiler barrier to enfore the memory ordering */
+    asm volatile("" ::: "memory");
+
+    /* Update the state to prevent nested exceptions prior to this point
+     * that could cause oe_context on the stack and td states overwritten.
+     * That is, any exception occurs prior to this point will cause the
+     * following oe_enter performs the early return flow (i.e., oe_enter will
+     * early return if state is not OE_TD_STATE_SECOND_LEVEL_EXCEPTION_HANDLING
+     * for the case of nested exceptions) */
+    td->state = OE_TD_STATE_SECOND_LEVEL_EXCEPTION_HANDLING;
+
     // Traverse the existing exception handlers, stop when
     // OE_EXCEPTION_CONTINUE_EXECUTION is found.
     uint64_t handler_ret = OE_EXCEPTION_CONTINUE_SEARCH;
@@ -328,6 +339,9 @@ void oe_real_exception_dispatcher(oe_context_t* oe_context)
         }
 
         td->host_signal = 0;
+
+        /* Compiler barrier to enfore the memory ordering */
+        asm volatile("" ::: "memory");
 
         /* Retore the state */
         td->state = OE_TD_STATE_RUNNING;
@@ -484,12 +498,6 @@ void oe_virtual_exception_dispatcher(
             td->faulting_address = exinfo->maddr;
             td->error_code = exinfo->errcd;
         }
-
-        /* Update the state here to indicate the second-level exception
-         * handler is running next. This allows both exiting and the following
-         * entering flows to skip updating the state; i.e., the second-level
-         * exception handler can run with this state. */
-        td->state = OE_TD_STATE_SECOND_LEVEL_EXCEPTION_HANDLING;
 
         // Modify the ssa_gpr so that e_resume will go to second pass exception
         // handler.

--- a/enclave/core/sgx/exit.S
+++ b/enclave/core/sgx/exit.S
@@ -125,14 +125,18 @@ oe_asm_exit:
 .update_td_state:
     lfence
 
-    // Do not update the state if the enclave exits in the middle
-    // the exception handling (e.g., exiting from the first-level
-    // exception handler), exits after an illegal instruction
-    // emulation, or the enclave is aborted
+    // Do not update the state in the following cases:
+    // a. The enclave exists from the first-level exception handler
+    cmpq $TD_STATE_FIRST_LEVEL_EXCEPTION_HANDLING, td_state(%r11)
+    je .execute_eexit
+    // b. The enclave exists in the middle of second-level exception handler
+    // (e.g., making an OCALL)
     cmpq $TD_STATE_SECOND_LEVEL_EXCEPTION_HANDLING, td_state(%r11)
     je .execute_eexit
+    // c. The enclave exists after an illegal instruction (e.g., cpuid) emulation
     cmpq $TD_STATE_FIRST_LEVEL_EXCEPTION_HANDLING, td_previous_state(%r11)
     je .execute_eexit
+    // d. The enclave exists while it is aborted
     cmpq $TD_STATE_ABORTED, td_state(%r11)
     je .execute_eexit
 


### PR DESCRIPTION
Modify the state machine update logic in the exception handling code to reflect the window at the beginning of the second-level exception handler, where OE cannot handle exceptions. More details are as follows.

The OE runtime stores the register states on the stack at the beginning of the second-level handler (`oe_exception_dispatcher`) and resumes the register states stored in the stack at the end of the handler. If an exception occurs before or during the register storing, the following exception handling flow will cause the stack overwritten, and therefore OE will fail to resume the execution. Similarly, an exception occurs early enough during the second-level handler could cause td states overwritten. To guard such exceptions, this PR delays the td state update to `OE_TD_STATE_SECOND_LEVEL_EXCEPTION_HANDLING`. Any exception occurs prior to the state update will cause the following oe_enter performs early return (i.e., oe_enter will do early return if the state is  not `OE_TD_STATE_SECOND_LEVEL_EXCEPTION_HANDLING` for the case of nested exceptions).

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>