### PR TITLE
Use deep-copy in the data-sealing sample

### DIFF
--- a/samples/data-sealing/README.md
+++ b/samples/data-sealing/README.md
@@ -87,13 +87,24 @@ All three enclaves are almost identical except signed by two different private.p
 
 There are two ECALLs implemented inside each enclave library.
 
+#### shared data structure
+
+```c
+typedef struct _data_t
+{
+    uint8_t* data;
+    size_t size;
+} data_t;
+```
+The structure is used by the ECALLs to pass deep-copied buffer.
+
 #### seal_data
 
 ```c
 int seal_data(int sealPolicy, 
               unsigned char* opt_mgs, size_t opt_msg_len, 
-              unsigned char* data, size_t data_size, 
-              sealed_data_t** sealed_data, size_t* sealed_data_size)
+              unsigned char* data, size_t data_size,
+              data_t* sealed_data)
 ```
 
  The enclave allocates the following sealed data structure and fills with iv,encrypted data, and other fields before adding the generated signature to it.
@@ -122,8 +133,7 @@ typedef struct _sealed_data_t
 #### unseal_data
 
 ```c
-int unseal_data(sealed_data_t* sealed_data, size_t sealed_data_size,
-                unsigned char** data, size_t* data_size)
+int unseal_data(const data_t* sealed_data, data_t* output_data)
 ```
 
 - `seal_data` calls `oe_get_seal_key` with key info from `sealed_data_t`.

--- a/samples/data-sealing/common/CMakeLists.txt
+++ b/samples/data-sealing/common/CMakeLists.txt
@@ -23,5 +23,6 @@ if (WIN32)
   maybe_build_using_clangw(common)
 endif ()
 
-target_include_directories(common PUBLIC ${CMAKE_SOURCE_DIR}
-                                         ${CMAKE_BINARY_DIR})
+target_include_directories(
+  common PUBLIC ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}
+                ${CMAKE_CURRENT_BINARY_DIR})

--- a/samples/data-sealing/common/dispatcher.cpp
+++ b/samples/data-sealing/common/dispatcher.cpp
@@ -13,15 +13,14 @@ int ecall_dispatcher::seal_data(
     size_t optional_message_size,
     const unsigned char* data,
     size_t data_size,
-    sealed_data_t** sealed_data,
-    size_t* sealed_data_size)
+    data_t* sealed_data)
 {
     oe_result_t ret;
     uint8_t* blob;
     size_t blob_size;
     sealed_data_t* temp_sealed_data;
 
-    if (optional_message_size > sizeof((*sealed_data)->optional_message))
+    if (optional_message_size > sizeof(temp_sealed_data->optional_message))
         return OE_INVALID_PARAMETER;
 
     const oe_seal_setting_t settings[] = {OE_SEAL_SET_POLICY(seal_policy)};
@@ -48,7 +47,7 @@ int ecall_dispatcher::seal_data(
     }
 
     temp_sealed_data =
-        (sealed_data_t*)oe_host_malloc(sizeof(*temp_sealed_data) + blob_size);
+        (sealed_data_t*)malloc(sizeof(*temp_sealed_data) + blob_size);
     if (temp_sealed_data == NULL)
     {
         ret = OE_OUT_OF_MEMORY;
@@ -63,8 +62,8 @@ int ecall_dispatcher::seal_data(
     temp_sealed_data->sealed_blob_size = blob_size;
     memcpy(temp_sealed_data + 1, blob, blob_size);
 
-    *sealed_data = temp_sealed_data;
-    *sealed_data_size = sizeof(*temp_sealed_data) + blob_size;
+    sealed_data->data = (uint8_t*)temp_sealed_data;
+    sealed_data->size = sizeof(*temp_sealed_data) + blob_size;
 
 exit:
     oe_free(blob);
@@ -72,47 +71,43 @@ exit:
 }
 
 int ecall_dispatcher::unseal_data(
-    const sealed_data_t* sealed_data,
-    size_t sealed_data_size,
-    unsigned char** data,
-    size_t* data_size)
+    const data_t* sealed_data,
+    data_t* output_data)
 {
+    sealed_data_t* unwrapped_sealed_data;
+    size_t temp_data_size;
     uint8_t* temp_data;
 
-    if (sealed_data_size !=
-        sealed_data->sealed_blob_size + sizeof(*sealed_data))
+    unwrapped_sealed_data = (sealed_data_t*)sealed_data->data;
+
+    if (sealed_data->size != unwrapped_sealed_data->sealed_blob_size +
+                                 sizeof(*unwrapped_sealed_data))
     {
         TRACE_ENCLAVE(
             "Seal data does not match the seal data size. Expected %zd, got: "
             "%zd",
-            sealed_data->sealed_blob_size + sizeof(*sealed_data),
-            sealed_data_size);
+            unwrapped_sealed_data->sealed_blob_size +
+                sizeof(*unwrapped_sealed_data),
+            sealed_data->size);
         return ERROR_INVALID_PARAMETER;
     }
 
     int ret = (int)oe_unseal(
-        (const uint8_t*)(sealed_data + 1),
-        sealed_data->sealed_blob_size,
-        sealed_data->optional_message,
-        strlen((char*)sealed_data->optional_message),
+        (const uint8_t*)(unwrapped_sealed_data + 1),
+        unwrapped_sealed_data->sealed_blob_size,
+        unwrapped_sealed_data->optional_message,
+        strlen((char*)unwrapped_sealed_data->optional_message),
         &temp_data,
-        data_size);
+        &temp_data_size);
     if (ret != OE_OK)
     {
         TRACE_ENCLAVE("oe_unseal() returns %d\n", ret);
         goto exit;
     }
 
