### PR TITLE
Add missing include to `log.h`

### DIFF
--- a/include/openenclave/log.h
+++ b/include/openenclave/log.h
@@ -4,6 +4,8 @@
 #ifndef _OE_LOG_H
 #define _OE_LOG_H
 
+#include "bits/defs.h"
+
 OE_EXTERNC_BEGIN
 
 typedef enum _oe_log_level


### PR DESCRIPTION
Noticed while building an external app, that including `openenclave/log.h` without `bits/defs.h` first produces an error:

```
/opt/openenclave/include/openenclave/log.h:7:1: error: unknown type name 'OE_EXTERNC_BEGIN'
OE_EXTERNC_BEGIN
^
/opt/openenclave/include/openenclave/log.h:22:1: error: unknown type name 'OE_EXTERNC_END'
OE_EXTERNC_END
```

This include should come from `log.h`, not rely on external include order.