### PR TITLE
Fix thread-local alignment issue with lld linker

### DIFF
--- a/enclave/core/sgx/td_basic.c
+++ b/enclave/core/sgx/td_basic.c
@@ -114,7 +114,7 @@ void td_init(oe_sgx_td_t* td)
         oe_sgx_td_set_exception_handler_stack(td, NULL, 0);
         td->exception_handler_stack_bitmask = 0;
 
-        oe_thread_local_init(td);
+        oe_sgx_thread_local_init(td);
     }
 }
 
@@ -138,7 +138,7 @@ void td_clear(oe_sgx_td_t* td)
     // pthread_create_key.
     oe_thread_destruct_specific();
 
-    oe_thread_local_cleanup(td);
+    oe_sgx_thread_local_cleanup(td);
 
     // The call sites and depth are cleaned up after the thread-local storage is
     // cleaned up since thread-local dynamic destructors could make ocalls.

--- a/enclave/core/sgx/threadlocal.h
+++ b/enclave/core/sgx/threadlocal.h
@@ -13,13 +13,18 @@ OE_EXTERNC_BEGIN
  * Initialize the thread-local section for a given thread.
  * This must be called immediately after td itself is initialized.
  */
-oe_result_t oe_thread_local_init(oe_sgx_td_t* td);
+oe_result_t oe_sgx_thread_local_init(oe_sgx_td_t* td);
 
 /**
  * Cleanup the thread-local section for a given thread.
  * This must be called *before* the td itself is cleaned up.
  */
-oe_result_t oe_thread_local_cleanup(oe_sgx_td_t* td);
+oe_result_t oe_sgx_thread_local_cleanup(oe_sgx_td_t* td);
+
+/**
+ * Get starting offset of thread-local section.
+ */
+uint64_t oe_sgx_get_thread_local_start_offset();
 
 OE_EXTERNC_END
 

--- a/host/sgx/loadelf.c
+++ b/host/sgx/loadelf.c
@@ -367,6 +367,24 @@ static oe_result_t _stage_image_segments(
                             ph->p_vaddr);
                     }
                 }
+                else
+                {
+                    // When clang's lld is used, the alignment of tdata section
+                    // could be different from the program header alignment. We
+                    // have not observed such a discrepancy with the GNU ld. It
+                    // has been observed that in the cases of discrepancy, the
+                    // compiler generates code based on the alignment in the
+                    // program header.
+                    if (image->tdata_align != ph->p_align)
+                    {
+                        OE_TRACE_VERBOSE(
+                            "Overriding tdata_align (%d) with alignment from "
+                            "program header (%d).",
+                            image->tdata_align,
+                            ph->p_align);
+                        image->tdata_align = ph->p_align;
+                    }
+                }
                 if (image->tdata_size != ph->p_filesz)
                 {
                     // Always assert on size mismatch.
@@ -377,6 +395,7 @@ static oe_result_t _stage_image_segments(
                         image->tdata_size,
                         ph->p_filesz);
                 }
