### PR TITLE
Add dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Copyright (c) Open Enclave SDK contributors.
-# SPDX-License-Identifier: MIT
+# Licensed under the MIT License.
 #
 # For documentation on the format of this file, see
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Copyright (c) Open Enclave SDK contributors.
+# SPDX-License-Identifier: MIT
+#
+# For documentation on the format of this file, see
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
Dependabot will automatically file a pull request when there is
a newer version of a dependency available. The principle is
that openenclave should always upgrade to use the latest release of
each dependency whenever possible to get bug fixes and security
patches.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>