### PR TITLE
Fix fs check in windows simulation mode

### DIFF
--- a/host/sgx/windows/exception.c
+++ b/host/sgx/windows/exception.c
@@ -42,7 +42,8 @@ static LONG WINAPI _handle_simulation_mode_exception(
                 // Check if the exception was due to an incorrect FS value.
                 sgx_tcs_t* sgx_tcs = (sgx_tcs_t*)binding->tcs;
                 uint64_t enclave_fsbase = enclave_start + sgx_tcs->fsbase;
-                if (context->SegFs != enclave_fsbase)
+                void* current_fsbase = oe_get_fs_register_base();
+                if ((uint64_t)current_fsbase != enclave_fsbase)
                 {
                     // Update the FS register and continue execution.
                     oe_set_fs_register_base((void*)enclave_fsbase);


### PR DESCRIPTION
Fix the use of context->SegFs, which is the value of the segment instead of address.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>