### PR TITLE
Simulating page faults on SGX enclaves in debug mode on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `compiler-rt`. `oelibc` includes LLVM's `compiler-rt-10.0.1`.
 - Update logging function setup API name for SGX Quote Provider plugin to `sgx_ql_set_logging_callback` and mark API name `sgx_ql_set_logging_function` as deprecated.
 - Add new policy type `OE_POLICY_ENDORSEMENTS_BASELINE` for `oe_verify_evidence` API to pass additional parameters to QVL for more advanced quote validation.
+- The CapturePFGPExceptions preference is now supported in SGX1 debug mode on Linux.
+  - When setting CapturePFGPExceptions=1, OE will simulate all the SIGSEGV as #PF by forwarding the host information (faulting address) to in-enclave exception handlers.
+  - Note that this feature is for debug only and there is no guarantee that the simulated behavior works the same as the hardware feature in SGX2.
 
 ## Changed
 - Updated libcxx to version 10.0.1

--- a/enclave/core/sgx/exception.c
+++ b/enclave/core/sgx/exception.c
@@ -6,6 +6,7 @@
 #include <openenclave/internal/cpuid.h>
 #include <openenclave/internal/sgx/td.h>
 #include <openenclave/internal/thread.h>
+#include "../tracee.h"
 #include "context.h"
 #include "cpuid.h"
 #include "init.h"
