### PR TITLE
Ensure that oe_enclave_properties_sgx doesn't use GOT in globals.c

### DIFF
--- a/enclave/core/sgx/globals.c
+++ b/enclave/core/sgx/globals.c
@@ -7,8 +7,24 @@
 
 /* Note: The variables below are initialized during enclave loading */
 
-OE_EXPORT extern volatile const oe_sgx_enclave_properties_t
-    oe_enclave_properties_sgx;
+//
+// Declare an invalid oeinfo to ensure .oeinfo section exists
+// - This object is defined weak. Since it is defined in this compilation unit
+//   and -fPIE is used, compiler will emit code to access it without use of
+//   GOT. Thus, oe_enclave_properties_sgx can be used prior to relocation like
+//   _enclave_rva, _reloc_rva etc.
+// - If the enclave has the macro defined, then that definition would be
+//   picked up.
+// - If enclave doesn't have the macro defined, it must go through
+//   oesign to update the stucture, which would override the value.
+//
+OE_WEAK OE_SET_ENCLAVE_SGX(
+    OE_UINT16_MAX,
+    OE_UINT16_MAX,
+    false,
+    OE_UINT16_MAX,
+    OE_UINT16_MAX,
+    OE_UINT16_MAX);
 
 /**
  *****************************************************************************

--- a/enclave/core/sgx/properties.c
+++ b/enclave/core/sgx/properties.c
@@ -25,17 +25,5 @@ OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 96);
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 144);
 OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 1960);
 
-//
-// Declare an invalid oeinfo to ensure .oeinfo section exists
-// - This object won't be linked if enclave has the macro defined.
-// - If enclave does't have the macro defined, it must go through
-//   oesign to update the stucture, which would override the value.
-//
-
-OE_SET_ENCLAVE_SGX(
-    OE_UINT16_MAX,
-    OE_UINT16_MAX,
-    false,
-    OE_UINT16_MAX,
-    OE_UINT16_MAX,
-    OE_UINT16_MAX);
+/* The definition of default oe_enclave_properties_sgx has been moved to
+ * globals.c */


### PR DESCRIPTION
This allows oe_enclave_properties_sgx to be used even before
relocations have been done, just like _enclave_rva, _reloc_rva etc.
Thus core api oe_is_within_enclave, oe_is_outside_enclave can be used
anywhere in enclave code, even before relocations.

To ensure that no GOT is used, a weak definition of oe_enclave_properties is defined in
globals.c. This definition willl be put in .oeinfo section.
If an enclave uses the OE_SET_ENCLAVE_SGX macro, then a strong definition will be emitted
which will override the weak definition.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>