-    *data = (unsigned char*)oe_host_malloc(*data_size);
-    if (*data == NULL)
-    {
-        ret = OE_OUT_OF_MEMORY;
-        goto exit;
-    }
-
-    memcpy(*data, temp_data, *data_size);
+    output_data->data = temp_data;
+    output_data->size = temp_data_size;
 
 exit:
-    oe_free(temp_data);
     return ret;
 }

--- a/samples/data-sealing/common/dispatcher.h
+++ b/samples/data-sealing/common/dispatcher.h
@@ -6,6 +6,7 @@
 #include <openenclave/enclave.h>
 #include <openenclave/seal.h>
 #include <string>
+#include "datasealing_args.h"
 #include "shared.h"
 
 using namespace std;
@@ -26,14 +27,9 @@ class ecall_dispatcher
         size_t opt_msg_len,
         const unsigned char* data,
         size_t data_size,
-        sealed_data_t** sealed_data,
-        size_t* sealed_data_size);
+        data_t* sealed_data);
 
-    int unseal_data(
-        const sealed_data_t* sealed_data,
-        size_t sealed_data_size,
-        unsigned char** data,
-        size_t* data_size);
+    int unseal_data(const data_t* sealed_data, data_t* output_data);
 
   private:
     void dump_data(const char* name, unsigned char* data, size_t data_size);

--- a/samples/data-sealing/datasealing.edl
+++ b/samples/data-sealing/datasealing.edl
@@ -6,19 +6,23 @@ enclave {
     from "platform.edl" import *;
 
     include "common/shared.h"
+
+    struct data_t
+    {
+        [size=size] uint8_t* data;
+        size_t size;
+    };
+
     trusted {
         public int seal_data(int sealPolicy,
                              [in, size = opt_msg_len] unsigned char* opt_mgs,
                              size_t opt_msg_len,
                              [in, size = data_size] unsigned char* data,
                              size_t data_size,
-                             [out] sealed_data_t** sealed_data,
-                             [out] size_t* sealed_data_size);
+                             [out] data_t* sealed_data);
 
-        public int unseal_data([in, size = sealed_data_size] sealed_data_t *sealed_data,
-                               size_t sealed_data_size,
-                               [out] unsigned char** data,
-                               [out] size_t *data_size);
+        public int unseal_data([in] const data_t* sealed_data,
+                               [out] data_t* output_data);
 
     };
 