@@ -474,6 +475,7 @@ void oe_virtual_exception_dispatcher(
     uint64_t* arg_out)
 {
     SSA_Info ssa_info = {0};
+    oe_exception_record_t* oe_exception_record = NULL;
 
     /* Validate the td state, which ensures the function
      * is only invoked by the exception entry code path (see enter.S) */
@@ -491,9 +493,21 @@ void oe_virtual_exception_dispatcher(
         return;
     }
 
-    /* Only keep the host signal for non-nested exceptions */
-    if (td->exception_nesting_level == 1)
+    /* arg_in could be either the value of the host signal when the enclave
+     * opts in the thread interrupt or the host pointer of a
+     * oe_exception_record_t that includes the information of page fault just
+     * occurred (debug mode only). */
+    if (td->exception_nesting_level == 1 && arg_in <= MAX_SIGNAL_NUMBER)
+    {
+        /* Only keep the host signal for non-nested exceptions */
         td->host_signal = arg_in;
+    }
+    else if (
+        is_enclave_debug_allowed() &&
+        oe_is_outside_enclave((void*)arg_in, sizeof(oe_exception_record_t)))
+    {
+        oe_exception_record = (oe_exception_record_t*)arg_in;
+    }
 
     uint64_t gprsgx_offset = (uint64_t)ssa_info.base_address +
                              ssa_info.frame_byte_size - OE_SGX_GPR_BYTE_SIZE;
@@ -531,10 +545,22 @@ void oe_virtual_exception_dispatcher(
     }
     else
     {
-        /* The unknown exception type indicates a host signal request. Validate
-         * the states on the td to ensure that the thread is handling the
-         * host signal */
-        if (!oe_sgx_td_host_signal_registered(td, (int)td->host_signal) ||
+        /* If the enclave is in debug mode and the oe_exception_record
+         * has been set, simulate the page fault based on host-passed
+         * information. This can either happen if the enclave runs with
+         * SGX1 CPUs or set CapturePFGPExceptions=0 on SGX2 CPUs. */
+        if (is_enclave_debug_allowed() && oe_exception_record)
+        {
+            td->exception_code = OE_EXCEPTION_PAGE_FAULT;
+            td->exception_flags |= OE_EXCEPTION_FLAGS_HARDWARE;
+
+            td->faulting_address = oe_exception_record->faulting_address;
+            td->error_code = OE_SGX_PAGE_FAULT_US_FLAG;
+        }
+        /* For the rest of cases, validate the states on the td to ensure that
+         * the thread is handling the host signal */
+        else if (
+            !oe_sgx_td_host_signal_registered(td, (int)td->host_signal) ||
             td->exception_nesting_level != 1 ||
             td->is_handling_host_signal != 1)
         {
@@ -572,8 +598,9 @@ void oe_virtual_exception_dispatcher(
     {
         /* The following codes can only be captured with SGX2 and the
          * MISCSELECT[0] bit is set to 1. */
-        if (td->exception_code == OE_EXCEPTION_PAGE_FAULT ||
-            td->exception_code == OE_EXCEPTION_ACCESS_VIOLATION)
+        if (ssa_gpr->exit_info.as_fields.valid &&
+            (td->exception_code == OE_EXCEPTION_PAGE_FAULT ||
+             td->exception_code == OE_EXCEPTION_ACCESS_VIOLATION))
         {
             sgx_exinfo_t* exinfo =
                 (sgx_exinfo_t*)(gprsgx_offset - OE_SGX_MISC_BYTE_SIZE);

--- a/host/sgx/exception.c
+++ b/host/sgx/exception.c
@@ -17,6 +17,22 @@
 
 oe_enclave_t* oe_query_enclave_instance(void* tcs);
 
+/* The host will forward the #PF information to the enclave when
+ * this variable is set. The enclave runs on SGX1 CPUs will simulate
+ * #PF based on the forwarded information only in debug mode.
+ * By default, the variable is set only when CapturePFGPExceptions=1
+ * on SGX1 CPUs. */
+static volatile int _debug_pf_simulation;
+
+#define LINUX_SIGSEGV 11
+
+void oe_sgx_host_enable_debug_pf_simulation(void);
+
+void oe_sgx_host_enable_debug_pf_simulation(void)
+{
+    _debug_pf_simulation = 1;
+}
+
 /* Platform neutral exception handler */
 uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
 {
@@ -24,6 +40,7 @@ uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
     uint64_t tcs_address = context->rbx;
     uint64_t exit_address = context->rip;
     uint64_t signal_number = context->signal_number;
+    uint64_t faulting_address = context->faulting_address;
 
     // Check if the signal happens inside the enclave.
     if ((exit_address == OE_AEP_ADDRESS) && (exit_code == ENCLU_ERESUME))
@@ -47,13 +64,26 @@ uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
         // Set the flag marks this thread is handling an enclave exception.
         thread_data->flags |= _OE_THREAD_HANDLING_EXCEPTION;
 
+        // Pass the faulting address to allow the enclave to simulate
+        // #PF in debug mode
+        oe_exception_record_t oe_exception_record = {0};
+        oe_exception_record.faulting_address = faulting_address;
+
         // Call into enclave first pass exception handler.
         uint64_t arg_out = 0;
+        uint64_t arg_in = 0;
+
+        /* Only pass the oe_exception_record if the signal number is SIGSEGV
+         * (Linux definition) for #PF simulation. If the signal_number is
+         * neither zero nor SIGSEGV, pass the number for in-enclave thread
+         * interrupt support. For the rest of cases, pass zero value. */
+        if (signal_number == LINUX_SIGSEGV && _debug_pf_simulation)
+            arg_in = (uint64_t)&oe_exception_record;
+        else if (signal_number != 0 && signal_number != LINUX_SIGSEGV)
+            arg_in = signal_number;
+
         oe_result_t result = oe_ecall(
-            enclave,
-            OE_ECALL_VIRTUAL_EXCEPTION_HANDLER,
-            signal_number,
-            &arg_out);
+            enclave, OE_ECALL_VIRTUAL_EXCEPTION_HANDLER, arg_in, &arg_out);
 
         // Reset the flag
         thread_data->flags &= (~_OE_THREAD_HANDLING_EXCEPTION);

--- a/host/sgx/exception.h
+++ b/host/sgx/exception.h
@@ -13,6 +13,7 @@ typedef struct _host_exception_context
     uint64_t rbx;
     uint64_t rip;
     uint64_t signal_number;
+    uint64_t faulting_address;
 } oe_host_exception_context_t;
 
 /* Initialize the exception processing. */

--- a/host/sgx/linux/exception.c
+++ b/host/sgx/linux/exception.c
@@ -53,13 +53,16 @@ static void _host_signal_handler(
     host_context.rax = (uint64_t)context->uc_mcontext.gregs[REG_RAX];
     host_context.rbx = (uint64_t)context->uc_mcontext.gregs[REG_RBX];
     host_context.rip = (uint64_t)context->uc_mcontext.gregs[REG_RIP];
+    /* si_addr (same as CR2) will have lower 12 bits cleared by the
+     * SGX hardware for an enclave faulting access. */
+    host_context.faulting_address = (uint64_t)sig_info->si_addr;
 
     host_context.signal_number = (uint64_t)sig_num;
     for (size_t i = 0; i < DEFAULT_SIGNALS_NUMBER; i++)
     {
-        if (sig_num == default_signals[i])
+        if (sig_num == default_signals[i] && sig_num != SIGSEGV)
         {
-            /* Do not pass the number of default signals */
+            /* Do not pass the number of default signals except for SIGSEGV */
             host_context.signal_number = 0;
             break;
         }

--- a/tests/pf_gp_exceptions/CMakeLists.txt
+++ b/tests/pf_gp_exceptions/CMakeLists.txt
@@ -9,6 +9,10 @@ endif ()
 
 add_enclave_test(tests/pf_gp_exceptions pf_gp_exceptions_host
                  sgx_pf_gp_exceptions_enc_signed)
+set_enclave_tests_properties(tests/pf_gp_exceptions PROPERTIES SKIP_RETURN_CODE
+                             2)
 
 add_enclave_test(tests/pf_gp_exceptions_unsigned pf_gp_exceptions_host
                  sgx_pf_gp_exceptions_enc_unsigned)
+set_enclave_tests_properties(tests/pf_gp_exceptions_unsigned PROPERTIES
+                             SKIP_RETURN_CODE 2)

--- a/tests/pf_gp_exceptions/enc/enc.c
+++ b/tests/pf_gp_exceptions/enc/enc.c
@@ -14,6 +14,8 @@ static uint32_t error_code;
 static uint32_t exception_code;
 static uint64_t bypass_bytes;
 
+bool is_enclave_debug_allowed();
+
 uint64_t test_pfgp_handler(oe_exception_record_t* exception_record)
 {
     if (exception_record->code == OE_EXCEPTION_PAGE_FAULT)
@@ -36,32 +38,101 @@ uint64_t test_pfgp_handler(oe_exception_record_t* exception_record)
     return OE_EXCEPTION_CONTINUE_EXECUTION;
 }
 
-int enc_pf_gp_exceptions()
+int enc_pf_gp_exceptions(int is_misc_region_supported, int is_on_windows)
 {
-    oe_result_t result;
+    /* Skip PF simulation on Windows */
+    if (is_on_windows && !is_misc_region_supported)
+        return 2;
 
-    result = oe_add_vectored_exception_handler(false, test_pfgp_handler);
-    if (result != OE_OK)
+    /* For SGX1 enclaves, the PF simulation is only supported in debug mode */
+    if (!is_misc_region_supported && !is_enclave_debug_allowed())
+        return 2;
+
+    if (oe_add_vectored_exception_handler(false, test_pfgp_handler) != OE_OK)
     {
         return -1;
     }
 
-    /* Trigger #PF */
-    faulting_address = 1;
+    /* Trigger #PF by writing to a read-only enclave code page.
+     * The faulting address within enclave memory range will always have
+     * lower 12 bits cleared on both non-simulation (SGX2) and simulation (SGX1)
+     * cases. */
+    faulting_address = 0;
     bypass_bytes = MOV_INSTRUCTION_BYTES;
-    asm volatile("mov $8, %%r8\n\t"
-                 "mov (%%r8), %%r8" ::
-                     : "r8");
-    OE_TEST(faulting_address == 8);
-    OE_TEST(exception_code == OE_EXCEPTION_PAGE_FAULT);
+    uint64_t code_page = (uint64_t)enc_pf_gp_exceptions;
+    const uint64_t page_size = 0x1000;
+
+    code_page = (code_page + (page_size - 1)) & ~(page_size - 1);
+
+    asm volatile("mov $1, %0" : "=r"(*(uint64_t*)code_page));
+
+    if (is_misc_region_supported)
+    {
+        OE_TEST(faulting_address == code_page);
+        OE_TEST(exception_code == OE_EXCEPTION_PAGE_FAULT);
+    }
+    else
+    {
+        /* faulting_address is passed in by the host */
+        OE_TEST(faulting_address == code_page);
+        OE_TEST(exception_code == OE_EXCEPTION_PAGE_FAULT);
+        OE_TEST(error_code == OE_SGX_PAGE_FAULT_US_FLAG);
+    }
+    oe_host_printf("Test #PF on 0x%lx passed\n", faulting_address);
+
+    /* Trigger #PF by reading to an unmapped address on the host.
+     * The faulting address on the host memory will not have lower 12-bits
+     * cleared in non-simulation case (SGX2). In debug mode (SGX1 with
+     * CapturePFGPExceptions=1), the faulting address will always be
+     * page-aligned (passed by the host). */
+    faulting_address = 0;
+    bypass_bytes = MOV_INSTRUCTION_BYTES;
+    uint64_t unmapped_address = 0x1001;
+    uint64_t unmapped_address_aligned = unmapped_address & ~(page_size - 1);
+
+    asm volatile("mov $1, %0" : "=r"(*(uint64_t*)unmapped_address));
+
+    if (is_misc_region_supported)
+    {
+        /* Expect the address without lower 12-bits cleared */
+        OE_TEST(faulting_address == unmapped_address);
+        OE_TEST(exception_code == OE_EXCEPTION_PAGE_FAULT);
+
+        oe_host_printf(
+            "Test #PF on 0x%lx passed (aligned)\n", unmapped_address);
+    }
+    else
+    {
+        /* faulting_address is passed in by the host, always page-aligned */
+        OE_TEST(faulting_address == unmapped_address_aligned);
+        OE_TEST(exception_code == OE_EXCEPTION_PAGE_FAULT);
+        OE_TEST(error_code == OE_SGX_PAGE_FAULT_US_FLAG);
+
+        oe_host_printf(
+            "Test #PF on 0x%lx passed (unaligned)\n", unmapped_address);
+    }
 
     /* Trigger #GP */
     faulting_address = 1;
     bypass_bytes = LGDT_INSTRUCTION_BYTES;
     asm volatile("lgdt 0x00");
-    /* faulting_address should be cleared */
-    OE_TEST(faulting_address == 0);
-    OE_TEST(exception_code == OE_EXCEPTION_ACCESS_VIOLATION);
+    if (is_misc_region_supported)
+    {
+        /* faulting_address should be cleared */
+        OE_TEST(faulting_address == 0);
+        OE_TEST(exception_code == OE_EXCEPTION_ACCESS_VIOLATION);
+    }
+    else
+    {
+        /* faulting_address is passed in by the host */
+        OE_TEST(faulting_address == 0);
+        /* In debug mode (SGX1 with CapturePFGPExceptions=1),
+         * simulating all the SIGSEGV exceptions (including #GP)
+         * as #PF. */
+        OE_TEST(exception_code == OE_EXCEPTION_PAGE_FAULT);
+        OE_TEST(error_code == OE_SGX_PAGE_FAULT_US_FLAG);
+    }
+    oe_host_printf("Test #GP passed\n");
 
     return 0;
 }

--- a/tests/pf_gp_exceptions/enc/sign.conf
+++ b/tests/pf_gp_exceptions/enc/sign.conf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Enclave settings:
-Debug=1
+Debug=0
 CapturePFGPExceptions=1
 NumHeapPages=1024
 NumStackPages=1024

--- a/tests/pf_gp_exceptions/host/CMakeLists.txt
+++ b/tests/pf_gp_exceptions/host/CMakeLists.txt
@@ -12,6 +12,11 @@ add_custom_command(
 
 add_executable(pf_gp_exceptions_host host.c pf_gp_exceptions_u.c)
 
+string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
+if (BUILD_TYPE_UPPER STREQUAL "DEBUG")
+  target_compile_definitions(pf_gp_exceptions_host PRIVATE DEBUG)
+endif ()
+
 target_include_directories(pf_gp_exceptions_host
                            PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(pf_gp_exceptions_host oehost)

--- a/tests/pf_gp_exceptions/pf_gp_exceptions.edl
+++ b/tests/pf_gp_exceptions/pf_gp_exceptions.edl
@@ -7,6 +7,6 @@ enclave {
     from "openenclave/edl/sgx/platform.edl" import *;
 
     trusted {
-        public int enc_pf_gp_exceptions();
+        public int enc_pf_gp_exceptions(int is_misc_region_supported, int is_on_windows);
     };
 };


### PR DESCRIPTION
This PR upstreams the support of #PF simulation for SGX enclaves in debug mode. With the PR, the enclave application running on SGX1 CPUs can also capture the #PF in exception handlers for debugging purposes. Note that the hardware support of #PF delivery is only available on SGX2 CPUs (by setting CapturePFGPExceptions=1).

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>