### PR TITLE
Bump up SymCrypt-OpenSSL and SymCrypt module 1

### DIFF
--- a/3rdparty/symcrypt_engine/CMakeLists.txt
+++ b/3rdparty/symcrypt_engine/CMakeLists.txt
@@ -7,15 +7,37 @@ set(OPENSSL_DIR ${PROJECT_SOURCE_DIR}/3rdparty/openssl/openssl)
 set(SYMCRYPT_ENGINE_DIR
     ${CMAKE_CURRENT_SOURCE_DIR}/SymCrypt-OpenSSL/SymCryptEngine)
 
+# Use CACHE so that the variables can be globally accessible
+set(SYMCRYPT_VERSION_MAJOR
+    "101"
+    CACHE INTERNAL "")
+set(SYMCRYPT_VERSION_MINOR
+    "3"
+    CACHE INTERNAL "")
+set(SYMCRYPT_VERSION_PATCH
+    "0"
+    CACHE INTERNAL "")
+set(SYMCRYPT_VERSION
+    "${SYMCRYPT_VERSION_MAJOR}.${SYMCRYPT_VERSION_MINOR}.${SYMCRYPT_VERSION_PATCH}"
+    CACHE INTERNAL "")
+set(SYMCRYPT_NAME
+    "libsymcrypt.so.${SYMCRYPT_VERSION}"
+    CACHE INTERNAL "")
+# The linker only takes one number after ".so"
+set(SYMCRYPT_LINK_NAME
+    "libsymcrypt.so.${SYMCRYPT_VERSION_MAJOR}"
+    CACHE INTERNAL "")
+
 # Download the SymCrypt release package at config-time
 # The SymCrypt OpenSSL engine build requires the SymCrypt header
 include(FetchContent)
 FetchContent_Declare(
   symcrypt_package
-  SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/SymCrypt
-  URL https://github.com/microsoft/SymCrypt/releases/download/SymCrypt_v100.20_master_2021-12-01T112555-0800_31fb2e9/symcrypt_AMD64_openenclave_100.20.0-31fb2e94-pre.tgz
+  SOURCE_DIR
+  ${CMAKE_CURRENT_BINARY_DIR}/SymCrypt
+  URL https://github.com/microsoft/SymCrypt/releases/download/v101.3.0/symcrypt_AMD64_oe_full_v101.3.0-31e06ae.tgz
   URL_HASH
-    SHA256=8d08f459e57751cd94580395922be905f51c172dd06f3ea0db403febb7b53e3e)
+    SHA256=53fcbdbae3925b82e880c102969dc4c646b36dffbca602d2f85f967d54e958e7)
 
 # Make the downloaded package globally available
 FetchContent_GetProperties(symcrypt_package)

