### PR TITLE
Internal support of extra data for SGX enclaves

### DIFF
--- a/include/openenclave/internal/load.h
+++ b/include/openenclave/internal/load.h
@@ -111,7 +111,10 @@ struct _oe_enclave_image
         oe_enclave_t* enclave,
         uint64_t* vaddr);
 
-    oe_result_t (*sgx_patch)(oe_enclave_image_t* image, size_t enclave_size);
+    oe_result_t (*sgx_patch)(
+        oe_enclave_image_t* image,
+        size_t enclave_size,
+        size_t extra_data_size);
 
     oe_result_t (*sgx_get_debug_modules)(
         oe_enclave_image_t* image,

--- a/include/openenclave/internal/sgx/extradata.h
+++ b/include/openenclave/internal/sgx/extradata.h
@@ -1,0 +1,59 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_INTERNAL_SGX_EXTRADATA_H
+#define _OE_INTERNAL_SGX_EXTRADATA_H
+
+#include <openenclave/bits/defs.h>
+#include <openenclave/bits/result.h>
+#include <openenclave/bits/types.h>
+#include <openenclave/internal/sgxcreate.h>
+
+OE_EXTERNC_BEGIN
+
+#define OE_LOAD_EXTRA_ENCLAVE_DATA_HOOK_ARG_MAGIC 0x793d33e0efb446d0
+
+typedef struct oe_load_extra_enclave_data_hook_arg
+{
+    uint64_t magic;
+    oe_sgx_load_context_t* sgx_load_context;
+    uint64_t enclave_base;
+    uint64_t enclave_start;
+    uint64_t base_vaddr; /* address relative to the enclave start */
+    uint64_t vaddr;      /* address relative to the extra data start */
+} oe_load_extra_enclave_data_hook_arg_t;
+
+/**
+ * May be registered by the host application via
+ * oe_register_load_extra_enclave_data_hook to add additional enclave data pages
+ * immediately before the enclave heap. The hook will be invoked by the loader
+ * twice: In the first time, the loader constructs a dummy **arg** and passes
+ * **baseaddr** as zero, expecting the hook to invoke oe_load_extra_enclave_data
+ * and returns the total size of extra data (will be stored as part of **arg**).
+ * In the second time, the loader constructs the **arg** with necessary
+ * parameters and passes the **baseaddr** as the starting address to which the
+ * extra data will be loaded, expecting the hook to invoke
+ * oe_load_extra_enclave_data to load each extra data page.
+ */
+typedef oe_result_t (*oe_load_extra_enclave_data_hook_t)(
+    oe_load_extra_enclave_data_hook_arg_t* arg,
+    uint64_t baseaddr);
+
+void oe_register_load_extra_enclave_data_hook(
+    oe_load_extra_enclave_data_hook_t hook);
+
+/**
+ * Called by the host application (from oe_load_extra_enclave_data_hook) to add
+ * one page of enclave data. The **vaddr** is relative to the starting address
+ * of the extra data (use 0 for adding the first page).
+ */
+oe_result_t oe_load_extra_enclave_data(
+    oe_load_extra_enclave_data_hook_arg_t* arg,
+    uint64_t vaddr,
+    const void* page,
+    uint64_t flags,
+    bool extend);
+
+OE_EXTERNC_END
+
+#endif /* _OE_INTERNAL_SGX_EXTRADATA_H */

--- a/tests/sgx/CMakeLists.txt
+++ b/tests/sgx/CMakeLists.txt
@@ -5,3 +5,5 @@ if (UNIX)
   add_subdirectory(td_state)
   add_subdirectory(thread_interrupt)
 endif ()
+
+add_subdirectory(extra_data)

--- a/tests/sgx/extra_data/CMakeLists.txt
+++ b/tests/sgx/extra_data/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/sgx/extra_data extra_data_host sgx_extra_data_enc
+                 nozerobase)
+
+# Only test with zero-based feature on Linux
+if (UNIX)
+  add_enclave_test(tests/sgx/extra_data_with_zerobase extra_data_host
+                   sgx_extra_data_zerobase_enc zerobase)
+  set_enclave_tests_properties(tests/sgx/extra_data_with_zerobase PROPERTIES
+                               SKIP_RETURN_CODE 2)
+endif ()

--- a/tests/sgx/extra_data/README.md
+++ b/tests/sgx/extra_data/README.md
@@ -1,0 +1,2 @@
+This test shows how to add an extra page of enclave data (after the enclave
+ELF and before the heap).

--- a/tests/sgx/extra_data/enc/CMakeLists.txt
+++ b/tests/sgx/extra_data/enc/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../extra_data.edl)
+
+add_custom_command(
+  OUTPUT extra_data_t.h extra_data_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(TARGET sgx_extra_data_enc SOURCES enc.c props.c
+            ${CMAKE_CURRENT_BINARY_DIR}/extra_data_t.c)
+
+enclave_include_directories(sgx_extra_data_enc PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})
+
+if (UNIX)
+  add_enclave(TARGET sgx_extra_data_zerobase_enc SOURCES enc.c props_zerobase.c
+              ${CMAKE_CURRENT_BINARY_DIR}/extra_data_t.c)
+
+  enclave_include_directories(sgx_extra_data_zerobase_enc PRIVATE
+                              ${CMAKE_CURRENT_BINARY_DIR})
+endif ()

--- a/tests/sgx/extra_data/enc/enc.c
+++ b/tests/sgx/extra_data/enc/enc.c
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/globals.h>
+#include <openenclave/internal/tests.h>
+#include "extra_data_t.h"
+
+int extra_data_ecall(void)
+{
+    const uint8_t* heap = __oe_get_heap_base();
+    OE_TEST(heap != NULL);
+
+    const uint8_t* page = heap - OE_PAGE_SIZE;
+
+    /* check contents of extra page */
+    for (size_t i = 0; i < OE_PAGE_SIZE; i++)
+    {
+        OE_TEST(page[i] == 0xab);
+    }
+
+    return 0;
+}