+
                 break;
             }
             default:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -167,6 +167,7 @@ if (UNIX
     add_subdirectory(thread)
     add_subdirectory(threadcxx)
     add_subdirectory(thread_local)
+    add_subdirectory(thread_local_alignment)
     add_subdirectory(thread_local_large)
     add_subdirectory(thread_local_no_tdata)
     add_subdirectory(VectorException)

--- a/tests/thread_local_alignment/CMakeLists.txt
+++ b/tests/thread_local_alignment/CMakeLists.txt
@@ -1,0 +1,64 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+# Use add_enclave_test to ensure the enclave binaries are copied from the pre-built directory
+# when ADD_WINDOWS_ENCLAVE_TESTS is ON and BUILD_ENCLAVES is OFF.
+add_enclave_test(tests/thread_local_alignment alignment_host alignment_enc_16_8)
+
+add_test(
+  NAME thread_local_alignment_1x
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND host/alignment_host enc/alignment_enc_1_8 enc/alignment_enc_1_16
+          enc/alignment_enc_1_32 enc/alignment_enc_1_64 enc/alignment_enc_1_128)
+
+add_test(
+  NAME thread_local_alignment_2x
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND host/alignment_host enc/alignment_enc_2_8 enc/alignment_enc_2_16
+          enc/alignment_enc_2_32 enc/alignment_enc_2_64 enc/alignment_enc_2_128)
+
+add_test(
+  NAME thread_local_alignment_4x
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND host/alignment_host enc/alignment_enc_4_8 enc/alignment_enc_4_16
+          enc/alignment_enc_4_32 enc/alignment_enc_4_64 enc/alignment_enc_4_128)
+
+add_test(
+  NAME thread_local_alignment_8x
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND host/alignment_host enc/alignment_enc_8_8 enc/alignment_enc_8_16
+          enc/alignment_enc_8_32 enc/alignment_enc_8_64 enc/alignment_enc_8_128)
+
+add_test(
+  NAME thread_local_alignment_16x
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND
+    host/alignment_host enc/alignment_enc_16_8 enc/alignment_enc_16_16
+    enc/alignment_enc_16_32 enc/alignment_enc_16_64 enc/alignment_enc_16_128)
+
+add_test(
+  NAME thread_local_alignment_32x
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND
+    host/alignment_host enc/alignment_enc_32_8 enc/alignment_enc_32_16
+    enc/alignment_enc_32_32 enc/alignment_enc_32_64 enc/alignment_enc_32_128)
+
+add_test(
+  NAME thread_local_alignment_64x
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND
+    host/alignment_host enc/alignment_enc_64_8 enc/alignment_enc_64_16
+    enc/alignment_enc_64_32 enc/alignment_enc_64_64 enc/alignment_enc_64_128)
+
+add_test(
+  NAME thread_local_alignment_128x
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND
+    host/alignment_host enc/alignment_enc_128_8 enc/alignment_enc_128_16
+    enc/alignment_enc_128_32 enc/alignment_enc_128_64 enc/alignment_enc_128_128)

--- a/tests/thread_local_alignment/alignment.edl
+++ b/tests/thread_local_alignment/alignment.edl
@@ -1,0 +1,16 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public void enc_test_alignment();
+    };
+};

