### PR TITLE
Update Ansible and fix E2E tests

### DIFF
--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -9,9 +9,10 @@ library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 
 GLOBAL_TIMEOUT_MINUTES = 480
 
-JENKINS_USER_CREDS_ID = "oeadmin-credentials"
-OETOOLS_REPO = "oejenkinscidockerregistry.azurecr.io"
-OETOOLS_REPO_CREDENTIALS_ID = "oejenkinscidockerregistry"
+JENKINS_USER_CREDS_ID = 'oeadmin-credentials'
+OETOOLS_REPO = 'oejenkinscidockerregistry.azurecr.io'
+OETOOLS_REPO_CREDENTIALS_ID = 'oejenkinscidockerregistry'
+SERVICE_PRINCIPAL_CREDENTIALS_ID = 'SERVICE_PRINCIPAL_OSTCLAB'
 AZURE_IMAGES_MAP = [
     "win2019": [
         "image": "MicrosoftWindowsServer:WindowsServer:2019-datacenter-gensecond:latest",
@@ -38,42 +39,50 @@ def get_commit_id() {
     return last_commit_id
 }
 
-def buildLinuxManagedImage(String os_type, String version, String image_id, String image_version) {
-
+def buildLinuxManagedImage(String os_type, String version, String managed_image_name_id, String gallery_image_version) {
+    stage('Check Prerequisites') {
+        retry(10) {
+            sh """#!/bin/bash
+                sleep 5
+                curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+                sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com \$(lsb_release -cs) main"
+                ${helpers.WaitForAptLock()}
+                sudo apt-get update && sudo apt-get install packer
+            """
+        }
+    }
     stage("${OS_NAME_MAP[os_type]} ${version} Build") {
-        def managed_image_name_id = image_id
-        def gallery_image_version = image_version
-        withEnv(["DOCKER_REGISTRY=${OETOOLS_REPO}",
-            "MANAGED_IMAGE_NAME_ID=${managed_image_name_id}",
-            "GALLERY_IMAGE_VERSION=${gallery_image_version}"]) {
-            stage("Clean-up Resources") {
-                def az_cleanup_existing_image_version_script = """
-                    az login --service-principal -u \$SERVICE_PRINCIPAL_ID -p \$SERVICE_PRINCIPAL_PASSWORD --tenant \$TENANT_ID
-                    az account set -s \$SUBSCRIPTION_ID
-
-                    # If the target image version doesn't exist, the below
-                    # command will not fail because it is idempotent.
-                    az sig image-version delete \
-                        --resource-group ${RESOURCE_GROUP} \
-                        --gallery-name ${GALLERY_NAME} \
-                        --gallery-image-definition ${os_type}-${version} \
-                        --gallery-image-version ${gallery_image_version}
-                """
-                common.azureEnvironment(az_cleanup_existing_image_version_script, params.OE_DEPLOY_IMAGE)
-            }
+        withEnv([
+                "DOCKER_REGISTRY=${OETOOLS_REPO}",
+                "MANAGED_IMAGE_NAME_ID=${managed_image_name_id}",
+                "GALLERY_IMAGE_VERSION=${gallery_image_version}",
+                "RESOURCE_GROUP=${params.RESOURCE_GROUP}",
+                "GALLERY_NAME=${params.GALLERY_NAME}"]) {
             stage("Run Packer Job") {
                 timeout(GLOBAL_TIMEOUT_MINUTES) {
-                    withCredentials([usernamePassword(credentialsId: OETOOLS_REPO_CREDENTIALS_ID,
-                                                    usernameVariable: "DOCKER_USER_NAME",
-                                                    passwordVariable: "DOCKER_USER_PASSWORD"),
-                                    usernamePassword(credentialsId: JENKINS_USER_CREDS_ID,
-                                                    usernameVariable: "SSH_USERNAME",
-                                                    passwordVariable: "SSH_PASSWORD")]) {
-                        def cmd = ("""packer build -force \
-                                        -var-file=${WORKSPACE}/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/${os_type}-${version}-variables.json \
-                                        ${WORKSPACE}/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/packer-${os_type}.json""")
-                        common.exec_with_retry(10, 60) {
-                            common.azureEnvironment(cmd, params.OE_DEPLOY_IMAGE)
+                    withCredentials([
+                            usernamePassword(credentialsId: JENKINS_USER_CREDS_ID,
+                                             usernameVariable: "SSH_USERNAME",
+                                             passwordVariable: "SSH_PASSWORD"),
+                            usernamePassword(credentialsId: OETOOLS_REPO_CREDENTIALS_ID,
+                                             usernameVariable: "DOCKER_USER_NAME",
+                                             passwordVariable: "DOCKER_USER_PASSWORD"),
+                            usernamePassword(credentialsId: SERVICE_PRINCIPAL_CREDENTIALS_ID,
+                                             passwordVariable: 'SERVICE_PRINCIPAL_PASSWORD',
+                                             usernameVariable: 'SERVICE_PRINCIPAL_ID'),
+                            string(credentialsId: 'OSCTLabSubID', variable: 'SUBSCRIPTION_ID'),
+                            string(credentialsId: 'TenantID', variable: 'TENANT_ID')]) {
+                        sh '''#!/bin/bash
+                            az login --service-principal -u ${SERVICE_PRINCIPAL_ID} -p ${SERVICE_PRINCIPAL_PASSWORD} --tenant ${TENANT_ID}
+                            az account set -s ${SUBSCRIPTION_ID}
+                        '''
+                        retry(5) {
+                            sh """#!/bin/bash
+                                packer build -force \
+                                    -var-file=${WORKSPACE}/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/${os_type}-${version}-variables.json \
+                                    -var "use_azure_cli_auth=true" \
+                                    ${WORKSPACE}/.jenkins/infrastructure/provision/templates/packer/azure_managed_image/packer-${os_type}.json
+                            """
                         }
                     }
                 }
@@ -274,6 +283,33 @@ node(params.AGENTS_LABEL) {
         image_id = params.IMAGE_ID ?: "${version}-${commit_id}"
 
         println("IMAGE_VERSION: ${image_version}\nIMAGE_ID: ${image_id}")
+    }
+    stage("Install Azure CLI") {
+        retry(10) {
+            sh """
+                sleep 5
+                ${helpers.WaitForAptLock()}
+                sudo apt-get update
+                sudo apt-get -y install ca-certificates curl apt-transport-https lsb-release gnupg
+                curl -sL https://packages.microsoft.com/keys/microsoft.asc |
+                    gpg --dearmor |
+                    sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+                AZ_REPO=\$(lsb_release -cs)
+                echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ \$AZ_REPO main" |
+                    sudo tee /etc/apt/sources.list.d/azure-cli.list
+                ${helpers.WaitForAptLock()}
+                sudo apt-get update
+                sudo apt-get -y install azure-cli
+            """
+        }
+    }
+    stage("Install Ansible") {
+        retry(10) {
+            sh """#!/bin/bash
+                ${helpers.WaitForAptLock()}
+                sudo ${WORKSPACE}/scripts/ansible/install-ansible.sh
+            """
+        }
     }
     stage("Build Agents") {
         parallel "Build Windows Server 2019 - nonSGX"       : { buildWindowsManagedImage("win2019", "ws2019-nonSGX", "SGX1FLC-NoIntelDrivers", image_id, image_version) },

--- a/.jenkins/infrastructure/build_docker_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_docker_images.Jenkinsfile
@@ -9,7 +9,7 @@ OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID = "oeciteamdockerhub"
 
 parallel "Windows Stage": {
         stage("Build Windows Docker Containers") {
-          build job: '/CI-CD_Infrastructure/Windows-Docker-Container-Build',
+          build job: '/Private/CICD_Infrastructure/Windows-Docker-Container-Build',
           parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY_NAME),
                        string(name: 'BRANCH_NAME', value: env.BRANCH_NAME),
                        string(name: 'INTERNAL_REPO', value: OETOOLS_REPO),
@@ -23,7 +23,7 @@ parallel "Windows Stage": {
         }
     }, "Linux Stage": {
         stage("Build Linux Docker Containers") {
-          build job: '/CI-CD_Infrastructure/Linux-Docker-Container-Build',
+          build job: '/Private/CICD_Infrastructure/Linux-Docker-Container-Build',
           parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY_NAME),
                        string(name: 'BRANCH_NAME', value: env.BRANCH_NAME),
                        string(name: 'INTERNAL_REPO', value: OETOOLS_REPO),
@@ -32,6 +32,7 @@ parallel "Windows Stage": {
                        string(name: 'DOCKER_TAG', value: env.DOCKER_TAG),
                        string(name: 'AGENTS_LABEL', value: env.AGENTS_LABEL),
                        string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
+                       string(name: 'SGX_VERSION', value: params.SGX_VERSION),
                        booleanParam(name: 'PUBLISH_DOCKER_HUB', value: env.PUBLISH_DOCKER_HUB),
                        booleanParam(name: 'TAG_LATEST', value: env.TAG_LATEST)]
         }

--- a/.jenkins/infrastructure/e2e_testing.Jenkinsfile
+++ b/.jenkins/infrastructure/e2e_testing.Jenkinsfile
@@ -36,18 +36,19 @@ println("IMAGE_VERSION: ${IMAGE_VERSION}")
 println("DOCKER_TAG: ${DOCKER_TAG}")
 
 stage("Build Docker Containers") {
-    build job: '/CI-CD_Infrastructure/OpenEnclave-Build-Docker-Images',
+    build job: '/Private/CICD_Infrastructure/OpenEnclave-Build-Docker-Images',
           parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
                        string(name: 'BRANCH_NAME', value: env.BRANCH),
                        string(name: 'DOCKER_TAG', value: DOCKER_TAG),
                        string(name: 'AGENTS_LABEL', value: env.IMAGES_BUILD_LABEL),
                        string(name: 'WINDOWS_AGENTS_LABEL', value: env.WINDOWS_IMAGES_BUILD_LABEL),
                        string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
+                       string(name: 'SGX_VERSION', value: params.SGX_VERSION),
                        booleanParam(name: 'TAG_LATEST', value: false)]
 }
 
 stage("Build Jenkins Agents Images") {
-    build job: '/CI-CD_Infrastructure/OpenEnclave-Build-Azure-Managed-Images',
+    build job: '/Private/CICD_Infrastructure/OpenEnclave-Build-Azure-Managed-Images',
           parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
                        string(name: 'BRANCH_NAME', value: env.BRANCH),
                        string(name: 'OE_DEPLOY_IMAGE', value: "oetools-20.04:${DOCKER_TAG}"),
@@ -62,7 +63,7 @@ stage("Build Jenkins Agents Images") {
 }
 
 stage("Run tests on new Agents") {
-    build job: '/CI-CD_Infrastructure/OpenEnclave-Testing',
+    build job: '/Private/CICD_Infrastructure/OpenEnclave-Testing',
           parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
                        string(name: 'BRANCH_NAME', value: env.BRANCH),
                        string(name: 'DOCKER_TAG', value: DOCKER_TAG),
@@ -77,7 +78,7 @@ stage("Run tests on new Agents") {
 
 if(env.PRODUCTION_IMAGES_GALLERY_NAME) {
     stage("Update production infrastructure") {
-        build job: '/CI-CD_Infrastructure/OpenEnclave-Update-Production-Infrastructure',
+        build job: '/Private/CICD_Infrastructure/OpenEnclave-Update-Production-Infrastructure',
             parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
                          string(name: 'BRANCH_NAME', value: env.BRANCH),
                          string(name: 'RESOURCE_GROUP', value: env.RESOURCE_GROUP),

--- a/.jenkins/library/vars/common.groovy
+++ b/.jenkins/library/vars/common.groovy
@@ -160,6 +160,29 @@ def emailJobStatus(String status) {
 }
 
 /**
+ * Installs Azure CLI from Microsoft repository (Ubuntu distributions only)
+ */
+def installAzureCLI() {
+    retry(10) {
+        sh """
+            sleep 5
+            ${helpers.WaitForAptLock()}
+            sudo apt-get update
+            sudo apt-get -y install ca-certificates curl apt-transport-https lsb-release gnupg
+            curl -sL https://packages.microsoft.com/keys/microsoft.asc |
+                gpg --dearmor |
+                sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+            AZ_REPO=\$(lsb_release -cs)
+            echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ \$AZ_REPO main" |
+                sudo tee /etc/apt/sources.list.d/azure-cli.list
+            ${helpers.WaitForAptLock()}
+            sudo apt-get update
+            sudo apt-get -y install azure-cli
+        """
+    }
+}
+
+/**
  * Compile open-enclave on Windows platform, generate NuGet package out of it, 
  * install the generated NuGet package, and run samples tests against the installation.
  */

--- a/scripts/ansible/.ansible-lint
+++ b/scripts/ansible/.ansible-lint
@@ -1,6 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
-cryptography==3.3.2
-ansible>=4.10,<=5.2.0
-cmake_format==0.6.9
-pywinrm==0.2.1
+---
+
+skip_list:
+  - 503
+  - 204

--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -57,7 +57,6 @@ ansible-playbook jenkins-setup.yml
 
 # Supported platforms by the Ansible playbooks
 
-* Ubuntu 16.04
 * Ubuntu 18.04
-* Red Hat Enterprise Linux 8
+* Ubuntu 20.04
 * Windows Server 2019 (ACC VM)

--- a/scripts/ansible/install-ansible.sh
+++ b/scripts/ansible/install-ansible.sh
@@ -37,3 +37,9 @@ else
 fi
 
 pip3 install -U -r "$DIR/requirements.txt"
+
+ansible-galaxy collection install community.general
+ansible-galaxy collection install ansible.windows
+ansible-galaxy collection install community.windows
+
+ansible --version

--- a/scripts/ansible/oe-contributors-acc-setup-no-psw.yml
+++ b/scripts/ansible/oe-contributors-acc-setup-no-psw.yml
@@ -2,18 +2,18 @@
 # Licensed under the MIT License.
 
 ---
-    - hosts: localhost
-      any_errors_fatal: true
-      become: yes
-      tasks:
-        - import_role:
-            name: linux/openenclave
-            tasks_from: environment-setup.yml
+- hosts: localhost
+  any_errors_fatal: true
+  become: yes
+  tasks:
+    - import_role:
+        name: linux/openenclave
+        tasks_from: environment-setup.yml
 
-        - import_role:
-            name: linux/intel
-            tasks_from: sgx-driver.yml
+    - import_role:
+        name: linux/intel
+        tasks_from: sgx-driver.yml
 
-        - import_role:
-            name: linux/az-dcap-client
-            tasks_from: stable-install.yml
+    - import_role:
+        name: linux/az-dcap-client
+        tasks_from: stable-install.yml

--- a/scripts/ansible/oe-windows-acc-setup.yml
+++ b/scripts/ansible/oe-windows-acc-setup.yml
@@ -8,10 +8,10 @@
   tasks:
     - name: OE setup | Set installer URLs from the OE storage account
       set_fact:
-        intel_psw_url:       "https://registrationcenter-download.intel.com/akdlm/irc_nas/18233/Intel%20SGX%20PSW%20for%20Windows%20v2.14.100.3.exe"
-        intel_psw_hash:      "6DA4DB8E0495404253FA9CF737622A5AE8F4943F611180EF12FB48C0EAA13812"
-        intel_dcap_url:      "https://registrationcenter-download.intel.com/akdlm/irc_nas/18232/Intel%20SGX%20DCAP%20for%20Windows%20v1.12.100.3.exe"
-        intel_dcap_hash:     "885772E40F66DE2D2E2AE3E214AEB04E51F8173C8F61F013C1DAD57C01D846A5"
+        intel_psw_url:       "https://registrationcenter-download.intel.com/akdlm/irc_nas/18335/Intel%20SGX%20PSW%20for%20Windows%20v2.14.101.1.exe"
+        intel_psw_hash:      "467A6D316C1FFE62CF212593C2E0B0CB7B5FB86F680FEB017EE4D1170C954E60"
+        intel_dcap_url:      "https://registrationcenter-download.intel.com/akdlm/irc_nas/18336/Intel%20SGX%20DCAP%20for%20Windows%20v1.12.101.1.exe"
+        intel_dcap_hash:     "7B7BC3460117142E5E9497F3D42D2C50DCBB6146DA73FC95232597D1FCC386C8"
         git_url:             "https://oejenkins.blob.core.windows.net/oejenkins/Git-2.31.1-64-bit.exe"
         git_hash:            "C43611EB73AD1F17F5C8CC82AE51C3041A2E7279E0197CCF5F739E9129CE426E"
         seven_zip_url:       "https://oejenkins.blob.core.windows.net/oejenkins/7z1806-x64.msi"
@@ -67,7 +67,7 @@
         start_mode: delayed
 
     - name: OE setup | Windows Updates
-      block: 
+      block:
         - name: Install all security, critical, and rollup updates without a scheduled task
           win_updates:
             category_names:

--- a/scripts/ansible/roles/common/jenkins/tasks/agent-provision.yml
+++ b/scripts/ansible/roles/common/jenkins/tasks/agent-provision.yml
@@ -50,7 +50,7 @@
     url: "{{ jenkins_url }}"
     user: "{{ jenkins_admin_name }}"
     password: "{{ jenkins_admin_password }}"
-  when: (script_output.output.lstrip('Result:') | trim) == ""
+  when: (script_output.output.lstrip('Result:') | trim) | length == 0
 
 - name: Jenkins | Extract the Jenkins agent secret
   jenkins_script:

--- a/scripts/ansible/roles/linux/az-dcap-client/tasks/stable-install.yml
+++ b/scripts/ansible/roles/linux/az-dcap-client/tasks/stable-install.yml
@@ -3,4 +3,4 @@
 
 ---
 - name: Install Azure DCAP Client for {{ ansible_distribution }}
-  include_tasks: "{{ ansible_distribution | lower }}/stable-install.yml"
+  ansible.builtin.include_tasks: "{{ ansible_distribution | lower }}/stable-install.yml"

--- a/scripts/ansible/roles/linux/az-dcap-client/tasks/ubuntu/stable-install.yml
+++ b/scripts/ansible/roles/linux/az-dcap-client/tasks/ubuntu/stable-install.yml
@@ -2,7 +2,8 @@
 # Licensed under the MIT License.
 
 ---
-- include_role:
+- name: Add Microsoft Repository
+  ansible.builtin.include_role:
     name: linux/common
     tasks_from: apt-repo.yml
   vars:
@@ -10,7 +11,7 @@
     apt_repository: "deb [arch=amd64] https://packages.microsoft.com/ubuntu/{{ ansible_distribution_version }}/prod {{ ansible_distribution_release }} main"
 
 - name: Install the official Azure-DCAP-Client APT package
-  apt:
+  ansible.builtin.apt:
     name: az-dcap-client
     state: latest
     update_cache: yes

--- a/scripts/ansible/roles/linux/az-dcap-client/tasks/validation.yml
+++ b/scripts/ansible/roles/linux/az-dcap-client/tasks/validation.yml
@@ -11,4 +11,4 @@
     path: "{{ item }}"
   with_items: "{{ validation_distribution_files }}"
   register: file
-  failed_when: file.stat.exists == False
+  failed_when: not file.stat.exists

--- a/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
+++ b/scripts/ansible/roles/linux/common/tasks/apt-repo.yml
@@ -3,11 +3,11 @@
 
 ---
 - name: Include distribution vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
 
 - name: Install apt-transport-https APT package
-  apt:
+  ansible.builtin.apt:
     name: apt-transport-https
     state: latest
   retries: 100
@@ -15,7 +15,7 @@
   until: add_transport is success
 
 - name: Add APT repository key
-  apt_key:
+  ansible.builtin.apt_key:
     url: "{{ apt_key_url }}"
     state: present
   retries: 10
@@ -23,7 +23,7 @@
   until: add_key is success
 
 - name: Add APT repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "{{ apt_repository }}"
     state: present
     update_cache: yes

--- a/scripts/ansible/roles/linux/common/tasks/yum-repo.yml
+++ b/scripts/ansible/roles/linux/common/tasks/yum-repo.yml
@@ -3,7 +3,7 @@
 
 ---
 - name: Add YUM repository key
-  rpm_key:
+  ansible.builtin.rpm_key:
     key: "{{ yum_repository_key_path }}"
     state: present
   retries: 10
@@ -11,7 +11,7 @@
   until: add_yum_repo_key is success
 
 - name: Add YUM repository
-  yum:
+  ansible.builtin.yum:
     name: "{{ yum_repository_rpm_url }}"
     state: present
   retries: 10

--- a/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
@@ -3,14 +3,14 @@
 
 ---
 - name: Gather Ansible facts
-  setup:
+  ansible.builtin.gather_facts:
 
 - name: Include distribution release specific vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
 
 - name: Install Docker prerequisite packages
-  apt:
+  ansible.builtin.apt:
     name: "{{ ci_apt_packages }}"
     state: latest
     update_cache: yes
@@ -19,22 +19,26 @@
 # Workaround for Ubuntu 18.04 Docker container tests
 # https://github.com/intel/linux-sgx/blob/a85fbe9a55767681b0f799a66555b123312fb72c/linux/installer/common/psw/install.sh#L66-L99
 - name: Create /etc/init directory
-  file:
+  ansible.builtin.file:
     path: /etc/init
     state: directory
 
-- import_role:
+- name: Import OpenEnclave Setup Tasks
+  ansible.builtin.import_role:
     name: linux/openenclave
     tasks_from: environment-setup.yml
 
-- import_role:
+- name: Import OpenEnclave Setup Cross ARM tasks
+  ansible.builtin.import_role:
     name: linux/openenclave
     tasks_from: environment-setup-cross-arm.yml
 
-- import_role:
+- name: Import Intel SGX Packages tasks
+  ansible.builtin.import_role:
     name: linux/intel
     tasks_from: sgx-packages.yml
 
-- import_role:
+- name: Import Az DCAP Client Tasks
+  ansible.builtin.import_role:
     name: linux/az-dcap-client
     tasks_from: stable-install.yml

--- a/scripts/ansible/roles/linux/docker/tasks/stable-install.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/stable-install.yml
@@ -3,8 +3,8 @@
 
 ---
 - name: Include distribution vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/main.yml"
 
 - name: Setup Docker
-  include_tasks: "{{ ansible_distribution | lower }}/stable-install.yml"
+  ansible.builtin.include_tasks: "{{ ansible_distribution | lower }}/stable-install.yml"

--- a/scripts/ansible/roles/linux/docker/tasks/ubuntu/stable-install.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/ubuntu/stable-install.yml
@@ -3,7 +3,7 @@
 
 ---
 - name: Docker | Add the APT repository key
-  apt_key:
+  ansible.builtin.apt_key:
     url: "https://download.docker.com/linux/ubuntu/gpg"
     state: present
   retries: 10
@@ -12,7 +12,7 @@
   until: result is success
 
 - name: Docker | Add the APT repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
     state: present
     update_cache: yes
@@ -21,12 +21,35 @@
   register: result
   until: result is success
 
-- name: Docker | Install Docker-CE
-  apt:
-    name: "{{ docker_packages }}"
+- name: Docker | Install Docker packages
+  ansible.builtin.apt:
+    name: "{{ item }}"
     state: latest
     update_cache: yes
+  with_items: "{{ docker_packages }}"
   retries: 10
   delay: 10
   register: result
   until: result is success
+
+- name: Docker | Install Docker for Python
+  when: docker_ansible is defined and docker_ansible | bool
+  block:
+
+    - name: Docker | Install pip3
+      ansible.builtin.apt:
+        name: python3-pip
+        state: present
+      when:
+        - "'python3-pip' not in ansible_facts.packages"
+        - "'python3' in ansible_facts.packages"
+      register:
+        pip3_installed
+
+    - name: Docker | Install Docker Python 3 library
+      ansible.builtin.pip:
+        name: docker
+        executable: pip3
+      when: >
+        "'python3-pip' in ansible_facts.packages" or
+        pip3_installed.changed

--- a/scripts/ansible/roles/linux/docker/tasks/validation.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/validation.yml
@@ -3,22 +3,20 @@
 
 ---
 - name: Include distribution vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/main.yml"
 
 - name: Check for existing required binaries
-  stat:
+  ansible.builtin.stat:
     path: "{{ item }}"
   with_items: "{{ validation_binaries }}"
   register: binary
-  failed_when: binary.stat.executable == False
+  failed_when: not binary.stat.executable
 
-- name: Docker version check
-  command: "docker --version"
-  register: docker_check_version
-  failed_when: docker_check_version.stdout.find(docker_target_version) == -1
+- name: Check Docker and Dockerd
+  community.general.docker_host_info:
+  register: docker_result
 
-- name: Dockerd version check
-  command: "dockerd --version"
-  register: dockerd_check_version
-  failed_when: dockerd_check_version.stdout.find(dockerd_target_version) == -1
+- name: Print Docker host info
+  ansible.builtin.debug:
+    var: docker_result.host_info

--- a/scripts/ansible/roles/linux/docker/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/docker/vars/ubuntu/main.yml
@@ -4,6 +4,8 @@
 ---
 docker_packages:
   - "docker-ce"
+  - "docker-ce-cli"
+  - "containerd.io"
 
 docker_target_version: "18.09"
 dockerd_target_version: "18.09"

--- a/scripts/ansible/roles/linux/intel/tasks/driver-validation.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/driver-validation.yml
@@ -3,14 +3,14 @@
 
 ---
 - name: Include distribution vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/main.yml"
 
 - name: Include distribution release specific vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
 
 - name: Check default driver files
-  stat:
+  ansible.builtin.stat:
     path: "{{ item }}"
   loop: "{{ intel_dcap_driver_files }}"

--- a/scripts/ansible/roles/linux/intel/tasks/packages-validation.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/packages-validation.yml
@@ -3,16 +3,16 @@
 
 ---
 - name: Include distribution vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/main.yml"
 
 - name: Include distribution release specific vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
 
 - name: Check for existing required files
-  stat:
+  ansible.builtin.stat:
     path: "{{ item }}"
   with_items: "{{ packages_validation_distribution_files }}"
   register: file
-  failed_when: file.stat.exists == False
+  failed_when: not file.stat.exists

--- a/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
@@ -3,24 +3,24 @@
 
 ---
 - name: Gather Ansible facts
-  setup:
+  ansible.builtin.gather_facts:
 
 - name: Populate service facts
-  service_facts:
+  ansible.builtin.service_facts:
 
 - name: Include distribution vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/main.yml"
 
 - name: Check default driver files
-  stat:
+  ansible.builtin.stat:
     path: "{{ item }}"
   loop: "{{ intel_dcap_driver_files }}"
   ignore_errors: yes
   register: intel_sgx_driver
 
 - name: Trigger driver installation based on file existence
-  set_fact:
+  ansible.builtin.set_fact:
     intel_sgx_driver_exists: yes
   loop: "{{ intel_sgx_driver.results }}"
   loop_control:
@@ -31,21 +31,21 @@
   block:
 
   - name: Include distribution release specific vars
-    include_vars:
+    ansible.builtin.include_vars:
       file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
 
   - name: Install the SGX driver requirements
-    include_tasks: "{{ ansible_distribution | lower }}/sgx-driver-requirements.yml"
+    ansible.builtin.include_tasks: "{{ ansible_distribution | lower }}/sgx-driver-requirements.yml"
 
   - name: Ensure aesmd service stopped
-    service:
+    ansible.builtin.service:
       name: aesmd
       state: stopped
     when: "'aesmd.service' in ansible_facts.services"
 
   - name: Download Intel SGX DCAP Driver
-    get_url:
-      url: "{{intel_sgx_w_flc_driver_url}}"
+    ansible.builtin.get_url:
+      url: "{{ intel_sgx_w_flc_driver_url }}"
       dest: /tmp/sgx_linux_x64_driver.bin
       mode: 0755
       timeout: 120
@@ -53,8 +53,8 @@
     when: flc_enabled|bool
 
   - name: Download Intel SGX1 Driver
-    get_url:
-      url: "{{intel_sgx1_driver_url}}"
+    ansible.builtin.get_url:
+      url: "{{ intel_sgx1_driver_url }}"
       dest: /tmp/sgx_linux_x64_driver.bin
       mode: 0755
       timeout: 120
@@ -62,15 +62,15 @@
     when: not flc_enabled|bool
 
   - name: Install the Intel SGX Driver
-    command: /tmp/sgx_linux_x64_driver.bin
+    ansible.builtin.command: /tmp/sgx_linux_x64_driver.bin
 
   - name: Remove the Intel SGX driver installer
-    file:
+    ansible.builtin.file:
       path: /tmp/sgx_linux_x64_driver.bin
       state: absent
 
   - name: Add user to sgx_prv group
-    user:
+    ansible.builtin.user:
       name: "{{ lookup('env', 'USER') }}"
       group: sgx_prv
     when:
@@ -78,7 +78,7 @@
      - intel_sgx_prv_permissions | bool
 
   - name: Set out-of-proc attestation by default
-    lineinfile:
+    ansible.builtin.lineinfile:
       path: /etc/environment
       state: present
       line: SGX_AESM_ADDR=1
@@ -87,7 +87,7 @@
         not intel_sgx_driver_exists
 
 - name: Ensure aesmd service running
-  service:
+  ansible.builtin.service:
     name: aesmd
     state: started
     enabled: yes

--- a/scripts/ansible/roles/linux/intel/tasks/sgx-packages.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/sgx-packages.yml
@@ -3,15 +3,15 @@
 
 ---
 - name: Gather Ansible facts
-  setup:
+  ansible.builtin.gather_facts:
 
 - name: Include distribution vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/main.yml"
 
 - name: Include distribution release specific vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
 
 - name: Install the SGX packages
-  include_tasks: "{{ ansible_distribution | lower }}/sgx-packages-install.yml"
+  ansible.builtin.include_tasks: "{{ ansible_distribution | lower }}/sgx-packages-install.yml"

--- a/scripts/ansible/roles/linux/intel/tasks/ubuntu/sgx-driver-requirements.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/ubuntu/sgx-driver-requirements.yml
@@ -3,7 +3,7 @@
 
 ---
 - name: Install the dkms package
-  apt:
+  ansible.builtin.apt:
     name:
       - "dkms"
     state: latest

--- a/scripts/ansible/roles/linux/intel/tasks/ubuntu/sgx-packages-install.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/ubuntu/sgx-packages-install.yml
@@ -2,7 +2,8 @@
 # Licensed under the MIT License.
 
 ---
-- include_role:
+- name: Install Intel SGX repo
+  ansible.builtin.include_role:
     name: linux/common
     tasks_from: apt-repo.yml
   vars:
@@ -10,21 +11,21 @@
     apt_repository: "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu {{ ansible_distribution_release }} main"
 
 - name: Install the Intel libsgx package dependencies
-  apt:
+  ansible.builtin.apt:
     name: "{{ intel_sgx_package_dependencies }}"
     state: latest
     update_cache: yes
     install_recommends: no
 
 - name: Install the Intel libsgx packages
-  apt:
+  ansible.builtin.apt:
     name: "{{ intel_sgx_packages }}"
     state: latest
     update_cache: yes
     install_recommends: no
 
 - name: Install the Intel DCAP packages
-  apt:
+  ansible.builtin.apt:
     name: "{{ intel_dcap_packages }}"
     state: latest
     update_cache: yes

--- a/scripts/ansible/roles/linux/jenkins/tasks/packer.yml
+++ b/scripts/ansible/roles/linux/jenkins/tasks/packer.yml
@@ -3,11 +3,15 @@
 
 ---
 - name: Include distribution vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/main.yml"
 
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
 - name: Jenkins | Install Java JRE needed by Jenkins
-  package:
+  ansible.builtin.package:
     name: "{{ java_packages }}"
     state: latest
   retries: 10
@@ -16,50 +20,60 @@
   until: result is success
 
 - name: Jenkins | Create the Jenkins group
-  group:
+  ansible.builtin.group:
     name: jenkins
     state: present
 
 - name: Jenkins | Add the Jenkins user
-  user:
+  ansible.builtin.user:
     name: jenkins
     group: jenkins
     state: present
 
-- import_role:
+- name: Jenkins | Import Docker install tasks
+  ansible.builtin.import_role:
     name: linux/docker
     tasks_from: stable-install.yml
+  vars:
+    docker_ansible: True
 
-- name: Docker | Add the Jenkins system user to the Docker group
-  user:
+- name: Jenkins | Add the Jenkins system user to the Docker group
+  ansible.builtin.user:
     name: jenkins
     groups: docker
     append: yes
 
-- name: Determine if sgx_prv group exists
-  getent:
+- name: Jenkins | Determine if sgx_prv group exists
+  ansible.builtin.getent:
     database: group
     key: sgx_prv
 
 # This task may not be useful if the same user is removed during VM generalization and deprovisioning.
-- name: Add user to sgx_prv group
-  user:
+- name: Jenkins | Add user to sgx_prv group
+  ansible.builtin.user:
     name: "{{ jenkins_admin_name }}"
     groups: sgx_prv
     append: yes
   when: "'sgx_prv' in ansible_facts.getent_group"
 
-- name: Jenkins | Pre-pull CI/CD Docker images
-  shell: |
-    set -o errexit
-    docker login {{ docker_registry }} -u {{ docker_user_name }} -p {{ docker_user_password }}
-    docker pull {{ docker_registry }}/oetools-18.04:{{ docker_tag }}
-    docker pull {{ docker_registry }}/oetools-20.04:{{ docker_tag }}
+- name: Jenkins | Docker Login
+  community.general.docker_login:
+    registry_url: "{{ docker_registry }}"
+    username: "{{ docker_user_name }}"
+    password: "{{ docker_user_password }}"
+    reauthorize: yes
+
+- name: Jenkins | Docker pull images
+  community.general.docker_image:
+    name: "{{ item }}"
+    source: pull
+  with_items:
+    - "{{ docker_registry }}/oetools-18.04:{{ docker_tag }}"
+    - "{{ docker_registry }}/oetools-20.04:{{ docker_tag }}"
   retries: 10
   delay: 10
-  register: result
-  until: result is success
-  when: (docker_registry is defined and
-         docker_user_name is defined and
-         docker_user_password is defined and
-         docker_tag is defined)
+
+- name: Jenkins | Docker Logout
+  community.general.docker_login:
+    registry_url: "{{ docker_registry }}"
+    state: absent

--- a/scripts/ansible/roles/linux/jenkins/tasks/slave-setup.yml
+++ b/scripts/ansible/roles/linux/jenkins/tasks/slave-setup.yml
@@ -3,19 +3,20 @@
 
 ---
 - block:
-  - import_role:
+  - name: Import Jenkins agent provision tasks
+    ansible.builtin.import_role:
       name: common/jenkins
       tasks_from: agent-provision.yml
     delegate_to: localhost
   become: no
 
-- name: Check if node_secret fact is defined
-  fail:
+- name: Jenkins | Check if node_secret fact is defined
+  ansible.builtin.fail:
     msg: "The node_secret fact is not defined!"
   when: node_secret is undefined
 
 - name: Jenkins | Install Java JRE needed by Jenkins
-  apt:
+  ansible.builtin.apt:
     name: openjdk-8-jre
     state: latest
     update_cache: yes
@@ -25,55 +26,56 @@
   until: result is success
 
 - name: Jenkins | Create the Jenkins group
-  group:
+  ansible.builtin.group:
     name: jenkins
     state: present
 
 - name: Jenkins | Add the Jenkins user
-  user:
+  ansible.builtin.user:
     name: jenkins
     group: jenkins
     state: present
 
-- import_role:
+- name: Jenkins | Import Docker install tasks
+  ansible.builtin.import_role:
     name: linux/docker
     tasks_from: stable-install.yml
 
-- name: Docker | Add the Jenkins system user to the Docker group
-  user:
+- name: Jenkins | Add the Jenkins system user to the Docker group
+  ansible.builtin.user:
     name: jenkins
     groups: docker
 
-- name: Make Jenkins JNLP slave directories
-  file:
+- name: Jenkins | Make Jenkins JNLP slave directories
+  ansible.builtin.file:
     path: "{{ jenkins_agent_root_dir }}"
     state: directory
     owner: jenkins
     group: jenkins
 
-- name: Template Jenkins JNLP slave files
-  template:
+- name: Jenkins | Template Jenkins JNLP slave files
+  ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   with_items:
     - { src: jenkins-slave.service.j2, dest: /etc/systemd/system/jenkins-slave.service, mode: 755 }
     - { src: jenkins-slave.default.j2, dest: /etc/default/jenkins-slave, mode: 644 }
 
-- name: Start Jenkins JNLP slave
-  systemd:
+- name: Jenkins | Start Jenkins JNLP slave
+  ansible.builtin.systemd:
     name: jenkins-slave
     enabled: yes
     state: restarted
     daemon_reload: yes
 
-- name: Configure Git in target image to enable merge/rebase actions - email
-  git_config:
+- name: Jenkins | Configure Git in target image to enable merge/rebase actions - email
+  community.general.git_config:
     name: user.email
     scope: system
     value: '{{ ci_team_email }}'
 
-- name: Configure Git in target image to enable merge/rebase actions - name
-  git_config:
+- name: Jenkins | Configure Git in target image to enable merge/rebase actions - name
+  community.general.git_config:
     name: user.name
     scope: system
     value: '{{ ci_team_name }}'

--- a/scripts/ansible/roles/linux/jenkins/tasks/validation.yml
+++ b/scripts/ansible/roles/linux/jenkins/tasks/validation.yml
@@ -3,8 +3,8 @@
 
 ---
 - name: Check for existing required binaries
-  stat:
+  ansible.builtin.stat:
     path: "{{ item }}"
   with_items: "{{ validation_binaries }}"
   register: binary
-  failed_when: binary.stat.executable == False
+  failed_when: not binary.stat.executable

--- a/scripts/ansible/roles/linux/openenclave/tasks/environment-setup-cross-arm.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/environment-setup-cross-arm.yml
@@ -3,31 +3,34 @@
 
 ---
 - name: Include base setup
-  include_tasks: environment-setup.yml
+  ansible.builtin.include_tasks: environment-setup.yml
 
 - name: Mark existing APT repositories as x86/64
-  replace:
+  ansible.builtin.replace:
     path: /etc/apt/sources.list
     regexp: '^deb h'
     replace: 'deb [arch=amd64,i386] h'
 
 - name: Enable ARM64 architecture
-  command: dpkg --add-architecture arm64
+  ansible.builtin.command: dpkg --add-architecture arm64
 
-- apt_repository:
+- name: Add Ubuntu main repository
+  ansible.builtin.apt_repository:
     repo: deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports {{ ansible_distribution_release }} main restricted universe multiverse
     state: present
 
-- apt_repository:
+- name: Add Ubuntu updates repository
+  ansible.builtin.apt_repository:
     repo: deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports {{ ansible_distribution_release }}-updates main restricted universe multiverse
     state: present
 
-- apt_repository:
+- name: Add Ubuntu backports repository
+  ansible.builtin.apt_repository:
     repo: deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports {{ ansible_distribution_release }}-backports main restricted universe multiverse
     state: present
 
 - name: Install the additional Open Enclave prerequisites APT packages for ARM development
-  apt:
+  ansible.builtin.apt:
     name: "{{ apt_arm_packages }}"
     state: latest
     update_cache: yes

--- a/scripts/ansible/roles/linux/openenclave/tasks/environment-setup.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/environment-setup.yml
@@ -3,21 +3,21 @@
 
 ---
 - name: Gather Ansible facts
-  setup:
+  ansible.builtin.gather_facts:
 
 - name: Include distribution vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/main.yml"
 
 - name: Install distribution packages
-  include_tasks: "{{ ansible_distribution | lower }}/packages-install.yml"
+  ansible.builtin.include_tasks: "{{ ansible_distribution | lower }}/packages-install.yml"
 
 - name: Setup lvi dependencies
-  include_tasks: "{{ ansible_distribution | lower }}/lvi-setup.yml"
+  ansible.builtin.include_tasks: "{{ ansible_distribution | lower }}/lvi-setup.yml"
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Install CMake 3.13.1
-  unarchive:
+  ansible.builtin.unarchive:
     src: https://cmake.org/files/v3.13/cmake-3.13.1-Linux-x86_64.tar.gz
     dest: "{{ cmake_prefix }}"
     remote_src: yes
@@ -27,7 +27,7 @@
   until: result is success
 
 - name: Create CMake symbolic links
-  file:
+  ansible.builtin.file:
     src: "{{ cmake_prefix }}/cmake-3.13.1-Linux-x86_64/bin/{{ item }}"
     dest: "{{ cmake_prefix }}/bin/{{ item }}"
     force: yes

--- a/scripts/ansible/roles/linux/openenclave/tasks/stable-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/stable-install.yml
@@ -3,9 +3,10 @@
 
 ---
 - name: Gather Ansible facts
-  setup:
+  ansible.builtin.gather_facts:
 
-- include_role:
+- name: Add Microsoft repository
+  ansible.builtin.include_role:
     name: linux/common
     tasks_from: apt-repo.yml
   vars:
@@ -13,7 +14,7 @@
     apt_repository: "deb [arch=amd64] https://packages.microsoft.com/ubuntu/{{ ansible_distribution_version }}/prod {{ ansible_distribution_release }} main"
 
 - name: Install the official Open Enclave APT package
-  apt:
+  ansible.builtin.apt:
     name: open-enclave
     state: latest
     update_cache: yes

--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/lvi-setup.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/lvi-setup.yml
@@ -3,84 +3,85 @@
 #
 
 ---
-- set_fact:
+- name: Set clang and lvi facts
+  ansible.builtin.set_fact:
     clang_previous_version: "8"
     clang_current_version: "10"
     local_lvi_directory: '/usr/local/lvi-mitigation'
     scripts_lvi_directory: '{{ playbook_dir }}/../lvi-mitigation'
 
 - name: Detect currently installed glibc version
-  shell: "ldd --version | awk '/ldd/{print $NF}'"
+  ansible.builtin.shell: "ldd --version | awk '/ldd/{print $NF}'"
   changed_when: false
   register: glibc_version
 
 - name: Detect installed clang (previous version)
-  shell: "which clang-{{ clang_previous_version }}"
+  ansible.builtin.shell: "which clang-{{ clang_previous_version }}"
   changed_when: false
   register: previous_clang
   ignore_errors: yes
 
 - name: Detect currently installed clang++ (previous version)
-  shell: "which clang++-{{ clang_previous_version }}"
+  ansible.builtin.shell: "which clang++-{{ clang_previous_version }}"
   changed_when: false
   register: previous_clangcpp
   ignore_errors: yes
 
 - name: Detect installed clang (current version)
-  shell: "which clang-{{ clang_current_version }}"
+  ansible.builtin.shell: "which clang-{{ clang_current_version }}"
   changed_when: false
   register: current_clang
   ignore_errors: yes
 
 - name: Detect installed clang++ (current version)
-  shell: "which clang++-{{ clang_current_version }}"
+  ansible.builtin.shell: "which clang++-{{ clang_current_version }}"
   changed_when: false
   register: current_clangcpp
   ignore_errors: yes
 
 - name: Detect currently installed gcc
-  shell: "which gcc"
+  ansible.builtin.shell: "which gcc"
   changed_when: false
   register: gcc
 
 - name: Detect currently installed gcpp
-  shell: "which g++"
+  ansible.builtin.shell: "which g++"
   changed_when: false
   register: gcpp
 
 - name: Creates directories
-  file:
+  ansible.builtin.file:
     path: '{{ local_lvi_directory }}/bin'
     state: directory
 
 - name: Download as/ld tarball
-  get_url:
+  ansible.builtin.get_url:
     url: 'https://download.01.org/intel-sgx/sgx-linux/2.13/as.ld.objdump.gold.r3.tar.gz'
     dest: '/tmp/'
   register: asldobjdump
 
 - name: Extract as and ld binaries
-  unarchive:
+  ansible.builtin.unarchive:
     src: "{{ asldobjdump.dest }}"
     dest: '{{ local_lvi_directory }}/'
     remote_src: yes
   when: asldobjdump.changed
 
 - name: Clean up as/ld tarball
-  file:
+  ansible.builtin.file:
     path: "{{ asldobjdump.dest }}"
     state: absent
   when: asldobjdump.changed
-  
+
 - name: Create symbolic link to as
-  file:
+  ansible.builtin.file:
     src: '{{ local_lvi_directory }}/external/toolset/ubuntu{{ ansible_distribution_version }}/as'
     dest: '{{ local_lvi_directory }}/bin/as'
     state: link
     force: yes
 
 - name: Create symbolic link to ld
-  file:
+  ansible.builtin.file:
     src: '{{ local_lvi_directory }}/external/toolset/ubuntu{{ ansible_distribution_version }}/ld'
     dest: '{{ local_lvi_directory }}/bin/ld'
     state: link
@@ -88,29 +89,29 @@
   when: glibc_version.stdout >= '2.27'
 
 - name: Copy scripts
-  copy:
+  ansible.builtin.copy:
     src: '{{ scripts_lvi_directory }}/'
     dest: '{{ local_lvi_directory }}/bin'
     mode: 'u=rx,g=rx,o=rx'
 
 - name: Create clang wrapper (previous version)
-  shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=clang-{{ clang_previous_version }} --path={{ local_lvi_directory }}/bin"
-  when: previous_clang.stdout != ""
+  ansible.builtin.shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=clang-{{ clang_previous_version }} --path={{ local_lvi_directory }}/bin"
+  when: previous_clang.stdout | length > 0
 
 - name: Create clang++ wrapper (previous version)
-  shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=clang++-{{ clang_previous_version }} --path={{ local_lvi_directory }}/bin"
-  when: previous_clangcpp.stdout != ""
+  ansible.builtin.shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=clang++-{{ clang_previous_version }} --path={{ local_lvi_directory }}/bin"
+  when: previous_clangcpp.stdout | length > 0
 
 - name: Create clang wrapper (current version)
-  shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=clang-{{ clang_current_version }} --path={{ local_lvi_directory }}/bin"
-  when: current_clang.stdout != ""
+  ansible.builtin.shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=clang-{{ clang_current_version }} --path={{ local_lvi_directory }}/bin"
+  when: current_clang.stdout | length > 0
 
 - name: Create clang++ wrapper (current version)
-  shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=clang++-{{ clang_current_version }} --path={{ local_lvi_directory }}/bin"
-  when: current_clangcpp.stdout != ""
+  ansible.builtin.shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=clang++-{{ clang_current_version }} --path={{ local_lvi_directory }}/bin"
+  when: current_clangcpp.stdout | length > 0
 
 - name: Create symbolic links to clang (previous version)
-  file:
+  ansible.builtin.file:
     src: '{{ item.path }}'
     dest: '{{ local_lvi_directory }}/bin/{{ item.dest }}'
     state: link
@@ -118,10 +119,10 @@
   with_items:
     - { path: '{{ previous_clang.stdout }}', dest: 'clang-{{ clang_previous_version }}_symlink' }
     - { path: '{{ previous_clangcpp.stdout }}', dest: 'clang++-{{ clang_previous_version }}_symlink'}
-  when: previous_clang.stdout != "" and previous_clangcpp.stdout != ""
+  when: previous_clang.stdout | length > 0 and previous_clangcpp.stdout | length > 0
 
 - name: Create symbolic links to clang (current version)
-  file:
+  ansible.builtin.file:
     src: '{{ item.path }}'
     dest: '{{ local_lvi_directory }}/bin/{{ item.dest }}'
     state: link
@@ -129,18 +130,18 @@
   with_items:
     - { path: '{{ current_clang.stdout }}', dest: 'clang-{{ clang_current_version }}_symlink' }
     - { path: '{{ current_clangcpp.stdout }}', dest: 'clang++-{{ clang_current_version }}_symlink'}
-  when: current_clang.stdout != "" and current_clangcpp.stdout != ""
+  when: current_clang.stdout  | length > 0 and current_clangcpp.stdout | length > 0
 
 - name: Create gcc wrapper
-  shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=gcc --path={{ local_lvi_directory }}/bin"
-  when: gcc.stdout != ""
+  ansible.builtin.shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=gcc --path={{ local_lvi_directory }}/bin"
+  when: gcc.stdout | length > 0
 
 - name: Create g++ wrapper
-  shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=g++ --path={{ local_lvi_directory }}/bin"
-  when: gcpp.stdout != ""
+  ansible.builtin.shell: "sh {{ local_lvi_directory }}/bin/generate_wrapper --name=g++ --path={{ local_lvi_directory }}/bin"
+  when: gcpp.stdout | length > 0
 
 - name: Create symbolic links to gcc
-  file:
+  ansible.builtin.file:
     src: '{{ item.path }}'
     dest: '{{ local_lvi_directory }}/bin/{{ item.dest }}'
     state: link
@@ -148,4 +149,4 @@
   with_items:
     - { path: '{{ gcc.stdout }}', dest: 'gcc_symlink' }
     - { path: '{{ gcpp.stdout }}', dest: 'g++_symlink' }
-  when: gcc.stdout != "" and gcpp.stdout != ""
+  when: gcc.stdout | length > 0 and gcpp.stdout | length > 0

--- a/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/ubuntu/packages-install.yml
@@ -2,14 +2,16 @@
 # Licensed under the MIT License.
 
 ---
-- include_role:
+- name: Add Microsoft repository
+  ansible.builtin.include_role:
     name: linux/common
     tasks_from: apt-repo.yml
   vars:
     apt_key_url: "https://packages.microsoft.com/keys/microsoft.asc"
     apt_repository: "deb [arch=amd64] https://packages.microsoft.com/ubuntu/{{ ansible_distribution_version }}/prod {{ ansible_distribution_release }} main"
 
-- include_role:
+- name: Add llvm repository
+  ansible.builtin.include_role:
     name: linux/common
     tasks_from: apt-repo.yml
   vars:
@@ -17,7 +19,7 @@
     apt_repository: "{{ llvm_apt_repository }}"
 
 - name: Install all the Open Enclave prerequisites APT packages for development
-  apt:
+  ansible.builtin.apt:
     name: "{{ apt_packages }}"
     state: latest
     update_cache: yes

--- a/scripts/ansible/roles/linux/openenclave/tasks/validation.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/validation.yml
@@ -3,45 +3,45 @@
 
 ---
 - name: Include distribution vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/main.yml"
 
 - name: Include distribution release specific vars
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
 
 - name: Check for existing required binaries
-  stat:
+  ansible.builtin.stat:
     path: "{{ item }}"
   with_items: "{{ validation_binaries | union(validation_distribution_binaries) }}"
   register: binary
-  failed_when: binary.stat.executable == False
+  failed_when: not binary.stat.executable
 
 - name: Check for existing required directories
-  stat:
+  ansible.builtin.stat:
     path: "{{ item }}"
   with_items: "{{ validation_directories }}"
   register: directory
-  failed_when: directory.stat.isdir == False
+  failed_when: not directory.stat.isdir
 
 - name: Check for existing required files
-  stat:
+  ansible.builtin.stat:
     path: "{{ item }}"
   with_items: "{{ validation_distribution_files }}"
   register: file
-  failed_when: file.stat.exists == False
+  failed_when: not file.stat.exists
 
 - name: Cmake version check
-  command: "cmake --version"
+  ansible.builtin.command: "cmake --version"
   register: cmake_check_version
   failed_when: cmake_check_version.stdout.find(cmake_target_version) == -1
 
 - name: Clang version check
-  command: "{{ clang_binary_name }} --version"
+  ansible.builtin.command: "{{ clang_binary_name }} --version"
   register: clang_check_version
   failed_when: clang_check_version.stdout.find(clang_target_version) == -1
 
 - name: GCC version check
-  command: "gcc --version"
+  ansible.builtin.command: "gcc --version"
   register: gcc_check_version
   failed_when: gcc_check_version.stdout.find(gcc_target_version) == -1

--- a/scripts/ansible/roles/windows/az-dcap-client/tasks/validation.yml
+++ b/scripts/ansible/roles/windows/az-dcap-client/tasks/validation.yml
@@ -3,32 +3,32 @@
 
 ---
 - name: Azure DCAP Client | Include vars
-  include_vars: "{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_os_family | lower }}.yml"
 
 - name: Azure DCAP Client | Check for existing required folders
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ item }}"
   with_items: "{{ validation_directories }}"
   register: directory
-  failed_when: directory.stat.isdir == False
+  failed_when: not directory.stat.isdir
 
 - name: Azure DCAP Client | Check for existing required executables and files
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ item }}"
   with_items: "{{ validation_binaries }}"
   register: file
-  failed_when: file.stat.isreg == False
+  failed_when: not file.stat.isreg
 
 - block:
     - name: Azure DCAP Client | Check for the LC driver registry key
-      win_reg_stat:
+      ansible.windows.win_reg_stat:
         path: '{{ lc_driver.reg_path }}'
         name: '{{ lc_driver.reg_key }}'
       register: reg_key
       failed_when: reg_key.value != 1
 
     - name: Azure DCAP Client | Check if Intel SGX is installed
-      win_shell: '(Get-CimInstance -ClassName Win32_Product -Filter "Name=''Intel® Software Guard Extensions Platform Software''") -eq $null'
+      ansible.windows.win_shell: '(Get-CimInstance -ClassName Win32_Product -Filter "Name=''Intel® Software Guard Extensions Platform Software''") -eq $null'
       register: result
       failed_when: result.stdout == "True\r\n"
 

--- a/scripts/ansible/roles/windows/jenkins/tasks/packer.yml
+++ b/scripts/ansible/roles/windows/jenkins/tasks/packer.yml
@@ -4,28 +4,27 @@
 ---
 
 - name: Include vars
-  include_vars: "{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_os_family | lower }}.yml"
 
 - name: Make sure that Jenkins home exists
-  win_file:
+  ansible.windows.win_file:
     path: "{{ jenkins_agent_root_dir }}"
     state: directory
 
 - name: Oracle JDK8 - Download
-  win_get_url:
+  ansible.windows.win_get_url:
     url: "{{ jdk8_url }}"
     headers:
       Cookie: "oraclelicense=accept-securebackup-cookie"
     dest: "{{ tmp_dir }}\\jdk-windows-x64.exe"
 
 - name: Oracle JDK8 - Install
-  raw: "{{ tmp_dir }}\\jdk-windows-x64.exe /s REBOOT=Disable REMOVEOUTOFDATEJRES=1"
-
+  ansible.builtin.raw: "{{ tmp_dir }}\\jdk-windows-x64.exe /s REBOOT=Disable REMOVEOUTOFDATEJRES=1"
 
 - name: Configure Git in target image to enable merge/rebase actions - email
-  win_shell: |
+  ansible.windows.win_shell: |
     git config --system user.email '{{ ci_team_email }}'
 
 - name: Configure Git in target image to enable merge/rebase actions - name
-  win_shell: |
+  ansible.windows.win_shell: |
     git config --system user.name '{{ ci_team_name }}'

--- a/scripts/ansible/roles/windows/jenkins/tasks/slave-setup.yml
+++ b/scripts/ansible/roles/windows/jenkins/tasks/slave-setup.yml
@@ -4,27 +4,28 @@
 ---
 
 - name: Include vars
-  include_vars: "{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_os_family | lower }}.yml"
 
 - block:
-  - import_role:
+  - name: Import Jenkins agent provision tasks
+    ansible.builtin.import_role:
       name: common/jenkins
       tasks_from: agent-provision.yml
     delegate_to: localhost
   become: no
 
 - name: Check if node_secret fact is defined
-  fail:    
+  ansible.builtin.fail:
     msg: "The node_secret fact is not defined!"
   when: node_secret is undefined
 
 - name: Make sure that Jenkins home exists
-  win_file:
+  ansible.windows.win_file:
     path: "{{ jenkins_agent_root_dir }}"
     state: directory
 
 - name: Download slave-agent.jnlp from Jenkins Master
-  win_get_url:
+  ansible.windows.win_get_url:
     url: "{{ jenkins_url }}/computer/{{ jenkins_agent_name }}/slave-agent.jnlp"
     force_basic_auth: yes
     url_username: '{{ jenkins_admin_name }}'
@@ -32,7 +33,7 @@
     dest: "{{ jenkins_agent_root_dir }}/slave-agent.jnlp"
 
 - name: Download agent.jar from Jenkins Master
-  win_get_url:
+  ansible.windows.win_get_url:
     url: "{{ jenkins_url }}/jnlpJars/agent.jar"
     force_basic_auth: yes
     url_username: "{{ jenkins_admin_name }}"
@@ -40,42 +41,42 @@
     dest: "{{ jenkins_agent_root_dir }}/agent.jar"
 
 - name: Oracle JDK8 - Download
-  win_get_url:
+  ansible.windows.win_get_url:
     url: "{{ jdk8_url }}"
     headers:
       Cookie: "oraclelicense=accept-securebackup-cookie"
     dest: "{{ tmp_dir }}\\jdk-windows-x64.exe"
 
 - name: Oracle JDK8 - Install
-  raw: "{{ tmp_dir }}\\jdk-windows-x64.exe /s REBOOT=Disable REMOVEOUTOFDATEJRES=1"
+  ansible.builtin.raw: "{{ tmp_dir }}\\jdk-windows-x64.exe /s REBOOT=Disable REMOVEOUTOFDATEJRES=1"
 
 - name: Windows | Check if the service wrapper exists
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ jenkins_agent_root_dir }}/servicewrapper.exe"
   register: servicewrapper_info
 
 - name: Windows | Get the service wrapper
   block:
     - name: Windows | Download the service wrapper zip file
-      win_get_url:
+      ansible.windows.win_get_url:
         url: "{{ servicewrapper_url }}"
         dest: "{{ tmp_dir }}\\service-wrapper.zip"
         timeout: 60
       retries: 3
 
     - name: Windows | Unzip the service-wrapper zip archive
-      win_unzip:
+      community.windows.win_unzip:
         src: "{{ tmp_dir }}\\service-wrapper.zip"
         dest: "{{ tmp_dir }}\\service-wrapper"
 
     - name: Windows | Move the service wrapper to the expected location
-      win_copy:
+      ansible.windows.win_copy:
         src: "{{ tmp_dir }}\\service-wrapper\\service-wrapper.exe"
         dest: "{{ jenkins_agent_root_dir }}\\servicewrapper.exe"
         remote_src: yes
 
     - name: Windows | Remove service-wrapper temporary files
-      win_file:
+      ansible.windows.win_file:
         state: absent
         path: "{{ item }}"
       with_items:
@@ -86,12 +87,12 @@
 - name: Jenkins Slave | Create the service wrapper config file
   block:
     - name: Jenkins Slave | Remove existing service wrapper config file
-      win_file:
+      ansible.windows.win_file:
         state: absent
         path: '{{ jenkins_agent_root_dir }}/jenkins-servicewrapper-config.ini'
 
     - name: Jenkins Slave | Create the new service wrapper config file
-      win_lineinfile:
+      community.windows.win_lineinfile:
         path: '{{ jenkins_agent_root_dir }}/jenkins-servicewrapper-config.ini'
         create: yes
         line: |
@@ -100,7 +101,7 @@
           service-command=java.exe -jar {{ jenkins_agent_root_dir }}/agent.jar -jnlpUrl {{ jenkins_url }}/computer/{{ jenkins_agent_name }}/slave-agent.jnlp -secret {{ node_secret }}
 
 - name: Jenkins Slave | Create Jenkins Slave JNLP Windows service
-  win_service:
+  ansible.windows.win_service:
     name: jenkins-slave
     display_name: Jenkins Slave
     description: Jenkins Slave service
@@ -108,7 +109,7 @@
       "{{ jenkins_agent_root_dir }}/servicewrapper.exe" --config "{{ jenkins_agent_root_dir }}/jenkins-servicewrapper-config.ini"
 
 - name: Jenkins Slave | Set service failure command
-  win_shell: >-
+  ansible.windows.win_shell: >-
     sc.exe failure jenkins-slave reset=40 actions=restart/0/restart/0/run/30000
     command="powershell.exe Move-Item
     \\\`"{{ jenkins_agent_root_dir }}/jenkins-slave.log\\\`"
@@ -116,18 +117,18 @@
     Restart-Service jenkins-slave"
 
 - name: Jenkins Slave | Enable jenkins-slave service failure flags
-  win_shell: sc.exe failureflag jenkins-slave 1
+  ansible.windows.win_shell: sc.exe failureflag jenkins-slave 1
 
 - name: Jenkins Slave | Start service
-  win_service:
+  ansible.windows.win_service:
     name: jenkins-slave
     start_mode: auto
     state: started
 
 - name: Configure Git in target image to enable merge/rebase actions - email
-  win_shell: |
+  ansible.windows.win_shell: |
     git config --system user.email '{{ ci_team_email }}'
 
 - name: Configure Git in target image to enable merge/rebase actions - name
-  win_shell: |
+  ansible.windows.win_shell: |
     git config --system user.name '{{ ci_team_name }}'

--- a/scripts/ansible/roles/windows/jenkins/tasks/validation.yml
+++ b/scripts/ansible/roles/windows/jenkins/tasks/validation.yml
@@ -3,12 +3,11 @@
 
 ---
 - name: Include vars
-  include_vars: "{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_os_family | lower }}.yml"
 
 - name: Check for existing required executables and files
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ item }}"
   with_items: "{{ validation_binaries }}"
   register: file
-  failed_when: file.stat.isreg == False
-
+  failed_when: not file.stat.isreg

--- a/scripts/ansible/roles/windows/openenclave/tasks/validation.yml
+++ b/scripts/ansible/roles/windows/openenclave/tasks/validation.yml
@@ -3,33 +3,33 @@
 
 ---
 - name: Include vars
-  include_vars: "{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_os_family | lower }}.yml"
 
 - name: Check for existing required folders and files
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ item }}"
   with_items: "{{ validation_directories }}"
   register: directory
-  failed_when: directory.stat.isdir == False
+  failed_when: not directory.stat.isdir
 
 - name: Check for existing required executables and files
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ item }}"
   with_items: "{{ validation_binaries + validation_files }}"
   register: file
-  failed_when: file.stat.isreg == False
+  failed_when: not file.stat.isreg
 
 - name: CMake version check
-  win_command: vcvars64.bat x64 && cmake --version
+  ansible.windows.win_command: vcvars64.bat x64 && cmake --version
   register: cmake_check_version
   failed_when: cmake_check_version.stdout.find(cmake_target_version) == -1
 
 - name: Ninja version check
-  win_command: vcvars64.bat x64 && ninja --version
+  ansible.windows.win_command: vcvars64.bat x64 && ninja --version
   register: ninja_check_version
   failed_when: ninja_check_version.stdout.find(ninja_target_version) == -1
 
 - name: Clang version check
-  raw: "clang --version"
+  ansible.builtin.raw: "clang --version"
   register: clang_check_version
   failed_when: clang_check_version.stdout.find(clang_target_version) == -1


### PR DESCRIPTION
Changes to Ansible:
* Update to Ansible 4.10 for Ubuntu 18.04
* Update to Ansible 5.2.0 for Ubuntu 20.04
* Added Ansible Galaxy modules that cannot be assumed are built-in to Ansible installation script
* Fixed Ansible linting issues and added an .ansible_lint file to skip certain rules 503 (tasks vs handlers), and 204 (line length)
* Fixed Intel PSW/DCAP version for Ansible Windows role
* Install Docker Python library when needed for Ansible setup
* Use Docker modules for Ansible instead of running bash commands
* Install docker-ce-cli and containerd.io when installing docker-ce as recommended by Docker's installation documentation.

* Update README.md for Ansible to latest supported OSes

Other changes
* Remove dependency on Docker oetools-deploy for packer builds, as the image is no longer maintained and the packer version within no longer works for our builds.
* Fix broken references to Jenkins job paths
* Fix link to devkits url
* Add `common.installAzureCLI` to OpenEnclaveJenkinsLibrary for future use