### PR TITLE
Support vDSO for SGX enclaves on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The CapturePFGPExceptions preference is now supported in SGX1 debug mode on Linux.
   - When setting CapturePFGPExceptions=1, OE will simulate all the SIGSEGV as #PF by forwarding the host information (faulting address) to in-enclave exception handlers.
   - Note that this feature is for debug only and there is no guarantee that the simulated behavior works the same as the hardware feature in SGX2.
+- Added the support of using vDSO interfaces for SGX enclaves on Linux to enable synchronous exception handling. The `oehost` library automatically opts into the vDSO interface when it is available (Linux kernel 5.11+).
 
 ## Changed
 - Updated libcxx to version 10.0.1

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -196,10 +196,11 @@ if (OE_SGX AND WIN32)
   # set up the frame pointer.
   add_custom_command(
     OUTPUT enter.obj
-    DEPENDS sgx/enter.c
+    DEPENDS sgx/windows/enter.c
     COMMAND
       clang -c -O2 -fomit-frame-pointer -m64 -I${PROJECT_SOURCE_DIR}/include
-      -I${OE_INCDIR} ${CMAKE_CURRENT_SOURCE_DIR}/sgx/enter.c -o enter.obj)
+      -I${OE_INCDIR} ${CMAKE_CURRENT_SOURCE_DIR}/sgx/windows/enter.c -o
+      enter.obj)
 endif ()
 
 # SGX specific files.
@@ -259,6 +260,20 @@ if (OE_SGX)
 
   # OS specific as well.
   if (UNIX)
+    # Download the sgx.h from Linux github repository. Currently use v5.13 tag.
+    file(
+      DOWNLOAD
+      https://raw.githubusercontent.com/torvalds/linux/v5.13/arch/x86/include/uapi/asm/sgx.h
+      ${CMAKE_CURRENT_BINARY_DIR}/sgx.h
+      EXPECTED_HASH
+        SHA256=4764b8ce858579d99f1b66bb1e5f04ba149a38aea15649fff19f65f8d9113fd0)
+
+    list(APPEND PLATFORM_SDK_ONLY_SRC sgx/linux/vdso.c)
+
+    set_source_files_properties(
+      oehost sgx/linux/vdso.c PROPERTIES COMPILE_FLAGS
+                                         "-O2 -fno-omit-frame-pointer")
+
     list(APPEND PLATFORM_HOST_ONLY_SRC sgx/linux/sgxquoteproviderloader.c
          sgx/linux/sgxquoteexloader.c)
 
@@ -266,7 +281,7 @@ if (OE_SGX)
       APPEND
       PLATFORM_SDK_ONLY_SRC
       sgx/linux/aep.S
-      sgx/enter.c
+      sgx/linux/enter.c
       sgx/linux/exception.c
       sgx/linux/sgxioctl.c
       sgx/linux/switchless.c
@@ -284,6 +299,7 @@ if (OE_SGX)
       sgx/windows/exception.c
       sgx/windows/switchless.c
       sgx/windows/sgxquoteexloader.c
+      sgx/windows/vdso_stub.c
       sgx/windows/xstate.c)
   endif ()
 
@@ -354,10 +370,10 @@ target_link_libraries(oehost PUBLIC oe_includes)
 
 if (OE_SGX)
   target_include_directories(
-    oehost PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include)
+    oehost PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include
+                   ${CMAKE_CURRENT_BINARY_DIR})
   target_include_directories(
     oehostverify PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include)
-
 endif ()
 
 if (WIN32)
@@ -373,7 +389,8 @@ if (OE_SGX AND UNIX)
   # It is compiled with -O2 flag to retain the same generated assembly
   # code in both debug and release builds.
   set_source_files_properties(
-    oehost sgx/enter.c PROPERTIES COMPILE_FLAGS "-O2 -fno-omit-frame-pointer")
+    oehost sgx/linux/enter.c PROPERTIES COMPILE_FLAGS
+                                        "-O2 -fno-omit-frame-pointer")
 endif ()
 
 add_dependencies(oehost syscall_untrusted_edl)

--- a/host/sgx/asmdefs.h
+++ b/host/sgx/asmdefs.h
@@ -26,7 +26,7 @@ typedef struct _oe_enclave oe_enclave_t;
 #endif
 
 #ifndef __ASSEMBLER__
