### PR TITLE
Use statically allocated buffer for logging.

### DIFF
--- a/enclave/core/tracee.c
+++ b/enclave/core/tracee.c
@@ -79,6 +79,7 @@ void oe_log_init_ecall(const char* enclave_path, uint32_t log_level)
 
 static void* _enclave_log_context = NULL;
 static oe_enclave_log_callback_t _enclave_log_callback = NULL;
+static char _trace_buffer[OE_LOG_MESSAGE_LEN_MAX];
 
 oe_result_t oe_enclave_log_set_callback(
     void* context,
@@ -99,7 +100,7 @@ done:
     return result;
 }
 
-static oe_result_t oe_log_enclave_message(
+static oe_result_t _log_enclave_message(
     oe_log_level_t level,
     const char* message)
 {
@@ -107,9 +108,6 @@ static oe_result_t oe_log_enclave_message(
 
     if (!message)
         OE_RAISE_NO_TRACE(OE_UNEXPECTED);
-
-    // Take the log file lock.
-    OE_CHECK_NO_TRACE(oe_mutex_lock(&_log_lock));
 
     if (_enclave_log_callback)
     {
@@ -122,17 +120,15 @@ static oe_result_t oe_log_enclave_message(
         if (level > _active_log_level)
         {
             result = OE_OK;
-            goto cleanup;
+            goto done;
         }
 
         if ((result = oe_log_ocall(level, message)) != OE_OK)
-            goto cleanup;
+            goto done;
     }
 
     result = OE_OK;
 
-cleanup:
-    oe_mutex_unlock(&_log_lock);
 done:
     return result;
 }
@@ -144,6 +140,7 @@ oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...)
     int n = 0;
     int bytes_written = 0;
     char* message = NULL;
+    bool locked = false;
 
     // Skip logging for non-debug-allowed enclaves
     if (!is_enclave_debug_allowed())
@@ -159,18 +156,19 @@ oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...)
         goto done;
     }
 
-    if (!(message = oe_malloc(OE_LOG_MESSAGE_LEN_MAX)))
-        OE_RAISE_NO_TRACE(OE_OUT_OF_MEMORY);
+    // Take the log file lock.
+    OE_CHECK_NO_TRACE(oe_mutex_lock(&_log_lock));
+    locked = true;
 
-    bytes_written =
-        oe_snprintf(message, OE_LOG_MESSAGE_LEN_MAX, "%s:", _enclave_filename);
+    bytes_written = oe_snprintf(
+        _trace_buffer, OE_LOG_MESSAGE_LEN_MAX, "%s:", _enclave_filename);
 
     if (bytes_written < 0)
         goto done;
 
     oe_va_start(ap, fmt);
     n = oe_vsnprintf(
-        &message[bytes_written],
+        &_trace_buffer[bytes_written],
         OE_LOG_MESSAGE_LEN_MAX - (size_t)bytes_written,
         fmt,
         ap);
@@ -179,12 +177,11 @@ oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...)
     if (n < 0)
         goto done;
 
-    result = oe_log_enclave_message(level, message);
+    result = _log_enclave_message(level, message);
 
 done:
-
-    if (message)
-        oe_free(message);
+    if (locked)
+        oe_mutex_unlock(&_log_lock);
 
     return result;
 }


### PR DESCRIPTION
This allows logging to be used even when enclave is out of memory

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>