--- a/tests/thread_local_alignment/enc/CMakeLists.txt
+++ b/tests/thread_local_alignment/enc/CMakeLists.txt
@@ -1,0 +1,95 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../alignment.edl)
+
+add_custom_command(
+  OUTPUT alignment_t.h alignment_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(USE_LD "")
+if (UNIX)
+  find_program(OE_LLD lld)
+  if (NOT OE_LLD)
+    # Run tests with default linker. May not lock down alignment issue.
+    message(
+      "-- lld not found. thread_local_alignment tests require lld for lockdown alignment issues."
+    )
+  else ()
+    set(USE_LD "-fuse-ld=lld")
+  endif ()
+else ()
+  # On Windows lld is used by default.
+endif ()
+
+macro (alignment_enclave TBSS_ALIGNMENT TDATA_ALIGNMENT)
+  set(ENCLAVE_NAME alignment_enc_${TBSS_ALIGNMENT}_${TDATA_ALIGNMENT})
+  add_enclave(
+    TARGET
+    ${ENCLAVE_NAME}
+    UUID
+    71b0822f-42a3-4543-a97c-ca491f76b82c
+    SOURCES
+    enc.c
+    ${CMAKE_CURRENT_BINARY_DIR}/alignment_t.c)
+
+  enclave_compile_definitions(
+    ${ENCLAVE_NAME} PRIVATE TBSS_ALIGNMENT=${TBSS_ALIGNMENT}
+    TDATA_ALIGNMENT=${TDATA_ALIGNMENT})
+  enclave_include_directories(${ENCLAVE_NAME} PRIVATE
+                              ${CMAKE_CURRENT_BINARY_DIR})
+
+  enclave_link_libraries(${ENCLAVE_NAME} oelibc ${USE_LD})
+  maybe_build_using_clangw(${ENCLAVE_NAME})
+endmacro ()
+
+alignment_enclave(1 8)
+alignment_enclave(1 16)
+alignment_enclave(1 32)
+alignment_enclave(1 64)
+alignment_enclave(1 128)
+
+alignment_enclave(2 8)
+alignment_enclave(2 16)
+alignment_enclave(2 32)
+alignment_enclave(2 64)
+alignment_enclave(2 128)
+
+alignment_enclave(4 8)
+alignment_enclave(4 16)
+alignment_enclave(4 32)
+alignment_enclave(4 64)
+alignment_enclave(4 128)
+
+alignment_enclave(8 8)
+alignment_enclave(8 16)
+alignment_enclave(8 32)
+alignment_enclave(8 64)
+alignment_enclave(8 128)
+
+alignment_enclave(16 8)
+alignment_enclave(16 16)
+alignment_enclave(16 32)
+alignment_enclave(16 64)
+alignment_enclave(16 128)
+
+alignment_enclave(32 8)
+alignment_enclave(32 16)
+alignment_enclave(32 32)
+alignment_enclave(32 64)
+alignment_enclave(32 128)
+
+alignment_enclave(64 8)
+alignment_enclave(64 16)
+alignment_enclave(64 32)
+alignment_enclave(64 64)
+alignment_enclave(64 128)
+
+alignment_enclave(128 8)
+alignment_enclave(128 16)
+alignment_enclave(128 32)
+alignment_enclave(128 64)
+alignment_enclave(128 128)

--- a/tests/thread_local_alignment/enc/enc.c
+++ b/tests/thread_local_alignment/enc/enc.c
@@ -1,0 +1,51 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+
+#include "alignment_t.h"
+
+__attribute__((aligned(TBSS_ALIGNMENT))) __thread uint16_t tbss_var[1];
+
+__attribute__((aligned(TDATA_ALIGNMENT))) __thread uint16_t tdata_var[1] = {
+    12345};
+
+uint64_t oe_sgx_get_thread_local_start_offset();
+
+void enc_test_alignment()
+{
+    volatile uint16_t v1 = tbss_var[0];
+    volatile uint16_t v2 = tdata_var[0];
+    OE_TEST(v1 == 0);
+    OE_TEST(v2 == 12345);
+
+    uint64_t fs;
+    asm volatile("mov %%fs:0, %0" : "=r"(fs));
+    uint64_t off1 = fs - (uint64_t)tbss_var;
+    uint64_t off2 = fs - (uint64_t)tdata_var;
+
+    uint64_t start_offset = oe_sgx_get_thread_local_start_offset();
+    printf(
+        "tbss_var offset = %ld, tdata_var offset = %ld, computed start offset "
+        "= %ld\n",
+        off1,
+        off2,
+        start_offset);
+
+    // Assert that tbss variables follow tdata variables.
+    OE_TEST(start_offset >= off1);
+
+    // Assert that compiler generated offset and the computed offsets are the
+    // same.
+    OE_TEST(start_offset == off2);
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/thread_local_alignment/host/CMakeLists.txt
+++ b/tests/thread_local_alignment/host/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../alignment.edl)
+
+add_custom_command(
+  OUTPUT alignment_u.h alignment_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(alignment_host host.c alignment_u.c)
+
+target_include_directories(alignment_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(alignment_host oehost)

--- a/tests/thread_local_alignment/host/host.c
+++ b/tests/thread_local_alignment/host/host.c
@@ -1,0 +1,50 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+
+#include "alignment_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc < 2)
+    {
+        fprintf(stderr, "Usage: %s enclave1 [enclave2 ...]\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    for (int ii = 1; ii < argc; ++ii)
+    {
+        enclave = NULL;
+        printf("Testing %s\n", argv[ii]);
+        fflush(stdout);
+
+        if ((result = oe_create_alignment_enclave(
+                 argv[ii], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) !=
+            OE_OK)
+            oe_put_err(
+                "oe_create_enclave() failed for %s: result=%u",
+                argv[ii],
+                result);
+
+        result = enc_test_alignment(enclave);
+
+        if (result != OE_OK)
+            oe_put_err("alignment test failed for %s\n", argv[ii]);
+
+        OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+        fflush(stdout);
+    }
+
+    printf("=== passed all tests (thread_local_alignment)\n");
+
+    return 0;
+}


### PR DESCRIPTION
When lld is used to link enclaves (typically in Windows), there is a mismatch
between the alignment values in tdata section and PT.TLS program header.
The compiler generates code based on the alignment value in PT.TLS program header,
whereas OE relies on tdata's alignment. This results in a mismatch between
OE's thread-local template instantation and compiler's expectation.

This issue does not manifest with GNU ld which is default on Linux.
On Windows, where lld is used for enclave, this issue manifests only for
certain combinations of alignment values of tdata and tbss sections, and
for specific enclave binary code. One cannot predict whether given a tbss value and
tdata value, the issue would arise.

The fix is to use PT.TLS alignment for tdata section.

Long term, OE needs to follow the strategy of relying only on PT.TLS program header
as is done by MUSL.

This PR also adds tests locking down correct behavior for various alignment combinations
of tdata and tbss. For, many of the combinations being tried out, the issue is seen
to occur and the fix is validated.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>