### PR TITLE
Use deep-copy in the attestation sample

### DIFF
--- a/samples/attestation/README.md
+++ b/samples/attestation/README.md
@@ -97,12 +97,9 @@ The host does the following in this sample:
       get_evidence_with_public_key(enclave_a,
                                    &ret,
                                    format_id,
-                                   format_settings,
-                                   format_settings_size,
+                                   &format_settings,
                                    &pem_key,
-                                   &pem_key_size,
-                                   &evidence,
-                                   &evidence_size);
+                                   &evidence);
       ```
 
       Where:
@@ -117,11 +114,9 @@ The host does the following in this sample:
       ```c
       verify_evidence_and_set_public_key(enclave_a,
                                          &ret,
-                                         format_id,
-                                         pem_key,
-                                         pem_key_size,
-                                         evidence,
-                                         evidence_size);
+                                         &format_id,
+                                         &pem_key,
+                                         &evidence);
       ```
 
       In the enclave_b's implementation of `verify_evidence_and_set_public_key()`, it calls `oe_verify_evidence()`, which will be described in the enclave section to handle all the platform-specfic evidence validation operations. If successful the public key in `pem_key` will be stored inside the enclave for future use.

--- a/samples/attestation/attestation.edl
+++ b/samples/attestation/attestation.edl
@@ -6,39 +6,55 @@ enclave {
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 
+    struct format_settings_t
+    {
+        [size=size] uint8_t* buffer;
+        size_t size;
+    };
+
+    struct pem_key_t
+    {
+        [size=size] uint8_t* buffer;
+        size_t size;
+    };
+
+    struct evidence_t
+    {
+        [size=size] uint8_t* buffer;
+        size_t size;
+    };
+
+    struct message_t
+    {
+        [size=size] uint8_t* data;
+        size_t size;
+    };
+
     trusted {
         public int get_enclave_format_settings(
             [in] const oe_uuid_t* format_id,
-            [out] uint8_t** format_settings,
-            [out] size_t* format_settings_size);
+            [out] format_settings_t* format_settings);
 
         // Return the public key of this enclave along with the enclave's evidence.
         // Another enclave can use the evidence to attest the enclave and verify
         // the integrity of the public key.
         public int get_evidence_with_public_key(
             [in] const oe_uuid_t* format_id,
-            [in, size=format_settings_size] uint8_t* format_settings_buffer,
-            size_t format_settings_size,
-            [out] uint8_t **pem_key,
-            [out] size_t *pem_key_size,
-            [out] uint8_t **evidence_buffer,
-            [out] size_t *evidence_buffer_size);
+            [in] format_settings_t* format_settings,
+            [out] pem_key_t *pem_key,
+            [out] evidence_t *evidence_buffer);
 
         // Attest and store the public key of another enclave
         public int verify_evidence_and_set_public_key(
             [in] const oe_uuid_t* format_id,
-            [in, count=pem_key_size] uint8_t *pem_key,
-            size_t pem_key_size,
-            [in, count=evidence_size] uint8_t *evidence,
-            size_t evidence_size);
+            [in] pem_key_t *pem_key,
+            [in] evidence_t *evidence);
 
         // Encrypt message for another enclave using the public key stored for it
-        public int generate_encrypted_message( [out] uint8_t** data,
-                                               [out] size_t*  size);
+        public int generate_encrypted_message([out] message_t* message);
 
         // Process encrypted message
-        public int process_encrypted_message(  [in, count=size] uint8_t* data,
-                                               size_t  size);
+        public int process_encrypted_message([in] message_t* message);
     };
 
     //untrusted {

--- a/samples/attestation/common/CMakeLists.txt
+++ b/samples/attestation/common/CMakeLists.txt
@@ -22,5 +22,6 @@ target_compile_definitions(common PUBLIC OE_API_VERSION=2)
 target_link_libraries(
   common PUBLIC openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB}
                 openenclave::oelibcxx)
-target_include_directories(common PUBLIC ${CMAKE_SOURCE_DIR}
-                                         ${CMAKE_BINARY_DIR})
+target_include_directories(
+  common PUBLIC ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}
+                ${CMAKE_CURRENT_BINARY_DIR})

--- a/samples/attestation/common/attestation.h
+++ b/samples/attestation/common/attestation.h
@@ -5,9 +5,11 @@
 #define OE_SAMPLES_ATTESTATION_ENC_ATTESTATION_H
 
 #include <openenclave/enclave.h>
+#include "attestation_args.h"
 #include "crypto.h"
 
 #define ENCLAVE_SECRET_DATA_SIZE 16
+
 class Attestation
 {
   private:

--- a/samples/attestation/common/dispatcher.cpp
+++ b/samples/attestation/common/dispatcher.cpp
@@ -62,10 +62,9 @@ exit:
 
 int ecall_dispatcher::get_enclave_format_settings(
     const oe_uuid_t* format_id,
-    uint8_t** format_settings_buffer,
-    size_t* format_settings_buffer_size)
+    format_settings_t* format_settings)
 {
-    uint8_t* format_settings = nullptr;
+    uint8_t* format_settings_buffer = nullptr;
     size_t format_settings_size = 0;
     int ret = 1;
 
@@ -79,33 +78,32 @@ int ecall_dispatcher::get_enclave_format_settings(
     // settings can attest this enclave.
     TRACE_ENCLAVE("get_enclave_format_settings");
     if (m_attestation->get_format_settings(
-            format_id, &format_settings, &format_settings_size) == false)
+            format_id, &format_settings_buffer, &format_settings_size) == false)
     {
         TRACE_ENCLAVE("get_enclave_format_settings failed");
         goto exit;
     }
 
-    if (format_settings && format_settings_size)
+    if (format_settings_buffer && format_settings_size)
     {
-        // Allocate memory on the host and copy the format settings over.
-        // TODO: the following code is not TEE-agnostic, as it assumes the
-        // enclave can directly write into host memory
-        *format_settings_buffer =
-            (uint8_t*)oe_host_malloc(format_settings_size);
-        if (*format_settings_buffer == nullptr)
+        format_settings->buffer = (uint8_t*)malloc(format_settings_size);
+        if (format_settings->buffer == nullptr)
         {
             ret = OE_OUT_OF_MEMORY;
             TRACE_ENCLAVE("copying format_settings failed, out of memory");
             goto exit;
         }
-        memcpy(*format_settings_buffer, format_settings, format_settings_size);
-        *format_settings_buffer_size = format_settings_size;
-        oe_verifier_free_format_settings(format_settings);
+        memcpy(
+            format_settings->buffer,
+            format_settings_buffer,
+            format_settings_size);
+        format_settings->size = format_settings_size;
+        oe_verifier_free_format_settings(format_settings_buffer);
     }
     else
     {
-        *format_settings_buffer = nullptr;
-        *format_settings_buffer_size = 0;
+        format_settings->buffer = nullptr;
+        format_settings->size = 0;
     }
     ret = 0;
 
@@ -123,17 +121,13 @@ exit:
  */
 int ecall_dispatcher::get_evidence_with_public_key(
     const oe_uuid_t* format_id,
-    uint8_t* format_settings,
-    size_t format_settings_size,
-    uint8_t** pem_key,
-    size_t* pem_key_size,
-    uint8_t** evidence_buffer,
-    size_t* evidence_buffer_size)
+    format_settings_t* format_settings,
+    pem_key_t* pem_key,
+    evidence_t* evidence)
 {
     uint8_t pem_public_key[512];
-    uint8_t* evidence = nullptr;
+    uint8_t* evidence_buffer = nullptr;
     size_t evidence_size = 0;
-    uint8_t* key_buffer = nullptr;
     int ret = 1;
 
     TRACE_ENCLAVE("get_evidence_with_public_key");
@@ -149,42 +143,37 @@ int ecall_dispatcher::get_evidence_with_public_key(
     // receives the key can attest this enclave.
     if (m_attestation->generate_attestation_evidence(
             format_id,
-            format_settings,
-            format_settings_size,
+            format_settings->buffer,
+            format_settings->size,
             pem_public_key,
             sizeof(pem_public_key),
-            &evidence,
+            &evidence_buffer,
             &evidence_size) == false)
     {
         TRACE_ENCLAVE("get_evidence_with_public_key failed");
         goto exit;
     }
 
-    // Allocate memory on the host and copy the evidence over.
-    // TODO: the following code is not TEE-agnostic, as it assumes the
-    // enclave can directly write into host memory
-    *evidence_buffer = (uint8_t*)oe_host_malloc(evidence_size);
-    if (*evidence_buffer == nullptr)
+    evidence->buffer = (uint8_t*)malloc(evidence_size);
+    if (evidence->buffer == nullptr)
     {
         ret = OE_OUT_OF_MEMORY;
         TRACE_ENCLAVE("copying evidence_buffer failed, out of memory");
         goto exit;
     }
-    memcpy(*evidence_buffer, evidence, evidence_size);
-    *evidence_buffer_size = evidence_size;
-    oe_free_evidence(evidence);
+    memcpy(evidence->buffer, evidence_buffer, evidence_size);
+    evidence->size = evidence_size;
+    oe_free_evidence(evidence_buffer);
 
-    key_buffer = (uint8_t*)oe_host_malloc(512);
-    if (key_buffer == nullptr)
+    pem_key->buffer = (uint8_t*)malloc(sizeof(pem_public_key));
+    if (pem_key->buffer == nullptr)
     {
         ret = OE_OUT_OF_MEMORY;
         TRACE_ENCLAVE("copying key_buffer failed, out of memory");
         goto exit;
     }
-    memcpy(key_buffer, pem_public_key, sizeof(pem_public_key));
-
-    *pem_key = key_buffer;
-    *pem_key_size = sizeof(pem_public_key);
+    memcpy(pem_key->buffer, pem_public_key, sizeof(pem_public_key));
+    pem_key->size = sizeof(pem_public_key);
 
     ret = 0;
     TRACE_ENCLAVE("get_evidence_with_public_key succeeded");
@@ -192,22 +181,26 @@ int ecall_dispatcher::get_evidence_with_public_key(
 exit:
     if (ret != 0)
     {
+        if (evidence_buffer)
+            oe_free_evidence(evidence_buffer);
+        if (pem_key)
+        {
+            free(pem_key->buffer);
+            pem_key->size = 0;
+        }
         if (evidence)
-            oe_free_evidence(evidence);
-        if (key_buffer)
-            oe_host_free(key_buffer);
-        if (*evidence_buffer)
-            oe_host_free(*evidence_buffer);
+        {
+            free(evidence->buffer);
+            evidence->size = 0;
+        }
     }
     return ret;
 }
 
 int ecall_dispatcher::verify_evidence_and_set_public_key(
     const oe_uuid_t* format_id,
-    uint8_t* pem_key,
-    size_t pem_key_size,
-    uint8_t* evidence,
-    size_t evidence_size)
+    pem_key_t* pem_key,
+    evidence_t* evidence)
 {
     int ret = 1;
 
@@ -219,13 +212,20 @@ int ecall_dispatcher::verify_evidence_and_set_public_key(
 
     // Attest the evidence and accompanying key.
     if (m_attestation->attest_attestation_evidence(
-            format_id, evidence, evidence_size, pem_key, pem_key_size) == false)
+            format_id,
+            evidence->buffer,
+            evidence->size,
+            pem_key->buffer,
+            pem_key->size) == false)
     {
         TRACE_ENCLAVE("verify_evidence_and_set_public_key failed.");
         goto exit;
     }
 
-    memcpy(m_crypto->get_the_other_enclave_public_key(), pem_key, pem_key_size);
+    memcpy(
+        m_crypto->get_the_other_enclave_public_key(),
+        pem_key->buffer,
+        pem_key->size);
 
     ret = 0;
     TRACE_ENCLAVE("verify_evidence_and_set_public_key succeeded.");
@@ -234,11 +234,11 @@ exit:
     return ret;
 }
 
-int ecall_dispatcher::generate_encrypted_message(uint8_t** data, size_t* size)
+int ecall_dispatcher::generate_encrypted_message(message_t* message)
 {
     uint8_t encrypted_data_buffer[1024];
     size_t encrypted_data_size;
-    uint8_t* host_buffer;
+    uint8_t* buffer;
     int ret = 1;
 
     if (m_initialized == false)
@@ -259,30 +259,27 @@ int ecall_dispatcher::generate_encrypted_message(uint8_t** data, size_t* size)
         goto exit;
     }
 
-    // TODO: the following code is not TEE-agnostic, as it assumes the
-    // enclave can directly write into host memory
-    host_buffer = (uint8_t*)oe_host_malloc(encrypted_data_size);
-    if (host_buffer == nullptr)
+    buffer = (uint8_t*)malloc(encrypted_data_size);
+    if (buffer == nullptr)
     {
         ret = OE_OUT_OF_MEMORY;
         TRACE_ENCLAVE("copying host_buffer failed, out of memory");
         goto exit;
     }
-    memcpy(host_buffer, encrypted_data_buffer, encrypted_data_size);
+    memcpy(buffer, encrypted_data_buffer, encrypted_data_size);
     TRACE_ENCLAVE(
         "enclave: generate_encrypted_message: encrypted_data_size = %ld",
         encrypted_data_size);
-    *data = host_buffer;
-    *size = encrypted_data_size;
+
+    message->data = buffer;
+    message->size = encrypted_data_size;
 
     ret = 0;
 exit:
     return ret;
 }
 
-int ecall_dispatcher::process_encrypted_message(
-    uint8_t* encrypted_data,
-    size_t encrypted_data_size)
+int ecall_dispatcher::process_encrypted_message(message_t* message)
 {
     uint8_t data[1024];
     size_t data_size = 0;
@@ -295,8 +292,7 @@ int ecall_dispatcher::process_encrypted_message(
     }
 
     data_size = sizeof(data);
-    if (m_crypto->decrypt(
-            encrypted_data, encrypted_data_size, data, &data_size))
+    if (m_crypto->decrypt(message->data, message->size, data, &data_size))
     {
         // This is where the business logic for verifying the data should be.
         // In this sample, both enclaves start with identical data in

--- a/samples/attestation/common/dispatcher.h
+++ b/samples/attestation/common/dispatcher.h
@@ -31,29 +31,22 @@ class ecall_dispatcher
     ~ecall_dispatcher();
     int get_enclave_format_settings(
         const oe_uuid_t* format_id,
-        uint8_t** format_settings,
-        size_t* format_settings_size);
+        format_settings_t* format_settings);
 
     int get_evidence_with_public_key(
         const oe_uuid_t* format_id,
-        uint8_t* format_settings,
-        size_t format_settings_size,
-        uint8_t** pem_key,
-        size_t* pem_key_size,
-        uint8_t** evidence_buffer,
-        size_t* evidence_buffer_size);
+        format_settings_t* format_settings,
+        pem_key_t* pem_key,
+        evidence_t* evidence);
+
     int verify_evidence_and_set_public_key(
         const oe_uuid_t* format_id,
-        uint8_t* pem_key,
-        size_t pem_key_size,
-        uint8_t* evidence,
-        size_t evidence_size);
+        pem_key_t* pem_key,
+        evidence_t* evidence);
 
-    int generate_encrypted_message(uint8_t** data, size_t* size);
+    int generate_encrypted_message(message_t* message);
 
-    int process_encrypted_message(
-        uint8_t* encrypted_data,
-        size_t encrypted_data_size);
+    int process_encrypted_message(message_t* message);
 
   private:
     bool initialize(const char* name);

--- a/samples/attestation/enclave_a/ecalls.cpp
+++ b/samples/attestation/enclave_a/ecalls.cpp
@@ -32,11 +32,9 @@ static ecall_dispatcher dispatcher("Enclave1", &config_data);
 const char* enclave_name = "Enclave1";
 int get_enclave_format_settings(
     const oe_uuid_t* format_id,
-    uint8_t** format_settings,
-    size_t* format_settings_size)
+    format_settings_t* format_settings)
 {
-    return dispatcher.get_enclave_format_settings(
-        format_id, format_settings, format_settings_size);
+    return dispatcher.get_enclave_format_settings(format_id, format_settings);
 }
 
 /**
@@ -46,43 +44,32 @@ int get_enclave_format_settings(
  */
 int get_evidence_with_public_key(
     const oe_uuid_t* format_id,
-    uint8_t* format_settings,
-    size_t format_settings_size,
-    uint8_t** pem_key,
-    size_t* pem_key_size,
-    uint8_t** evidence,
-    size_t* evidence_size)
+    format_settings_t* format_settings,
+    pem_key_t* pem_key,
+    evidence_t* evidence)
 {
     return dispatcher.get_evidence_with_public_key(
-        format_id,
-        format_settings,
-        format_settings_size,
-        pem_key,
-        pem_key_size,
-        evidence,
-        evidence_size);
+        format_id, format_settings, pem_key, evidence);
 }
 
 // Attest and store the public key of another enclave.
 int verify_evidence_and_set_public_key(
     const oe_uuid_t* format_id,
-    uint8_t* pem_key,
-    size_t pem_key_size,
-    uint8_t* evidence,
-    size_t evidence_size)
+    pem_key_t* pem_key,
+    evidence_t* evidence)
 {
     return dispatcher.verify_evidence_and_set_public_key(
-        format_id, pem_key, pem_key_size, evidence, evidence_size);
+        format_id, pem_key, evidence);
 }
 
 // Encrypt message for another enclave using the public key stored for it.
-int generate_encrypted_message(uint8_t** data, size_t* size)
+int generate_encrypted_message(message_t* message)
 {
-    return dispatcher.generate_encrypted_message(data, size);
+    return dispatcher.generate_encrypted_message(message);
 }
 
 // Process encrypted message
-int process_encrypted_message(uint8_t* data, size_t size)
+int process_encrypted_message(message_t* message)
 {
-    return dispatcher.process_encrypted_message(data, size);
+    return dispatcher.process_encrypted_message(message);
 }

--- a/samples/attestation/enclave_b/ecalls.cpp
+++ b/samples/attestation/enclave_b/ecalls.cpp
@@ -33,11 +33,9 @@ const char* enclave_name = "Enclave2";
 
 int get_enclave_format_settings(
     const oe_uuid_t* format_id,
-    uint8_t** format_settings,
-    size_t* format_settings_size)
+    format_settings_t* format_settings)
 {
-    return dispatcher.get_enclave_format_settings(
-        format_id, format_settings, format_settings_size);
+    return dispatcher.get_enclave_format_settings(format_id, format_settings);
 }
 
 /**
@@ -47,43 +45,32 @@ int get_enclave_format_settings(
  */
 int get_evidence_with_public_key(
     const oe_uuid_t* format_id,
-    uint8_t* format_settings,
-    size_t format_settings_size,
-    uint8_t** pem_key,
-    size_t* pem_key_size,
-    uint8_t** evidence,
-    size_t* evidence_size)
+    format_settings_t* format_settings,
+    pem_key_t* pem_key,
+    evidence_t* evidence)
 {
     return dispatcher.get_evidence_with_public_key(
-        format_id,
-        format_settings,
-        format_settings_size,
-        pem_key,
-        pem_key_size,
-        evidence,
-        evidence_size);
+        format_id, format_settings, pem_key, evidence);
 }
 
 // Attest and store the public key of another enclave.
 int verify_evidence_and_set_public_key(
     const oe_uuid_t* format_id,
-    uint8_t* pem_key,
-    size_t pem_key_size,
-    uint8_t* evidence,
-    size_t evidence_size)
+    pem_key_t* pem_key,
+    evidence_t* evidence)
 {
     return dispatcher.verify_evidence_and_set_public_key(
-        format_id, pem_key, pem_key_size, evidence, evidence_size);
+        format_id, pem_key, evidence);
 }
 
 // Encrypt message for another enclave using the public key stored for it.
-int generate_encrypted_message(uint8_t** data, size_t* size)
+int generate_encrypted_message(message_t* message)
 {
-    return dispatcher.generate_encrypted_message(data, size);
+    return dispatcher.generate_encrypted_message(message);
 }
 
 // Process encrypted message
-int process_encrypted_message(uint8_t* data, size_t size)
+int process_encrypted_message(message_t* message)
 {
-    return dispatcher.process_encrypted_message(data, size);
+    return dispatcher.process_encrypted_message(message);
 }

--- a/samples/attestation/host/host.cpp
+++ b/samples/attestation/host/host.cpp
@@ -49,12 +49,9 @@ int attest_one_enclave_to_the_other(
 {
     oe_result_t result = OE_OK;
     int ret = 1;
-    uint8_t* pem_key = NULL;
-    size_t pem_key_size = 0;
-    uint8_t* evidence = NULL;
-    size_t evidence_size = 0;
-    uint8_t* format_settings = NULL;
-    size_t format_settings_size = 0;
+    format_settings_t format_settings = {0};
+    evidence_t evidence = {0};
+    pem_key_t pem_key = {0};
 
     printf(
         "\n\nHost: ********** Attest %s to %s **********\n\n",
@@ -63,11 +60,7 @@ int attest_one_enclave_to_the_other(
 
     printf("Host: Requesting %s format settings\n", verifier_enclave_name);
     result = get_enclave_format_settings(
-        verifier_enclave,
-        &ret,
-        format_id,
-        &format_settings,
-        &format_settings_size);
+        verifier_enclave, &ret, format_id, &format_settings);
     if ((result != OE_OK) || (ret != 0))
     {
         printf("Host: get_format_settings failed. %s\n", oe_result_str(result));
@@ -84,12 +77,9 @@ int attest_one_enclave_to_the_other(
         attester_enclave,
         &ret,
         format_id,
-        format_settings,
-        format_settings_size,
+        &format_settings,
         &pem_key,
-        &pem_key_size,
-        &evidence,
-        &evidence_size);
+        &evidence);
     if ((result != OE_OK) || (ret != 0))
     {
         printf(
@@ -99,19 +89,16 @@ int attest_one_enclave_to_the_other(
             ret = 1;
         goto exit;
     }
-    printf("Host: %s's  public key: \n%s\n", attester_enclave_name, pem_key);
+    printf(
+        "Host: %s's  public key: \n%s\n",
+        attester_enclave_name,
+        pem_key.buffer);
 
     printf(
         "Host: verify_evidence_and_set_public_key in %s\n",
         verifier_enclave_name);
     result = verify_evidence_and_set_public_key(
-        verifier_enclave,
-        &ret,
-        format_id,
-        pem_key,
-        pem_key_size,
-        evidence,
-        evidence_size);
+        verifier_enclave, &ret, format_id, &pem_key, &evidence);
     if ((result != OE_OK) || (ret != 0))
     {
         printf(
@@ -123,9 +110,9 @@ int attest_one_enclave_to_the_other(
     }
 
 exit:
-    free(pem_key);
-    free(evidence);
-    free(format_settings);
+    free(pem_key.buffer);
+    free(evidence.buffer);
+    free(format_settings.buffer);
     return ret;
 }
 
@@ -133,8 +120,7 @@ int main(int argc, const char* argv[])
 {
     oe_enclave_t* enclave_a = NULL;
     oe_enclave_t* enclave_b = NULL;
-    uint8_t* encrypted_message = NULL;
-    size_t encrypted_message_size = 0;
+    message_t encrypted_message = {0};
     oe_result_t result = OE_OK;
     int ret = 1;
     uint32_t flags = OE_ENCLAVE_FLAG_DEBUG;
@@ -209,8 +195,7 @@ int main(int argc, const char* argv[])
     // With successfully attestation on each other, we are ready to exchange
     // data between enclaves, securely via asymmetric encryption
     printf("Host: Requesting encrypted message from 1st enclave\n");
-    result = generate_encrypted_message(
-        enclave_a, &ret, &encrypted_message, &encrypted_message_size);
+    result = generate_encrypted_message(enclave_a, &ret, &encrypted_message);
     if ((result != OE_OK) || (ret != 0))
     {
         printf(
@@ -222,8 +207,7 @@ int main(int argc, const char* argv[])
     }
 
     printf("Host: Sending the encrypted message to 2nd enclave\n");
-    result = process_encrypted_message(
-        enclave_b, &ret, encrypted_message, encrypted_message_size);
+    result = process_encrypted_message(enclave_b, &ret, &encrypted_message);
     if ((result != OE_OK) || (ret != 0))
     {
         printf(
@@ -240,12 +224,11 @@ int main(int argc, const char* argv[])
         "***\n\n");
 
     // Free host memory allocated by the first enclave
-    free(encrypted_message);
-    encrypted_message = NULL;
+    free(encrypted_message.data);
+    encrypted_message.data = NULL;
 
     printf("Host: Requesting encrypted message from 2nd enclave\n");
-    result = generate_encrypted_message(
-        enclave_b, &ret, &encrypted_message, &encrypted_message_size);
+    result = generate_encrypted_message(enclave_b, &ret, &encrypted_message);
     if ((result != OE_OK) || (ret != 0))
     {
         printf(
@@ -257,8 +240,7 @@ int main(int argc, const char* argv[])
     }
 
     printf("Sending encrypted message to 1st enclave=====\n");
-    result = process_encrypted_message(
-        enclave_a, &ret, encrypted_message, encrypted_message_size);
+    result = process_encrypted_message(enclave_a, &ret, &encrypted_message);
     if ((result != OE_OK) || (ret != 0))
     {
         printf(
@@ -273,7 +255,7 @@ int main(int argc, const char* argv[])
 
 exit:
     // Free host memory allocated by the enclave.
-    free(encrypted_message);
+    free(encrypted_message.data);
 
     printf("Host: Terminating enclaves\n");
     if (enclave_a)


### PR DESCRIPTION
Use deep-copy in the attestation sample to get rid of oe_host_malloc

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>