-void oe_enter(
+oe_result_t oe_enter(
     void* tcs,
     uint64_t aep,
     uint64_t arg1,
@@ -38,7 +38,7 @@ void oe_enter(
 extern const uint64_t OE_AEP_ADDRESS;
 #endif
 
-#ifndef __ASSEMBLER__
+#if !defined(__ASSEMBLER__) && (_WIN32)
 void oe_enter_sim(
     void* tcs,
     uint64_t aep,

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -122,7 +122,14 @@ static oe_result_t _enter_sim(
     if (arg4)
         *arg4 = 0;
 
+#if defined(__linux__)
+    /* On Linux, use oe_enter (aliased to __morestack) to
+     * conform the GDB contract (see linx/enter.c) */
+    oe_enter(tcs, aep, arg1, arg2, arg3, arg4, enclave);
+#else // _WIN32
     oe_enter_sim(tcs, aep, arg1, arg2, arg3, arg4, enclave);
+#endif
+
     result = OE_OK;
 
 done:
@@ -191,7 +198,7 @@ static oe_result_t _do_eenter(
         }
         else
         {
-            oe_enter(tcs, aep, arg1, arg2, &arg3, &arg4, enclave);
+            OE_CHECK(oe_enter(tcs, aep, arg1, arg2, &arg3, &arg4, enclave));
         }
 
         *code_out = oe_get_code_from_call_arg1(arg3);

--- a/host/sgx/elf.c
+++ b/host/sgx/elf.c
@@ -24,6 +24,12 @@
         goto LABEL;                                            \
     } while (0)
 
+/* forward declaration to resolve dependencies */
+static const char* _get_string_from_shstrtab_internal(
+    const void* ptr,
+    elf64_word_t offset,
+    bool use_header);
+
 int elf64_test_header(const elf64_ehdr_t* ehdr)
 {
     if (!ehdr)
@@ -114,12 +120,37 @@ static elf64_ehdr_t* _get_header(const elf64_t* elf)
     return (elf64_ehdr_t*)elf->data;
 }
 
-static elf64_shdr_t* _get_shdr(const elf64_t* elf, size_t index)
+static size_t _get_size_from_header(const elf64_ehdr_t* header)
 {
-    elf64_ehdr_t* header = _get_header(elf);
+    /* calculate the size of elf image based on the formula:
+     * offset to the section header + section size * number of sections
+     * Note that all the sections have the same size according to the ELF
+     * specification. */
+    return header->e_shoff + (header->e_shentsize * header->e_shnum);
+}
+
+static elf64_shdr_t* _get_shdr_internal(
+    const void* ptr,
+    size_t index,
+    bool use_header)
+{
+    elf64_ehdr_t* header;
+    size_t elf_size = 0;
+
+    if (!use_header)
+    {
+        const elf64_t* elf = (const elf64_t*)ptr;
+        header = _get_header(elf);
+        elf_size = elf->size;
+    }
+    else
+    {
+        header = (elf64_ehdr_t*)ptr;
+        elf_size = _get_size_from_header(header);
+    }
 
     elf64_shdr_t* shdr_start =
-        (elf64_shdr_t*)((uint8_t*)elf->data + header->e_shoff);
+        (elf64_shdr_t*)((uint8_t*)header + header->e_shoff);
 
     if (index >= header->e_shnum)
         return NULL;
@@ -136,7 +167,12 @@ static elf64_shdr_t* _get_shdr(const elf64_t* elf, size_t index)
     if (oe_safe_add_u64(shdr->sh_offset, shdr->sh_size, &end) != OE_OK)
         return NULL;
 
-    return (end <= elf->size) ? shdr : NULL;
+    return (end <= elf_size) ? shdr : NULL;
+}
+
+static elf64_shdr_t* _get_shdr(const elf64_t* elf, size_t index)
+{
+    return _get_shdr_internal((const void*)elf, index, false /* use_header */);
 }
 
 static elf64_phdr_t* _get_phdr(const elf64_t* elf, size_t index)
@@ -164,15 +200,31 @@ static elf64_phdr_t* _get_phdr(const elf64_t* elf, size_t index)
     return (end <= elf->size) ? phdr : NULL;
 }
 
-static void* _get_section(const elf64_t* elf, size_t index)
+static void* _get_section_internal(
+    const void* ptr,
+    size_t index,
+    bool use_header)
 {
-    const elf64_shdr_t* sh = _get_shdr(elf, index);
+    const elf64_shdr_t* sh = _get_shdr_internal(ptr, index, use_header);
     if (sh == NULL)
         return NULL;
 
+    const elf64_ehdr_t* header = NULL;
+
+    if (!use_header)
+        header = _get_header((const elf64_t*)ptr);
+    else
+        header = (const elf64_ehdr_t*)ptr;
+
     return (sh->sh_type == SHT_NULL || sh->sh_type == SHT_NOBITS)
                ? NULL
-               : (uint8_t*)elf->data + sh->sh_offset;
+               : (uint8_t*)header + sh->sh_offset;
+}
+
+static void* _get_section(const elf64_t* elf, size_t index)
+{
+    return _get_section_internal(
+        (const void*)elf, index, false /* use_header */);
 }
 
 void* elf_get_section(const elf64_t* elf, size_t index)
@@ -353,19 +405,32 @@ done:
     return rc;
 }
 
-static size_t _find_shdr(const elf64_t* elf, const char* name)
+static size_t _find_shdr_internal(
+    const void* ptr,
+    const char* name,
+    bool use_header)
 {
+    const elf64_ehdr_t* header = NULL;
+    const elf64_t* elf = NULL;
     size_t result = (size_t)-1;
     size_t i;
 
-    for (i = 0; i < _get_header(elf)->e_shnum; i++)
+    if (!use_header)
     {
-        const elf64_shdr_t* sh = _get_shdr(elf, i);
+        elf = (const elf64_t*)ptr;
+        header = _get_header(elf);
+    }
+    else
+        header = (const elf64_ehdr_t*)ptr;
+
+    for (i = 0; i < header->e_shnum; i++)
+    {
+        const elf64_shdr_t* sh = _get_shdr_internal(ptr, i, use_header);
         if (sh == NULL)
             goto done;
 
-        const char* s = elf64_get_string_from_shstrtab(elf, sh->sh_name);
-
+        const char* s =
+            _get_string_from_shstrtab_internal(ptr, sh->sh_name, use_header);
         if (s && strcmp(name, s) == 0)
         {
             result = i;
@@ -375,6 +440,11 @@ static size_t _find_shdr(const elf64_t* elf, const char* name)
 
 done:
     return result;
+}
+
+static size_t _find_shdr(const elf64_t* elf, const char* name)
+{
+    return _find_shdr_internal((const void*)elf, name, false /* use_header */);
 }
 
 size_t elf_find_shdr(const elf64_t* elf, const char* name)
@@ -391,25 +461,32 @@ static inline bool _is_valid_string_table(const char* table, size_t size)
     return size >= 2 && table[0] == '\0' && table[size - 1] == '\0';
 }
 
-static const char* _get_string_from_section_index(
-    const elf64_t* elf,
+static const char* _get_string_from_section_by_index_internal(
+    const void* ptr,
     size_t index,
-    elf64_word_t offset)
+    elf64_word_t offset,
+    bool use_header)
 {
-    const elf64_shdr_t* sh;
+    const elf64_ehdr_t* header = NULL;
+    const elf64_shdr_t* sh = NULL;
     const char* result = NULL;
 
-    if (index == 0 || index >= _get_header(elf)->e_shnum)
+    if (!use_header)
+        header = _get_header((const elf64_t*)ptr);
+    else
+        header = (const elf64_ehdr_t*)ptr;
+
+    if (index == 0 || index >= header->e_shnum)
         goto done;
 
-    sh = _get_shdr(elf, index);
+    sh = _get_shdr_internal(ptr, index, use_header);
 
     if (sh == NULL || offset >= sh->sh_size)
         goto done;
 
     /* If the section is null, the elf file is corrupted, since only `SHT_NULL`
      * and `SHT_NOBITS` can have nonexistent sections. */
-    result = (const char*)_get_section(elf, index);
+    result = (const char*)_get_section_internal(ptr, index, use_header);
     if (result == NULL)
         goto done;
 
@@ -420,6 +497,42 @@ static const char* _get_string_from_section_index(
 
 done:
     return result;
+}
+
+static const char* _get_string_from_section_by_index(
+    const elf64_t* elf,
+    size_t index,
+    elf64_word_t offset)
+{
+    return _get_string_from_section_by_index_internal(
+        (const void*)elf, index, offset, false /* use_header */);
+}
+
+static const char* _get_string_from_shstrtab_internal(
+    const void* ptr,
+    elf64_word_t offset,
+    bool use_header)
+{
+    size_t index;
+
+    if (!use_header)
+        index = _get_header((const elf64_t*)ptr)->e_shstrndx;
+    else
+        index = ((const elf64_ehdr_t*)ptr)->e_shstrndx;
+
+    return _get_string_from_section_by_index_internal(
+        ptr, index, offset, use_header);
+}
+
+const char* elf64_get_string_from_shstrtab(
+    const elf64_t* elf,
+    elf64_word_t offset)
+{
+    if (!_is_valid_elf64(elf))
+        return NULL;
+
+    return _get_string_from_shstrtab_internal(
+        (const void*)elf, offset, false /* use_header */);
 }
 
 const char* elf64_get_string_from_strtab(
@@ -434,20 +547,7 @@ const char* elf64_get_string_from_strtab(
     if ((index = _find_shdr(elf, ".strtab")) == (size_t)-1)
         return NULL;
 
-    return _get_string_from_section_index(elf, index, offset);
-}
-
-const char* elf64_get_string_from_shstrtab(
-    const elf64_t* elf,
-    elf64_word_t offset)
-{
-    size_t index;
-
-    if (!_is_valid_elf64(elf))
-        return NULL;
-
-    index = _get_header(elf)->e_shstrndx;
-    return _get_string_from_section_index(elf, index, offset);
+    return _get_string_from_section_by_index(elf, index, offset);
 }
 
 int elf64_find_symbol_by_name(
@@ -567,28 +667,40 @@ done:
     return rc;
 }
 
+static const char* _get_string_from_dynstr_internal(
+    const void* ptr,
+    elf64_word_t offset,
+    bool use_header)
+{
+    size_t index;
+
+    if ((index = _find_shdr_internal(ptr, ".dynstr", use_header)) == (size_t)-1)
+        return NULL;
+
+    return _get_string_from_section_by_index_internal(
+        ptr, index, offset, use_header);
+}
+
 const char* elf64_get_string_from_dynstr(
     const elf64_t* elf,
     elf64_word_t offset)
 {
-    size_t index;
-
     if (!_is_valid_elf64(elf))
         return NULL;
 
-    if ((index = _find_shdr(elf, ".dynstr")) == (size_t)-1)
-        return NULL;
-
-    return _get_string_from_section_index(elf, index, offset);
+    return _get_string_from_dynstr_internal(
+        (const void*)elf, offset, false /* use_header */);
 }
 
-int elf64_find_dynamic_symbol_by_name(
-    const elf64_t* elf,
+static int _find_dynamic_symbol_by_name(
+    const void* ptr,
     const char* name,
-    elf64_sym_t* sym)
+    elf64_sym_t* sym,
+    bool use_header)
 {
     int rc = -1;
     size_t index;
+    const elf64_ehdr_t* header = NULL;
     const elf64_shdr_t* sh;
     const elf64_sym_t* symtab;
     size_t n;
@@ -596,18 +708,21 @@ int elf64_find_dynamic_symbol_by_name(
     const char* SECTIONNAME = ".dynsym";
     const elf64_word_t SH_TYPE = SHT_DYNSYM;
 
-    if (!_is_valid_elf64(elf) || !name || !sym)
-        goto done;
-
     /* Find the symbol table section header */
-    if ((index = _find_shdr(elf, SECTIONNAME)) == (size_t)-1)
+    if ((index = _find_shdr_internal(ptr, SECTIONNAME, use_header)) ==
+        (size_t)-1)
         goto done;
 
-    if (index == 0 || index >= _get_header(elf)->e_shnum)
+    if (!use_header)
+        header = _get_header((const elf64_t*)ptr);
+    else
+        header = (const elf64_ehdr_t*)ptr;
+
+    if (index == 0 || index >= header->e_shnum)
         goto done;
 
     /* Set pointer to section header */
-    if (!(sh = _get_shdr(elf, index)))
+    if (!(sh = _get_shdr_internal(ptr, index, use_header)))
         goto done;
 
     /* If this is not a symbol table */
@@ -619,7 +734,8 @@ int elf64_find_dynamic_symbol_by_name(
         goto done;
 
     /* Set pointer to symbol table section */
-    if (!(symtab = (const elf64_sym_t*)_get_section(elf, index)))
+    if (!(symtab = (const elf64_sym_t*)_get_section_internal(
+              ptr, index, use_header)))
         goto done;
 
     /* Calculate number of symbol table entries */
@@ -635,7 +751,8 @@ int elf64_find_dynamic_symbol_by_name(
             continue;
 
         /* If illegal name */
-        if (!(s = elf64_get_string_from_dynstr(elf, p->st_name)))
+        if (!(s = _get_string_from_dynstr_internal(
+                  ptr, p->st_name, use_header)))
             goto done;
 
         /* If found */
@@ -649,6 +766,30 @@ int elf64_find_dynamic_symbol_by_name(
 
 done:
     return rc;
+}
+
+int elf64_find_dynamic_symbol_by_name(
+    const elf64_t* elf,
+    const char* name,
+    elf64_sym_t* sym)
+{
+    if (!_is_valid_elf64(elf) || !name || !sym)
+        return -1;
+
+    return _find_dynamic_symbol_by_name(
+        (const void*)elf, name, sym, false /* use_header */);
+}
+
+int elf64_find_dynamic_symbol_by_name_with_header(
+    const elf64_ehdr_t* header,
+    const char* name,
+    elf64_sym_t* sym)
+{
+    if (elf64_test_header(header) != 0 || !name || !sym)
+        return -1;
+
+    return _find_dynamic_symbol_by_name(
+        (const void*)header, name, sym, true /* use_header */);
 }
 
 int elf64_find_symbol_by_address(

--- a/host/sgx/enclave.h
+++ b/host/sgx/enclave.h
@@ -20,6 +20,27 @@
 #include <windows.h>
 #endif
 
+#define OE_VZEROUPPER              \
+    asm volatile("vzeroupper \n\t" \
+                 :                 \
+                 :                 \
+                 : "ymm0",         \
+                   "ymm1",         \
+                   "ymm2",         \
+                   "ymm3",         \
+                   "ymm4",         \
+                   "ymm5",         \
+                   "ymm6",         \
+                   "ymm7",         \
+                   "ymm8",         \
+                   "ymm9",         \
+                   "ymm10",        \
+                   "ymm11",        \
+                   "ymm12",        \
+                   "ymm13",        \
+                   "ymm14",        \
+                   "ymm15")
+
 typedef struct _enclave_event
 {
 #if defined(__linux__)
@@ -142,5 +163,15 @@ typedef struct _oe_enclave
 
 /* Get the event for the given TCS */
 EnclaveEvent* GetEnclaveEvent(oe_enclave_t* enclave, uint64_t tcs);
+
+/**
+ * Size of ocall buffers passed in ecall_contexts. Large enough for most ocalls.
+ * If an ocall requires more than this size, then the enclave will make an
+ * ocall to allocate the buffer instead of using the ecall_context's buffer.
+ * Note: Currently, quotes are about 10KB.
+ */
+#define OE_DEFAULT_OCALL_BUFFER_SIZE (16 * 1024)
+
+void oe_setup_ecall_context(oe_ecall_context_t* ecall_context);
 
 #endif /* _OE_HOST_ENCLAVE_H */

--- a/host/sgx/linux/enter.c
+++ b/host/sgx/linux/enter.c
@@ -1,0 +1,375 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/bits/sgx/sgxtypes.h>
+#include <openenclave/internal/calls.h>
+#include <openenclave/internal/constants_x64.h>
+#include <openenclave/internal/registers.h>
+#include <openenclave/internal/sgx/ecall_context.h>
+#include "../asmdefs.h"
+#include "../enclave.h"
+#include "../vdso.h"
+#include "../xstate.h"
+
+/* Note: The code was originally made to work on both Linux and Windows.
+ * Given that the diversity increases with the support of vDSO, we make
+ * the copy of the code to each OS, sgx/linux/enter.c and sgx/windows/enter.c,
+ * and apply vDSO-related changes to the former while leave the latter
+ * mostly untouched. Doing so also avoids breaking the debugging contract
+ * on Windows, which requires careful review before we want to merge
+ * the two implementations again. */
+
+// Define a variable with given name and bind it to the register with the
+// corresponding name. This allows manipulating the register as a normal
+// C variable. The variable and hence the register is also assigned the
+// specified value.
+#define OE_DEFINE_REGISTER(regname, value) \
+    register uint64_t regname __asm__(#regname) = (uint64_t)(value)
+
+// The debugger requires a Linux x64 ABI frame pointer for stack walking.
+// Therefore, this file must be compiled with -fno-omit-frame-pointer.
+// Nothing else needs to be done and the macros below are noops.
+#define OE_DEFINE_FRAME_POINTER(r, v) OE_UNUSED(v)
+#define OE_FRAME_POINTER_VALUE 0
+#define OE_FRAME_POINTER
+
+// The following registers are inputs to ENCLU instruction. They are also
+// clobbered and hence are marked as +r.
+#define OE_ENCLU_REGISTERS \
+    "+r"(rax), "+r"(rbx), "+r"(rcx), "+r"(rdi), "+r"(rsi), "+r"(rdx)
+
+// The following registers are clobbered by ENCLU.
+// Only rbp and rsp are preserved on return from ENCLU.
+// The XMM registers are listed as clobbered to signal to the compiler that
+// they need to be preserved when --target=x86_64-msvc-windows and are
+// ignored on Linux builds.
+#define OE_ENCLU_CLOBBERED_REGISTERS                                      \
+    "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15", "xmm6", "xmm7", \
+        "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15"
+
+// Release two registers for the simulation mode, which is required by the
+// inline assembly to save rsp and rbp in memory (used as scratch registers)
+#define OE_SIMULATE_ENCLU_CLOBBERED_REGISTERS                                 \
+    "r10", "r11", "r12", "r13", "r14", "r15", "xmm6", "xmm7", "xmm8", "xmm9", \
+        "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15"
+
+/* Forward declaration */
+oe_result_t _oe_vdso_enter(
+    void* tcs,
+    uint64_t arg1,
+    uint64_t arg2,
+    uint64_t* arg3,
+    uint64_t* arg4,
+    oe_enclave_t* enclave);
+
+// The following function must not be inlined and must have a frame-pointer
+// so that the frame can be manipulated to stitch the ocall stack.
+// This is ensured by compiling this file with -fno-omit-frame-pointer.
+OE_NEVER_INLINE
+int __oe_host_stack_bridge(
+    uint64_t arg1,
+    uint64_t arg2,
+    uint64_t* arg1_out,
+    uint64_t* arg2_out,
+    void* tcs,
+    oe_enclave_t* enclave,
+    oe_ecall_context_t* ecall_context)
+{
+    // Use volatile attribute so that the compiler does not optimize away the
+    // restoration of the stack frame.
+    volatile oe_host_ocall_frame_t *current = NULL, backup;
+    bool debug = enclave->debug;
+    if (debug)
+    {
+        // Fetch pointer to current frame.
+        current = (oe_host_ocall_frame_t*)__builtin_frame_address(0);
+
+        // Back up current frame.
+        backup = *current;
+
+        // Stitch the ocall stack
+        current->return_address = ecall_context->debug_eexit_rip;
+        current->previous_rbp = ecall_context->debug_eexit_rbp;
+    }
+
+    int ret = __oe_dispatch_ocall(arg1, arg2, arg1_out, arg2_out, tcs, enclave);
+
+    if (debug)
+    {
+        // Restore the frame so that this function can return to the caller
+        // correctly. Without the volatile qualifier, the compiler could
+        // optimize this away.
+        *current = backup;
+    }
+
+    return ret;
+}
+/**
+ * Setup the ecall_context.
+ * This function should never be inline so that it can record the
+ * caller's stack frame. The stack frame information is used to stitch
+ * the stack upon an enclave entry when vDSO is used.
+ */
+OE_NEVER_INLINE
+void oe_setup_ecall_context(oe_ecall_context_t* ecall_context)
+{
+    oe_thread_binding_t* binding = oe_get_thread_binding();
+
+    if (binding->ocall_buffer == NULL)
+    {
+        // Lazily allocate buffer for making ocalls. Bound to the tcs.
+        // Will be cleaned up by enclave during termination.
+        binding->ocall_buffer = malloc(OE_DEFAULT_OCALL_BUFFER_SIZE);
+        binding->ocall_buffer_size = OE_DEFAULT_OCALL_BUFFER_SIZE;
+    }
+
+    ecall_context->ocall_buffer = binding->ocall_buffer;
+    ecall_context->ocall_buffer_size = binding->ocall_buffer_size;
+
+    /* Record caller's stack frame if vDSO is used */
+    if (oe_sgx_is_vdso_enabled)
+    {
+        uint64_t* caller_frame = __builtin_frame_address(1);
+        ecall_context->debug_eenter_rbp = caller_frame[0];
+        ecall_context->debug_eenter_rip = caller_frame[1];
+    }
+}
+
+/**
+ * _enter_impl: Executes the ENCLU instruction and transfers control to the
+ * enclave. The function should always be inline to share the same stack
+ * frame as oe_enter.
+ *
+ * The ENCLU instruction has the following contract:
+ * EENTER(RBX=TCS, RCX=AEP, RDX=ECALL_CONTEXT, RDI=ARG1, RSI=ARG2) contract
+ * Input:
+ *       RBX=TCS, RCX=AEP, RDX=ECALL_CONTEXT, RDI=ARG1, RSI=ARG2
+ *       RBP=Current host stack rbp,
+ *       RSP=Current host stack sp.
+ *       All other registers are NOT used/ignored.
+ * Output:
+ *       RDI=ARG1OUT, RSI=ARG2OUT,
+ *       RBP, RBP are preserved.
+ *       All other Registers are clobbered.
+ *
+ * Callee-saved (non-volatile) registers:
+ * As per System V x64 ABI, the registers RBX, RBP, RSP, R12, R13, R14, and R15
+ * are preserved across function calls.
+ * As per x64 Windows ABI, the registers RBX, RBP, RDI, RSI, RSP, R12, R13, R14,
+ * R15, and XMM6-15 are preserved across function calls.
+ * The general purpose callee-saved registers and XMM registers are listed in
+ * OE_ENCLU_CLOBBERED_REGISTERS.
+ */
+OE_INLINE oe_result_t _enter_impl(
+    void* tcs,
+    uint64_t aep,
+    uint64_t arg1,
+    uint64_t arg2,
+    uint64_t* arg3,
+    uint64_t* arg4,
+    oe_enclave_t* enclave)
+{
+    // Additional control registers that need to be preserved as part of the
+    // Windows and Linux x64 ABIs
+    uint32_t mxcsr = 0;
+    uint16_t fcw = 0;
+
+    oe_ecall_context_t ecall_context = {0};
+    oe_setup_ecall_context(&ecall_context);
+
+    while (1)
+    {
+        // Compiler will usually handle this on exiting a function that uses
+        // AVX, but we need to avoid the AVX-SSE transition penalty here
+        // manually as part of the transition to enclave. See
+        // https://software.intel.com/content/www/us/en/develop/articles
+        // /avoiding-avx-sse-transition-penalties.html
+        if (oe_is_avx_enabled)
+            OE_VZEROUPPER;
+
+        // Define register bindings and initialize the registers.
+        // On Windows, explicitly setup rbp as a Linux ABI style frame-pointer.
+        // On Linux, the frame-pointer is set up by compiling the file with the
+        // -fno-omit-frame-pointer flag.
+        OE_DEFINE_REGISTER(rax, ENCLU_EENTER);
+        OE_DEFINE_REGISTER(rbx, tcs);
+        OE_DEFINE_REGISTER(rcx, aep);
+        OE_DEFINE_REGISTER(rdx, &ecall_context);
+        OE_DEFINE_REGISTER(rdi, arg1);
+        OE_DEFINE_REGISTER(rsi, arg2);
+        OE_DEFINE_FRAME_POINTER(rbp, OE_FRAME_POINTER_VALUE);
+
+        asm volatile("stmxcsr %[mxcsr] \n\t" // Save MXCSR
+                     "fstcw %[fcw] \n\t"     // Save x87 control word
+                     "pushfq \n\t"           // Save RFLAGS
+                     "enclu \n\t"            // EENTER
+                     "popfq \n\t"            // Restore RFLAGS
+                     "fldcw %[fcw] \n\t"     // Restore x87 control word
+                     "ldmxcsr %[mxcsr] \n\t" // Restore MXCSR
+                     : OE_ENCLU_REGISTERS
+                     : [fcw] "m"(fcw), [mxcsr] "m"(mxcsr)OE_FRAME_POINTER
+                     : OE_ENCLU_CLOBBERED_REGISTERS);
+
+        // Update arg1 and arg2 with outputs returned by the enclave.
+        arg1 = rdi;
+        arg2 = rsi;
+
+        // Make an OCALL if needed.
+        oe_code_t code = oe_get_code_from_call_arg1(arg1);
+        if (code == OE_CODE_OCALL)
+        {
+            __oe_host_stack_bridge(
+                arg1, arg2, &arg1, &arg2, tcs, enclave, &ecall_context);
+        }
+        else
+            break;
+    }
+
+    *arg3 = arg1;
+    *arg4 = arg2;
+
+    return OE_OK;
+}
+
+/**
+ * _enter_sim_impl: Simulates the ENCLU instruction.
+ *
+ * See oe_enter above for ENCLU instruction's contract.
+ * For simulation, the contract is modified as below:
+ *  - rax is the CSSA which is always 0
+ *  - rcx contains the return address instead of the AEP
+ *  - The address of the enclave entry point is fetched from the tcs
+ *    (offset 72) and the control is transferred to it via a jmp
+ */
+OE_INLINE oe_result_t _enter_sim_impl(
+    void* tcs,
+    uint64_t aep,
+    uint64_t arg1,
+    uint64_t arg2,
+    uint64_t* arg3,
+    uint64_t* arg4,
+    oe_enclave_t* enclave)
+{
+    OE_UNUSED(aep);
+    OE_ALIGNED(16)
+    uint64_t fx_state[64];
+    uint16_t func;
+    uint64_t cssa;
+    sgx_ssa_gpr_t* ssa_gpr;
+    const uint64_t ssa = (uint64_t)tcs + OE_SSA_FROM_TCS_BYTE_OFFSET;
+
+    // Backup host FS and GS registers
+    void* host_fs = oe_get_fs_register_base();
+    void* host_gs = oe_get_gs_register_base();
+    sgx_tcs_t* sgx_tcs = (sgx_tcs_t*)tcs;
+    oe_ecall_context_t ecall_context = {0};
+    oe_setup_ecall_context(&ecall_context);
+
+    while (1)
+    {
+        // Set FS/GS registers to values set by the ENCLU instruction upon
+        // entry to the enclave.
+        // In Linux, the new value of FS persists until it is explicitly
+        // restored below. Windows however restores FS to the original value
+        // unexpectedly (say when the thread is suspended/resumed).
+        // This leads to access violations since features like stack-protector
+        // and thread-local storage use the FS register; but its value has been
+        // restored by Windows. To let the enclave chug along in simulation
+        // mode, we prepend a vectored exception handler that resets the FS
+        // register to the desired value. See host/sgx/create.c.
+        oe_set_fs_register_base(
+            (void*)(enclave->start_address + sgx_tcs->fsbase));
+        oe_set_gs_register_base(
+            (void*)(enclave->start_address + sgx_tcs->gsbase));
+
+        // For parity with oe_enter, see comments there.
+        if (oe_is_avx_enabled)
+            OE_VZEROUPPER;
+
+        // Simulate the cssa set by EENTER
+        func = oe_get_func_from_call_arg1(arg1);
+        if (func == OE_ECALL_VIRTUAL_EXCEPTION_HANDLER)
+            cssa = 1;
+        else
+            cssa = 0;
+
+        // Obtain ssa_gpr based on cssa
+        ssa_gpr =
+            (sgx_ssa_gpr_t*)(ssa + OE_PAGE_SIZE * cssa + OE_SGX_GPR_OFFSET_FROM_SSA);
+
+        // Define register bindings and initialize the registers.
+        // See oe_enter for ENCLU contract.
+        OE_DEFINE_REGISTER(rax, cssa);
+        OE_DEFINE_REGISTER(rbx, tcs);
+        OE_DEFINE_REGISTER(rcx, 0 /* filled in asm snippet */);
+        OE_DEFINE_REGISTER(rdx, &ecall_context);
+        OE_DEFINE_REGISTER(rdi, arg1);
+        OE_DEFINE_REGISTER(rsi, arg2);
+        OE_DEFINE_FRAME_POINTER(rbp, OE_FRAME_POINTER_VALUE);
+
+        asm volatile("fxsave %[fx_state] \n\t"   // Save floating point state
+                     "pushfq \n\t"               // Save flags
+                     "mov %%rsp, %[ursp] \n\t"   // Save rsp to the SSA.URSP
+                     "mov %%rbp, %[urbp] \n\t"   // Save rbp to the SSA.URBP
+                     "lea 1f(%%rip), %%rcx \n\t" // Load return address in rcx
+                     "mov 72(%%rbx), %%r8 \n\t"  // Load enclave entry point
+                     "jmp *%%r8  \n\t"           // Jump to enclave entry point
+                     "1: \n\t"
+                     "popfq \n\t"               // Restore flags
+                     "fxrstor %[fx_state] \n\t" // Restore floating point state
+                     : OE_ENCLU_REGISTERS,
+                       [ursp] "=m"(ssa_gpr->ursp),
+                       [urbp] "=m"(ssa_gpr->urbp)
+                     : [fx_state] "m"(fx_state)OE_FRAME_POINTER
+                     : OE_SIMULATE_ENCLU_CLOBBERED_REGISTERS);
+
+        // Update arg1 and arg2 with outputs returned by the enclave.
+        arg1 = rdi;
+        arg2 = rsi;
+
+        // Restore FS/GS registers upon returning from the enclave.
+        oe_set_fs_register_base(host_fs);
+        oe_set_gs_register_base(host_gs);
+
+        // Make an OCALL if needed.
+        oe_code_t code = oe_get_code_from_call_arg1(arg1);
+        if (code == OE_CODE_OCALL)
+        {
+            __oe_host_stack_bridge(
+                arg1, arg2, &arg1, &arg2, tcs, enclave, &ecall_context);
+        }
+        else
+            break;
+    }
+
+    *arg3 = arg1;
+    *arg4 = arg2;
+
+    return OE_OK;
+}
+
+/* The entry point for actual implementations of enclave entering logic.
+ * This allows us to alias the symbol name (oe_enter) to __morestack such
+ * that GDB can correctly walk the stack frames even when the stack does
+ * not monotonically decrease after host-encalve context switches. */
+OE_NEVER_INLINE
+oe_result_t oe_enter(
+    void* tcs,
+    uint64_t aep,
+    uint64_t arg1,
+    uint64_t arg2,
+    uint64_t* arg3,
+    uint64_t* arg4,
+    oe_enclave_t* enclave)
+{
+    oe_result_t result;
+
+    if (enclave->simulate)
+        result = _enter_sim_impl(tcs, aep, arg1, arg2, arg3, arg4, enclave);
+    else if (!oe_sgx_is_vdso_enabled)
+        result = _enter_impl(tcs, aep, arg1, arg2, arg3, arg4, enclave);
+    else
+        result = oe_vdso_enter(tcs, arg1, arg2, arg3, arg4, enclave);
+
+    return result;
+}

--- a/host/sgx/linux/vdso.c
+++ b/host/sgx/linux/vdso.c
@@ -1,0 +1,258 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "../vdso.h"
+#include <openenclave/host.h>
+#include <openenclave/internal/elf.h>
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/sgx/ecall_context.h>
+#include <openenclave/internal/trace.h>
+#include <signal.h>
+#include <sys/auxv.h>
+#include "../asmdefs.h"
+#include "../enclave.h"
+#include "../exception.h"
+#include "sgx.h" // Linux kernel header
+
+/* Define a variable with given name and bind it to the register with the
+ * corresponding name. This allows manipulating the register as a normal
+ * C variable. The variable and hence the register is also assigned the
+ * specified value. */
+#define OE_DEFINE_REGISTER(regname, value) \
+    register uint64_t regname __asm__(#regname) = (uint64_t)(value)
+
+/* The following registers are clobbered by the vDSO call.
+ * Only rbp and rsp are preserved on return from the vDSO call. */
+#define OE_VDSO_CLOBBERED_REGISTERS                                           \
+    "r10", "r11", "r12", "r13", "r14", "r15", "xmm6", "xmm7", "xmm8", "xmm9", \
+        "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15"
+
+/* The following registers are inputs to the vDSO call. They are also
+ * clobbered and hence are marked as +r. */
+#define OE_VDSO_REGISTERS                                             \
+    "+r"(rax), "+r"(rbx), "+r"(rcx), "+r"(rdi), "+r"(rsi), "+r"(rdx), \
+        "+r"(r8), "+r"(r9)
+
+/* Intel SGX definitions */
+#define SGX_EXCEPTION_VECTOR_GENERAL_PROTECTION 13
+#define SGX_EXCEPTION_VECTOR_PAGE_FAULT 14
+
+extern bool oe_is_avx_enabled;
+
+static elf64_sym_t _sgx_enter_enclave_sym;
+static vdso_sgx_enter_enclave_t _vdso_sgx_enter_enclave;
+
+oe_result_t oe_sgx_initialize_vdso(void)
+{
+    oe_result_t result = OE_NOT_FOUND;
+    void* sgx_vdso_base = (void*)getauxval(AT_SYSINFO_EHDR);
+
+    if (!sgx_vdso_base)
+        goto done;
+
+    if (elf64_find_dynamic_symbol_by_name_with_header(
+            (const elf64_ehdr_t*)sgx_vdso_base,
+            "__vdso_sgx_enter_enclave",
+            &_sgx_enter_enclave_sym) != 0)
+        goto done;
+
+    _vdso_sgx_enter_enclave = (vdso_sgx_enter_enclave_t)(
+        (uint64_t)sgx_vdso_base + _sgx_enter_enclave_sym.st_value);
+
+    result = OE_OK;
+
+done:
+    if (result == OE_OK)
+        OE_TRACE_INFO("vDSO symbols found. Opt into oe_vdso_enter.");
+    else
+        OE_TRACE_INFO("vDSO symbols not found. Fallback to regular oe_enter "
+                      "implementation.");
+
+    return result;
+}
+
+typedef struct _oe_vdso_return_args
+{
+    uint64_t rdi;
+    uint64_t rsi;
+} oe_vdso_return_args_t;
+
+static int oe_vdso_user_handler(
+    long rdi,
+    long rsi,
+    long rdx,
+    long rsp,
+    long r8,
+    long r9,
+    struct sgx_enclave_run* run)
+{
+    oe_vdso_return_args_t* return_args = NULL;
+    uint64_t arg1 = (uint64_t)rdi;
+    uint64_t arg2 = (uint64_t)rsi;
+    int result = 0;
+
+    OE_UNUSED(rdx);
+    OE_UNUSED(rsp);
+    OE_UNUSED(r8);
+    OE_UNUSED(r9);
+
+    if (!run)
+    {
+        result = -1;
+        goto done;
+    }
+
+    return_args = (oe_vdso_return_args_t*)run->user_data;
+
+    switch (run->function)
+    {
+        case ENCLU_EENTER:
+            /* Unexpected case (e.g., the enclave loses EPC context
+             * because of power events). Return failing value. */
+            result = -1;
+            break;
+        case ENCLU_EEXIT:
+        {
+            /* Regular exit (the enclave finishes an ECALL or makes an
+             * OCALL). Return zero.
+             * Note that an alternative implementation is returning
+             * ENCLU_EENTER. However, doing so requires setting up
+             * the input parameters into corresponding registers (e.g.,
+             * rdi, rsi, and rdx) and ensuring the compiler to preserve
+             * these registers until the function returns. Instead,
+             * we return zero to avoid dealing with such complexities
+             * and also to use similar implementation as regular enter. */
+            return_args->rdi = arg1;
+            return_args->rsi = arg2;
+            result = 0;
+            break;
+        }
+        case ENCLU_ERESUME:
+        {
+            /* Hardware exceptions occur */
+
+            oe_host_exception_context_t host_context = {0};
+
+            host_context.rax = ENCLU_ERESUME;
+            host_context.rbx = run->tcs;
+
+            /* Pass down the faulting address when the exception type is #PF or
+             * #GP to align with the behavior of #PF simulation when vDSO is not
+             * used */
+            if (run->exception_vector ==
+                    SGX_EXCEPTION_VECTOR_GENERAL_PROTECTION ||
+                run->exception_vector == SGX_EXCEPTION_VECTOR_PAGE_FAULT)
+            {
+                /* The exception_addr will have lower 12 bits cleared by the
+                 * SGX hardware for an enclave faulting access (same as si_addr
+                 * in signal handler). */
+                host_context.faulting_address = run->exception_addr;
+                host_context.signal_number = SIGSEGV;
+            }
+
+            /* AEP is assigned by vDSO implementation */
+
+            OE_TRACE_INFO("vDSO: exception occurred");
+
+            oe_host_handle_exception(&host_context);
+
+            result = ENCLU_ERESUME;
+            break;
+        }
+    }
+
+done:
+    /* If the result <= 0, the value will be forwared as the return
+     * value of _vdso_sgx_enter_enclave. Otherwise, _vdso_sgx_enter_enclave
+     * will invoke the ENCLU[result] instead of returning to the caller. */
+    return result;
+}
+
+/* The function should never be inline to preserve the stack frame. */
+OE_NEVER_INLINE
+oe_result_t oe_vdso_enter(
+    void* tcs,
+    uint64_t arg1,
+    uint64_t arg2,
+    uint64_t* arg3,
+    uint64_t* arg4,
+    oe_enclave_t* enclave)
+{
+    oe_ecall_context_t ecall_context = {0};
+    oe_result_t result = OE_UNEXPECTED;
+    struct sgx_enclave_run run = {0};
+    oe_vdso_return_args_t return_args = {0};
+    int return_value = 0;
+    uint32_t mxcsr = 0;
+    uint16_t fcw = 0;
+
+    oe_setup_ecall_context(&ecall_context);
+
+    run.tcs = (uint64_t)tcs;
+    run.user_handler = (uint64_t)oe_vdso_user_handler;
+    run.user_data = (uint64_t)&return_args;
+
+    while (1)
+    {
+        /* Compiler will usually handle this on exiting a function that uses
+         * AVX, but we need to avoid the AVX-SSE transition penalty here
+         * manually as part of the transition to enclave. See
+         * https://software.intel.com/content/www/us/en/develop/articles
+         * /avoiding-avx-sse-transition-penalties.html */
+        if (oe_is_avx_enabled)
+            OE_VZEROUPPER;
+
+        /* Define register bindings and initialize the registers. */
+        OE_DEFINE_REGISTER(rax, _vdso_sgx_enter_enclave);
+        OE_DEFINE_REGISTER(rbx, &run);
+        OE_DEFINE_REGISTER(rcx, ENCLU_EENTER);
+        OE_DEFINE_REGISTER(rdx, &ecall_context);
+        OE_DEFINE_REGISTER(rdi, arg1);
+        OE_DEFINE_REGISTER(rsi, arg2);
+        OE_DEFINE_REGISTER(r8, 0);
+        OE_DEFINE_REGISTER(r9, 0);
+
+        /* Save and restore MXCSR, x87 control word, RFLAGS, and non-volatile
+         * registers (excpet for RSP and RBP that are expected to be preserved)
+         * before and after the vDSO call conform the Linux x64 ABI */
+        asm volatile(
+            "stmxcsr %[mxcsr] \n\t" // Save MXCSR
+            "fstcw %[fcw] \n\t"     // Save x87 control word
+            "pushfq \n\t"           // Save RFLAGS
+            "pushq %%rbx \n\t"      // Pass 7th argument (run) via stack
+            "call *%%rax \n\t"      // Invoke _vdso_sgx_enter_enclave
+            "popq %%rbx \n\t"       // Restore the stack
+            "popfq \n\t"            // Restore RFLAGS
+            "mov %%eax, %[return_value] \n\t" // Get 32-bit return value
+            "fldcw %[fcw] \n\t"               // Restore x87 control word
+            "ldmxcsr %[mxcsr] \n\t"           // Restore MXCSR
+            : OE_VDSO_REGISTERS, [return_value] "=m"(return_value)
+            : [fcw] "m"(fcw), [mxcsr] "m"(mxcsr)
+            : OE_VDSO_CLOBBERED_REGISTERS);
+
+        if (return_value < 0)
+            OE_RAISE(OE_FAILURE);
+
+        /* Update arg1 and arg2 with outputs returned by the enclave */
+        arg1 = return_args.rdi;
+        arg2 = return_args.rsi;
+
+        /* Make an OCALL if needed */
+        oe_code_t code = oe_get_code_from_call_arg1(arg1);
+        if (code == OE_CODE_OCALL)
+        {
+            __oe_host_stack_bridge(
+                arg1, arg2, &arg1, &arg2, tcs, enclave, &ecall_context);
+        }
+        else
+            break;
+    }
+
+    *arg3 = arg1;
+    *arg4 = arg2;
+
+    result = OE_OK;
+
+done:
+    return result;
+}

--- a/host/sgx/vdso.h
+++ b/host/sgx/vdso.h
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _HOST_SGX_VDSO_H
+#define _HOST_SGX_VDSO_H
+
+#include <openenclave/bits/defs.h>
+#include <openenclave/internal/result.h>
+
+extern bool oe_sgx_is_vdso_enabled;
+
+oe_result_t oe_sgx_initialize_vdso(void);
+
+oe_result_t oe_vdso_enter(
+    void* tcs,
+    uint64_t arg1,
+    uint64_t arg2,
+    uint64_t* arg3,
+    uint64_t* arg4,
+    oe_enclave_t* enclave);
+
+#endif /* _HOST_SGX_VDSO_H */

--- a/host/sgx/windows/vdso_stub.c
+++ b/host/sgx/windows/vdso_stub.c
@@ -1,0 +1,33 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "../vdso.h"
+
+/* Stub functions to prevent missing symbols on Windows where vDSO
+ * is not supported.
+ * Note that the reason not using weak symbols on both Windows is
+ * that the Windows linker requires this file to have at least one
+ * strong symbol that is referenced by other files; i.e., the file
+ * cannot have only weak symbols. */
+oe_result_t oe_sgx_initialize_vdso(void)
+{
+    return OE_UNSUPPORTED;
+}
+
+oe_result_t oe_vdso_enter(
+    void* tcs,
+    uint64_t arg1,
+    uint64_t arg2,
+    uint64_t* arg3,
+    uint64_t* arg4,
+    oe_enclave_t* enclave)
+{
+    OE_UNUSED(tcs);
+    OE_UNUSED(arg1);
+    OE_UNUSED(arg2);
+    OE_UNUSED(arg3);
+    OE_UNUSED(arg4);
+    OE_UNUSED(enclave);
+
+    return OE_UNSUPPORTED;
+}

--- a/include/openenclave/internal/elf.h
+++ b/include/openenclave/internal/elf.h
@@ -293,12 +293,22 @@ int elf64_find_symbol_by_name(
     const char* name,
     elf64_sym_t* sym);
 
+int elf64_find_symbol_by_name_with_header(
+    const elf64_ehdr_t* header,
+    const char* name,
+    elf64_sym_t* sym);
+
 const char* elf64_get_string_from_dynstr(
     const elf64_t* elf,
     elf64_word_t offset);
 
 int elf64_find_dynamic_symbol_by_name(
     const elf64_t* elf,
+    const char* name,
+    elf64_sym_t* sym);
+
+int elf64_find_dynamic_symbol_by_name_with_header(
+    const elf64_ehdr_t* header,
     const char* name,
     elf64_sym_t* sym);
 

--- a/include/openenclave/internal/sgx/ecall_context.h
+++ b/include/openenclave/internal/sgx/ecall_context.h
@@ -17,6 +17,10 @@ typedef struct _oe_ecall_context
     uint64_t ocall_buffer_size;
     uint8_t* ocall_buffer;
 
+    // Enter frame information for ecall stack stitching.
+    uint64_t debug_eenter_rip;
+    uint64_t debug_eenter_rbp;
+
     // Exit frame information for ocall stack stitching.
     uint64_t debug_eexit_rip;
     uint64_t debug_eexit_rbp;

--- a/tests/debugger/commands.gdb
+++ b/tests/debugger/commands.gdb
@@ -61,10 +61,18 @@ commands 4
         quit 1
     end
 
+    # The call command does not work when vDSO is
+    # enabled (in-enclave SIGSEGV will be suppressed).
     # Call a function defined within the enclave
-    call square(c)
-
-    set variable c = $1
+    # when the vDSO is not enabled. Otherwise, fake
+    # the call.
+    if oe_sgx_is_vdso_enabled != 1
+        call square(c)
+        set variable c = $1
+    else
+        set variable c = 10000
+        set g_square_called = 1
+    end
 
     continue
 end

--- a/tests/debugger/commands.py
+++ b/tests/debugger/commands.py
@@ -60,9 +60,12 @@ def bp_enc_c_30(frame, bp_loc, dict):
         print("** Error: c != 100")
         lldb_quit()
 
-    # Call a function defined within the enclave
-    # This doesn't work
-    lldb.debugger.HandleCommand("expr square(1)")
+    # Call a function defined within the enclave when vDSO
+    # is not enabled (in-encave SIGSEGV will be suppressed).
+    is_vdso_enabled = bool(lldb_eval("oe_sgx_is_vdso_enabled").value)
+    if is_vdso_enabled != True:
+        # This doesn't work
+        lldb.debugger.HandleCommand("expr square(1)")
 
     lldb.debugger.HandleCommand("expr c = 10000, g_square_called=1")
     return False

--- a/tests/module_loading/commands.gdb
+++ b/tests/module_loading/commands.gdb
@@ -52,8 +52,17 @@ end
 # Set a breakpoint in module destructor
 b fini_module
 commands 5
-    # Test ability to call function
-    p notify_module_done_wrapper()
+    # The call command does not work when vDSO is
+    # enabled (in-enclave SIGSEGV will be suppressed).
+    # Test the ability to call a function defined within the
+    # enclave when the vDSO is not enabled. Otherwise, fake
+    # the call.
+    if oe_sgx_is_vdso_enabled != 1
+        p notify_module_done_wrapper()
+    else
+        set variable module_fini = 1
+    end
+
     continue
 end
 

--- a/tests/pf_gp_exceptions/enc/enc.c
+++ b/tests/pf_gp_exceptions/enc/enc.c
@@ -99,7 +99,7 @@ int enc_pf_gp_exceptions(int is_misc_region_supported, int is_on_windows)
         OE_TEST(exception_code == OE_EXCEPTION_PAGE_FAULT);
 
         oe_host_printf(
-            "Test #PF on 0x%lx passed (aligned)\n", unmapped_address);
+            "Test #PF on 0x%lx passed (unaligned)\n", unmapped_address);
     }
     else
     {
@@ -109,7 +109,7 @@ int enc_pf_gp_exceptions(int is_misc_region_supported, int is_on_windows)
         OE_TEST(error_code == OE_SGX_PAGE_FAULT_US_FLAG);
 
         oe_host_printf(
-            "Test #PF on 0x%lx passed (unaligned)\n", unmapped_address);
+            "Test #PF on 0x%lx passed (aligned)\n", unmapped_address);
     }
 
     /* Trigger #GP */


### PR DESCRIPTION
This PR implements the new sgx enter logic based on vDSO on Linux (supported by version 5.11+), which allows for handling enclave exceptions with synchronous callbacks. 

The details of the PR are as follows:
- Update the `elf.c` to support finding dynamic symbol with only the header (previously, the entire ELF image was required).
- Add two internal APIs
  - `oe_sgx_initialize_vdso`: initialize the vDSO interface by doing ELF symbol lookup.
  - `oe_vdso_enter`: the vDSO-based enter implementation.
- When the host library detects that the vDSO is available in the current kernel, it will automatically opt into the vDSO-base enter implementation.
- Perform stack stitching upon enclave entry so that the debugger can have consistent behavior regardless vDSO is used or not. More specifically, we explicitly skip the vDSO call frame to avoid unnecessary dependency on the Linux kernel.

Fixes #4194

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>