--- a/samples/data-sealing/enclave_a_v1/ecalls.cpp
+++ b/samples/data-sealing/enclave_a_v1/ecalls.cpp
@@ -17,26 +17,14 @@ int seal_data(
     size_t opt_msg_len,
     unsigned char* data,
     size_t data_size,
-    sealed_data_t** sealed_data,
-    size_t* sealed_data_size)
+    data_t* sealed_data)
 {
     printf("Enclave: seal_data\n");
     return dispatcher.seal_data(
-        sealPolicy,
-        opt_mgs,
-        opt_msg_len,
-        data,
-        data_size,
-        sealed_data,
-        sealed_data_size);
+        sealPolicy, opt_mgs, opt_msg_len, data, data_size, sealed_data);
 }
-int unseal_data(
-    sealed_data_t* sealed_data,
-    size_t sealed_data_size,
-    unsigned char** data,
-    size_t* data_size)
+int unseal_data(const data_t* sealed_data, data_t* output_data)
 {
     printf("Enclave: unseal_data\n");
-    return dispatcher.unseal_data(
-        sealed_data, sealed_data_size, data, data_size);
+    return dispatcher.unseal_data(sealed_data, output_data);
 }

--- a/samples/data-sealing/enclave_a_v2/ecalls.cpp
+++ b/samples/data-sealing/enclave_a_v2/ecalls.cpp
@@ -17,24 +17,12 @@ int seal_data(
     size_t opt_msg_len,
     unsigned char* data,
     size_t data_size,
-    sealed_data_t** sealed_data,
-    size_t* sealed_data_size)
+    data_t* sealed_data)
 {
     return dispatcher.seal_data(
-        sealPolicy,
-        opt_mgs,
-        opt_msg_len,
-        data,
-        data_size,
-        sealed_data,
-        sealed_data_size);
+        sealPolicy, opt_mgs, opt_msg_len, data, data_size, sealed_data);
 }
-int unseal_data(
-    sealed_data_t* sealed_data,
-    size_t sealed_data_size,
-    unsigned char** data,
-    size_t* data_size)
+int unseal_data(const data_t* sealed_data, data_t* output_data)
 {
-    return dispatcher.unseal_data(
-        sealed_data, sealed_data_size, data, data_size);
+    return dispatcher.unseal_data(sealed_data, output_data);
 }

--- a/samples/data-sealing/enclave_b/ecalls.cpp
+++ b/samples/data-sealing/enclave_b/ecalls.cpp
@@ -17,24 +17,12 @@ int seal_data(
     size_t opt_msg_len,
     unsigned char* data,
     size_t data_size,
-    sealed_data_t** sealed_data,
-    size_t* sealed_data_size)
+    data_t* sealed_data)
 {
     return dispatcher.seal_data(
-        sealPolicy,
-        opt_mgs,
-        opt_msg_len,
-        data,
-        data_size,
-        sealed_data,
-        sealed_data_size);
+        sealPolicy, opt_mgs, opt_msg_len, data, data_size, sealed_data);
 }
-int unseal_data(
-    sealed_data_t* sealed_data,
-    size_t sealed_data_size,
-    unsigned char** data,
-    size_t* data_size)
+int unseal_data(const data_t* sealed_data, data_t* output_data)
 {
-    return dispatcher.unseal_data(
-        sealed_data, sealed_data_size, data, data_size);
+    return dispatcher.unseal_data(sealed_data, output_data);
 }


### PR DESCRIPTION
Use deepcopy feature in the data-sealing sample to get rid of oe_host_malloc.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>