### PR TITLE
Skip pf_gp_exceptions test on non-FLC systems

### DIFF
--- a/host/sgx/cpuid.h
+++ b/host/sgx/cpuid.h
@@ -13,6 +13,9 @@
 #error "oe_get_cpuid(): no cpuid intrinsic mapping for this compiler"
 #endif
 
+#define CPUID_EXTENDED_FEATURE_FLAGS_LEAF 0x07
+#define CPUID_EXTENDED_FEATURE_FLAGS_SGX_FLC_MASK 0x40000000
+
 #define CPUID_SGX_LEAF 0x12
 #define CPUID_SGX_KSS_MASK 0x80
 #define CPUID_SGX_MISC_EXINFO_MASK 0x01

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -107,7 +107,7 @@ static void _initialize_enclave_host()
 }
 #endif // OEHOSTMR
 
-static bool _is_kss_supported()
+bool oe_sgx_is_kss_supported(void)
 {
     uint32_t eax, ebx, ecx, edx;
     eax = ebx = ecx = edx = 0;
@@ -119,7 +119,7 @@ static bool _is_kss_supported()
     return (eax & CPUID_SGX_KSS_MASK);
 }
 
-static bool _is_misc_region_supported()
+bool oe_sgx_is_misc_region_supported(void)
 {
     uint32_t eax, ebx, ecx, edx;
     eax = ebx = ecx = edx = 0;
@@ -1003,7 +1003,7 @@ oe_result_t oe_sgx_build_enclave(
     if (props.config.flags.capture_pf_gp_exceptions)
     {
         /* Only opt into the feature if CPU (SGX2) supports the MISC region. */
-        if (_is_misc_region_supported())
+        if (oe_sgx_is_misc_region_supported())
             context->capture_pf_gp_exceptions_enabled = 1;
 #if !defined(OEHOSTMR) && defined(__linux__)
         else if (props.config.attributes & OE_SGX_FLAGS_DEBUG)
@@ -1038,7 +1038,8 @@ oe_result_t oe_sgx_build_enclave(
 
     if (props.config.attributes & OE_SGX_FLAGS_KSS)
     {
-        if ((context->type == OE_SGX_LOAD_TYPE_CREATE) && !_is_kss_supported())
+        if ((context->type == OE_SGX_LOAD_TYPE_CREATE) &&
+            !oe_sgx_is_kss_supported())
         {
             // Fail if the CPU does not support KSS and the enclave specifies
             // the KSS flag
@@ -1052,7 +1053,7 @@ oe_result_t oe_sgx_build_enclave(
     }
 
     // if config_id data is passed and kss is not supported
-    if (context->use_config_id && !_is_kss_supported())
+    if (context->use_config_id && !oe_sgx_is_kss_supported())
     {
         if (!context->config_data->ignore_if_unsupported)
         {

--- a/host/sgx/tests.c
+++ b/host/sgx/tests.c
@@ -13,7 +13,7 @@ static void _check_quote_provider(void)
     _has_quote_provider = (oe_initialize_quote_provider() == OE_OK);
 }
 
-bool oe_has_sgx_quote_provider(void)
+bool oe_sgx_has_quote_provider(void)
 {
     static oe_once_type once = OE_H_ONCE_INITIALIZER;
     oe_once(&once, _check_quote_provider);

--- a/host/sgx/tests.c
+++ b/host/sgx/tests.c
@@ -4,6 +4,7 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/sgx/tests.h>
 #include "../hostthread.h"
+#include "cpuid.h"
 #include "sgxquoteprovider.h"
 
 static bool _has_quote_provider = false;
@@ -18,4 +19,17 @@ bool oe_sgx_has_quote_provider(void)
     static oe_once_type once = OE_H_ONCE_INITIALIZER;
     oe_once(&once, _check_quote_provider);
     return _has_quote_provider;
+}
+
+bool oe_sgx_is_flc_supported(void)
+{
+    uint32_t eax, ebx, ecx, edx;
+    eax = ebx = ecx = edx = 0;
+
+    // Obtain feature information using CPUID
+    oe_get_cpuid(
+        CPUID_EXTENDED_FEATURE_FLAGS_LEAF, 0x0, &eax, &ebx, &ecx, &edx);
+
+    // Check if FLC is supported by the processor
+    return ecx & CPUID_EXTENDED_FEATURE_FLAGS_SGX_FLC_MASK;
 }

--- a/include/openenclave/internal/sgx/tests.h
+++ b/include/openenclave/internal/sgx/tests.h
@@ -14,6 +14,11 @@ OE_EXTERNC_BEGIN
  */
 bool oe_sgx_has_quote_provider(void);
 
+/*
+ * Return whether SGX FLC is supported by the processor.
+ */
+bool oe_sgx_is_flc_supported(void);
+
 OE_EXTERNC_END
 
 #endif // _OE_INTERNAL_SGX_TESTS_H

--- a/include/openenclave/internal/sgx/tests.h
+++ b/include/openenclave/internal/sgx/tests.h
@@ -11,7 +11,7 @@ OE_EXTERNC_BEGIN
 /*
  * Return whether SGX quote provider libraries are available in the system.
  */
-bool oe_has_sgx_quote_provider(void);
+bool oe_sgx_has_quote_provider(void);
 
 OE_EXTERNC_END
 

--- a/include/openenclave/internal/sgx/tests.h
+++ b/include/openenclave/internal/sgx/tests.h
@@ -5,6 +5,7 @@
 #define _OE_INTERNAL_SGX_TESTS_H
 
 #include <openenclave/bits/defs.h>
+#include <openenclave/internal/sgxcreate.h>
 
 OE_EXTERNC_BEGIN
 

--- a/include/openenclave/internal/sgxcreate.h
+++ b/include/openenclave/internal/sgxcreate.h
@@ -117,6 +117,9 @@ oe_result_t oe_sgx_validate_enclave_properties(
     const oe_sgx_enclave_properties_t* properties,
     const char** field_name);
 
+bool oe_sgx_is_kss_supported(void);
+bool oe_sgx_is_misc_region_supported(void);
+
 OE_EXTERNC_END
 
 #endif /* _OE_SGXCREATE_H */

--- a/tests/attestation_cert_apis/host/host.cpp
+++ b/tests/attestation_cert_apis/host/host.cpp
@@ -131,7 +131,7 @@ void run_test(oe_enclave_t* enclave, int test_type)
 
 int main(int argc, const char* argv[])
 {
-    if (!oe_has_sgx_quote_provider())
+    if (!oe_sgx_has_quote_provider())
     {
         // this test should not run on any platforms where DCAP libraries are
         // not found.

--- a/tests/attestation_plugin/host/host.c
+++ b/tests/attestation_plugin/host/host.c
@@ -43,7 +43,7 @@ void host_verify(
 
 int main(int argc, const char* argv[])
 {
-    if (!oe_has_sgx_quote_provider())
+    if (!oe_sgx_has_quote_provider())
     {
         // this test should not run on any platforms where DCAP libraries are
         // not found.

--- a/tests/attestation_plugin_cert/host/host.cpp
+++ b/tests/attestation_plugin_cert/host/host.cpp
@@ -170,7 +170,7 @@ int main(int argc, const char* argv[])
     oe_result_t result;
     oe_enclave_t* enclave = nullptr;
 
-    if (!oe_has_sgx_quote_provider())
+    if (!oe_sgx_has_quote_provider())
     {
         // this test should not run on any platforms where DCAP libraries are
         // not found.

--- a/tests/child_process/host/host.cpp
+++ b/tests/child_process/host/host.cpp
@@ -36,10 +36,9 @@ int main(int argc, const char* argv[])
         fprintf(stderr, "Usage: %s ENCLAVE_PATH TEST_NUMBER\n", argv[0]);
         exit(1);
     }
-    if (!oe_sgx_has_quote_provider())
+    if (!oe_sgx_is_flc_supported())
     {
-        // this test should not run on any platforms where FLC is not supported
-        OE_TRACE_INFO("=== tests skipped when DCAP libraries are not found.\n");
+        OE_TRACE_INFO("=== tests skipped when FLC is not supported.\n");
         return SKIP_RETURN_CODE;
     }
     oe_enclave_t* enclave = NULL;

--- a/tests/child_process/host/host.cpp
+++ b/tests/child_process/host/host.cpp
@@ -36,7 +36,7 @@ int main(int argc, const char* argv[])
         fprintf(stderr, "Usage: %s ENCLAVE_PATH TEST_NUMBER\n", argv[0]);
         exit(1);
     }
-    if (!oe_has_sgx_quote_provider())
+    if (!oe_sgx_has_quote_provider())
     {
         // this test should not run on any platforms where FLC is not supported
         OE_TRACE_INFO("=== tests skipped when DCAP libraries are not found.\n");

--- a/tests/config_id/host/host.c
+++ b/tests/config_id/host/host.c
@@ -2,22 +2,10 @@
 // Licensed under the MIT License.
 
 #include <openenclave/host.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include "../common.h"
-#include "../host/sgx/cpuid.h"
 #include "config_id_u.h"
-
-static bool _is_kss_supported()
-{
-    uint32_t eax, ebx, ecx, edx;
-    eax = ebx = ecx = edx = 0;
-
-    // Obtain feature information using CPUID
-    oe_get_cpuid(0x12, 0x1, &eax, &ebx, &ecx, &edx);
-
-    // Check if KSS (bit 7) is supported by the processor
-    return eax & (1 << 7);
-}
 
 int main(int argc, const char* argv[])
 {
@@ -56,7 +44,7 @@ int main(int argc, const char* argv[])
     optional_settings.setting_type = OE_SGX_ENCLAVE_CONFIG_DATA;
     optional_settings.u.config_data = &optional_config_data_setting;
 
-    if (_is_kss_supported())
+    if (oe_sgx_is_kss_supported())
     {
         result = oe_create_config_id_enclave(
             argv[1],

--- a/tests/debug-mode/host/host.c
+++ b/tests/debug-mode/host/host.c
@@ -87,7 +87,7 @@ static void _test_debug_signed(const char* path)
     /* Signed debug mode should always pass. */
     _launch_enclave_success(path, _create_flags(SGX_DEBUG), 1);
     _launch_enclave_success(path, _create_flags(SGX_DEBUG_AUTO), 1);
-    if (oe_sgx_has_quote_provider())
+    if (oe_sgx_is_flc_supported())
     {
         /* Only works with FLC */
         _launch_enclave_success(path, _create_flags(SGX_NON_DEBUG), 0);
@@ -106,7 +106,7 @@ static void _test_non_debug_signed(const char* path)
 {
     /* Debug mode should fail. Non-debug mode should pass. */
     _launch_enclave_fail(path, _create_flags(SGX_DEBUG), OE_DEBUG_DOWNGRADE);
-    if (oe_sgx_has_quote_provider())
+    if (oe_sgx_is_flc_supported())
     {
         /* Only works with FLC */
         _launch_enclave_success(path, _create_flags(SGX_NON_DEBUG), 0);

--- a/tests/debug-mode/host/host.c
+++ b/tests/debug-mode/host/host.c
@@ -87,7 +87,7 @@ static void _test_debug_signed(const char* path)
     /* Signed debug mode should always pass. */
     _launch_enclave_success(path, _create_flags(SGX_DEBUG), 1);
     _launch_enclave_success(path, _create_flags(SGX_DEBUG_AUTO), 1);
-    if (oe_has_sgx_quote_provider())
+    if (oe_sgx_has_quote_provider())
     {
         /* Only works with FLC */
         _launch_enclave_success(path, _create_flags(SGX_NON_DEBUG), 0);
@@ -106,7 +106,7 @@ static void _test_non_debug_signed(const char* path)
 {
     /* Debug mode should fail. Non-debug mode should pass. */
     _launch_enclave_fail(path, _create_flags(SGX_DEBUG), OE_DEBUG_DOWNGRADE);
-    if (oe_has_sgx_quote_provider())
+    if (oe_sgx_has_quote_provider())
     {
         /* Only works with FLC */
         _launch_enclave_success(path, _create_flags(SGX_NON_DEBUG), 0);

--- a/tests/eeid_plugin/host/host.c
+++ b/tests/eeid_plugin/host/host.c
@@ -353,7 +353,7 @@ int main(int argc, const char* argv[])
         exit(1);
     }
 
-    if (!oe_has_sgx_quote_provider())
+    if (!oe_sgx_has_quote_provider())
     {
         // this test should not run on any platforms where DCAP libraries are
         // not found.

--- a/tests/pf_gp_exceptions/host/host.c
+++ b/tests/pf_gp_exceptions/host/host.c
@@ -4,10 +4,10 @@
 #include <limits.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "../host/sgx/cpuid.h"
 #include "pf_gp_exceptions_u.h"
 
 #ifdef _WIN32
@@ -17,18 +17,6 @@ static int is_on_windows = 0;
 #endif
 
 #define SKIP_RETURN_CODE 2
-
-static bool _is_misc_region_supported()
-{
-    uint32_t eax, ebx, ecx, edx;
-    eax = ebx = ecx = edx = 0;
-
-    // Obtain feature information using CPUID
-    oe_get_cpuid(CPUID_SGX_LEAF, 0x0, &eax, &ebx, &ecx, &edx);
-
-    // Check if EXINFO is supported by the processor
-    return (ebx & CPUID_SGX_MISC_EXINFO_MASK);
-}
 
 int main(int argc, const char* argv[])
 {
@@ -46,7 +34,7 @@ int main(int argc, const char* argv[])
     flags &= ~(uint32_t)OE_ENCLAVE_FLAG_DEBUG;
     flags |= (uint32_t)OE_ENCLAVE_FLAG_DEBUG_AUTO;
 
-    int is_misc_region_supported = _is_misc_region_supported();
+    int is_misc_region_supported = oe_sgx_is_misc_region_supported();
 
     result = oe_create_pf_gp_exceptions_enclave(
         argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);

--- a/tests/pf_gp_exceptions/host/host.c
+++ b/tests/pf_gp_exceptions/host/host.c
@@ -39,6 +39,12 @@ int main(int argc, const char* argv[])
     result = oe_create_pf_gp_exceptions_enclave(
         argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);
 
+    if (result == OE_PLATFORM_ERROR && !oe_sgx_is_flc_supported())
+    {
+        // creation of non-debug enclave may fail on non-FLC systems
+        return SKIP_RETURN_CODE;
+    }
+
     /* The enclave creation should succeed on both SGX1 and SGX2 machines. */
     if (result != OE_OK)
         oe_put_err("oe_create_enclave(): result=%u", result);

--- a/tests/qeidentity/host/host.cpp
+++ b/tests/qeidentity/host/host.cpp
@@ -48,7 +48,7 @@ int main(int argc, const char* argv[])
         oe_put_err("oe_create_enclave(): result=%u", result);
     }
 
-    if (oe_has_sgx_quote_provider())
+    if (oe_sgx_has_quote_provider())
     {
         run_parse_advisoryids_json_test();
         run_qe_identity_test_cases(enclave);

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -55,7 +55,7 @@ extern int FileToBytes(const char* path, std::vector<uint8_t>* output);
 
 void generate_and_save_report(oe_enclave_t* enclave)
 {
-    if (!oe_has_sgx_quote_provider())
+    if (!oe_sgx_has_quote_provider())
         return;
 
     static uint8_t* report;
@@ -180,7 +180,7 @@ int main(int argc, const char* argv[])
                 enclave, 0, nullptr, 0, &report_buffer, &report_buffer_size) ==
             OE_UNSUPPORTED);
     }
-    else if (oe_has_sgx_quote_provider())
+    else if (oe_sgx_has_quote_provider())
     {
         static oe_uuid_t sgx_ecdsa_uuid = {OE_FORMAT_UUID_SGX_ECDSA};
 

--- a/tests/sgx/extra_data/host/host.c
+++ b/tests/sgx/extra_data/host/host.c
@@ -72,7 +72,7 @@ int main(int argc, const char* argv[])
 
     const bool enable_zerobase = strcmp(argv[2], "zerobase") == 0;
 
-    if (enable_zerobase && !oe_has_sgx_quote_provider())
+    if (enable_zerobase && !oe_sgx_has_quote_provider())
     {
         // this test should not run on any platforms where FLC is not supported
         printf("=== tests skipped when DCAP libraries are not found.\n");

--- a/tests/sgx/extra_data/host/host.c
+++ b/tests/sgx/extra_data/host/host.c
@@ -72,10 +72,9 @@ int main(int argc, const char* argv[])
 
     const bool enable_zerobase = strcmp(argv[2], "zerobase") == 0;
 
-    if (enable_zerobase && !oe_sgx_has_quote_provider())
+    if (enable_zerobase && !oe_sgx_is_flc_supported())
     {
-        // this test should not run on any platforms where FLC is not supported
-        printf("=== tests skipped when DCAP libraries are not found.\n");
+        printf("=== tests skipped when FLC is not supported.\n");
         return SKIP_RETURN_CODE;
     }
 

--- a/tests/sgx_zerobase/host/host.cpp
+++ b/tests/sgx_zerobase/host/host.cpp
@@ -37,10 +37,9 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    if (!oe_sgx_has_quote_provider())
+    if (!oe_sgx_is_flc_supported())
     {
-        // this test should not run on any platforms where FLC is not supported
-        OE_TRACE_INFO("=== tests skipped when DCAP libraries are not found.\n");
+        OE_TRACE_INFO("=== tests skipped when FLC is not supported.\n");
         return SKIP_RETURN_CODE;
     }
 

--- a/tests/sgx_zerobase/host/host.cpp
+++ b/tests/sgx_zerobase/host/host.cpp
@@ -50,7 +50,7 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    if (!oe_has_sgx_quote_provider())
+    if (!oe_sgx_has_quote_provider())
     {
         // this test should not run on any platforms where FLC is not supported
         OE_TRACE_INFO("=== tests skipped when DCAP libraries are not found.\n");

--- a/tests/sgx_zerobase/host/host.cpp
+++ b/tests/sgx_zerobase/host/host.cpp
@@ -10,24 +10,11 @@
 #include <sys/mman.h>
 #include <iostream>
 
-#include "../host/sgx/cpuid.h"
 #include "sgx_zerobase_u.h"
 
 #define SKIP_RETURN_CODE 2
 
 const char* message = "Hello world from Host\n\0";
-
-static bool _is_misc_region_supported()
-{
-    uint32_t eax, ebx, ecx, edx;
-    eax = ebx = ecx = edx = 0;
-
-    // Obtain feature information using CPUID
-    oe_get_cpuid(CPUID_SGX_LEAF, 0x0, &eax, &ebx, &ecx, &edx);
-
-    // Check if EXINFO is supported by the processor
-    return (ebx & CPUID_SGX_MISC_EXINFO_MASK);
-}
 
 int test_ocall(const char* message)
 {
@@ -152,7 +139,7 @@ int main(int argc, const char* argv[])
     }
 
     /* Enclave memory access tests */
-    if (_is_misc_region_supported())
+    if (oe_sgx_is_misc_region_supported())
     {
         bool exception = false;
 

--- a/tests/stack_overflow_exception/host/host.c
+++ b/tests/stack_overflow_exception/host/host.c
@@ -4,25 +4,13 @@
 #include <limits.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
+#include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "../host/sgx/cpuid.h"
 #include "stack_overflow_exception_u.h"
 
 static bool enclave_stack_overflowed = false;
-
-static bool _is_misc_region_supported()
-{
-    uint32_t eax, ebx, ecx, edx;
-    eax = ebx = ecx = edx = 0;
-
-    // Obtain feature information using CPUID
-    oe_get_cpuid(CPUID_SGX_LEAF, 0x0, &eax, &ebx, &ecx, &edx);
-
-    // Check if EXINFO is supported by the processor
-    return (ebx & CPUID_SGX_MISC_EXINFO_MASK);
-}
 
 void host_notify_stack_overflowed()
 {
@@ -51,7 +39,7 @@ int main(int argc, const char* argv[])
     if (flags & OE_ENCLAVE_FLAG_SIMULATE)
         printf("Simulation mode does not support exceptions. Skip the test "
                "ECALL.\n");
-    else if (_is_misc_region_supported())
+    else if (oe_sgx_is_misc_region_supported())
     {
         OE_TEST(enc_stack_overflow_exception(enclave) == OE_ENCLAVE_ABORTING);
         OE_TEST(enclave_stack_overflowed == true);

--- a/tests/tls_e2e/host/host.cpp
+++ b/tests/tls_e2e/host/host.cpp
@@ -352,7 +352,7 @@ done:
 
 int main(int argc, const char* argv[])
 {
-    if (!oe_has_sgx_quote_provider())
+    if (!oe_sgx_has_quote_provider())
     {
         // this test should not run on any platforms where DCAP libraries are
         // not found.

--- a/tests/tools/oecertdump/host/host.cpp
+++ b/tests/tools/oecertdump/host/host.cpp
@@ -277,7 +277,7 @@ int main(int argc, const char* argv[])
 {
     int ret = 0;
 
-    if (!oe_has_sgx_quote_provider())
+    if (!oe_sgx_has_quote_provider())
     {
         fprintf(
             stderr, "FAILURE: DCAP libraries must be present for this test.\n");

--- a/tests/tools/oesign/test-enclave/host/host.c
+++ b/tests/tools/oesign/test-enclave/host/host.c
@@ -105,7 +105,7 @@ int main(int argc, const char* argv[])
     /* check_kss_extended_ids currently assumes the quote provider is available.
      * Skip if there is no quote provider for now.
      */
-    if (_is_kss_supported() && oe_has_sgx_quote_provider())
+    if (_is_kss_supported() && oe_sgx_has_quote_provider())
     {
         result = check_kss_extended_ids(
             enclave,

--- a/tests/tools/oesign/test-enclave/host/host.c
+++ b/tests/tools/oesign/test-enclave/host/host.c
@@ -7,24 +7,8 @@
 #include <openenclave/internal/sgx/tests.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
-#include "../host/sgx/cpuid.h"
 
 #include "oesign_test_u.h"
-
-static bool _is_kss_supported()
-{
-    uint32_t eax, ebx, ecx, edx;
-    eax = ebx = ecx = edx = 0;
-
-    // Obtain feature information using CPUID
-    oe_get_cpuid(0x12, 0x1, &eax, &ebx, &ecx, &edx);
-
-    // Check if KSS (bit 7) is supported by the processor
-    if (!(eax & (1 << 7)))
-        return false;
-    else
-        return true;
-}
 
 int main(int argc, const char* argv[])
 {
@@ -42,7 +26,7 @@ int main(int argc, const char* argv[])
 
     // Create the enclave
     uint32_t flags = oe_get_create_flags();
-    bool is_kss_supported = _is_kss_supported();
+    bool is_kss_supported = oe_sgx_is_kss_supported();
 
     /* Load the ELF image */
     if ((result = oe_load_enclave_image(argv[1], &oeimage)) != OE_OK)
@@ -105,7 +89,7 @@ int main(int argc, const char* argv[])
     /* check_kss_extended_ids currently assumes the quote provider is available.
      * Skip if there is no quote provider for now.
      */
-    if (_is_kss_supported() && oe_sgx_has_quote_provider())
+    if (is_kss_supported && oe_sgx_has_quote_provider())
     {
         result = check_kss_extended_ids(
             enclave,

--- a/tools/oeutil/host/generate_evidence.cpp
+++ b/tools/oeutil/host/generate_evidence.cpp
@@ -1683,7 +1683,7 @@ int oeutil_generate_evidence(int argc, const char* argv[])
     int ret = 0;
     printf("NOTICE: oeutil generate-evidence is purely a debugging utility and "
            "not suitable for production use.\n\n");
-    if (!oe_has_sgx_quote_provider())
+    if (!oe_sgx_has_quote_provider())
     {
         fprintf(
             stderr, "FAILURE: DCAP libraries must be present for this test.\n");


### PR DESCRIPTION
The enclave config of this test has been changed to Debug=0. Such an enclave can't be loaded on non-FLC systems.

As it was related to my change, I also changed other things:
* Some tests checked for an installed quote provider, but they actually should check for FLC.
* Some tests duplicated similar checking functions. I removed these duplications.