--- a/3rdparty/symcrypt_engine/README.md
+++ b/3rdparty/symcrypt_engine/README.md
@@ -1,0 +1,9 @@
+SymCrypt OpenSSL Engine
+===========
+
+This directory includes the necessary files to build the SymCrypt OpenSSL engine
+that work with Open Enclave. The version of dependencies are as follows.
+
+- (SymCrypt-OpenSSL)[https://github.com/microsoft/SymCrypt-OpenSSL] (tag: v1.1.0)
+
+- (SymCrypt)[https://github.com/microsoft/SymCrypt] (releases: v101.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - Updated libcxx to version 10.0.1
 - Updated the mbedTLS from 2.16 LTS to 2.28 LTS
+- Updated the SymCrypt-OpenSSL to v1.1.0
+- Updated the support of the SymCrypt module to v101.3.0
 
 [v0.17.][v0.17.7_log]
 ### Changed

--- a/cmake/add_enclave.cmake
+++ b/cmake/add_enclave.cmake
@@ -206,7 +206,8 @@ function (add_enclave_sgx)
   elseif (ENCLAVE_CRYPTO_LIB_LOWER STREQUAL "symcrypt_fips")
     enclave_link_libraries(
       ${ENCLAVE_TARGET} oesymcryptengine oecryptoopenssl
-      ${CMAKE_BINARY_DIR}/3rdparty/symcrypt_engine/SymCrypt/lib/libsymcrypt.so)
+      ${CMAKE_BINARY_DIR}/3rdparty/symcrypt_engine/SymCrypt/lib/${SYMCRYPT_NAME}
+    )
   endif ()
 
   if (ENCLAVE_CXX)

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -193,19 +193,13 @@ list(APPEND NEEDS_STDC_NAMES ${MUSL_SRC_DIR}/prng/rand.c
 
 list(APPEND W_NO_CONVERSION ${MUSL_SRC_DIR}/prng/rand.c)
 
-set_property(
-  SOURCE ${W_NO_CONVERSION}
-  APPEND_STRING
-  PROPERTY COMPILE_FLAGS "-Wno-conversion")
+set_property(SOURCE ${W_NO_CONVERSION} APPEND_STRING PROPERTY COMPILE_FLAGS
+                                                              "-Wno-conversion")
 
-set_property(
-  SOURCE ${NEEDS_STDC_NAMES}
-  APPEND_STRING
-  PROPERTY COMPILE_FLAGS " -I${CORELIBC_INCLUDES}")
-set_property(
-  SOURCE ${NEEDS_STDC_NAMES}
-  APPEND
-  PROPERTY COMPILE_DEFINITIONS OE_NEED_STDC_NAMES)
+set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND_STRING
+             PROPERTY COMPILE_FLAGS " -I${CORELIBC_INCLUDES}")
+set_property(SOURCE ${NEEDS_STDC_NAMES} APPEND PROPERTY COMPILE_DEFINITIONS
+                                                        OE_NEED_STDC_NAMES)
 
 maybe_build_using_clangw(oecore)
 
@@ -291,15 +285,14 @@ if (OE_SGX)
   list(
     APPEND
     DEFAULT_VISIBILITY
+    __stack_chk_fail.c
     ${MUSL_SRC_DIR}/sting/memcmp.c
     ${MUSL_SRC_DIR}/string/x86_64/memcpy.s
     ${MUSL_SRC_DIR}/string/x86_64/memmove.s
     ${MUSL_SRC_DIR}/string/x86_64/memset.s)
 
-  set_property(
-    SOURCE ${DEFAULT_VISIBILITY}
-    APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -fvisibility=default")
+  set_property(SOURCE ${DEFAULT_VISIBILITY} APPEND_STRING
+               PROPERTY COMPILE_FLAGS " -fvisibility=default")
 endif ()
 
 enclave_compile_options(oecore INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)

--- a/include/openenclave/internal/elf.h
+++ b/include/openenclave/internal/elf.h
@@ -139,6 +139,7 @@ ELF_EXTERNC_BEGIN
 /* elf64_dyn.d_tag */
 #define DT_NULL 0
 #define DT_NEEDED 1
+#define DT_PLTGOT 3
 #define DT_STRTAB 5
 #define DT_SYMTAB 6
 #define DT_RELA 7

--- a/include/openenclave/internal/load.h
+++ b/include/openenclave/internal/load.h
@@ -77,6 +77,9 @@ struct _oe_enclave_elf_image
     /* Offset to write back to the file oe_sgx_enclave_properties_t
      * during signing */
     uint64_t oeinfo_file_pos;
+
+    /* Offset of the dynamic section. Needed by submodule allocation */
+    uint64_t dynamic_rva;
 };
 
 typedef enum _oe_image_type

--- a/samples/attested_tls/CMakeLists.txt
+++ b/samples/attested_tls/CMakeLists.txt
@@ -31,16 +31,21 @@ if (OE_CRYPTO_LIB STREQUAL "openssl_symcrypt_fips")
   include(FetchContent)
   FetchContent_Declare(
     symcrypt_package
-    SOURCE_DIR ${CMAKE_BINARY_DIR}/SymCrypt
-    URL https://github.com/microsoft/SymCrypt/releases/download/SymCrypt_v100.20_master_2021-12-01T112555-0800_31fb2e9/symcrypt_AMD64_openenclave_100.20.0-31fb2e94-pre.tgz
+    SOURCE_DIR
+    ${CMAKE_BINARY_DIR}/SymCrypt
+    URL https://github.com/microsoft/SymCrypt/releases/download/v101.3.0/symcrypt_AMD64_oe_full_v101.3.0-31e06ae.tgz
     URL_HASH
-      SHA256=8d08f459e57751cd94580395922be905f51c172dd06f3ea0db403febb7b53e3e)
+      SHA256=53fcbdbae3925b82e880c102969dc4c646b36dffbca602d2f85f967d54e958e7)
 
   # Make the downloaded package globally available
   FetchContent_GetProperties(symcrypt_package)
   if (NOT symcrypt_package_POPULATED)
     FetchContent_Populate(symcrypt_package)
   endif ()
+
+  # The linker can only resolve up to single number after .so
+  file(COPY_FILE ${CMAKE_BINARY_DIR}/SymCrypt/lib/libsymcrypt.so.101.3.0
+       ${CMAKE_BINARY_DIR}/libsymcrypt.so.101)
 
   # Option passed in oeedger8r to include entropy.edl (required by
   # SymCrypt FIPS module)

