### PR TITLE
Tentative update to dependabot to only allow releases of snmalloc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    allow:
+      - dependency-name: "snmalloc"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
Suggested in #4443