### PR TITLE
Support wrfsbase for SGX enclaves

### DIFF
--- a/tests/sgx/CMakeLists.txt
+++ b/tests/sgx/CMakeLists.txt
@@ -7,3 +7,4 @@ if (UNIX)
 endif ()
 
 add_subdirectory(extra_data)
+add_subdirectory(wrfsbase)

--- a/tests/sgx/wrfsbase/CMakeLists.txt
+++ b/tests/sgx/wrfsbase/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/sgx/wrfsbase wrfsbase_host sgx_wrfsbase_enc 0)
+add_enclave_test(tests/sgx/wrfsbase_negative wrfsbase_host sgx_wrfsbase_enc 1)

--- a/tests/sgx/wrfsbase/enc/CMakeLists.txt
+++ b/tests/sgx/wrfsbase/enc/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../wrfsbase.edl)
+
+add_custom_command(
+  OUTPUT wrfsbase_t.h wrfsbase_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(TARGET sgx_wrfsbase_enc SOURCES enc.c
+            ${CMAKE_CURRENT_BINARY_DIR}/wrfsbase_t.c)
+
+enclave_include_directories(sgx_wrfsbase_enc PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/sgx/wrfsbase/enc/enc.c
+++ b/tests/sgx/wrfsbase/enc/enc.c
@@ -1,0 +1,47 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/print.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/sgx/td.h>
+#include <openenclave/internal/tests.h>
+#include "wrfsbase_t.h"
+
+void enc_wrfsbase(int negative_test)
+{
+    static uint64_t temp_td[256];
+    void* old_fs;
+    void* new_fs;
+    void* recovered_fs;
+
+    temp_td[0] = (uint64_t)temp_td;
+
+    asm volatile("mov %%fs:0, %0" : "=r"(old_fs));
+
+    /* change FS */
+    asm volatile("wrfsbase %0 " : : "a"(temp_td));
+    asm volatile("mov %%fs:0, %0" : "=r"(new_fs));
+
+    if (negative_test)
+    {
+        oe_sgx_td_t* td = oe_sgx_get_td();
+        /* unreachable, dummy test to use td */
+        OE_TEST(td->state == OE_TD_STATE_ABORTED);
+    }
+
+    /* restore FS */
+    asm volatile("wrfsbase %0 " : : "a"(old_fs));
+    asm volatile("mov %%fs:0, %0" : "=r"(recovered_fs));
+
+    OE_TEST(new_fs == temp_td);
+    OE_TEST(recovered_fs == old_fs);
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/sgx/wrfsbase/host/CMakeLists.txt
+++ b/tests/sgx/wrfsbase/host/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../wrfsbase.edl)
+
+add_custom_command(
+  OUTPUT wrfsbase_u.h wrfsbase_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(wrfsbase_host host.c wrfsbase_u.c)
+
+target_include_directories(wrfsbase_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(wrfsbase_host oehost)

--- a/tests/sgx/wrfsbase/host/host.c
+++ b/tests/sgx/wrfsbase/host/host.c
@@ -1,0 +1,50 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include "wrfsbase_u.h"
+
+oe_enclave_t* enclave;
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+
+    if (argc != 3)
+    {
+        fprintf(
+            stderr,
+            "Usage: %s ENCLAVE_PATH testname negative_test(boolean)\n",
+            argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+    int negative_test = atoi(argv[2]);
+
+    if ((result = oe_create_wrfsbase_enclave(
+             argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    if (!negative_test)
+    {
+        result = enc_wrfsbase(enclave, 0);
+        if (result != OE_OK)
+            oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+        OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+    }
+    else
+    {
+        result = enc_wrfsbase(enclave, 1);
+        if (result != OE_ENCLAVE_ABORTING)
+            oe_put_err("oe_call_enclave() failed: result=%u", result);
+    }
+
+    printf("=== passed all tests (wrfsbase)\n");
+
+    return 0;
+}

--- a/tests/sgx/wrfsbase/wrfsbase.edl
+++ b/tests/sgx/wrfsbase/wrfsbase.edl
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+    from "openenclave/edl/sgx/platform.edl" import *;
+
+    trusted {
+        public void enc_wrfsbase(int negative_test);
+    };
+};


### PR DESCRIPTION
This PR adds the support of wrfsbase instruction by emulating the instruction through exception handling. In addition, the PR now allows applications to change FS register at runtime.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>