### PR TITLE
Increase the maximum TCS value for SGX enclaves

### DIFF
--- a/include/openenclave/bits/sgx/sgxproperties.h
+++ b/include/openenclave/bits/sgx/sgxproperties.h
@@ -26,7 +26,7 @@ typedef struct _oe_sgx_enclave_image_info_t
 } oe_sgx_enclave_image_info_t;
 
 /* Max number of threads in an enclave supported */
-#define OE_SGX_MAX_TCS 32
+#define OE_SGX_MAX_TCS 1024
 
 // oe_sgx_enclave_properties_t SGX enclave properties derived type
 #define OE_SGX_FLAGS_DEBUG 0x0000000000000002ULL


### PR DESCRIPTION
Increases the value of maximum TCS from 32 to 1000, allowing SGX applications to create more threads.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>