### PR TITLE
Update install_oe_sdk-Ubuntu_18.04.md

### DIFF
--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
@@ -32,7 +32,7 @@ sudo ./sgx_linux_x64_driver.bin
 ```
 
 > This may not be the latest Intel SGX DCAP driver.
-> Please check with [Intel's SGX site](https://01.org/intel-software-guard-extensions/downloads) or 
+> Please check with [Intel's SGX site](https://01.org/intel-software-guard-extensions/downloads)
 > if a more recent SGX DCAP driver exists.
 
 ### 3. Install the Intel and Open Enclave packages and dependencies

--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md
@@ -26,13 +26,13 @@ wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add 
 ```bash
 sudo apt update
 sudo apt -y install dkms
-wget https://download.01.org/intel-sgx/sgx-dcap/1.4/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.21.bin -O sgx_linux_x64_driver.bin
+wget https://download.01.org/intel-sgx/sgx-dcap/1.10/linux/distro/ubuntu18.04-server/sgx_linux_x64_driver_1.41.bin -O sgx_linux_x64_driver.bin
 chmod +x sgx_linux_x64_driver.bin
 sudo ./sgx_linux_x64_driver.bin
 ```
 
 > This may not be the latest Intel SGX DCAP driver.
-> Please check with [Intel's SGX site](https://01.org/intel-software-guard-extensions/downloads)
+> Please check with [Intel's SGX site](https://01.org/intel-software-guard-extensions/downloads) or 
 > if a more recent SGX DCAP driver exists.
 
 ### 3. Install the Intel and Open Enclave packages and dependencies


### PR DESCRIPTION
The 1.21 driver mentioned in the readme encounters an error when installing on Ubuntu 18.04. Updated to reference the 1.41 driver instead.