### PR TITLE
Fix bug in powershell formatting scripts when only 1 file is staged

### DIFF
--- a/scripts/format-cmake.ps1
+++ b/scripts/format-cmake.ps1
@@ -65,7 +65,7 @@ foreach ($opt in $args)
 
     { @("-s", "--staged") -contains $_ }
         {
-            $userFiles=(git diff --cached --name-only --diff-filter=ACMR);
+            $userFiles=@(git diff --cached --name-only --diff-filter=ACMR);
             break;
         }
 

--- a/scripts/format-code.ps1
+++ b/scripts/format-code.ps1
@@ -65,7 +65,7 @@ foreach ($opt in $args)
 
     { @("-s", "--staged") -contains $_ }
         {
-            $userFiles=(git diff --cached --name-only --diff-filter=ACMR);
+            $userFiles=@(git diff --cached --name-only --diff-filter=ACMR);
             break;
         }
 


### PR DESCRIPTION
Powershell was hitting an exception converting a value of type "System.String" to type "System.Collections.ArrayList".

For discussion of the fix, see the TechNet discussion at
https://social.technet.microsoft.com/Forums/Lync/en-US/ed6bbd2a-63a9-47d2-b63e-2fc4a2524625/systemcollectionsarraylist-problems-when-populated-with-one-row

Signed-off-by: Dave Thaler <dthaler@microsoft.com>