### PR TITLE
Use github mirror of libc-test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 	branch = openenclave-musl-1.2.2
 [submodule "3rdparty/musl/libc-test"]
 	path = 3rdparty/musl/libc-test
-	url = https://repo.or.cz/libc-test.git
+	url = https://github.com/openenclave/openenclave-musl-libc-tests
 [submodule "3rdparty/symcrypt_engine/SymCrypt-OpenSSL"]
 	path = 3rdparty/symcrypt_engine/SymCrypt-OpenSSL
 	url = https://github.com/microsoft/SymCrypt-OpenSSL

--- a/3rdparty/musl/README.md
+++ b/3rdparty/musl/README.md
@@ -20,11 +20,11 @@ suite. The structure of the directory is as follows.
     ```
   - Ensure the OE SDK builds and tests run successfully.
 
-- libc-test/ (commit: `a51df71b050f3f9dfdc0a7d90978b57277b582ec`)
+- libc-test/ (commit: `b7ec467969a53756258778fa7d9b045f912d1c93`)
 
   The clone of libc-test that is included as a git submodule, which points to a recent
   commit. We usually update the submodule along with musl libc with following procedure:
-  - Checkout the more recent commit (the date that matches the version of musl libc)
+  - Checkout the more recent commit
     ```
     cd libc-test
     git fetch


### PR DESCRIPTION
The original git server of libc-test is extremely not stable. Use the github mirror instead.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>