### PR TITLE
myst-sync-symbols +  debugger tweaks.

### DIFF
--- a/debugger/gdb-extension/mprotect.py
+++ b/debugger/gdb-extension/mprotect.py
@@ -18,6 +18,7 @@ class MystMprotectBreakpoint(gdb.Breakpoint):
         self.bt_spec = []
         self.breaks = []
         self._welcome()
+        self._disable()
 
     def stop(self):
         # Fetch the addr, len, prot parameters as well as the current thread.

--- a/debugger/oelldb
+++ b/debugger/oelldb
@@ -22,11 +22,11 @@ export PYTHONPATH=$OE_LLDB_PLUGIN_DIR
 export LD_PRELOAD=$OE_LLDB_PTRACE_PATH
 
 # Use latest version of installed lldb.
-for v in "-12" "-11" "-10" "-9" "-8" "-7" ""; do
+for v in "-13" "-12" "-11" "-10" "-9" "-8" ""; do
     if [ -n "$(command -v lldb$v)" ]; then
 	lldb$v -o "command script import lldb_sgx_plugin" "$@"
 	exit "$?"
     fi
 done
-echo "oelldb requires lldb-7 or above."
+echo "oelldb requires lldb-8 or above."
 exit 1


### PR DESCRIPTION
myst-sync-symbols  debugger function can be called to ensure that the symbols for the mystikos-loaded
enclave modules are loaded by the debugger.

Intended usage in rr

   -  checkpoints
      Create checkpoints in rr using the `checkpoint` command.
      To resume execution at a checkpoint do:
      rr) restart <checkpoint-num>
      rr) myst-sync-symbols

   - goto
      Use the `--goto <event-num>` command to directly go to a specific event.
         $ rr replay <bug-id> -d /path/to/myst-gdb --goto <event-num> -M
         ...
         rr) myst-sync-symbols

     The `-M` option causes rr to print event numbers which can be used as
     an indication of location numbers to jump to at various points in execution.

myst-analyze-symbols
command to analyze symbols.

myst-prot is turned off by default.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>