### PR TITLE
Use deepcopy in oe_sgx_backtrace_symbols_ocall

### DIFF
--- a/host/sgx/ocalls/debug.c
+++ b/host/sgx/ocalls/debug.c
@@ -99,15 +99,13 @@ oe_result_t oe_sgx_backtrace_symbols_ocall(
     oe_enclave_t* oe_enclave,
     const uint64_t* buffer,
     size_t size,
-    void* symbols_buffer,
-    size_t symbols_buffer_size,
-    size_t* symbols_buffer_size_out)
+    oe_symbols_t* symbols)
 {
     oe_result_t result = OE_UNEXPECTED;
     char** strings = NULL;
 
     /* Reject invalid parameters. */
-    if (!oe_enclave || !buffer || size > OE_INT_MAX || !symbols_buffer_size_out)
+    if (!oe_enclave || !buffer || size > OE_INT_MAX || !symbols)
         OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Convert the addresses into symbol strings. */
@@ -117,14 +115,8 @@ oe_result_t oe_sgx_backtrace_symbols_ocall(
         OE_RAISE(OE_FAILURE);
     }
 
-    *symbols_buffer_size_out = symbols_buffer_size;
-
     OE_CHECK(oe_argv_to_buffer(
-        (const char**)strings,
-        size,
-        symbols_buffer,
-        symbols_buffer_size,
-        symbols_buffer_size_out));
+        (const char**)strings, size, &symbols->buffer, &symbols->size));
 
     result = OE_OK;
 

--- a/include/openenclave/edl/sgx/debug.edl
+++ b/include/openenclave/edl/sgx/debug.edl
@@ -18,6 +18,12 @@ enclave
     // intentionally kept in host memory.
     include "openenclave/bits/types.h"
 
+    struct oe_symbols_t
+    {
+        [size = size] void* buffer;
+        size_t size;
+    };
+
     untrusted
     {
         // Translate the addresses in buffer[] into symbol names.
@@ -26,9 +32,7 @@ enclave
             [user_check] oe_enclave_t* oe_enclave,
             [in, count=size] const uint64_t* buffer,
             size_t size,
-            [out, size=symbols_buffer_size] void* symbols_buffer,
-            size_t symbols_buffer_size,
-            [out] size_t* symbols_buffer_size_out);
+            [out] oe_symbols_t* symbols);
 
 	// Log the given backtrace.
 	oe_result_t oe_sgx_log_backtrace_ocall(

--- a/include/openenclave/internal/argv.h
+++ b/include/openenclave/internal/argv.h
@@ -23,8 +23,7 @@ oe_result_t oe_buffer_to_argv(
 oe_result_t oe_argv_to_buffer(
     const char* argv[],
     size_t argc,
-    void* buf_out,
-    size_t buf_size,
+    void** buf_out,
     size_t* buf_size_out);
 
 OE_EXTERNC_END

--- a/include/openenclave/internal/backtrace.h
+++ b/include/openenclave/internal/backtrace.h
@@ -30,7 +30,6 @@ char** oe_backtrace_symbols_impl(
     void* const* buffer,
     int size,
     void* (*malloc_fcn)(size_t),
-    void* (*realloc_fcn)(void*, size_t),
     void (*free_fcn)(void*));
 
 /**

--- a/libc/backtrace.c
+++ b/libc/backtrace.c
@@ -22,5 +22,5 @@ int backtrace(void** buffer, int size)
 
 char** backtrace_symbols(void* const* buffer, int size)
 {
-    return oe_backtrace_symbols_impl(buffer, size, malloc, realloc, free);
+    return oe_backtrace_symbols_impl(buffer, size, malloc, free);
 }

--- a/tests/argv/enc/enc.c
+++ b/tests/argv/enc/enc.c
@@ -11,31 +11,29 @@
 
 static void _test(const char* argv[], size_t argc)
 {
-    oe_result_t r;
-    size_t buf_size_out = 1;
+    void* buf = NULL;
+    size_t buf_size = 1;
+    char** argv_out;
 
-    r = oe_argv_to_buffer(argv, argc, NULL, 0, &buf_size_out);
+    OE_TEST(oe_argv_to_buffer(argv, argc, &buf, &buf_size) == OE_OK);
 
     if (argc == 0)
     {
-        OE_TEST(buf_size_out == 0);
+        OE_TEST(buf == NULL);
+        OE_TEST(buf_size == 0);
+
+        OE_TEST(
+            oe_buffer_to_argv(buf, buf_size, &argv_out, argc, malloc, free) ==
+            OE_INVALID_PARAMETER);
     }
     else
     {
-        void* buf;
-        size_t buf_size;
-        char** argv_out;
+        OE_TEST(buf != NULL);
+        OE_TEST(buf_size != 0);
 
-        OE_TEST(r == OE_BUFFER_TOO_SMALL);
-
-        buf_size = buf_size_out;
-        OE_TEST((buf = malloc(buf_size)));
-
-        r = oe_argv_to_buffer(argv, argc, buf, buf_size, &buf_size_out);
-        OE_TEST(r == OE_OK);
-
-        r = oe_buffer_to_argv(buf, buf_size, &argv_out, argc, malloc, free);
-        OE_TEST(r == OE_OK);
+        OE_TEST(
+            oe_buffer_to_argv(buf, buf_size, &argv_out, argc, malloc, free) ==
+            OE_OK);
 
         for (size_t i = 0; i < argc; i++)
         {

--- a/tests/edl_opt_out/enc/enc.c
+++ b/tests/edl_opt_out/enc/enc.c
@@ -35,7 +35,7 @@ void enc_edl_opt_out()
 #if defined(__x86_64__) || defined(_M_X64)
     /* debug.edl */
     OE_TEST(
-        oe_sgx_backtrace_symbols_ocall(NULL, NULL, NULL, 0, NULL, 0, NULL) ==
+        oe_sgx_backtrace_symbols_ocall(NULL, NULL, NULL, 0, NULL) ==
         OE_UNSUPPORTED);
 
     /* sgx/switchless.edl */


### PR DESCRIPTION
Replace double-call pattern with deep-copy in the oe_sgx_backtrace_symbols_ocall

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>