### PR TITLE
Update to GCC 9.4.0 on CI agents

### DIFF
--- a/scripts/ansible/roles/linux/openenclave/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/ubuntu/focal.yml
@@ -2,5 +2,5 @@
 # Licensed under the MIT License.
 
 ---
-gcc_target_version: "9.3.0"
+gcc_target_version: "9.4.0"
 clang_target_version: "10.0.1"


### PR DESCRIPTION
Updates to GCC 9.4.0 on Ubuntu 20.04

Tests:
https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/pipelines%2FAgnostic-Linux/detail/Agnostic-Linux/3808/pipeline/
https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/pipelines%2FAzure-Linux/detail/Azure-Linux/4060/pipeline/86/
https://oe-jenkins-dev.westeurope.cloudapp.azure.com/blue/organizations/jenkins/pipelines%2FAzure-Windows/detail/Azure-Windows/3926/pipeline/47/