--- a/samples/attested_tls/Makefile
+++ b/samples/attested_tls/Makefile
@@ -10,11 +10,13 @@ export OE_CRYPTO_LIB
 
 TARGETS =
 
-SYMCRYPT_TAR = symcrypt_AMD64_openenclave_100.20.0-31fb2e94-pre.tgz
-SYMCRYPT_URL = https://github.com/microsoft/SymCrypt/releases/download/SymCrypt_v100.20_master_2021-12-01T112555-0800_31fb2e9/${SYMCRYPT_TAR}
-SYMCRYPT_SHA256 = 8d08f459e57751cd94580395922be905f51c172dd06f3ea0db403febb7b53e3e
+SYMCRYPT_TAR = symcrypt_AMD64_oe_full_v101.3.0-31e06ae.tgz
+SYMCRYPT_URL = https://github.com/microsoft/SymCrypt/releases/download/v101.3.0/${SYMCRYPT_TAR}
+SYMCRYPT_SHA256 = 53fcbdbae3925b82e880c102969dc4c646b36dffbca602d2f85f967d54e958e7
 SYMCRYPT_DIR = SymCrypt
-SYMCRYPT_SO = libsymcrypt.so
+SYMCRYPT_SO = libsymcrypt.so.101.3.0
+# The linker can only resolve up to single number after .so
+SYMCRYPT_LINK_SO = libsymcrypt.so.101
 
 ifeq (${OE_CRYPTO_LIB}, openssl_symcrypt_fips)
 	TARGETS += symcrypt
@@ -30,8 +32,8 @@ symcrypt:
 	mkdir -p ${SYMCRYPT_DIR}
 	tar zxvf ${SYMCRYPT_TAR} -C ${SYMCRYPT_DIR}
 	rm ${SYMCRYPT_TAR}
-	cp ${SYMCRYPT_DIR}/lib/${SYMCRYPT_SO} server/enc
-	cp ${SYMCRYPT_DIR}/lib/${SYMCRYPT_SO} client/enc
+	cp ${SYMCRYPT_DIR}/lib/${SYMCRYPT_SO} server/enc/${SYMCRYPT_LINK_SO}
+	cp ${SYMCRYPT_DIR}/lib/${SYMCRYPT_SO} client/enc/${SYMCRYPT_LINK_SO}
 
 build:
 	echo ${OE_CRYPTO_LIB}
@@ -44,8 +46,8 @@ clean:
 	$(MAKE) -C client clean
 	$(MAKE) -C non_enc_client clean
 	rm -rf ${SYMCRYPT_DIR}
-	rm -f server/enc/${SYMCRYPT_SO}
-	rm -f client/enc/${SYMCRYPT_SO}
+	rm -f server/enc/${SYMCRYPT_LINK_SO}
+	rm -f client/enc/${SYMCRYPT_LINK_SO}
 
 run:
 	echo "Launch processes to establish an Attested TLS between two enclaves"

--- a/samples/attested_tls/client/enc/CMakeLists.txt
+++ b/samples/attested_tls/client/enc/CMakeLists.txt
@@ -67,18 +67,17 @@ elseif (${OE_CRYPTO_LIB} STREQUAL "mbedtls")
 elseif (${OE_CRYPTO_LIB} STREQUAL "openssl_symcrypt_fips")
   add_custom_command(
     TARGET tls_client_enc
-    COMMAND
-      ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/SymCrypt/lib/libsymcrypt.so
-      ${CMAKE_CURRENT_BINARY_DIR}/libsymcrypt.so)
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/libsymcrypt.so.101
+            ${CMAKE_CURRENT_BINARY_DIR}/libsymcrypt.so.101)
 
   target_link_libraries(
     tls_client_enc
     openenclave::oeenclave
     openenclave::oesymcryptengine
     openenclave::oecryptoopenssl
-    # Workaround: refer to the downloaded location so that we don't rely on the
+    # Workaround: refer to the root of the build location so that we don't rely on the
     # order of copy
-    ${CMAKE_BINARY_DIR}/SymCrypt/lib/libsymcrypt.so
+    ${CMAKE_BINARY_DIR}/libsymcrypt.so.101
     openenclave::oelibcxx
     openenclave::oehostsock
     openenclave::oehostresolver)

--- a/samples/attested_tls/client/enc/Makefile
+++ b/samples/attested_tls/client/enc/Makefile
@@ -23,7 +23,7 @@ endif
 EDL_USE_HOST_ENTROPY =
 
 ifeq (${OE_CRYPTO_LIB}, openssl_symcrypt_fips)
