### PR TITLE
Use if defined against compiler-specific macros to avoid undef warnings

### DIFF
--- a/include/openenclave/bits/properties.h
+++ b/include/openenclave/bits/properties.h
@@ -51,7 +51,7 @@ typedef struct _oe_enclave_properties_header
  * define the OE_SET_ENCLAVE_SGX macro. Only define on platforms that SGX is
  * supported on, otherwise define it to be nothing.
  */
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 #include "sgx/sgxproperties.h"
 #else
 #define OE_SET_ENCLAVE_SGX( \
@@ -63,7 +63,7 @@ typedef struct _oe_enclave_properties_header
     TCS_COUNT)
 #endif
 
-#if __aarch64__
+#ifdef __aarch64__
 #include "optee/opteeproperties.h"
 #else
 #define OE_SET_ENCLAVE_OPTEE( \

--- a/include/openenclave/bits/sgx/sgxtypes.h
+++ b/include/openenclave/bits/sgx/sgxtypes.h
@@ -56,7 +56,7 @@ OE_EXTERNC_BEGIN
 
 #define SGX_UNMASKED_EVENT 128 /* SGX EINIT error code */
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_STATIC_ASSERT(SGX_FLAGS_DEBUG == OE_SGX_FLAGS_DEBUG);
 OE_STATIC_ASSERT(SGX_FLAGS_MODE64BIT == OE_SGX_FLAGS_MODE64BIT);
 #endif
@@ -237,7 +237,7 @@ OE_PACK_END
 
 OE_CHECK_SIZE(sizeof(sgx_sigstruct_t), 1808);
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_CHECK_SIZE(sizeof(sgx_sigstruct_t), OE_SGX_SIGSTRUCT_SIZE);
 #endif
 

--- a/include/openenclave/edger8r/enclave.h
+++ b/include/openenclave/edger8r/enclave.h
@@ -169,7 +169,7 @@ void free(void* buffer);
     OE_EXPORT_CONST oe_ecall_func_t oe_ecalls_table[] = {NULL}; \
     OE_EXPORT_CONST size_t oe_ecalls_table_size = 0
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 /**
  * Get the internal status of the enclave.
  *
@@ -184,7 +184,7 @@ OE_INLINE oe_result_t oe_get_enclave_status()
 #endif
 
 // Define oe_lfence for Spectre mitigation in x86-64 platforms.
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 
 // x86_64 processor.
 #if defined(__clang__) || defined(__ICC) || defined(__INTEL_COMPILER) || \

--- a/include/openenclave/internal/properties.h
+++ b/include/openenclave/internal/properties.h
@@ -6,7 +6,7 @@
 
 #include <openenclave/bits/properties.h>
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 #include "sgx/sgxproperties.h"
 #endif
 

--- a/include/openenclave/internal/report.h
+++ b/include/openenclave/internal/report.h
@@ -8,7 +8,7 @@
 #include <openenclave/bits/types.h>
 #include <openenclave/internal/defs.h>
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 #include <openenclave/bits/sgx/sgxtypes.h>
 #endif
 

--- a/include/openenclave/internal/syscall/declarations.h
+++ b/include/openenclave/internal/syscall/declarations.h
@@ -11,7 +11,7 @@
 // For OE_SYS_ defines.
 // They are just used for asserting that they are equal to the corresponding
 // SYS_ ones.
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 #include <openenclave/internal/syscall/sys/bits/syscall_x86_64.h>
 #elif defined(__aarch64__)
 #include <openenclave/internal/syscall/sys/bits/syscall_aarch64.h>
@@ -137,7 +137,7 @@ OE_EXTERNC_BEGIN
  **/
 
 OE_DECLARE_SYSCALL3_M(SYS_accept);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL2(SYS_access);
 #endif
 OE_DECLARE_SYSCALL3_M(SYS_bind);
