### PR TITLE
Log host malloc invocations

### DIFF
--- a/host/ocalls/ocalls.c
+++ b/host/ocalls/ocalls.c
@@ -3,13 +3,31 @@
 
 #include <stdlib.h>
 
+#include <openenclave/internal/trace.h>
 #include "core_u.h"
 #include "ocalls.h"
+
+// Typically ocalls requiring less than this threshold are handled using
+// the ocall buffer itself.
+#define LARGE_ALLOCATION_THRESHOLD (16 * 1024)
 
 void HandleMalloc(uint64_t arg_in, uint64_t* arg_out)
 {
     if (arg_out)
+    {
         *arg_out = (uint64_t)malloc(arg_in);
+        // Log only large allocations in INFO. Rest are logged to VERBOSE.
+        if (arg_in < LARGE_ALLOCATION_THRESHOLD)
+        {
+            OE_TRACE_VERBOSE(
+                "oe_host_malloc(%ld) called to allocate host memory.", arg_in);
+        }
+        else
+        {
+            OE_TRACE_INFO(
+                "oe_host_malloc(%ld) called to allocate host memory.", arg_in);
+        }
+    }
 }
 
 void HandleFree(uint64_t arg)


### PR DESCRIPTION
This can be used to
- Determine if ocalls incur oe_host_malloc calls due to parameter sizes
- Determine whether there are unintended host memory allocations

Large allocations are logged in INFO mode and all host allocations are logged
in VERBOSE mode.

Lage allocation is defined as any allocation greater than 16 KB which is
currently the ocall buffer size.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>