### PR TITLE
[attestation] Add sgx_cpusvn, pcesvn, qeid and fmspc to claims

### DIFF
--- a/common/sgx/tcbinfo.h
+++ b/common/sgx/tcbinfo.h
@@ -57,6 +57,8 @@ typedef struct _oe_tcb_info_tcb_level
     size_t advisory_ids_size;
 } oe_tcb_info_tcb_level_t;
 
+#define OE_SGX_FMSPC_SIZE 6
+
 /*! \struct oe_parsed_tcb_info_t
  *  \brief TCB info excluding the TCB levels field.
  */
@@ -65,7 +67,7 @@ typedef struct _oe_parsed_tcb_info
     uint32_t version;
     oe_datetime_t issue_date;
     oe_datetime_t next_update;
-    uint8_t fmspc[6];
+    uint8_t fmspc[OE_SGX_FMSPC_SIZE];
     uint8_t pceid[2];
     uint8_t signature[64];
 

--- a/include/openenclave/attestation/sgx/evidence.h
+++ b/include/openenclave/attestation/sgx/evidence.h
@@ -137,7 +137,8 @@ OE_EXTERNC_BEGIN
 #define OE_CLAIM_SGX_CONFIG_ID "sgx_config_id"
 #define OE_CLAIM_SGX_CONFIG_SVN "sgx_config_svn"
 #define OE_CLAIM_SGX_ISV_FAMILY_ID "sgx_isv_family_id"
-#define OE_SGX_REQUIRED_CLAIMS_COUNT 9
+#define OE_CLAIM_SGX_CPU_SVN "sgx_cpu_svn"
+#define OE_SGX_REQUIRED_CLAIMS_COUNT 10
 
 // Optional: SQX Quote verification collaterals.
 #define OE_CLAIM_SGX_TCB_INFO "sgx_tcb_info"

--- a/include/openenclave/bits/evidence.h
+++ b/include/openenclave/bits/evidence.h
@@ -136,11 +136,26 @@ extern const char* OE_REQUIRED_CLAIMS[OE_REQUIRED_CLAIMS_COUNT];
 #define OE_CLAIM_VALIDITY_UNTIL "validity_until"
 
 /**
+ * SGX PCESVN of platform.
+ */
+#define OE_CLAIM_SGX_PCE_SVN "sgx_pce_svn"
+
+/**
+ * QEID from SGX quote user_data.
+ */
+#define OE_CLAIM_SGX_QE_ID "sgx_qe_id"
+
+/**
+ * FMSPC from SGX TCB info
+ */
+#define OE_CLAIM_SGX_FMSPC "sgx_fmspc"
+
+/**
  * @cond DEV
  *
  */
 
-#define OE_OPTIONAL_CLAIMS_COUNT 4
+#define OE_OPTIONAL_CLAIMS_COUNT 7
 // This array is needed for tests
 extern const char* OE_OPTIONAL_CLAIMS[OE_OPTIONAL_CLAIMS_COUNT];
 

--- a/include/openenclave/bits/sgx/sgxtypes.h
+++ b/include/openenclave/bits/sgx/sgxtypes.h
@@ -407,6 +407,7 @@ typedef struct _sgx_launch_token
 #define SGX_CPUSVN_SIZE 16
 #define SGX_KEYID_SIZE 32
 #define SGX_MAC_SIZE 16
+#define SGX_USERDATA_SIZE 20
 
 OE_PACK_BEGIN
 typedef struct _sgx_einittoken
@@ -690,7 +691,7 @@ typedef struct _sgx_quote
     uint8_t uuid[16];
 
     /* (28) */
-    uint8_t user_data[20];
+    uint8_t user_data[SGX_USERDATA_SIZE];
 
     /* (48) */
     sgx_report_body_t report_body;

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -402,6 +402,27 @@ static void* _find_claim(
     return NULL;
 }
 
+static void _find_fmspc(uint8_t* tcb_info, uint8_t* fmspc, size_t fmspc_size)
+{
+    char* substr = "fmspc";
+    char* p_fmspc;
+    long data = 0;
+    char hex[3];
+
+    p_fmspc = strstr((char*)tcb_info, substr);
+    p_fmspc = p_fmspc + 8; // move pointer to start of value
+    hex[2] = '\0';
+
+    for (size_t i = 0; i < fmspc_size; ++i)
+    {
+        hex[0] = *p_fmspc++;
+        hex[1] = *p_fmspc++;
+
+        data = strtol(hex, NULL, 16);
+        *(fmspc + i) = (uint8_t)data;
+    }
+}
+
 static void _test_claims(
     const oe_claim_t* claims,
     size_t claims_size,
@@ -529,6 +550,14 @@ static void _test_claims(
                              sgx_report_body->isvfamilyid,
                              sizeof(sgx_report_body->isvfamilyid)) == 0);
 
+    // Check SGX cpusvn
+    value = _find_claim(claims, claims_size, OE_CLAIM_SGX_CPU_SVN);
+    OE_TEST(
+        value != NULL &&
+        memcmp(
+            value, sgx_report_body->cpusvn, sizeof(sgx_report_body->cpusvn)) ==
+            0);
+
     // Check tcb status. If it is OE_SGX_TCB_STATUS_UP_TO_DATE or
     // OE_SGX_TCB_STATUS_SW_HARDENING_NEEDED, then oe_verify_evidence should
     // return OE_OK (tcb_level_valid is true), otherwise it should return
@@ -554,6 +583,16 @@ static void _test_claims(
     value = _find_claim(claims, claims_size, OE_CLAIM_VALIDITY_UNTIL);
     OE_TEST(is_local || value != NULL);
 
+    sgx_quote_t* sgx_quote = (sgx_quote_t*)report_body;
+    value = _find_claim(claims, claims_size, OE_CLAIM_SGX_PCE_SVN);
+    OE_TEST(
+        is_local || memcmp(value, &sgx_quote->pce_svn, sizeof(uint16_t)) == 0);
+
+    value = _find_claim(claims, claims_size, OE_CLAIM_SGX_QE_ID);
+    OE_TEST(
+        is_local ||
+        memcmp(value, sgx_quote->user_data, sizeof(sgx_quote->user_data)) == 0);
+
     // Check SGX optional claims:
     if (sgx_endorsements)
     {
@@ -570,6 +609,23 @@ static void _test_claims(
                                      value,
                                      sgx_endorsements->items[j].data,
                                      sgx_endorsements->items[j].size) == 0);
+        }
+
+        if (!is_local)
+        {
+            /* Verify the fmspc value returned is as expected */
+            oe_parsed_tcb_info_t parsed_tcb_info;
+            const size_t fmspc_size = sizeof(parsed_tcb_info.fmspc);
+            uint8_t* fmspc = (uint8_t*)malloc(fmspc_size);
+            OE_TEST(fmspc != NULL);
+
+            _find_fmspc(
+                sgx_endorsements->items[OE_SGX_ENDORSEMENT_FIELD_TCB_INFO].data,
+                fmspc,
+                fmspc_size);
+            value = _find_claim(claims, claims_size, OE_CLAIM_SGX_FMSPC);
+            OE_TEST(value != NULL && memcmp(value, fmspc, fmspc_size) == 0);
+            free(fmspc);
         }
     }
 


### PR DESCRIPTION
TASK 13092931

Add to the claims returned by oe_verify_evidence() the following new claims:

- [x] PCESVN -> From quote
- [x] CPUSVN -> from the sgx_report
- [x] QEID -> from quote.user_data
- [x] FMSPC -> from PCK certificate (TCBInfo)

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>