### PR TITLE
Increase timeout to account for jenkins-trigger.py sleeps

### DIFF
--- a/.jenkins/pipelines/Intel/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Intel/Linux/Jenkinsfile
@@ -43,9 +43,7 @@ pipeline {
         label globalvars.AGENTS_LABELS["ubuntu-nonsgx"]
     }
     options {
-        // Use this to make sure this pipeline does not cause
-        // a bottleneck.
-        timeout(time: 90, unit: 'MINUTES')
+        timeout(time: 240, unit: 'MINUTES')
     }
     stages {
         stage("Jenkins trigger") {


### PR DESCRIPTION
jenkins-trigger.py from Intel will wait up to approximately 3.5 hours: https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/pipelines/job/Intel-Agnostic/

Signed-off-by: Chris Yan <chrisyan@microsoft.com>