### PR TITLE
Upgrade to snmalloc 0.6.0

### DIFF
--- a/3rdparty/snmalloc/allocator.cpp
+++ b/3rdparty/snmalloc/allocator.cpp
@@ -4,32 +4,37 @@
 #include <openenclave/advanced/allocator.h>
 #include <openenclave/advanced/mallinfo.h>
 
-namespace snmalloc
-{
-__thread void* allocator_local;
-
-class ThreadAllocUntyped
-{
-  public:
-    static void* get();
-};
-
-void* ThreadAllocUntyped::get()
-{
-    return allocator_local;
-}
-} // namespace snmalloc
-
+#define SNMALLOC_PROVIDE_OWN_CONFIG
+#define SNMALLOC_USE_CXX17
 #define OPEN_ENCLAVE
 #define SNMALLOC_SGX
 #define SNMALLOC_USE_SMALL_CHUNKS
 #define SNMALLOC_EXTERNAL_THREAD_ALLOC
 #define SNMALLOC_NAME_MANGLE(a) oe_allocator_##a
 
+#include "./snmalloc/src/snmalloc/backend/fixedglobalconfig.h"
+#include "./snmalloc/src/snmalloc/snmalloc_core.h"
+
+namespace snmalloc
+{
+using Globals = snmalloc::FixedGlobals<snmalloc::PALOpenEnclave>;
+using Alloc = snmalloc::LocalAllocator<Globals>;
+
+class ThreadAllocExternal
+{
+  public:
+    static Alloc& get()
+    {
+        static __thread Alloc alloc;
+        return alloc;
+    }
+};
+} // namespace snmalloc
+
 // Enable the Open Enclave PAL(Platform Abstraction Layer) for Open Enclave,
 // see pal_open_enclave.h for details
-#include "./snmalloc/src/override/malloc-extensions.cc"
-#include "./snmalloc/src/override/malloc.cc"
+#include "./snmalloc/src/snmalloc/override/malloc-extensions.cc"
+#include "./snmalloc/src/snmalloc/override/malloc.cc"
 
 static size_t _max_heap_size;
 static malloc_info_v1 _info;
@@ -40,8 +45,7 @@ void oe_allocator_init(void* heap_start_address, void* heap_end_address)
         static_cast<uint8_t*>(heap_end_address) -
         static_cast<uint8_t*>(heap_start_address));
 
-    snmalloc::PALOpenEnclave::setup_initial_range(
-        heap_start_address, heap_end_address);
+    Globals::init(nullptr, heap_start_address, _max_heap_size);
 }
 
 void oe_allocator_cleanup(void)
@@ -50,13 +54,13 @@ void oe_allocator_cleanup(void)
 
 void oe_allocator_thread_init(void)
 {
-    allocator_local = current_alloc_pool()->acquire();
+    auto allocator = new (&ThreadAllocExternal::get()) snmalloc::Alloc();
+    allocator->init();
 }
 
 void oe_allocator_thread_cleanup(void)
 {
-    current_alloc_pool()->release(ThreadAlloc::get());
-    allocator_local = nullptr;
+    ThreadAllocExternal::get().teardown();
 }
 
 oe_result_t oe_allocator_mallinfo(oe_mallinfo_t* info)

--- a/tests/mman/enc/enc.c
+++ b/tests/mman/enc/enc.c
@@ -352,6 +352,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    1024, /* NumHeapPages */
-    1024, /* NumStackPages */
+    2048, /* NumHeapPages */
+    2048, /* NumStackPages */
     2);   /* NumTCS */

--- a/tests/mman/enc/enc.c
+++ b/tests/mman/enc/enc.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <openenclave/internal/tests.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <sys/mman.h>
 #include "../../../libc/mman.h"
 #include "mman_t.h"
@@ -63,6 +64,7 @@ static void _test_partial_unmapping(void)
     OE_TEST(m->end == p2_end);
 
     // Swap p1 and p2 if p2 lies before p1.
+    bool swapped = false;
     if (p2_start < p1_start)
     {
         uint64_t t = p1_start;
@@ -72,6 +74,7 @@ static void _test_partial_unmapping(void)
         t = p1_end;
         p1_end = p2_end;
         p2_end = t;
+        swapped = true;
     }
 
     // Do an unmap that starts within p1 and ends within p2.
@@ -82,22 +85,44 @@ static void _test_partial_unmapping(void)
 
     // Partial unmapping only changes the status vectors and not the bounds.
     m = oe_test_get_mappings();
-    OE_TEST(m->start == p2_start);
-    OE_TEST(m->end == p2_end);
-    m = m->next;
-    OE_TEST(m->start == p1_start);
-    OE_TEST(m->end == p1_end);
+    if (swapped)
+    {
+        OE_TEST(m->start == p1_start);
+        OE_TEST(m->end == p1_end);
+        m = m->next;
+        OE_TEST(m->start == p2_start);
+        OE_TEST(m->end == p2_end);
+    }
+    else
+    {
+        OE_TEST(m->start == p2_start);
+        OE_TEST(m->end == p2_end);
+        m = m->next;
+        OE_TEST(m->start == p1_start);
+        OE_TEST(m->end == p1_end);
+    }
 
     // Do another partial unmap.
     start -= OE_PAGE_SIZE;
     OE_TEST(munmap((void*)start, end - start) == 0);
     OE_TEST(errno == 0);
     m = oe_test_get_mappings();
-    OE_TEST(m->start == p2_start);
-    OE_TEST(m->end == p2_end);
-    m = m->next;
-    OE_TEST(m->start == p1_start);
-    OE_TEST(m->end == p1_end);
+    if (swapped)
+    {
+        OE_TEST(m->start == p1_start);
+        OE_TEST(m->end == p1_end);
+        m = m->next;
+        OE_TEST(m->start == p2_start);
+        OE_TEST(m->end == p2_end);
+    }
+    else
+    {
+        OE_TEST(m->start == p2_start);
+        OE_TEST(m->end == p2_end);
+        m = m->next;
+        OE_TEST(m->start == p1_start);
+        OE_TEST(m->end == p1_end);
+    }
 
     // Do an unmap till the start.
     // This ought to delete one mapping completely.
@@ -352,6 +377,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    2048, /* NumHeapPages */
-    2048, /* NumStackPages */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
     2);   /* NumTCS */

--- a/tests/openssl/enc/enc.c
+++ b/tests/openssl/enc/enc.c
@@ -90,6 +90,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    8192, /* HeapPageCount */
+    7200, /* HeapPageCount */
     128,  /* StackPageCount */
     8);   /* TCSCount */

--- a/tests/openssl/enc/enc.c
+++ b/tests/openssl/enc/enc.c
@@ -90,6 +90,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    6144, /* HeapPageCount */
+    8192, /* HeapPageCount */
     128,  /* StackPageCount */
     8);   /* TCSCount */

--- a/tests/stdcxx/enc/enc.cpp
+++ b/tests/stdcxx/enc/enc.cpp
@@ -241,6 +241,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    1024, /* NumHeapPages */
-    1024, /* NumStackPages */
+    576,  /* NumHeapPages */
+    512,  /* NumStackPages */
     2);   /* NumTCS */

--- a/tests/stdcxx/enc/enc.cpp
+++ b/tests/stdcxx/enc/enc.cpp
@@ -241,6 +241,6 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* Debug */
-    512,  /* NumHeapPages */
-    512,  /* NumStackPages */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
     2);   /* NumTCS */


### PR DESCRIPTION
Follow-up to #4483, to upgrade to snmalloc to [0.6.0](https://github.com/microsoft/snmalloc/releases/tag/0.6.0) final.