### PR TITLE
Enable compiling OE SDK with CC=clang-11 CXX=clang++-11

### DIFF
--- a/3rdparty/libunwind/README.md
+++ b/3rdparty/libunwind/README.md
@@ -19,6 +19,9 @@ The general porting approach is described as follows.
 - Provide a definition of **_Ux86_64_setcontext** that does not perform a
   system call (see [setcontext.S](setcontext.S))
 
+- To fix multiple definition errors in clang-11 and later, _U_dyn_info_list is declared WEAK in src/x86_64/Ginit.c.
+  This workaround is not needed in newer versions of libunwind.
+
 This port also works with the newer libunwind version 1.3.
 
 ```

--- a/3rdparty/libunwind/libunwind/src/x86_64/Ginit.c
+++ b/3rdparty/libunwind/libunwind/src/x86_64/Ginit.c
@@ -49,103 +49,103 @@ static struct unw_addr_space local_addr_space;
 
 unw_addr_space_t unw_local_addr_space = &local_addr_space;
 
-HIDDEN unw_dyn_info_list_t _U_dyn_info_list;
+WEAK HIDDEN unw_dyn_info_list_t _U_dyn_info_list;
 
 /* XXX fix me: there is currently no way to locate the dyn-info list
        by a remote unwinder.  On ia64, this is done via a special
        unwind-table entry.  Perhaps something similar can be done with
        DWARF2 unwind info.  */
 
-static void
-put_unwind_info (unw_addr_space_t as, unw_proc_info_t *proc_info, void *arg)
+static void put_unwind_info(
+    unw_addr_space_t as,
+    unw_proc_info_t* proc_info,
+    void* arg)
 {
-  /* it's a no-op */
+    /* it's a no-op */
 }
 
-static int
-get_dyn_info_list_addr (unw_addr_space_t as, unw_word_t *dyn_info_list_addr,
-                        void *arg)
+static int get_dyn_info_list_addr(
+    unw_addr_space_t as,
+    unw_word_t* dyn_info_list_addr,
+    void* arg)
 {
-  *dyn_info_list_addr = (unw_word_t) &_U_dyn_info_list;
-  return 0;
+    *dyn_info_list_addr = (unw_word_t)&_U_dyn_info_list;
+    return 0;
 }
 
 #define PAGE_SIZE 4096
-#define PAGE_START(a)   ((a) & ~(PAGE_SIZE-1))
+#define PAGE_START(a) ((a) & ~(PAGE_SIZE - 1))
 
 static int mem_validate_pipe[2] = {-1, -1};
 
-static inline void
-open_pipe (void)
+static inline void open_pipe(void)
 {
-  /* ignore errors for closing invalid fd's */
-  close (mem_validate_pipe[0]);
-  close (mem_validate_pipe[1]);
+    /* ignore errors for closing invalid fd's */
+    close(mem_validate_pipe[0]);
+    close(mem_validate_pipe[1]);
 
-  pipe2 (mem_validate_pipe, O_CLOEXEC | O_NONBLOCK);
+    pipe2(mem_validate_pipe, O_CLOEXEC | O_NONBLOCK);
 }
 
 ALWAYS_INLINE
-static int
-write_validate (void *addr)
+static int write_validate(void* addr)
 {
-  int ret = -1;
-  ssize_t bytes = 0;
+    int ret = -1;
+    ssize_t bytes = 0;
 
-  do
+    do
     {
-      char buf;
-      bytes = read (mem_validate_pipe[0], &buf, 1);
-    }
-  while ( errno == EINTR );
+        char buf;
+        bytes = read(mem_validate_pipe[0], &buf, 1);
+    } while (errno == EINTR);
 
-  int valid_read = (bytes > 0 || errno == EAGAIN || errno == EWOULDBLOCK);
-  if (!valid_read)
+    int valid_read = (bytes > 0 || errno == EAGAIN || errno == EWOULDBLOCK);
+    if (!valid_read)
     {
-      // re-open closed pipe
-      open_pipe ();
+        // re-open closed pipe
+        open_pipe();
     }
 
-  do
+    do
     {
-      /* use syscall insteadof write() so that ASAN does not complain */
-      ret = syscall (SYS_write, mem_validate_pipe[1], addr, 1);
-    }
-  while ( errno == EINTR );
+        /* use syscall insteadof write() so that ASAN does not complain */
+        ret = syscall(SYS_write, mem_validate_pipe[1], addr, 1);
+    } while (errno == EINTR);
 
-  return ret;
+    return ret;
 }
 
-static int (*mem_validate_func) (void *addr, size_t len);
-static int msync_validate (void *addr, size_t len)
+static int (*mem_validate_func)(void* addr, size_t len);
+static int msync_validate(void* addr, size_t len)
 {
-  if (msync (addr, len, MS_ASYNC) != 0)
+    if (msync(addr, len, MS_ASYNC) != 0)
     {
-      return -1;
+        return -1;
     }
 
-  return write_validate (addr);
+    return write_validate(addr);
 }
 
 #ifdef HAVE_MINCORE
-static int mincore_validate (void *addr, size_t len)
+static int mincore_validate(void* addr, size_t len)
 {
-  unsigned char mvec[2]; /* Unaligned access may cross page boundary */
-  size_t i;
+    unsigned char mvec[2]; /* Unaligned access may cross page boundary */
+    size_t i;
 
-  /* mincore could fail with EAGAIN but we conservatively return -1
-     instead of looping. */
-  if (mincore (addr, len, mvec) != 0)
+    /* mincore could fail with EAGAIN but we conservatively return -1
+       instead of looping. */
+    if (mincore(addr, len, mvec) != 0)
     {
-      return -1;
+        return -1;
     }
 
-  for (i = 0; i < (len + PAGE_SIZE - 1) / PAGE_SIZE; i++)
+    for (i = 0; i < (len + PAGE_SIZE - 1) / PAGE_SIZE; i++)
     {
-      if (!(mvec[i] & 1)) return -1;
+        if (!(mvec[i] & 1))
+            return -1;
     }
 
-  return write_validate (addr);
+    return write_validate(addr);
 }
 #endif
 
@@ -153,28 +153,29 @@ static int mincore_validate (void *addr, size_t len)
    mincore() returns incorrect value for MAP_PRIVATE mappings,
    such as stacks. If mincore() was available at compile time,
    check if we can actually use it. If not, use msync() instead. */
-HIDDEN void
-tdep_init_mem_validate (void)
+HIDDEN void tdep_init_mem_validate(void)
 {
-  open_pipe ();
+    open_pipe();
 
 #ifdef HAVE_MINCORE
-  unsigned char present = 1;
-  unw_word_t addr = PAGE_START((unw_word_t)&present);
-  unsigned char mvec[1];
-  int ret;
-  while ((ret = mincore ((void*)addr, PAGE_SIZE, mvec)) == -1 &&
-         errno == EAGAIN) {}
-  if (ret == 0 && (mvec[0] & 1))
+    unsigned char present = 1;
+    unw_word_t addr = PAGE_START((unw_word_t)&present);
+    unsigned char mvec[1];
+    int ret;
+    while ((ret = mincore((void*)addr, PAGE_SIZE, mvec)) == -1 &&
+           errno == EAGAIN)
     {
-      Debug(1, "using mincore to validate memory\n");
-      mem_validate_func = mincore_validate;
     }
-  else
+    if (ret == 0 && (mvec[0] & 1))
+    {
+        Debug(1, "using mincore to validate memory\n");
+        mem_validate_func = mincore_validate;
+    }
+    else
 #endif
     {
-      Debug(1, "using msync to validate memory\n");
-      mem_validate_func = msync_validate;
+        Debug(1, "using msync to validate memory\n");
+        mem_validate_func = msync_validate;
     }
 }
 
@@ -183,160 +184,183 @@ tdep_init_mem_validate (void)
 static unw_word_t last_good_addr[NLGA];
 static int lga_victim;
 
-static int
-validate_mem (unw_word_t addr)
+static int validate_mem(unw_word_t addr)
 {
-  int i, victim;
-  size_t len;
+    int i, victim;
+    size_t len;
 
-  if (PAGE_START(addr + sizeof (unw_word_t) - 1) == PAGE_START(addr))
-    len = PAGE_SIZE;
-  else
-    len = PAGE_SIZE * 2;
+    if (PAGE_START(addr + sizeof(unw_word_t) - 1) == PAGE_START(addr))
+        len = PAGE_SIZE;
+    else
+        len = PAGE_SIZE * 2;
 
-  addr = PAGE_START(addr);
+    addr = PAGE_START(addr);
 
-  if (addr == 0)
-    return -1;
-
-  for (i = 0; i < NLGA; i++)
-    {
-      if (last_good_addr[i] && (addr == last_good_addr[i]))
-        return 0;
-    }
-
-  if (mem_validate_func ((void *) addr, len) == -1)
-    return -1;
-
-  victim = lga_victim;
-  for (i = 0; i < NLGA; i++) {
-    if (!last_good_addr[victim]) {
-      last_good_addr[victim++] = addr;
-      return 0;
-    }
-    victim = (victim + 1) % NLGA;
-  }
-
-  /* All slots full. Evict the victim. */
-  last_good_addr[victim] = addr;
-  victim = (victim + 1) % NLGA;
-  lga_victim = victim;
-
-  return 0;
-}
-
-static int
-access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
-            void *arg)
-{
-  if (unlikely (write))
-    {
-      Debug (16, "mem[%016lx] <- %lx\n", addr, *val);
-      *(unw_word_t *) addr = *val;
-    }
-  else
-    {
-      /* validate address */
-      const struct cursor *c = (const struct cursor *)arg;
-      if (likely (c != NULL) && unlikely (c->validate)
-          && unlikely (validate_mem (addr))) {
-        Debug (16, "mem[%016lx] -> invalid\n", addr);
+    if (addr == 0)
         return -1;
-      }
-      *val = *(unw_word_t *) addr;
-      Debug (16, "mem[%016lx] -> %lx\n", addr, *val);
+
+    for (i = 0; i < NLGA; i++)
+    {
+        if (last_good_addr[i] && (addr == last_good_addr[i]))
+            return 0;
     }
-  return 0;
+
+    if (mem_validate_func((void*)addr, len) == -1)
+        return -1;
+
+    victim = lga_victim;
+    for (i = 0; i < NLGA; i++)
+    {
+        if (!last_good_addr[victim])
+        {
+            last_good_addr[victim++] = addr;
+            return 0;
+        }
+        victim = (victim + 1) % NLGA;
+    }
+
+    /* All slots full. Evict the victim. */
+    last_good_addr[victim] = addr;
+    victim = (victim + 1) % NLGA;
+    lga_victim = victim;
+
+    return 0;
 }
 
-static int
-access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
-            void *arg)
+static int access_mem(
+    unw_addr_space_t as,
+    unw_word_t addr,
+    unw_word_t* val,
+    int write,
+    void* arg)
 {
-  unw_word_t *addr;
-  ucontext_t *uc = ((struct cursor *)arg)->uc;
-
-  if (unw_is_fpreg (reg))
-    goto badreg;
-
-  if (!(addr = x86_64_r_uc_addr (uc, reg)))
-    goto badreg;
-
-  if (write)
+    if (unlikely(write))
     {
-      *(unw_word_t *) addr = *val;
-      Debug (12, "%s <- 0x%016lx\n", unw_regname (reg), *val);
+        Debug(16, "mem[%016lx] <- %lx\n", addr, *val);
+        *(unw_word_t*)addr = *val;
     }
-  else
+    else
     {
-      *val = *(unw_word_t *) addr;
-      Debug (12, "%s -> 0x%016lx\n", unw_regname (reg), *val);
+        /* validate address */
+        const struct cursor* c = (const struct cursor*)arg;
+        if (likely(c != NULL) && unlikely(c->validate) &&
+            unlikely(validate_mem(addr)))
+        {
+            Debug(16, "mem[%016lx] -> invalid\n", addr);
+            return -1;
+        }
+        *val = *(unw_word_t*)addr;
+        Debug(16, "mem[%016lx] -> %lx\n", addr, *val);
     }
-  return 0;
-
- badreg:
-  Debug (1, "bad register number %u\n", reg);
-  return -UNW_EBADREG;
+    return 0;
 }
 
-static int
-access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
-              int write, void *arg)
+static int access_reg(
+    unw_addr_space_t as,
+    unw_regnum_t reg,
+    unw_word_t* val,
+    int write,
+    void* arg)
 {
-  ucontext_t *uc = ((struct cursor *)arg)->uc;
-  unw_fpreg_t *addr;
+    unw_word_t* addr;
+    ucontext_t* uc = ((struct cursor*)arg)->uc;
 
-  if (!unw_is_fpreg (reg))
-    goto badreg;
+    if (unw_is_fpreg(reg))
+        goto badreg;
 
-  if (!(addr = x86_64_r_uc_addr (uc, reg)))
-    goto badreg;
+    if (!(addr = x86_64_r_uc_addr(uc, reg)))
+        goto badreg;
 
-  if (write)
+    if (write)
     {
-      Debug (12, "%s <- %08lx.%08lx.%08lx\n", unw_regname (reg),
-             ((long *)val)[0], ((long *)val)[1], ((long *)val)[2]);
-      *(unw_fpreg_t *) addr = *val;
+        *(unw_word_t*)addr = *val;
+        Debug(12, "%s <- 0x%016lx\n", unw_regname(reg), *val);
     }
-  else
+    else
     {
-      *val = *(unw_fpreg_t *) addr;
-      Debug (12, "%s -> %08lx.%08lx.%08lx\n", unw_regname (reg),
-             ((long *)val)[0], ((long *)val)[1], ((long *)val)[2]);
+        *val = *(unw_word_t*)addr;
+        Debug(12, "%s -> 0x%016lx\n", unw_regname(reg), *val);
     }
-  return 0;
+    return 0;
 
- badreg:
-  Debug (1, "bad register number %u\n", reg);
-  /* attempt to access a non-preserved register */
-  return -UNW_EBADREG;
+badreg:
+    Debug(1, "bad register number %u\n", reg);
+    return -UNW_EBADREG;
 }
 
-static int
-get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
-                      char *buf, size_t buf_len, unw_word_t *offp,
-                      void *arg)
+static int access_fpreg(
+    unw_addr_space_t as,
+    unw_regnum_t reg,
+    unw_fpreg_t* val,
+    int write,
+    void* arg)
 {
-  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+    ucontext_t* uc = ((struct cursor*)arg)->uc;
+    unw_fpreg_t* addr;
+
+    if (!unw_is_fpreg(reg))
+        goto badreg;
+
+    if (!(addr = x86_64_r_uc_addr(uc, reg)))
+        goto badreg;
+
+    if (write)
+    {
+        Debug(
+            12,
+            "%s <- %08lx.%08lx.%08lx\n",
+            unw_regname(reg),
+            ((long*)val)[0],
+            ((long*)val)[1],
+            ((long*)val)[2]);
+        *(unw_fpreg_t*)addr = *val;
+    }
+    else
+    {
+        *val = *(unw_fpreg_t*)addr;
+        Debug(
+            12,
+            "%s -> %08lx.%08lx.%08lx\n",
+            unw_regname(reg),
+            ((long*)val)[0],
+            ((long*)val)[1],
+            ((long*)val)[2]);
+    }
+    return 0;
+
+badreg:
+    Debug(1, "bad register number %u\n", reg);
+    /* attempt to access a non-preserved register */
+    return -UNW_EBADREG;
 }
 
-HIDDEN void
-x86_64_local_addr_space_init (void)
+static int get_static_proc_name(
+    unw_addr_space_t as,
+    unw_word_t ip,
+    char* buf,
+    size_t buf_len,
+    unw_word_t* offp,
+    void* arg)
 {
-  memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
-  local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
-  local_addr_space.acc.put_unwind_info = put_unwind_info;
-  local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;
-  local_addr_space.acc.access_mem = access_mem;
-  local_addr_space.acc.access_reg = access_reg;
-  local_addr_space.acc.access_fpreg = access_fpreg;
-  local_addr_space.acc.resume = x86_64_local_resume;
-  local_addr_space.acc.get_proc_name = get_static_proc_name;
-  unw_flush_cache (&local_addr_space, 0, 0);
+    return _Uelf64_get_proc_name(as, getpid(), ip, buf, buf_len, offp);
+}
 
-  memset (last_good_addr, 0, sizeof (unw_word_t) * NLGA);
-  lga_victim = 0;
+HIDDEN void x86_64_local_addr_space_init(void)
+{
+    memset(&local_addr_space, 0, sizeof(local_addr_space));
+    local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
+    local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
+    local_addr_space.acc.put_unwind_info = put_unwind_info;
+    local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;
+    local_addr_space.acc.access_mem = access_mem;
+    local_addr_space.acc.access_reg = access_reg;
+    local_addr_space.acc.access_fpreg = access_fpreg;
+    local_addr_space.acc.resume = x86_64_local_resume;
+    local_addr_space.acc.get_proc_name = get_static_proc_name;
+    unw_flush_cache(&local_addr_space, 0, 0);
+
+    memset(last_good_addr, 0, sizeof(unw_word_t) * NLGA);
+    lga_victim = 0;
 }
 
 #endif /* !UNW_REMOTE_ONLY */


### PR DESCRIPTION
The SDK can now be complied using clang-11. The default compiler is still clang-10.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>