@@ -146,21 +146,21 @@ OE_DECLARE_SYSCALL2(SYS_clock_gettime);
 OE_DECLARE_SYSCALL4_M(SYS_clock_nanosleep);
 OE_DECLARE_SYSCALL1_M(SYS_close);
 OE_DECLARE_SYSCALL3_M(SYS_connect);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL2(SYS_creat);
 #endif
 OE_DECLARE_SYSCALL1(SYS_dup);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL2(SYS_dup2);
 #endif
 OE_DECLARE_SYSCALL3(SYS_dup3);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL1(SYS_epoll_create);
 #endif
 OE_DECLARE_SYSCALL1(SYS_epoll_create1);
 OE_DECLARE_SYSCALL4(SYS_epoll_ctl);
 OE_DECLARE_SYSCALL5_M(SYS_epoll_pwait);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL4_M(SYS_epoll_wait);
 #endif
 OE_DECLARE_SYSCALL1(SYS_exit);
@@ -190,7 +190,7 @@ OE_DECLARE_SYSCALL0(SYS_getgid);
 OE_DECLARE_SYSCALL2(SYS_getgroups);
 OE_DECLARE_SYSCALL3_M(SYS_getpeername);
 OE_DECLARE_SYSCALL1(SYS_getpgid);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL0(SYS_getpgrp);
 #endif
 OE_DECLARE_SYSCALL0(SYS_getpid);
@@ -206,7 +206,7 @@ OE_DECLARE_SYSCALL0(SYS_getuid);
 // SYS_ioctl is called with 3 or more args.
 // However OE only uses the first 3 args.
 OE_DECLARE_SYSCALL3_M(SYS_ioctl);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL2(SYS_link);
 #endif
 OE_DECLARE_SYSCALL5(SYS_linkat);
@@ -216,10 +216,10 @@ OE_DECLARE_SYSCALL3(SYS_lseek);
  * lstat is required to compile musl/src/stat/fstatat.c, and hence
  * musl/src/stat/stat.c. SYS_lstat need not be implemented.
  */
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL2(SYS_lstat);
 #endif
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL2(SYS_mkdir);
 #endif
 OE_DECLARE_SYSCALL3(SYS_mkdirat);
@@ -230,13 +230,13 @@ OE_DECLARE_SYSCALL2(SYS_munmap);
 OE_DECLARE_SYSCALL5(SYS_mount);
 OE_DECLARE_SYSCALL2_M(SYS_nanosleep);
 OE_DECLARE_SYSCALL4(SYS_newfstatat);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 // Normally called with 3 args.
 // Called with 2 args in mustl/src/stdio/__fopen_rb_ca.c
 OE_DECLARE_SYSCALL2_M(SYS_open);
 #endif
 OE_DECLARE_SYSCALL2_M(SYS_openat);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL3_M(SYS_poll);
 #endif
 OE_DECLARE_SYSCALL4_M(SYS_ppoll);
@@ -251,16 +251,16 @@ OE_DECLARE_SYSCALL3_M(SYS_read);
 OE_DECLARE_SYSCALL3_M(SYS_readv);
 OE_DECLARE_SYSCALL6(SYS_recvfrom);
 OE_DECLARE_SYSCALL3_M(SYS_recvmsg);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL2(SYS_rename);
 #endif
 OE_DECLARE_SYSCALL4_M(SYS_renameat);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL1(SYS_rmdir);
 #endif
 /* Needed for sysconf. Currently unimplemented. */
 OE_DECLARE_SYSCALL3(SYS_sched_getaffinity);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL5_M(SYS_select);
 #endif
 OE_DECLARE_SYSCALL6(SYS_sendto);