-	OBJ_FILES += libsymcrypt.so
+	OBJ_FILES += libsymcrypt.so.101
 	EDL_USE_HOST_ENTROPY = -DEDL_USE_HOST_ENTROPY
 endif
 

--- a/samples/attested_tls/server/enc/CMakeLists.txt
+++ b/samples/attested_tls/server/enc/CMakeLists.txt
@@ -71,18 +71,17 @@ elseif (${OE_CRYPTO_LIB} STREQUAL "mbedtls")
 elseif (${OE_CRYPTO_LIB} STREQUAL "openssl_symcrypt_fips")
   add_custom_command(
     TARGET tls_server_enc
-    COMMAND
-      ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/SymCrypt/lib/libsymcrypt.so
-      ${CMAKE_CURRENT_BINARY_DIR}/libsymcrypt.so)
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/libsymcrypt.so.101
+            ${CMAKE_CURRENT_BINARY_DIR}/libsymcrypt.so.101)
 
   target_link_libraries(
     tls_server_enc
     openenclave::oeenclave
     openenclave::oesymcryptengine
     openenclave::oecryptoopenssl
-    # Workaround: refer to the downloaded location so that we don't rely on the
+    # Workaround: refer to the root of the build location so that we don't rely on the
     # order of copy
-    ${CMAKE_BINARY_DIR}/SymCrypt/lib/libsymcrypt.so
+    ${CMAKE_BINARY_DIR}/libsymcrypt.so.101
     openenclave::oelibcxx
     openenclave::oehostsock
     openenclave::oehostresolver)

--- a/samples/attested_tls/server/enc/Makefile
+++ b/samples/attested_tls/server/enc/Makefile
@@ -23,7 +23,7 @@ endif
 EDL_USE_HOST_ENTROPY =
 
 ifeq (${OE_CRYPTO_LIB}, openssl_symcrypt_fips)
-	OBJ_FILES += libsymcrypt.so
+	OBJ_FILES += libsymcrypt.so.101
 	EDL_USE_HOST_ENTROPY = -DEDL_USE_HOST_ENTROPY
 endif
 

--- a/tests/module_loading/commands.gdb
+++ b/tests/module_loading/commands.gdb
@@ -14,7 +14,7 @@ end
 
 # Set a breakpoint in enc.c (enclave)
 # This is a pending break point.
-b enc.c:37
+b enc.c:38
 commands 2
     printf "** Hit breakpoint in enclave\n"
 
@@ -39,7 +39,7 @@ commands 3
 end
 
 # Set a breakpoint by line number
-b module.c:19
+b module.c:20
 commands 4
     # Check that value has been set.
     if is_module_init != 1
@@ -67,7 +67,7 @@ commands 5
 end
 
 # Set breakpoint in square function
-b module.c:32
+b module.c:33
 commands 6
     # Evaluate expression
     set var r = a * a
@@ -75,7 +75,7 @@ commands 6
 end
 
 # Set conditional breakpoint
-b module.c:44
+b module.c:45
 commands 7
     p t
     set var t = a + b + k

--- a/tests/module_loading/commands.py
+++ b/tests/module_loading/commands.py
@@ -26,7 +26,7 @@ def bp_main(frame, bp_loc, dict):
     return False
 
 # Breakpoint in enc.c
-def bp_enc_c_37(frame, bp_loc, dict):
+def bp_enc_c_38(frame, bp_loc, dict):
     print("** Hit breakpoint in enclave")
 
     # Set debugger_test
@@ -46,7 +46,7 @@ def bp_init_module(frame, bp_loc, dict):
     return False
 
 # Breakpoint by line number in module
-def bp_module_c_19(frame, bp_loc, dict):
+def bp_module_c_20(frame, bp_loc, dict):
     # Check that value has been set
     is_module_init = lldb_eval("is_module_init")
     if int(is_module_init.value) != 1:
@@ -63,12 +63,12 @@ def bp_fini_module(frame, bp_loc, dict):
     return False
 
 # Breakpoint in square function
-def bp_module_c_32(frame, bp_loc, dict):
+def bp_module_c_33(frame, bp_loc, dict):
     lldb_expr("r = a * a")
     return False
 
 # Another breakpoint to test variable lookup
-def bp_module_c_44(frame, bp_loc, dict):
+def bp_module_c_45(frame, bp_loc, dict):
     lldb_expr(" t = a + b + k")
     t = lldb_eval("t")
     print("t = %s" % t.value)
