### PR TITLE
Cleanup unnecessary use of oe_host_malloc in the file-encryptor sample

### DIFF
--- a/samples/file-encryptor/enclave/mbedtls_src/encryptor.cpp
+++ b/samples/file-encryptor/enclave/mbedtls_src/encryptor.cpp
@@ -107,7 +107,7 @@ void ecall_dispatcher::close()
 {
     if (m_encrypt)
     {
-        oe_host_free(m_header);
+        free(m_header);
         m_header = nullptr;
     }
 

--- a/samples/file-encryptor/enclave/mbedtls_src/keys.cpp
+++ b/samples/file-encryptor/enclave/mbedtls_src/keys.cpp
@@ -412,12 +412,12 @@ int ecall_dispatcher::process_encryption_header(encryption_header_t* header)
 
     if (m_encrypt)
     {
-        // allocate host memory for the header and it will be returned back to
+        // allocate memory for the header and it will be copied back to
         // the host
-        m_header =
-            (encryption_header_t*)oe_host_malloc(sizeof(encryption_header_t));
+        m_header = (encryption_header_t*)malloc(sizeof(encryption_header_t));
         if (m_header == nullptr)
         {
+            TRACE_ENCLAVE("malloc failed");
             ret = 1;
             goto exit;
         }

--- a/samples/file-encryptor/enclave/openssl_src/encryptor.cpp
+++ b/samples/file-encryptor/enclave/openssl_src/encryptor.cpp
@@ -171,7 +171,7 @@ void ecall_dispatcher::close()
 {
     if (m_encrypt)
     {
-        oe_host_free(m_header);
+        free(m_header);
         m_header = nullptr;
     }
 

--- a/samples/file-encryptor/enclave/openssl_src/keys.cpp
+++ b/samples/file-encryptor/enclave/openssl_src/keys.cpp
@@ -393,13 +393,12 @@ int ecall_dispatcher::process_encryption_header(encryption_header_t* header)
 
     if (m_encrypt)
     {
-        // allocate host memory for the header and it will be returned back to
+        // allocate memory for the header and it will be copied back to
         // the host
-        m_header =
-            (encryption_header_t*)oe_host_malloc(sizeof(encryption_header_t));
+        m_header = (encryption_header_t*)malloc(sizeof(encryption_header_t));
         if (m_header == nullptr)
         {
-            TRACE_ENCLAVE("oe_host_malloc failed");
+            TRACE_ENCLAVE("malloc failed");
             ret = 1;
             goto exit;
         }


### PR DESCRIPTION
Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>