### PR TITLE
Bypass the FS check in oe_sgx_get_td during exceptions and oe_abort

### DIFF
--- a/enclave/core/sgx/exception.c
+++ b/enclave/core/sgx/exception.c
@@ -308,7 +308,10 @@ int _emulate_illegal_instruction(sgx_ssa_gpr_t* ssa_gpr)
 */
 void oe_real_exception_dispatcher(oe_context_t* oe_context)
 {
-    oe_sgx_td_t* td = oe_sgx_get_td();
+    /* Bypass the FS check given that we cannot except the application
+     * to restore the FS before an exception (if the application has
+     * modified the FS) */
+    oe_sgx_td_t* td = oe_sgx_get_td_no_fs_check();
 
     /* Validate the td state, which ensures the function
      * is only invoked after oe_virtual_exception_dispatcher */

--- a/enclave/core/sgx/init.h
+++ b/enclave/core/sgx/init.h
@@ -8,7 +8,7 @@
 #include "../init_fini.h"
 #include "td.h"
 
-void oe_initialize_enclave();
+void oe_initialize_enclave(oe_sgx_td_t* td);
 
 bool oe_apply_relocations(void);
 

--- a/enclave/core/sgx/tracee.c
+++ b/enclave/core/sgx/tracee.c
@@ -46,3 +46,9 @@ bool is_enclave_debug_allowed()
 done:
     return _is_enclave_debug_allowed == 1 ? true : false;
 }
+
+// Check the cached variable only
+bool is_enclave_debug_allowed_cached()
+{
+    return _is_enclave_debug_allowed == 1 ? true : false;
+}

--- a/enclave/core/tracee.h
+++ b/enclave/core/tracee.h
@@ -5,3 +5,4 @@
 #include <openenclave/log.h>
 
 bool is_enclave_debug_allowed();
+bool is_enclave_debug_allowed_cached();

--- a/include/openenclave/internal/sgx/td.h
+++ b/include/openenclave/internal/sgx/td.h
@@ -230,8 +230,11 @@ OE_STATIC_ASSERT(
     OE_THREAD_SPECIFIC_DATA_SIZE ==
     sizeof(oe_sgx_td_t) - OE_OFFSETOF(oe_sgx_td_t, thread_specific_data));
 
-/* Get the thread data object for the current thread */
-oe_sgx_td_t* oe_sgx_get_td(void);
+/* Get the thread data object for the current thread with FS check */
+oe_sgx_td_t* oe_sgx_get_td();
+
+/* Get the thread data object for the current thread without FS check */
+oe_sgx_td_t* oe_sgx_get_td_no_fs_check();
 
 void oe_sgx_td_clear_states(oe_sgx_td_t* td);
 

--- a/tests/sgx/wrfsbase/enc/enc.c
+++ b/tests/sgx/wrfsbase/enc/enc.c
@@ -8,34 +8,170 @@
 #include <openenclave/internal/tests.h>
 #include "wrfsbase_t.h"
 
