### PR TITLE
Migration to new Jenkins

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -91,7 +91,7 @@ if ( ! params.FORCE_TEST ) {
 stage("Trigger downstream pipelines") {
     parallel (
         "Agnostic Linux" : {
-            build job: '/pipelines/Agnostic-Linux',
+            build job: '/OpenEnclave/Agnostic-Linux',
                 parameters: [string(name: 'REPOSITORY_NAME', value: REPOSITORY_NAME),
                                 string(name: 'BRANCH_NAME', value: BRANCH_NAME),
                                 string(name: 'DOCKER_TAG', value: DOCKER_TAG),
@@ -100,7 +100,7 @@ stage("Trigger downstream pipelines") {
                                 booleanParam(name: 'FULL_TEST_SUITE', value: FULL_TEST_SUITE)]
         },
         "Azure Linux" : {
-            build job: '/pipelines/Azure-Linux',
+            build job: '/OpenEnclave/Azure-Linux',
                     parameters: [string(name: 'REPOSITORY_NAME', value: REPOSITORY_NAME),
                                 string(name: 'BRANCH_NAME', value: BRANCH_NAME),
                                 string(name: 'DOCKER_TAG', value: DOCKER_TAG),
@@ -112,12 +112,12 @@ stage("Trigger downstream pipelines") {
                                 booleanParam(name: 'FULL_TEST_SUITE', value: FULL_TEST_SUITE)]
         },
         "Intel Linux" : {
-            build job: '/pipelines/Intel-Agnostic',
+            build job: '/OpenEnclave/Intel-Agnostic',
                 parameters: [booleanParam(name: 'FULL_TEST_SUITE', value: FULL_TEST_SUITE)],
                 propagate: false
         },
         "Azure Windows" : {
-            build job: '/pipelines/Azure-Windows',
+            build job: '/OpenEnclave/Azure-Windows',
                     parameters: [string(name: 'REPOSITORY_NAME', value: REPOSITORY_NAME),
                                 string(name: 'BRANCH_NAME', value: BRANCH_NAME),
                                 string(name: 'DOCKER_TAG', value: DOCKER_TAG),

--- a/.jenkins/infrastructure/docker/build_linux_docker_images.Jenkinsfile
+++ b/.jenkins/infrastructure/docker/build_linux_docker_images.Jenkinsfile
@@ -178,19 +178,5 @@ pipeline {
                 }
             }
         }
-        stage("Push to OE Docker Registry") {
-            steps {
-                script {
-                    docker.withRegistry(params.INTERNAL_REPO, env.INTERNAL_REPO_CREDS) {
-                        common.exec_with_retry { oe1804.push() }
-                        common.exec_with_retry { oe2004.push() }
-                        if ( params.TAG_LATEST ) {
-                            common.exec_with_retry { oe1804.push('latest') }
-                            common.exec_with_retry { oe2004.push('latest') }
-                        }
-                    }
-                }
-            }
-        }
     }
 }

--- a/.jenkins/pipelines/OpenEnclave/releases/publish/Jenkinsfile
+++ b/.jenkins/pipelines/OpenEnclave/releases/publish/Jenkinsfile
@@ -79,8 +79,8 @@ EOF
                 helpers.releaseDownloadLinux(release_version, "open-enclave-hostverify", 'GitHub', 'Ubuntu', os_release)
                 sh """#!/bin/bash
                     echo "Publishing OpenEnclave ${release_version}"
-                    repoclient -c ${WORKSPACE}/config-Ubuntu${os_release}.json package add open-enclave"
-                    repoclient -c ${WORKSPACE}/config-Ubuntu${os_release}.json package add open-enclave-hostverify"
+                    repoclient -c ${WORKSPACE}/config-Ubuntu${os_release}.json package add open-enclave
+                    repoclient -c ${WORKSPACE}/config-Ubuntu${os_release}.json package add open-enclave-hostverify
                 """
             }
         }

--- a/README.md
+++ b/README.md
@@ -9,15 +9,14 @@ Integration Partners
 
 Agnostic Cloud Provider
 
-[![Provider Agnostic Regression Linux](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/Agnostic-Linux-Badge/badge/icon?subject=Provider%20Agnostic%20Regession)](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/Agnostic-Linux-Badge/)
+[![Provider Agnostic Regression Linux](https://openenclaveci.westus.cloudapp.azure.com/job/OpenEnclave/job/Badges/job/Agnostic-Linux/badge/icon?subject=Provider%20Agnostic%20Regression)](https://openenclaveci.westus.cloudapp.azure.com/job/OpenEnclave/job/Badges/job/Agnostic-Linux/)
 
 Azure
 
-[![Nightly Regression](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/Nightly/badge/icon?subject=Azure%20Regression%20Testing)](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/Nightly/)
-[![Azure Windows](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/Azure-Windows-Badge/badge/icon?subject=Azure-Windows)](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/Azure-Windows-Badge/)
-[![Nightly Libcxx](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/OpenEnclave-libcxx-tests/badge/icon?subject=Azure%20libcxx%20testing)](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/OpenEnclave-libcxx-tests/)
-[![Azure Linux](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/Azure-Linux-Badge/badge/icon?subject=Azure-Linux)](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/Azure-Linux-Badge/)
-[![Nightly Packages](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/OpenEnclave-nightly-packages/badge/icon?subject=Azure%20Package%20build)](https://oe-jenkins-dev.westeurope.cloudapp.azure.com/job/OpenEnclave/job/OpenEnclave-nightly-packages/)
+[![Azure Windows](https://openenclaveci.westus.cloudapp.azure.com/job/OpenEnclave/job/Badges/job/Azure-Windows/badge/icon?subject=Azure-Windows)](https://openenclaveci.westus.cloudapp.azure.com/job/OpenEnclave/job/Badges/job/Azure-Windows/)
+[![Nightly Libcxx](https://openenclaveci.westus.cloudapp.azure.com/job/OpenEnclave/job/Badges/job/OpenEnclave-libcxx-tests/badge/icon?subject=Azure%20libcxx%20testing)](https://openenclaveci.westus.cloudapp.azure.com/job/OpenEnclave/job/Badges/job/OpenEnclave-libcxx-tests/)
+[![Azure Linux](https://openenclaveci.westus.cloudapp.azure.com/job/OpenEnclave/job/Badges/job/Azure-Linux/badge/icon?subject=Azure-Linux)](https://openenclaveci.westus.cloudapp.azure.com/job/OpenEnclave/job/Badges/job/Azure-Linux/)
+[![Nightly Packages](https://openenclaveci.westus.cloudapp.azure.com/job/OpenEnclave/job/Badges/job/OpenEnclave-nightly-packages/badge/icon?subject=Nightly%20Packages)](https://openenclaveci.westus.cloudapp.azure.com/job/OpenEnclave/job/Badges/job/OpenEnclave-nightly-packages/)
 
 
 Introduction


### PR DESCRIPTION
This migrates to a new Jenkins url, and fixes bugs.

Note that I completely removed the badge for "Nightly Regression" because it is just the combination of "Provider Agnostic Regression Linux", "Azure Windows", and "Azure Linux".

Signed-off-by: Chris Yan <chrisyan@microsoft.com>