### PR TITLE
Add liboesign.a (internal only)

### DIFF
--- a/tests/tools/oesign/CMakeLists.txt
+++ b/tests/tools/oesign/CMakeLists.txt
@@ -7,6 +7,7 @@ if (BUILD_ENCLAVES)
   add_subdirectory(test-digest)
   add_subdirectory(test-inputs)
   add_subdirectory(test-sign)
+  add_subdirectory(test-lib)
 
   if (NOT WIN32)
     # Windows version of oesign does not use openssl, therefore there is no openssl engine support and

--- a/tests/tools/oesign/test-lib/CMakeLists.txt
+++ b/tests/tools/oesign/test-lib/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_executable(test_oesignlib test-oesignlib.c)
+
+target_link_libraries(test_oesignlib oesignlib oehostmr)
+
+# Exclude the target from build
+# From: https://stackoverflow.com/questions/30155619/expected-build-failure-tests-in-cmake
+set_target_properties(test_oesignlib PROPERTIES EXCLUDE_FROM_ALL TRUE
+                                                EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+
+# Exercise the library linking
+add_test(
+  NAME test_link_oesignlib
+  COMMAND ${CMAKE_COMMAND} --build . --target test_oesignlib --config
+          $<CONFIGURATION>
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/tools/oesign/test-lib/test-oesignlib.c
+++ b/tests/tools/oesign/test-lib/test-oesignlib.c
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <stdio.h>
+
+int oesign(
+    const char* enclave,
+    const char* conffile,
+    const char* keyfile,
+    const char* digest_signature,
+    const char* output_file,
+    const char* x509,
+    const char* engine_id,
+    const char* engine_load_path,
+    const char* key_id);
+
+int main()
+{
+    oesign(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+    return 0;
+}

--- a/tools/oesign/CMakeLists.txt
+++ b/tools/oesign/CMakeLists.txt
@@ -48,3 +48,31 @@ install(
 if (WITH_EEID)
   target_compile_definitions(oesign PRIVATE OE_WITH_EXPERIMENTAL_EEID)
 endif ()
+
+##==============================================================================
+##
+## Build a library out of the oesign sources
+##
+##==============================================================================
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${OE_LIBDIR}/openenclave/host")
+
+add_library(oesignlib ${SOURCES})
+
+target_compile_options(oesignlib PRIVATE -fPIC)
+
+set_target_properties(oesignlib PROPERTIES OUTPUT_NAME oesign)
+
+if (NOT HAVE_GETOPT_LONG)
+  target_include_directories(oesignlib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+endif ()
+
+target_link_libraries(oesignlib PRIVATE oe_includes)
+
+set_property(TARGET oesignlib PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
+
+target_compile_definitions(oesignlib PRIVATE BUILD_LIBRARY)
+
+if (WITH_EEID)
+  target_compile_definitions(oesignlib PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+endif ()

--- a/tools/oesign/main.c
+++ b/tools/oesign/main.c
@@ -578,6 +578,7 @@ int arg_handler(int argc, const char* argv[])
     return ret;
 }
 
+#if !defined(BUILD_LIBRARY)
 int main(int argc, const char* argv[])
 {
     oe_set_err_program_name(argv[0]);
@@ -592,3 +593,4 @@ int main(int argc, const char* argv[])
     ret = arg_handler(argc, argv);
     return ret;
 }
+#endif


### PR DESCRIPTION
This PR adds liboesign.a, which allows developers to embed oesign features into the host application.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>