### PR TITLE
SGX Debugging: Add ocall to log backtrace. Used in oe_abort

### DIFF
--- a/enclave/core/sgx/backtrace.c
+++ b/enclave/core/sgx/backtrace.c
@@ -33,7 +33,7 @@ oe_result_t _oe_sgx_backtrace_symbols_ocall(
     size_t* symbols_buffer_size_out);
 
 /**
- * Make the following OCALL weak to support the system EDL opt-in.
+ * Make the following OCALLs weak to support the system EDL opt-in.
  * When the user does not opt into (import) the EDL, the linker will pick
  * the following default implementation. If the user opts into the EDL,
  * the implemention (which is strong) in the oeedger8r-generated code will be
@@ -61,6 +61,23 @@ oe_result_t _oe_sgx_backtrace_symbols_ocall(
     return OE_UNSUPPORTED;
 }
 OE_WEAK_ALIAS(_oe_sgx_backtrace_symbols_ocall, oe_sgx_backtrace_symbols_ocall);
+
+oe_result_t _oe_sgx_log_backtrace_ocall(
+    oe_result_t* _retval,
+    oe_enclave_t* oe_enclave,
+    const uint64_t* buffer,
+    size_t size)
+{
+    OE_UNUSED(oe_enclave);
+    OE_UNUSED(buffer);
+    OE_UNUSED(size);
+
+    if (_retval)
+        *_retval = OE_UNSUPPORTED;
+
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_sgx_log_backtrace_ocall, oe_sgx_log_backtrace_ocall);
 
 /* Return null if address is outside of the enclave; else return ptr. */
 const void* _check_address(const void* ptr)

--- a/host/sgx/ocalls/debug.c
+++ b/host/sgx/ocalls/debug.c
@@ -8,6 +8,8 @@
 #include <openenclave/internal/safemath.h>
 
 #include "../enclave.h"
+#include "openenclave/internal/trace.h"
+#include "openenclave/log.h"
 #include "platform_u.h"
 
 static char** _backtrace_symbols(
@@ -123,6 +125,42 @@ oe_result_t oe_sgx_backtrace_symbols_ocall(
         symbols_buffer,
         symbols_buffer_size,
         symbols_buffer_size_out));
+
+    result = OE_OK;
+
+done:
+
+    if (strings)
+        free(strings);
+
+    return result;
+}
+
+oe_result_t oe_sgx_log_backtrace_ocall(
+    oe_enclave_t* oe_enclave,
+    const uint64_t* buffer,
+    size_t size)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    char** strings = NULL;
+
+    oe_log(OE_LOG_LEVEL_INFO, "Backtrace:\n");
+
+    /* Reject invalid parameters. */
+    if (!oe_enclave || !buffer || size > OE_INT_MAX)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    /* Convert the addresses into symbol strings. */
+    if (!(strings =
+              _backtrace_symbols(oe_enclave, (void* const*)buffer, (int)size)))
+    {
+        OE_RAISE(OE_FAILURE);
+    }
+
+    for (size_t i = 0; i < size; ++i)
+    {
+        oe_log(OE_LOG_LEVEL_INFO, "%s(): %p\n", strings[i], buffer[i]);
+    }
 
     result = OE_OK;
 

--- a/include/openenclave/edl/sgx/debug.edl
+++ b/include/openenclave/edl/sgx/debug.edl
@@ -29,5 +29,11 @@ enclave
             [out, size=symbols_buffer_size] void* symbols_buffer,
             size_t symbols_buffer_size,
             [out] size_t* symbols_buffer_size_out);
+
+	// Log the given backtrace.
+	oe_result_t oe_sgx_log_backtrace_ocall(
+            [user_check] oe_enclave_t* oe_enclave,
+            [in, count=size] const uint64_t* buffer,
+            size_t size);
     };
 };

--- a/tests/sgx/CMakeLists.txt
+++ b/tests/sgx/CMakeLists.txt
@@ -6,5 +6,6 @@ if (UNIX)
   add_subdirectory(thread_interrupt)
 endif ()
 
+add_subdirectory(backtrace)
 add_subdirectory(extra_data)
 add_subdirectory(wrfsbase)

