### PR TITLE
Update SymCrypt-OpenSSL

### DIFF
--- a/3rdparty/symcrypt_engine/CMakeLists.txt
+++ b/3rdparty/symcrypt_engine/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
+check_submodule_not_empty(SymCrypt-OpenSSL)
+
 set(OPENSSL_DIR ${PROJECT_SOURCE_DIR}/3rdparty/openssl/openssl)
 set(SYMCRYPT_ENGINE_DIR
     ${CMAKE_CURRENT_SOURCE_DIR}/SymCrypt-OpenSSL/SymCryptEngine)

--- a/tests/openssl/CMakeLists.txt
+++ b/tests/openssl/CMakeLists.txt
@@ -553,7 +553,7 @@ foreach (testcase ${openssltests})
     if ((NOT "${subtest_name}" IN_LIST UNSUPPORTED_SYMCRYPT_TESTS)
         AND (ENABLE_SYMCRYPT_OPENSSL_TESTS))
       set_enclave_tests_properties(
-        tests/openssl/${namesubtest_name}_symcrypt
+        tests/openssl/${subtest_name}_symcrypt
         PROPERTIES
         ENVIRONMENT
         "CTLOG_FILE=${OPENSSL_TEST_DIR}/ct/log_list.conf;TEST_CERTS_DIR=${OPENSSL_TEST_DIR}/certs"

--- a/tests/openssl/tests.unsupported.symcrypt
+++ b/tests/openssl/tests.unsupported.symcrypt
@@ -1,5 +1,3 @@
-# Memory leak
-dhtest
 # The test relies on OpenSSL default implementation
 ecdsatest
 # Use an AES-GCM IV which is not 12-bytes (192-bits)
@@ -10,5 +8,3 @@ rsa_mp_test
 evp_test-evpciph
 # Inconsistent implementation between OpenSSL and SymCrypt
 evp_test-evppkey
-# Memory leak
-ssl_test-cert-select


### PR DESCRIPTION
Update the SymCrypt-OpenSSL submodule that fixes few tests that failed with memory leak.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>