@@ -81,23 +81,23 @@ def run_test():
     bp = target.BreakpointCreateByName("main")
     bp.SetScriptCallbackFunction('commands.bp_main')
 
-    bp = target.BreakpointCreateByLocation("enc.c", 37)
-    bp.SetScriptCallbackFunction('commands.bp_enc_c_37')
+    bp = target.BreakpointCreateByLocation("enc.c", 38)
+    bp.SetScriptCallbackFunction('commands.bp_enc_c_38')
 
     bp = target.BreakpointCreateByName("init_module")
     bp.SetScriptCallbackFunction('commands.bp_init_module')
 
-    bp = target.BreakpointCreateByLocation("module.c", 19)
-    bp.SetScriptCallbackFunction('commands.bp_module_c_19')
+    bp = target.BreakpointCreateByLocation("module.c", 20)
+    bp.SetScriptCallbackFunction('commands.bp_module_c_20')
 
     bp = target.BreakpointCreateByName("fini_module")
     bp.SetScriptCallbackFunction('commands.bp_fini_module')
 
-    bp = target.BreakpointCreateByLocation("module.c", 32)
-    bp.SetScriptCallbackFunction('commands.bp_module_c_32')
+    bp = target.BreakpointCreateByLocation("module.c", 33)
+    bp.SetScriptCallbackFunction('commands.bp_module_c_33')
 
-    bp = target.BreakpointCreateByLocation("module.c", 44)
-    bp.SetScriptCallbackFunction('commands.bp_module_c_44')
+    bp = target.BreakpointCreateByLocation("module.c", 45)
+    bp.SetScriptCallbackFunction('commands.bp_module_c_45')
 
     # The `personality` syscall is used by lldb to turn off ASLR.
     # This syscall may not be permitted within containers.

--- a/tests/module_loading/module/CMakeLists.txt
+++ b/tests/module_loading/module/CMakeLists.txt
@@ -44,7 +44,9 @@ enclave_compile_options(
   # user. There are valid reasons for an end user to use built-ins.
   $<BUILD_INTERFACE:-fno-builtin-malloc
   -fno-builtin-calloc
-  -fno-builtin>)
+  -fno-builtin>
+  # Enable stack protector
+  -fstack-protector-strong)
 
 add_enclave_dependencies(module oelibc_includes)
 

--- a/tests/module_loading/module/module.c
+++ b/tests/module_loading/module/module.c
@@ -11,6 +11,7 @@ extern int is_module_init;
 
 void notify_module_done_wrapper();
 int oe_sgx_get_additional_host_entropy(uint8_t* data, size_t size);
+void __stack_chk_fail(void);
 
 __attribute__((constructor)) void init_module()
 {
@@ -57,6 +58,7 @@ int test_libc_symbols()
     TEST_SYMBOL(memcpy);
     TEST_SYMBOL(memmove);
     TEST_SYMBOL(memset);
+    TEST_SYMBOL(__stack_chk_fail);
     TEST_SYMBOL(oe_sgx_get_additional_host_entropy);
     TEST_SYMBOL(pthread_mutex_destroy);
     TEST_SYMBOL(pthread_mutex_init);

--- a/tests/openssl/enc/CMakeLists.txt
+++ b/tests/openssl/enc/CMakeLists.txt
@@ -64,8 +64,8 @@ if (ENABLE_SYMCRYPT_OPENSSL_TESTS)
     TARGET openssl-support
     COMMAND
       ${CMAKE_COMMAND} -E copy
-      ${CMAKE_BINARY_DIR}/3rdparty/symcrypt_engine/SymCrypt/lib/libsymcrypt.so
-      ${CMAKE_CURRENT_BINARY_DIR}/libsymcrypt.so)
+      ${CMAKE_BINARY_DIR}/3rdparty/symcrypt_engine/SymCrypt/lib/${SYMCRYPT_NAME}
+      ${CMAKE_CURRENT_BINARY_DIR}/${SYMCRYPT_LINK_NAME})
 endif ()
 
 # List the tests that require ssltestlib.c.


### PR DESCRIPTION
This PR updates the SymCrypt-OpenSSL submodule and the module loading support for SymCrypt v101.3.0.
The changes for the latter are as follows:

- Expose `__stack_chk_fail` to the module to support stack canary.
- Remove the logic on relying the existence of "DYNAMIC" symbol, which is stripped in the latest symcrypt binary, to find the offset of the dynamic section. Instead, we update the logic to find the offset from the section table.
- Add the support to handle the `DT_PLTGOT` entry relocation.


Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>