--- a/tests/sgx/backtrace/CMakeLists.txt
+++ b/tests/sgx/backtrace/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+# Add an enclave test to ensure that the enclave binaries are copied over.
+add_enclave_test(tests/sgx/backtrace-ensure-enclave sgx_backtrace_host
+                 sgx_backtrace_enc)
+
+add_test(
+  NAME tests/sgx/backtrace
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${OE_BASH} -c
+          "OE_LOG_LEVEL=INFO host/sgx_backtrace_host enc/sgx_backtrace_enc")
+
+set_tests_properties(
+  tests/sgx/backtrace
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION
+    "\
+test_print_backtrace.+\
+enc_test.+\
+ecall_enc_test.+\
+oe_handle_call_enclave_function.+\
+oe_abort.+\
+test_print_abort_backtrace.+\
+enc_test.+\
+ecall_enc_test.+\
+oe_handle_call_enclave_function.+\
+")

--- a/tests/sgx/backtrace/backtrace.edl
+++ b/tests/sgx/backtrace/backtrace.edl
@@ -1,0 +1,15 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+    from "openenclave/edl/sgx/attestation.edl" import *;
+    from "openenclave/edl/sgx/cpu.edl" import *;
+    from "openenclave/edl/sgx/thread.edl" import *;
+    from "openenclave/edl/sgx/debug.edl" import *;
+
+    trusted {
+        public void enc_test();
+    };
+};

--- a/tests/sgx/backtrace/enc/CMakeLists.txt
+++ b/tests/sgx/backtrace/enc/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../backtrace.edl)
+
+add_custom_command(
+  OUTPUT backtrace_t.h backtrace_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(TARGET sgx_backtrace_enc SOURCES enc.c
+            ${CMAKE_CURRENT_BINARY_DIR}/backtrace_t.c)
+
+enclave_link_libraries(sgx_backtrace_enc oelibc)
+
+enclave_include_directories(
+  sgx_backtrace_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/sgx/backtrace/enc/enc.c
+++ b/tests/sgx/backtrace/enc/enc.c
@@ -1,0 +1,48 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/tests.h>
+
+#include <execinfo.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "backtrace_t.h"
+
+#define NUM_FRAMES (32)
+
+OE_NEVER_INLINE
+void test_print_backtrace()
+{
+    oe_result_t r;
+    void* buffer[NUM_FRAMES];
+
+    int size = backtrace(buffer, NUM_FRAMES);
+    OE_TEST(size > 0 && size <= NUM_FRAMES);
+
+    OE_TEST(
+        oe_sgx_log_backtrace_ocall(
+            &r, oe_get_enclave(), (uint64_t*)buffer, (size_t)size) == OE_OK);
+    OE_TEST(r == OE_OK);
+}
+
+OE_NEVER_INLINE
+void test_print_abort_backtrace()
+{
+    oe_abort();
+    printf("This call exists to prevent a tail call (jump) to oe_abort");
+}
+
+void enc_test()
+{
+    test_print_backtrace();
+    test_print_abort_backtrace();
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/sgx/backtrace/host/CMakeLists.txt
+++ b/tests/sgx/backtrace/host/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../backtrace.edl)
+
+add_custom_command(
+  OUTPUT backtrace_u.h backtrace_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(sgx_backtrace_host host.c backtrace_u.c)
+
+target_include_directories(
+  sgx_backtrace_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+                             ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(sgx_backtrace_host oehost)

--- a/tests/sgx/backtrace/host/host.c
+++ b/tests/sgx/backtrace/host/host.c
@@ -1,0 +1,37 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include "backtrace_u.h"
+#include "openenclave/bits/result.h"
+
+const char* arg0;
+
+int main(int argc, const char* argv[])
+{
+    arg0 = argv[0];
+    oe_result_t r;
+    oe_enclave_t* enclave = NULL;
+    const oe_enclave_type_t type = OE_ENCLAVE_TYPE_SGX;
+    const uint32_t flags = oe_get_create_flags();
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE\n", argv[0]);
+        exit(1);
+    }
+
+    r = oe_create_backtrace_enclave(argv[1], type, flags, NULL, 0, &enclave);
+    OE_TEST(r == OE_OK);
+
+    OE_TEST(enc_test(enclave) == OE_ENCLAVE_ABORTING);
+
+    r = oe_terminate_enclave(enclave);
+    OE_TEST(r == OE_OK);
+
+    printf("=== passed all tests (%s)\n", argv[0]);
+
+    return 0;
+}


### PR DESCRIPTION
It is a long standing issue that oe_abort does not reveal enough information
about why an enclave is aborting. oe_abort issues are typically found by
running in the debugger. Running within the debugger is not possible in
certain workflows.

To solve this, a new OCALL oe_sgx_log_backtrace is introduced which, when
invoked from within the enclave, will log the current enclave backtrace.
oe_abort makes use of this call to log the backtrace prior to marking the
enclave as aborted. This OCALL does not require enclave memory allocation
and thus oe_abort due to out of memory errors should also be logged
(needs to be validated).

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>