### PR TITLE
Use deep-copy in the oe_get_report_v2 ecall

### DIFF
--- a/enclave/sgx/report.c
+++ b/enclave/sgx/report.c
@@ -206,37 +206,25 @@ oe_result_t oe_get_report_v2_ecall(
     uint32_t flags,
     const void* opt_params,
     size_t opt_params_size,
-    uint8_t** report_buffer,
-    size_t* report_buffer_size)
+    oe_report_buffer_t* report)
 {
     oe_result_t result = OE_UNEXPECTED;
-    uint8_t* report = NULL;
-    uint8_t* report_host = NULL;
-    size_t report_size = 0;
 
-    if (!report_buffer || !report_buffer_size)
+    if (!report)
         OE_RAISE(OE_INVALID_PARAMETER);
 
     OE_CHECK(oe_get_report_v2(
-        flags, NULL, 0, opt_params, opt_params_size, &report, &report_size));
-
-    report_host = oe_host_malloc(report_size);
-    if (!report_host)
-        OE_RAISE(OE_OUT_OF_MEMORY);
-
-    OE_CHECK(oe_memcpy_s(report_host, report_size, report, report_size));
-
-    *report_buffer = report_host;
-    *report_buffer_size = report_size;
-    report_host = NULL;
+        flags,
+        NULL,
+        0,
+        opt_params,
+        opt_params_size,
+        &report->buffer,
+        &report->size));
 
     result = OE_OK;
 
 done:
-    if (report)
-        oe_free_report(report);
-    if (report_host)
-        oe_free(report_host);
     return result;
 }
 

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -71,32 +71,24 @@ oe_result_t oe_get_report_v2(
     size_t* report_buffer_size)
 {
     oe_result_t result = OE_UNEXPECTED;
-    uint8_t* report = NULL;
-    size_t report_size = 0;
+    oe_report_buffer_t report = {0};
 
     if (!enclave || !report_buffer || !report_buffer_size)
         OE_RAISE(OE_INVALID_PARAMETER);
 
+    *report_buffer = NULL;
+    *report_buffer_size = 0;
+
     OE_CHECK(oe_get_report_v2_ecall(
-        enclave,
-        &result,
-        flags,
-        opt_params,
-        opt_params_size,
-        &report,
-        &report_size));
+        enclave, &result, flags, opt_params, opt_params_size, &report));
     OE_CHECK(result);
 
-    *report_buffer = report;
-    *report_buffer_size = report_size;
-    report = NULL;
+    *report_buffer = report.buffer;
+    *report_buffer_size = report.size;
 
     result = OE_OK;
 
 done:
-    if (report)
-        oe_free_report(report);
-
     if (result == OE_UNSUPPORTED)
         OE_TRACE_WARNING(
             "SGX remote attestation is not enabled. To enable, please add\n\n"

--- a/host/sgx/report_common.c
+++ b/host/sgx/report_common.c
@@ -17,6 +17,9 @@
 #if !defined(OE_BUILD_HOST_VERIFY)
 #include "core_u.h"
 #include "platform_u.h"
+#else
+/* Forward declaration */
+typedef struct _oe_report_buffer_t oe_report_buffer_t;
 #endif
 
 #include "quote.h"
@@ -32,8 +35,7 @@ oe_result_t _oe_get_report_v2_ecall(
     uint32_t flags,
     const void* opt_params,
     size_t opt_params_size,
-    uint8_t** report_buffer,
-    size_t* report_buffer_size);
+    oe_report_buffer_t* report_buffer);
 oe_result_t _oe_verify_local_report_ecall(
     oe_enclave_t* enclave,
     oe_result_t* _retval,
@@ -60,15 +62,13 @@ oe_result_t _oe_get_report_v2_ecall(
     uint32_t flags,
     const void* opt_params,
     size_t opt_params_size,
-    uint8_t** report_buffer,
-    size_t* report_buffer_size)
+    oe_report_buffer_t* report)
 {
     OE_UNUSED(enclave);
     OE_UNUSED(flags);
     OE_UNUSED(opt_params);
     OE_UNUSED(opt_params_size);
-    OE_UNUSED(report_buffer);
-    OE_UNUSED(report_buffer_size);
+    OE_UNUSED(report);
 
     if (_retval)
         *_retval = OE_UNSUPPORTED;

--- a/include/openenclave/edl/sgx/attestation.edl
+++ b/include/openenclave/edl/sgx/attestation.edl
@@ -29,6 +29,12 @@ enclave
         size_t size;
     };
 
+    struct oe_report_buffer_t
+    {
+        [size=size] uint8_t* buffer;
+        size_t size;
+    };
+
     trusted
     {
         public oe_result_t oe_get_sgx_report_ecall(
@@ -40,8 +46,7 @@ enclave
             uint32_t flags,
             [in, size=opt_params_size] const void* opt_params,
             size_t opt_params_size,
-            [out] uint8_t** report_buffer,
-            [out] size_t* report_buffer_size);
+            [out] oe_report_buffer_t* report);
 
         public oe_result_t oe_verify_local_report_ecall(
             [in, size=report_size] const uint8_t* report,

--- a/tests/edl_opt_out/host/host.c
+++ b/tests/edl_opt_out/host/host.c
@@ -54,7 +54,7 @@ int main(int argc, const char* argv[])
     /* sgx/attestation.edl */
     result = OE_OK;
     OE_TEST(
-        oe_get_report_v2_ecall(NULL, &result, 0, NULL, 0, NULL, NULL) ==
+        oe_get_report_v2_ecall(NULL, &result, 0, NULL, 0, NULL) ==
         OE_UNSUPPORTED);
     OE_TEST(result == OE_UNSUPPORTED);
     result = OE_OK;


### PR DESCRIPTION
Clean-up internal oe_get_report_v2 ecall to get rid of oe_host_malloc.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>