### PR TITLE
Ensure x64 ABI compatibility for oe_abort

### DIFF
--- a/libc/sgx/abort.S
+++ b/libc/sgx/abort.S
@@ -5,7 +5,7 @@
 .type abort, @function
 abort:
 .cfi_startproc
-
+    sub $8, %rsp // align rsp so that the call below is ABI compliant
     call oe_abort
     ud2
 


### PR DESCRIPTION
oe_abort is a C function. There are two contexts in which the function was being
called from assembly code without conformance to x64 ABI

1) In libc/abort.S. The RSP was not being aligned before the call instruction.
2) In enclave/core/sgx/exception.c. oe_continue_execution was being used to jump
   to oe_abort. oe_continue_execution (assembly functoin) uses the retq instruction
   instead of the call instruction to jump to target address. This works for jumping
   to actual location in which exception happened; however it could (depending on current
   RSP value) break x64 ABI when jumping to C functions.

This PR fixes both these issues.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>