--- a/tests/sgx/extra_data/enc/props.c
+++ b/tests/sgx/extra_data/enc/props.c
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    64,   /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/sgx/extra_data/enc/props_zerobase.c
+++ b/tests/sgx/extra_data/enc/props_zerobase.c
@@ -1,0 +1,18 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+
+OE_SET_ENCLAVE_SGX2(
+    1,       /* ProductID */
+    1,       /* SecurityVersion */
+    ({0}),   /* ExtendedProductID */
+    ({0}),   /* FamilyID */
+    true,    /* Debug */
+    true,    /* CapturePFGPExceptions */
+    false,   /* RequireKSS */
+    true,    /* CreateZeroBaseEnclave */
+    0x21000, /* StartAddress */
+    1024,    /* NumHeapPages */
+    1024,    /* NumStackPages */
+    4);      /* NumTCS */

--- a/tests/sgx/extra_data/extra_data.edl
+++ b/tests/sgx/extra_data/extra_data.edl
@@ -1,0 +1,14 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave
+{
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+    from "openenclave/edl/sgx/platform.edl" import *;
+
+    trusted
+    {
+        public int extra_data_ecall();
+    };
+};

--- a/tests/sgx/extra_data/host/CMakeLists.txt
+++ b/tests/sgx/extra_data/host/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../extra_data.edl)
+
+add_custom_command(
+  OUTPUT extra_data_u.h extra_data_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(extra_data_host host.c extra_data_u.c)
+
+target_include_directories(extra_data_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+if (UNIX)
+  # TODO issue #4130: Need to find a way around hard-coding host application base address
+  # on the application CMakeLists.txt.
+  target_link_libraries(extra_data_host oehost -Wl,-Ttext-segment,0x10000000)
+else ()
+  target_link_libraries(extra_data_host oehost)
+endif ()

--- a/tests/sgx/extra_data/host/host.c
+++ b/tests/sgx/extra_data/host/host.c
@@ -1,0 +1,107 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <assert.h>
+#include <malloc.h>
+#include <openenclave/bits/sgx/sgxtypes.h>
+#include <openenclave/corelibc/stdlib.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/sgx/extradata.h>
+#include <openenclave/internal/sgx/tests.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "extra_data_u.h"
+
+#define SKIP_RETURN_CODE 2
+
+static oe_result_t _load_extra_enclave_data_hook(
+    oe_load_extra_enclave_data_hook_arg_t* arg,
+    uint64_t baseaddr)
+{
+    uint64_t flags = 0;
+    uint8_t* page;
+    bool extend;
+
+    page = (uint8_t*)oe_memalign(4096, OE_PAGE_SIZE);
+    OE_TEST(page != NULL);
+
+    memset(page, 0xab, OE_PAGE_SIZE);
+
+    if (baseaddr == 0)
+    {
+        /* called once for measurement */
+        printf("oe_load_extra_enclave_data_hook(1)\n");
+        fflush(stdout);
+    }
+    else
+    {
+        /* called a second time for running enclave */
+        printf("oe_load_extra_enclave_data_hook(2)\n");
+        fflush(stdout);
+    }
+
+    /* add a regular page before the heap */
+    flags |= SGX_SECINFO_REG;
+    flags |= SGX_SECINFO_R;
+    flags |= SGX_SECINFO_W;
+    flags |= SGX_SECINFO_X;
+    extend = true;
+
+    OE_TEST(oe_load_extra_enclave_data(arg, 0, page, flags, extend) == OE_OK);
+
+    return OE_OK;
+}
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t r;
+    oe_enclave_t* enclave = NULL;
+    const oe_enclave_type_t type = OE_ENCLAVE_TYPE_SGX;
+    const uint32_t flags = oe_get_create_flags();
+    int retval;
+    const oe_enclave_setting_t* settings = NULL;
+    uint32_t settings_count = 0;
+
+    if (argc != 3)
+    {
+        fprintf(stderr, "Usage: %s <enclave> [zerobase|nozerobase]\n", argv[0]);
+        return 1;
+    }
+
+    const bool enable_zerobase = strcmp(argv[2], "zerobase") == 0;
+
+    if (enable_zerobase && !oe_has_sgx_quote_provider())
+    {
+        // this test should not run on any platforms where FLC is not supported
+        printf("=== tests skipped when DCAP libraries are not found.\n");
+        return SKIP_RETURN_CODE;
+    }
+
+    if (enable_zerobase && (flags & OE_ENCLAVE_FLAG_SIMULATE))
+    {
+        // zero-based enclaves are not supported in simulation mode
+        printf("=== tests skipped in simulation mode.\n");
+        return SKIP_RETURN_CODE;
+    }
+
+    oe_register_load_extra_enclave_data_hook(_load_extra_enclave_data_hook);
+
+    r = oe_create_extra_data_enclave(
+        argv[1], type, flags, settings, settings_count, &enclave);
+    OE_TEST(r == OE_OK);
+
+    r = extra_data_ecall(enclave, &retval);
+    OE_TEST(r == 0);
+
+    r = oe_terminate_enclave(enclave);
+    OE_TEST(r == OE_OK);
+
+    if (enable_zerobase)
+        printf("=== passed all tests (extra_data_with_zerobase)\n");
+    else
+        printf("=== passed all tests (extra_data)\n");
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds the non-public support for the host to add extra data to the SGX enclaves at load time (require explicitly opt-in). This feature is mainly used by complex applications (e.g., Mystikos) that closely depend on OE to include additional code/data in addition to base enclave image. 

See #3921 for more detail.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>