@@ -269,7 +269,7 @@ OE_DECLARE_SYSCALL5_M(SYS_setsockopt);
 OE_DECLARE_SYSCALL2_M(SYS_shutdown);
 OE_DECLARE_SYSCALL3_M(SYS_socket);
 OE_DECLARE_SYSCALL4_M(SYS_socketpair);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL2(SYS_stat);
 #endif
 /*
@@ -285,7 +285,7 @@ OE_DECLARE_SYSCALL4(SYS_wait4);
 OE_DECLARE_SYSCALL3_M(SYS_write);
 OE_DECLARE_SYSCALL3_M(SYS_writev);
 OE_DECLARE_SYSCALL1(SYS_uname);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DECLARE_SYSCALL1(SYS_unlink);
 #endif
 OE_DECLARE_SYSCALL3(SYS_unlinkat);

--- a/include/openenclave/internal/utils.h
+++ b/include/openenclave/internal/utils.h
@@ -141,7 +141,7 @@ OE_INLINE uint64_t StrCode(const char* s, uint64_t n)
 #error "Unsupported platform"
 #endif
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 #define OE_CPU_RELAX() asm volatile("pause" ::: "memory")
 #elif __aarch64__ || _M_ARM64
 /**

--- a/syscall/syscall.c
+++ b/syscall/syscall.c
@@ -44,7 +44,7 @@ OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_accept)
     return oe_accept(sockfd, addr, addrlen);
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL2(SYS_access)
 {
     oe_errno = 0;
@@ -99,7 +99,7 @@ OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_connect)
     return oe_connect(sd, addr, addrlen);
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL2(SYS_creat)
 {
     oe_errno = 0;
@@ -130,7 +130,7 @@ OE_WEAK OE_DEFINE_SYSCALL1(SYS_dup)
     return oe_dup(fd);
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL2(SYS_dup2)
 {
     oe_errno = 0;
@@ -160,7 +160,7 @@ done:
     return ret;
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL1(SYS_epoll_create)
 {
     oe_errno = 0;
@@ -197,7 +197,7 @@ OE_WEAK OE_DEFINE_SYSCALL5_M(SYS_epoll_pwait)
     return oe_epoll_pwait(epfd, events, maxevents, timeout, sigmask);
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL4_M(SYS_epoll_wait)
 {
     oe_errno = 0;
@@ -416,7 +416,7 @@ OE_WEAK OE_DEFINE_SYSCALL1(SYS_getpgid)
     return (long)oe_getpgid(pid);
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL0(SYS_getpgrp)
 {
     oe_errno = 0;
@@ -523,7 +523,7 @@ OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_ioctl)
     return oe_ioctl(fd, request, p1, p2, p3, p4);
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL2(SYS_link)
 {
     oe_errno = 0;
@@ -583,7 +583,7 @@ OE_WEAK OE_WEAK OE_DEFINE_SYSCALL3(SYS_lseek)
     return oe_lseek(fd, off, whence);
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL2(SYS_lstat)
 {
     OE_UNUSED(arg1);
@@ -593,7 +593,7 @@ OE_WEAK OE_DEFINE_SYSCALL2(SYS_lstat)
 }
 #endif
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL2(SYS_mkdir)
 {
     oe_errno = 0;
@@ -669,7 +669,7 @@ done:
     return ret;
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL2_M(SYS_open)
 {
     oe_va_list ap;
@@ -726,7 +726,7 @@ done:
     return ret;
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_poll)
 {
     oe_errno = 0;
@@ -905,7 +905,7 @@ OE_WEAK OE_DEFINE_SYSCALL3_M(SYS_recvmsg)
     return oe_recvmsg(sockfd, (struct oe_msghdr*)buf, flags);
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL2(SYS_rename)
 {
     oe_errno = 0;
@@ -954,7 +954,7 @@ done:
     return ret;
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL1(SYS_rmdir)
 {
     oe_errno = 0;
@@ -972,7 +972,7 @@ OE_WEAK OE_DEFINE_SYSCALL3(SYS_sched_getaffinity)
     return -1;
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL5_M(SYS_select)
 {
     oe_errno = 0;
@@ -1047,7 +1047,7 @@ OE_WEAK OE_DEFINE_SYSCALL4_M(SYS_socketpair)
     return oe_socketpair(domain, type, protocol, sv);
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL2(SYS_stat)
 {
     oe_errno = 0;
@@ -1111,7 +1111,7 @@ OE_WEAK OE_DEFINE_SYSCALL1(SYS_uname)
     return oe_uname(buf);
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_WEAK OE_DEFINE_SYSCALL1(SYS_unlink)
 {
     oe_errno = 0;
@@ -1176,7 +1176,7 @@ static long _syscall(
     switch (number)
     {
         OE_SYSCALL_DISPATCH(SYS_accept, arg1, arg2, arg3);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_access, arg1, arg2);
 #endif
         OE_SYSCALL_DISPATCH(SYS_bind, arg1, arg2, arg3);
@@ -1184,21 +1184,21 @@ static long _syscall(
         OE_SYSCALL_DISPATCH(SYS_close, arg1);
         OE_SYSCALL_DISPATCH(SYS_clock_nanosleep, arg1, arg2, arg3, arg4);
         OE_SYSCALL_DISPATCH(SYS_connect, arg1, arg2, arg3);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_creat, arg1, arg2);
 #endif
         OE_SYSCALL_DISPATCH(SYS_dup, arg1);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_dup2, arg1, arg2);
 #endif
         OE_SYSCALL_DISPATCH(SYS_dup3, arg1, arg2, arg3);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_epoll_create, arg1);
 #endif
         OE_SYSCALL_DISPATCH(SYS_epoll_create1, arg1);
         OE_SYSCALL_DISPATCH(SYS_epoll_ctl, arg1, arg2, arg3, arg4);
         OE_SYSCALL_DISPATCH(SYS_epoll_pwait, arg1, arg2, arg3, arg4, arg5);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_epoll_wait, arg1, arg2, arg3, arg4);
 #endif
         OE_SYSCALL_DISPATCH(SYS_exit, arg1);
@@ -1218,7 +1218,7 @@ static long _syscall(
         OE_SYSCALL_DISPATCH(SYS_getgroups, arg1, arg2);
         OE_SYSCALL_DISPATCH(SYS_getpeername, arg1, arg2, arg3);
         OE_SYSCALL_DISPATCH(SYS_getpgid, arg1);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_getpgrp);
 #endif
         OE_SYSCALL_DISPATCH(SYS_getpid);
@@ -1227,27 +1227,27 @@ static long _syscall(
         OE_SYSCALL_DISPATCH(SYS_getsockopt, arg1, arg2, arg3, arg4, arg5);
         OE_SYSCALL_DISPATCH(SYS_getuid);
         OE_SYSCALL_DISPATCH(SYS_ioctl, arg1, arg2, arg3, arg4, arg5, arg6);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_link, arg1, arg2);
 #endif
         OE_SYSCALL_DISPATCH(SYS_linkat, arg1, arg2, arg3, arg4, arg5);
         OE_SYSCALL_DISPATCH(SYS_listen, arg1, arg2);
         OE_SYSCALL_DISPATCH(SYS_lseek, arg1, arg2, arg3);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_lstat, arg1, arg2);
 #endif
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_mkdir, arg1, arg2);
 #endif
         OE_SYSCALL_DISPATCH(SYS_mkdirat, arg1, arg2, arg3);
         OE_SYSCALL_DISPATCH(SYS_mount, arg1, arg2, arg3, arg4, arg5);
         OE_SYSCALL_DISPATCH(SYS_nanosleep, arg1, arg2);
         OE_SYSCALL_DISPATCH(SYS_newfstatat, arg1, arg2, arg3, arg4);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_open, arg1, arg2, arg3);
 #endif
         OE_SYSCALL_DISPATCH(SYS_openat, arg1, arg2, arg3, arg4);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_poll, arg1, arg2, arg3);
 #endif
         OE_SYSCALL_DISPATCH(SYS_ppoll, arg1, arg2, arg3, arg4);
@@ -1259,14 +1259,14 @@ static long _syscall(
         OE_SYSCALL_DISPATCH(SYS_readv, arg1, arg2, arg3);
         OE_SYSCALL_DISPATCH(SYS_recvfrom, arg1, arg2, arg3, arg4, arg5, arg6);
         OE_SYSCALL_DISPATCH(SYS_recvmsg, arg1, arg2, arg3);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_rename, arg1, arg2);
 #endif
         OE_SYSCALL_DISPATCH(SYS_renameat, arg1, arg2, arg3, arg4, arg5);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_rmdir, arg1);
 #endif
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_select, arg1, arg2, arg3, arg4, arg5);
 #endif
         OE_SYSCALL_DISPATCH(SYS_sendto, arg1, arg2, arg3, arg4, arg5, arg6);
@@ -1275,14 +1275,14 @@ static long _syscall(
         OE_SYSCALL_DISPATCH(SYS_shutdown, arg1, arg2);
         OE_SYSCALL_DISPATCH(SYS_socket, arg1, arg2, arg3);
         OE_SYSCALL_DISPATCH(SYS_socketpair, arg1, arg2, arg3, arg4);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_stat, arg1, arg2);
 #endif
         OE_SYSCALL_DISPATCH(SYS_truncate, arg1, arg2);
         OE_SYSCALL_DISPATCH(SYS_write, arg1, arg2, arg3);
         OE_SYSCALL_DISPATCH(SYS_writev, arg1, arg2, arg3);
         OE_SYSCALL_DISPATCH(SYS_uname, arg1);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_unlink, arg1);
 #endif
         OE_SYSCALL_DISPATCH(SYS_unlinkat, arg1, arg2, arg3);

--- a/tests/c99_compliant/enc/enc.c
+++ b/tests/c99_compliant/enc/enc.c
@@ -14,7 +14,7 @@
 #include <openenclave/bits/report.h>
 #include <openenclave/bits/result.h>
 #include <openenclave/internal/plugin.h>
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 #include <openenclave/bits/sgx/epid.h>
 #include <openenclave/bits/sgx/sgxtypes.h>
 #endif

--- a/tests/crypto/enclave/enc/enc.c
+++ b/tests/crypto/enclave/enc/enc.c
@@ -62,7 +62,7 @@ OE_DEFINE_SYSCALL2_M(SYS_openat)
     return -1;
 }
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 OE_DEFINE_SYSCALL2_M(SYS_open)
 {
     oe_va_list ap;
@@ -161,7 +161,7 @@ static long _syscall_dispatch(
     switch (number)
     {
         OE_SYSCALL_DISPATCH(SYS_openat, arg1, arg2, arg3, arg4);
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
         OE_SYSCALL_DISPATCH(SYS_open, arg1, arg2, arg3);
 #endif
         OE_SYSCALL_DISPATCH(SYS_read, arg1, arg2, arg3);

--- a/tests/edl_opt_out/enc/enc.c
+++ b/tests/edl_opt_out/enc/enc.c
@@ -32,7 +32,7 @@ void enc_edl_opt_out()
     OE_TEST(oe_syscall_getpgid_ocall(NULL, 0) == OE_UNSUPPORTED);
     OE_TEST(oe_syscall_getgroups_ocall(NULL, 0, NULL) == OE_UNSUPPORTED);
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
     /* debug.edl */
     OE_TEST(
         oe_sgx_backtrace_symbols_ocall(NULL, NULL, NULL, 0, NULL, 0, NULL) ==

--- a/tests/edl_opt_out/host/host.c
+++ b/tests/edl_opt_out/host/host.c
@@ -36,7 +36,7 @@ int main(int argc, const char* argv[])
     /* logging.edl */
     OE_TEST(oe_log_init_ecall(NULL, NULL, 0) == OE_UNSUPPORTED);
 
-#if __x86_64__ || _M_X64
+#if defined(__x86_64__) || defined(_M_X64)
 #if defined(_WIN32)
     /*
      * On Windows, explicitly invoking the function so the attestation-related


### PR DESCRIPTION
Direct evaluate a macro could result in `undef` warnings. This PR updates such patterns to check whether the macro is defined.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>