### PR TITLE
[oeutil] Statically link oe_prereqs/OpenSSL/../libcrypto*.lib to oeutil.exe in Windows

### DIFF
--- a/tools/oeutil/host/CMakeLists.txt
+++ b/tools/oeutil/host/CMakeLists.txt
@@ -25,12 +25,22 @@ target_include_directories(oeutil PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
 
 target_link_libraries(oeutil oehost OpenSSL::SSL)
 
-# The X509_print_ex_fp function in OpenSSL requires to include applink.c, which
-# glues OpenSSL BIO and Win32 compiler run-time. But applink.c uses fopen() that
-# raises a W3 warning and triggers error C2220 (warning treated as error).
-# To work around for this internal tool, oecertdump will be compiled at w2 level.
 if (WIN32)
+  # The X509_print_ex_fp function in OpenSSL requires to include applink.c, which
+  # glues OpenSSL BIO and Win32 compiler run-time. But applink.c uses fopen() that
+  # raises a W3 warning and triggers error C2220 (warning treated as error).
+  # To work around for this internal tool, oecertdump will be compiled at w2 level.
   target_compile_options(oeutil PRIVATE /W2)
+
+  # OE build system uses OpenSSL installed by Git in Git/mingw64/,
+  # to generate enclave keys, which also contains libcrypto*.dll. However,
+  # oeutil.exe tool requires libcrypto-*-x64.dll that is provided in OpenSSL
+  # installed by install-windows-prereqs.ps1 script (Issue #4009).
+  # Statically link to oe_prereqs/OpenSSL/../libcrypto_static.lib to avoid
+  # runtime dll loading issues.
+  target_link_libraries(
+    oeutil
+    ${NUGET_PACKAGE_PATH}\\OpenSSL\\x64\\release\\lib\\libcrypto_static.lib)
 endif ()
 
 # Generate the oeutil binary in the the same directory with enclave binary


### PR DESCRIPTION
This PR resolves the issue #4009.
Since the OpenSSL from Git/mingw64 is used by our build system, removing it from/ moving it lower than oe_prereqs/OpenSSL in %path% globally is not an option.

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>