-void enc_wrfsbase(int negative_test)
+static void* fs_before_exception;
+
+static void _cpuid(
+    unsigned int leaf,
+    unsigned int subleaf,
+    unsigned int* eax,
+    unsigned int* ebx,
+    unsigned int* ecx,
+    unsigned int* edx)
+{
+    asm volatile("cpuid"
+                 // CPU id instruction returns values in the following registers
+                 : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx)
+                 // __leaf is passed in eax (0) and __subleaf in ecx (2)
+                 : "0"(leaf), "2"(subleaf));
+}
+
+// This function will generate the divide by zero function.
+// The handler will catch this exception and fix it, and continue execute.
+// It will return 0 if success.
+static int _divide_by_zero_exception_function(void)
+{
+    // Making ret, f and d volatile to prevent optimization
+    volatile int ret = 1;
+    volatile float f = 0;
+    volatile double d = 0;
+
+    f = 0.31f;
+    d = 0.32;
+
+    // Using inline assembly for idiv to prevent it being optimized out
+    // completely. Specify edi as the used register to ensure that 32-bit
+    // division is done. 64-bit division generates a 3 byte instruction rather
+    // than 2 bytes.
+    register int edi __asm__("edi") = 0;
+    asm volatile("idiv %1"
+                 : "=a"(ret)
+                 : "r"(edi) // Divisor of 0 is hard-coded
+                 : "%1",
+                   "cc"); // cc indicates that flags will be clobbered by ASM
+
+    // Check if the float registers are recovered correctly after the exception
+    // is handled.
+    if (f < 0.309 || f > 0.321 || d < 0.319 || d > 0.321)
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+static uint64_t _divide_by_zero_handler(oe_exception_record_t* exception_record)
+{
+    void* current_fs;
+
+    asm volatile("mov %%fs:0, %0" : "=r"(current_fs));
+
+    if (current_fs != fs_before_exception)
+        return OE_EXCEPTION_ABORT_EXECUTION;
+
+    if (exception_record->code != OE_EXCEPTION_DIVIDE_BY_ZERO)
+        return OE_EXCEPTION_ABORT_EXECUTION;
+
+    // Skip the idiv instruction - 2 is tied to the size of the idiv instruction
+    // and can change with a different compiler/build. Minimizing this with the
+    // use of the inline assembly for integer division
+    exception_record->context->rip += 2;
+    return OE_EXCEPTION_CONTINUE_EXECUTION;
+}
+
+void enc_wrfsbase(int simulation_mode, int negative_test)
 {
     static uint64_t temp_td[256];
-    void* old_fs;
+    void* original_fs_after_exception;
+    void* original_fs_after_cpuid;
+    void* original_fs;
+    void* new_fs_after_exception;
+    void* new_fs_after_cpuid;
     void* new_fs;
     void* recovered_fs;
 
+    OE_UNUSED(fs_before_exception);
+    OE_UNUSED(original_fs_after_cpuid);
+    OE_UNUSED(original_fs_after_exception);
+    OE_UNUSED(new_fs_after_cpuid);
+    OE_UNUSED(new_fs_after_exception);
+
+    OE_TEST(
+        oe_add_vectored_exception_handler(true, _divide_by_zero_handler) ==
+        OE_OK);
+
     temp_td[0] = (uint64_t)temp_td;
 
-    asm volatile("mov %%fs:0, %0" : "=r"(old_fs));
+    asm volatile("mov %%fs:0, %0" : "=r"(original_fs));
+
+    /* Only test with exceptions in non-simulation mode */
+    if (!simulation_mode)
+    {
+        fs_before_exception = original_fs;
+
+        /* Expect FS is persisted after an exception */
+        OE_TEST(_divide_by_zero_exception_function() == 0);
+
+        asm volatile("mov %%fs:0, %0" : "=r"(original_fs_after_exception));
+
+        /* Expect FS is persisted after CPUID emulation */
+        {
+            uint32_t cpuid_rax = 0;
+            uint32_t ebx = 0;
+            uint32_t ecx = 0;
+            uint32_t edx = 0;
+
+            _cpuid(0, 0, &cpuid_rax, &ebx, &ecx, &edx);
+        }
+
+        asm volatile("mov %%fs:0, %0" : "=r"(original_fs_after_cpuid));
+    }
 
     /* change FS */
     asm volatile("wrfsbase %0 " : : "a"(temp_td));
     asm volatile("mov %%fs:0, %0" : "=r"(new_fs));
 
+    /* Only test with exceptions in non-simulation mode */
+    if (!simulation_mode)
+    {
+        fs_before_exception = new_fs;
+
+        /* Expect FS is persisted after an exception */
+        OE_TEST(_divide_by_zero_exception_function() == 0);
+
+        asm volatile("mov %%fs:0, %0" : "=r"(new_fs_after_exception));
+
+        /* Expect FS is persisted after CPUID emulation */
+        {
+            uint32_t cpuid_rax = 0;
+            uint32_t ebx = 0;
+            uint32_t ecx = 0;
+            uint32_t edx = 0;
+
+            _cpuid(0, 0, &cpuid_rax, &ebx, &ecx, &edx);
+        }
+
+        asm volatile("mov %%fs:0, %0" : "=r"(new_fs_after_cpuid));
+    }
+
     if (negative_test)
     {
-        oe_sgx_td_t* td = oe_sgx_get_td();
-        /* unreachable, dummy test to use td */
-        OE_TEST(td->state == OE_TD_STATE_ABORTED);
+        /* Calling OCALLs will fail if FS is changed */
+        host_dummy();
     }
 
     /* restore FS */
-    asm volatile("wrfsbase %0 " : : "a"(old_fs));
+    asm volatile("wrfsbase %0 " : : "a"(original_fs));
     asm volatile("mov %%fs:0, %0" : "=r"(recovered_fs));
 
+    if (!simulation_mode)
+    {
+        OE_TEST(original_fs_after_exception == original_fs);
+        OE_TEST(original_fs_after_cpuid == original_fs);
+        OE_TEST(new_fs_after_exception == new_fs);
+        OE_TEST(new_fs_after_cpuid == new_fs);
+    }
     OE_TEST(new_fs == temp_td);
-    OE_TEST(recovered_fs == old_fs);
+    OE_TEST(recovered_fs == original_fs);
 }
 
 OE_SET_ENCLAVE_SGX(

--- a/tests/sgx/wrfsbase/host/host.c
+++ b/tests/sgx/wrfsbase/host/host.c
@@ -9,6 +9,10 @@
 
 oe_enclave_t* enclave;
 
+void host_dummy()
+{
+}
+
 int main(int argc, const char* argv[])
 {
     oe_result_t result;
@@ -23,7 +27,11 @@ int main(int argc, const char* argv[])
     }
 
     const uint32_t flags = oe_get_create_flags();
+    int simulation_mode = 0;
     int negative_test = atoi(argv[2]);
+
+    if (flags & OE_ENCLAVE_FLAG_SIMULATE)
+        simulation_mode = 1;
 
     if ((result = oe_create_wrfsbase_enclave(
              argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) != OE_OK)
@@ -31,7 +39,7 @@ int main(int argc, const char* argv[])
 
     if (!negative_test)
     {
-        result = enc_wrfsbase(enclave, 0);
+        result = enc_wrfsbase(enclave, simulation_mode, 0);
         if (result != OE_OK)
             oe_put_err("oe_call_enclave() failed: result=%u", result);
 
@@ -39,7 +47,7 @@ int main(int argc, const char* argv[])
     }
     else
     {
-        result = enc_wrfsbase(enclave, 1);
+        result = enc_wrfsbase(enclave, simulation_mode, 1);
         if (result != OE_ENCLAVE_ABORTING)
             oe_put_err("oe_call_enclave() failed: result=%u", result);
     }

--- a/tests/sgx/wrfsbase/wrfsbase.edl
+++ b/tests/sgx/wrfsbase/wrfsbase.edl
@@ -7,6 +7,10 @@ enclave {
     from "openenclave/edl/sgx/platform.edl" import *;
 
     trusted {
-        public void enc_wrfsbase(int negative_test);
+        public void enc_wrfsbase(int simulation_mode, int negative_test);
+    };
+
+    untrusted {
+        void host_dummy();
     };
 };


### PR DESCRIPTION
#4387 supports the wrfsbase instruction emulation, which allows the enclave to change FS at runtime. In addition, the PR assumes that the application has to manage the FS by itself; i.e., the application needs to restore the FS to OE's default value when the execution returns to OE runtime. If the application does not restore the FS value, the OE runtime will abort the enclave if the internal API `oe_sgx_get_td` detects the FS value mismatch.

This PR makes a few updates based on the following observations:
- It is not necessary to save and restore the FS value on OCALL enter and return because
  - The `oe_sgx_get_td` is called inthe same function: https://github.com/openenclave/openenclave/blob/0357d6ffcf754fe4dec114ba9a8632dab73f0ca9/enclave/core/sgx/calls.c#L768
  If the FS value is changed at this point, the oe_sgx_get_td should have abort the enclave already.
  - Invoking OCALL should be considered as returning to OE runtime, so the application is expected to restore the FS.

- There are currently two places that need to bypass the FS check in oe_sgx_get_td
   - second-stage exception handler: https://github.com/openenclave/openenclave/blob/0357d6ffcf754fe4dec114ba9a8632dab73f0ca9/enclave/core/sgx/exception.c#L311 given that we cannot expect the application to restore the FS before an exception.
   -  oe_abort which be invoked anywhere, including the second-stage exception handler: https://github.com/openenclave/openenclave/blob/0357d6ffcf754fe4dec114ba9a8632dab73f0ca9/enclave/core/sgx/exception.c#L317
  - The PR introduces `oe_sgx_get_td_no_fs_check` that are used by the above two places to bypass the FS check.
  - The PR also updates `oe_abort` so that it can be called by `oe_sgx_get_td` when FS check fails.
  - In addition, the PR introduces `oe_abort_with_td` to replace some `oe_abort` calls that were previously unavailable because of td was not initialized.






Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>