### PR TITLE
[attestation] Rename/ move claims to generic or sgx-specific lists accordingly. Cleanup oeutil::dump_claims().

### DIFF
--- a/common/sgx/collateral.c
+++ b/common/sgx/collateral.c
@@ -346,11 +346,6 @@ oe_result_t oe_validate_revocation_list(
             if (der_data_size == 0 || der_data == NULL)
                 OE_RAISE(OE_INVALID_PARAMETER);
 
-            // If CRL buffer has null terminator, need to remove it before
-            // sending the DER data to crypto API for reading.
-            if (sgx_endorsements->items[i].data[der_data_size - 1] == 0)
-                der_data_size -= 1;
-
             // Check if the CRL is composed of only hex digits
             for (size_t l = 0; l < der_data_size; l++)
             {
@@ -378,6 +373,11 @@ oe_result_t oe_validate_revocation_list(
                     "Failed to convert to DER. %s",
                     oe_result_str(result));
             }
+
+            // If CRL buffer has null terminator, need to remove it before
+            // sending the DER data to crypto API for reading.
+            if (der_data[der_data_size - 1] == 0)
+                der_data_size -= 1;
 
             OE_CHECK_MSG(
                 oe_crl_read_der(&crls[j], der_data, der_data_size),

--- a/docs/DesignDocs/RemoteAttestationCollaterals.md
+++ b/docs/DesignDocs/RemoteAttestationCollaterals.md
@@ -473,6 +473,8 @@ Current set of claims definitions:
 | tcb_date                   | oe_datetime_t      | Remote Only   |The date and time when the evidence's TCB level was certified.       |
 | validity_from              | oe_datetime_t      | Remote Only   |Overall datetime from which the evidence and endorsements are valid. |
 | validity_until             | oe_datetime_t      | Remote Only   |Overall datetime at which the evidence and endorsements expire.      |
+| ueid                       | uint8_t[33]        | Remote Only   |Universal Entity Identity (qe_id for SGX).                           |
+| hardware_model             | uint8_t[6]         | Remote Only   |Hardware family/ model identity (fmspc for SGX).                     |
 | sgx_pf_gp_exit_info_enabled| bool               | SGX           |Whether the enclave page fault and general protection exception are reported.|
 | sgx_isv_extended_product_id| uint8_t[16]        | SGX           |Enclave extended production id.                                      |
 | sgx_is_mode64bit           | bool               | SGX           |Whether the enclave is in 64bit mode.                                |
@@ -483,9 +485,6 @@ Current set of claims definitions:
 | sgx_config_svn             | uint16_t           | SGX           |Enclave configuration security version.                              |
 | sgx_isv_family_id          | uint8_t[16]        | SGX           |Enclave family ID.                                                   |
 | sgx_cpu_svn                | uint8_t[16]        | SGX           |Enclave CPU security version from sgx_report_t.                      |
-| sgx_pce_svn                | uint16_t           | SGX Remote    |PCE security version from quote.                                     |
-| sgx_qe_id                  | uint8_t[16]        | SGX Remote    |SGX Quoting Enclave ID, referred as QE_ID in SGX_ECDSA_QuoteGenReference_DCAP_API 3.1.4|
-| sgx_fmspc                  | uint8_t[6]         | SGX Remote    |SGX Family-Model-Stepping-Platform-Custom SKU from PCE certificate.  |
 | sgx_tcb_info               | uint8_t[dynamic]   | SGX Remote    |SGX TCB info in JSON format.                                         |
 | sgx_tcb_issuer_chain       | uint8_t[dynamic]   | SGX Remote    |SGX TCB info issuer certificates chain.                              |
 | sgx_pck_crl                | uint8_t[dynamic]   | SGX Remote    |CRL for SGX PCE certificates.                                        |
@@ -493,6 +492,7 @@ Current set of claims definitions:
 | sgx_crl_issuer_chain       | uint8_t[dynamic]   | SGX Remote    |CRL for SGX issuer chain CA certificates.                            |
 | sgx_qe_id_info             | uint8_t[dynamic]   | SGX Remote    |Quoting Enclave Identity details in JSON format, **noted: this is different from sgx_qe_id**|
 | sgx_qe_id_issuer_chain     | uint8_t[dynamic]   | SGX Remote    |Issuer chain certificates for Quoting Enclave Identity sign certificate.|
+| sgx_pce_svn                | uint16_t[dynamic]  | SGX Remote    |PCE security version from quote.                                     |
 
 
 

--- a/include/openenclave/attestation/sgx/evidence.h
+++ b/include/openenclave/attestation/sgx/evidence.h
@@ -140,7 +140,10 @@ OE_EXTERNC_BEGIN
 #define OE_CLAIM_SGX_CPU_SVN "sgx_cpu_svn"
 #define OE_SGX_REQUIRED_CLAIMS_COUNT 10
 
-// Optional: SQX Quote verification collaterals.
+/*
+ * Optional: SQX Quote data
+ */
+// SQX quote verification collaterals.
 #define OE_CLAIM_SGX_TCB_INFO "sgx_tcb_info"
 #define OE_CLAIM_SGX_TCB_ISSUER_CHAIN "sgx_tcb_issuer_chain"
 #define OE_CLAIM_SGX_PCK_CRL "sgx_pck_crl"
@@ -148,7 +151,10 @@ OE_EXTERNC_BEGIN
 #define OE_CLAIM_SGX_CRL_ISSUER_CHAIN "sgx_crl_issuer_chain"
 #define OE_CLAIM_SGX_QE_ID_INFO "sgx_qe_id_info"
 #define OE_CLAIM_SGX_QE_ID_ISSUER_CHAIN "sgx_qe_id_issuer_chain"
-#define OE_SGX_OPTIONAL_CLAIMS_COUNT 7
+#define OE_SGX_OPTIONAL_CLAIMS_SGX_COLLATERALS_COUNT 7
+// SGX PCESVN.
+#define OE_CLAIM_SGX_PCE_SVN "sgx_pce_svn"
+#define OE_SGX_OPTIONAL_CLAIMS_COUNT 8
 
 // Additional SGX specific claim: for the report data embedded in the SGX quote.
 

--- a/include/openenclave/bits/evidence.h
+++ b/include/openenclave/bits/evidence.h
@@ -38,6 +38,18 @@ OE_EXTERNC_BEGIN
 #define OE_UUID_SIZE 16
 
 /**
+ * The maximum size of UEID in bytes.
+ */
+#define OE_UEID_SIZE 33
+
+/**
+ * UEID types.
+ */
+#define OE_UEID_TYPE_RAND 0x01
+#define OE_UEID_TYPE_IEEE_EUI 0x02
+#define OE_UEID_TYPE_IMEI 0x03
+
+/**
  * Struct containing the definition for an UUID.
  */
 typedef struct _oe_uuid_t
@@ -136,26 +148,21 @@ extern const char* OE_REQUIRED_CLAIMS[OE_REQUIRED_CLAIMS_COUNT];
 #define OE_CLAIM_VALIDITY_UNTIL "validity_until"
 
 /**
- * SGX PCESVN of platform.
+ * Universal entity identity.
  */
-#define OE_CLAIM_SGX_PCE_SVN "sgx_pce_svn"
+#define OE_CLAIM_UEID "ueid"
 
 /**
- * QEID from SGX quote user_data.
+ * Hardware Model.
  */
-#define OE_CLAIM_SGX_QE_ID "sgx_qe_id"
-
-/**
- * FMSPC from SGX TCB info
- */
-#define OE_CLAIM_SGX_FMSPC "sgx_fmspc"
+#define OE_CLAIM_HARDWARE_MODEL "hardware_model"
 
 /**
  * @cond DEV
  *
  */
 
-#define OE_OPTIONAL_CLAIMS_COUNT 7
+#define OE_OPTIONAL_CLAIMS_COUNT 6
 // This array is needed for tests
 extern const char* OE_OPTIONAL_CLAIMS[OE_OPTIONAL_CLAIMS_COUNT];
 

--- a/tests/attestation_plugin/CMakeLists.txt
+++ b/tests/attestation_plugin/CMakeLists.txt
@@ -7,18 +7,14 @@ if (BUILD_ENCLAVES)
   add_subdirectory(enc)
 endif ()
 
-add_enclave_test(
-  tests/attestation_plugin_mbedtls plugin_host plugin_mbedtls_enc
-  ${CMAKE_CURRENT_SOURCE_DIR}/data/evidence
-  ${CMAKE_CURRENT_SOURCE_DIR}/data/endorsements)
+add_enclave_test(tests/attestation_plugin_mbedtls plugin_host
+                 plugin_mbedtls_enc)
 set_enclave_tests_properties(tests/attestation_plugin_mbedtls PROPERTIES
                              SKIP_RETURN_CODE 2)
 
 if (BUILD_OPENSSL)
-  add_enclave_test(
-    tests/attestation_plugin_openssl plugin_host plugin_openssl_enc
-    ${CMAKE_CURRENT_SOURCE_DIR}/data/evidence.txt
-    ${CMAKE_CURRENT_SOURCE_DIR}/data/endorsements.txt)
+  add_enclave_test(tests/attestation_plugin_openssl plugin_host
+                   plugin_openssl_enc)
   set_enclave_tests_properties(tests/attestation_plugin_openssl PROPERTIES
                                SKIP_RETURN_CODE 2)
 endif ()

--- a/tests/attestation_plugin/host/host.c
+++ b/tests/attestation_plugin/host/host.c
@@ -98,13 +98,9 @@ int main(int argc, const char* argv[])
     oe_result_t result;
     oe_enclave_t* enclave = NULL;
 
-    if (argc != 4)
+    if (argc != 2)
     {
-        fprintf(
-            stderr,
-            "Usage: %s ENCLAVE {abspath-to-evidence} "
-            "{abspath-to-endorsements}\n",
-            argv[0]);
+        fprintf(stderr, "Usage: %s ENCLAVE \n", argv[0]);
         exit(1);
     }
 


### PR DESCRIPTION
This is a code cleanup PR. This PR intends to 
1. move/ rename the claims that are returned by OE attestation in accordance with guidelines specified in IETF RAT draft. 
2. cleanup the dump_claims() in oeutil tool such that new claim addition is easier and requires only an update to the claims_format map structure.
