### PR TITLE
Support debug enclave check without depending on oe_sgx_get_td 

### DIFF
--- a/enclave/core/optee/tracee.c
+++ b/enclave/core/optee/tracee.c
@@ -5,7 +5,7 @@
 
 #include "../tracee.h"
 
-bool is_enclave_debug_allowed()
+bool oe_is_enclave_debug_allowed()
 {
     // TODO: Eventually, this must be modifiable.
     return true;

--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -706,7 +706,7 @@ static void _exit_enclave(uint64_t arg1, uint64_t arg2)
 {
     oe_sgx_td_t* td = oe_sgx_get_td();
 
-    if (is_enclave_debug_allowed())
+    if (oe_is_enclave_debug_allowed())
     {
         oe_ecall_context_t* host_ecall_context = td->host_ecall_context;
 
@@ -1052,11 +1052,7 @@ static void _stitch_ecall_stack(oe_sgx_td_t* td, uint64_t* first_enclave_frame)
 {
     oe_ecall_context_t* ecall_context = td->host_ecall_context;
 
-    /* Use is_enclave_debug_allowed_cached() given that the td may not
-     * be initialized at this point. This also means that the very first
-     * ecall stack stitching will always be bypassed (the OE_ECALL_INIT_ENCLAVE
-     * ECALL) because the default caching value is false. */
-    if (is_enclave_debug_allowed_cached())
+    if (oe_is_enclave_debug_allowed())
     {
         if (oe_is_outside_enclave(ecall_context, sizeof(*ecall_context)))
         {
@@ -1302,12 +1298,8 @@ void oe_abort_with_td(oe_sgx_td_t* td)
     uint64_t arg1 = oe_make_call_arg1(OE_CODE_ERET, 0, 0, OE_OK);
 
     /* Abort can be called with user-modified FS (e.g., FS check fails in
-     * oe_sgx_get_td()). To avoid using is_enclave_debug_allowed(), which
-     * depends on oe_sgx_get_td(), we base only on the cached value to
-     * determine if the enclave is in debug mode. If the
-     * is_enclave_debug_allowed has not beed called before, the following
-     * function will return false and the stack stitching will be skipped. */
-    if (is_enclave_debug_allowed_cached())
+     * oe_sgx_get_td()). */
+    if (oe_is_enclave_debug_allowed())
     {
         oe_ecall_context_t* host_ecall_context = td->host_ecall_context;
 

--- a/enclave/core/sgx/exception.c
+++ b/enclave/core/sgx/exception.c
@@ -387,7 +387,7 @@ void oe_real_exception_dispatcher(oe_context_t* oe_context)
 
     // Update the stitched callstack so that it points to the location that
     // raised the exception.
-    if (is_enclave_debug_allowed_cached())
+    if (oe_is_enclave_debug_allowed())
     {
         // Real exception dispatcher never returns. It is directly called by
         // oe_exception_dispatcher. It is safe to modify its frame.
@@ -527,7 +527,7 @@ void oe_virtual_exception_dispatcher(
         td->host_signal = arg_in;
     }
     else if (
-        is_enclave_debug_allowed() &&
+        oe_is_enclave_debug_allowed() &&
         oe_is_outside_enclave((void*)arg_in, sizeof(oe_exception_record_t)))
     {
         oe_exception_record = (oe_exception_record_t*)arg_in;
@@ -542,7 +542,7 @@ void oe_virtual_exception_dispatcher(
 
     // Update the stitched callstack so that it points to the location that
     // raised the exception.
-    if (is_enclave_debug_allowed_cached())
+    if (oe_is_enclave_debug_allowed())
     {
         // Start at the current frame.
         void** frame = (void**)__builtin_frame_address(0);
@@ -599,7 +599,7 @@ void oe_virtual_exception_dispatcher(
          * has been set, simulate the page fault based on host-passed
          * information. This can either happen if the enclave runs with
          * SGX1 CPUs or set CapturePFGPExceptions=0 on SGX2 CPUs. */
-        if (is_enclave_debug_allowed() && oe_exception_record)
+        if (oe_is_enclave_debug_allowed() && oe_exception_record)
         {
             td->exception_code = OE_EXCEPTION_PAGE_FAULT;
             td->exception_flags |= OE_EXCEPTION_FLAGS_HARDWARE;

--- a/enclave/core/sgx/init.c
+++ b/enclave/core/sgx/init.c
@@ -17,6 +17,7 @@
 #include <openenclave/internal/thread.h>
 #include "asmdefs.h"
 #include "td.h"
+#include "tracee.h"
 
 void oe_abort_with_td(oe_sgx_td_t* td) OE_NO_RETURN;
 
@@ -131,6 +132,9 @@ static oe_once_t _enclave_initialize_once;
 static void _initialize_enclave_imp(void)
 {
     _initialize_enclave_image();
+
+    if (oe_sgx_initialize_simulation_mode_cache(_td) != OE_OK)
+        oe_abort_with_td(_td);
 }
 
 /*

--- a/enclave/core/sgx/report.c
+++ b/enclave/core/sgx/report.c
@@ -13,9 +13,9 @@
 #include <openenclave/internal/safecrt.h>
 #include <openenclave/internal/safemath.h>
 #include <openenclave/internal/sgx/plugin.h>
-#include <openenclave/internal/sgx/td.h>
 #include <openenclave/internal/utils.h>
 #include "platform_t.h"
+#include "tracee.h"
 
 /**
  * Declare the prototypes of the following functions to avoid the
@@ -127,7 +127,7 @@ oe_result_t sgx_create_report(
         OE_CHECK(oe_memcpy_s(
             &rd, sizeof(sgx_report_data_t), report_data, report_data_size));
 
-    if (oe_sgx_get_td()->simulate)
+    if (oe_sgx_is_in_simulation_mode())
         OE_RAISE(OE_UNSUPPORTED);
 
     /* Invoke EREPORT instruction */

--- a/enclave/core/sgx/tracee.c
+++ b/enclave/core/sgx/tracee.c
@@ -3,19 +3,58 @@
 
 #include <openenclave/bits/sgx/sgxtypes.h>
 #include <openenclave/enclave.h>
+#include <openenclave/internal/raise.h>
 #include <openenclave/internal/report.h>
 #include <openenclave/internal/sgx/td.h>
 
 #include "../tracee.h"
 #include "report.h"
+#include "tracee.h"
 
 static volatile int _is_enclave_debug_allowed = -1;
+static volatile int _is_in_simulation_mode = -1;
+
+oe_result_t oe_sgx_initialize_simulation_mode_cache(oe_sgx_td_t* td)
+{
+    int simulation_mode =
+        __atomic_load_n(&_is_in_simulation_mode, __ATOMIC_ACQUIRE);
+    oe_result_t result = OE_OK;
+
+    if (simulation_mode != -1)
+        goto done;
+
+    if (!td)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    /* The td->simulate is set by the host (see _enter_sim in host/sgx/calls.c)
+     */
+    simulation_mode = td->simulate ? true : false;
+
+    __atomic_store_n(
+        &_is_in_simulation_mode, simulation_mode, __ATOMIC_RELEASE);
+
+done:
+    return result;
+}
+
+/* Determine if the enclave is in simulation mode based on the cached value. If
+ * the cached value is not initialized yet, the function returns false. */
+bool oe_sgx_is_in_simulation_mode()
+{
+    int simulation_mode =
+        __atomic_load_n(&_is_in_simulation_mode, __ATOMIC_ACQUIRE);
+
+    if (simulation_mode != -1)
+        goto done;
+
+done:
+    return simulation_mode == 1 ? true : false;
+}
 
 // Read an enclave's identity attribute to see to if it was signed as an debug
 // enclave
-bool is_enclave_debug_allowed()
+bool oe_is_enclave_debug_allowed()
 {
-    oe_sgx_td_t* td = NULL;
     int debug_allowed =
         __atomic_load_n(&_is_enclave_debug_allowed, __ATOMIC_ACQUIRE);
 
@@ -24,9 +63,8 @@ bool is_enclave_debug_allowed()
 
     // Start off by assuming debug is not allowed.
     debug_allowed = 0;
-    td = oe_sgx_get_td();
 
-    if (td && td->simulate)
+    if (oe_sgx_is_in_simulation_mode())
     {
         // Enclave in simulate mode is treated as debug_allowed
         debug_allowed = 1;
@@ -49,12 +87,4 @@ bool is_enclave_debug_allowed()
 
 done:
     return debug_allowed == 1 ? true : false;
-}
-
-// Check the cached variable only
-bool is_enclave_debug_allowed_cached()
-{
-    return __atomic_load_n(&_is_enclave_debug_allowed, __ATOMIC_ACQUIRE) == 1
-               ? true
-               : false;
 }

--- a/enclave/core/sgx/tracee.h
+++ b/enclave/core/sgx/tracee.h
@@ -1,0 +1,15 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_CORE_SGX_TRACEE_H
+#define _OE_CORE_SGX_TRACEE_H
+
+#include <openenclave/bits/result.h>
+#include <openenclave/corelibc/stdbool.h>
+#include <openenclave/internal/sgx/td.h>
+
+oe_result_t oe_sgx_initialize_simulation_mode_cache(oe_sgx_td_t* td);
+
+bool oe_sgx_is_in_simulation_mode();
+
+#endif /* _OE_CORE_SGX_TRACEE_H */

--- a/enclave/core/tracee.c
+++ b/enclave/core/tracee.c
@@ -143,7 +143,7 @@ oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...)
     bool locked = false;
 
     // Skip logging for non-debug-allowed enclaves
-    if (!is_enclave_debug_allowed())
+    if (!oe_is_enclave_debug_allowed())
     {
         result = OE_OK;
         goto done;

--- a/enclave/core/tracee.h
+++ b/enclave/core/tracee.h
@@ -4,5 +4,4 @@
 #include <openenclave/corelibc/stdbool.h>
 #include <openenclave/log.h>
 
-bool is_enclave_debug_allowed();
-bool is_enclave_debug_allowed_cached();
+bool oe_is_enclave_debug_allowed();

--- a/tests/debug-mode/enc/enc.c
+++ b/tests/debug-mode/enc/enc.c
@@ -8,5 +8,5 @@
 
 int test(void)
 {
-    return is_enclave_debug_allowed();
+    return oe_is_enclave_debug_allowed();
 }

--- a/tests/pf_gp_exceptions/enc/enc.c
+++ b/tests/pf_gp_exceptions/enc/enc.c
@@ -4,6 +4,7 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/print.h>
 #include <openenclave/internal/tests.h>
+#include "../../../enclave/core/tracee.h"
 #include "pf_gp_exceptions_t.h"
 
 #define MOV_INSTRUCTION_BYTES 3
@@ -13,8 +14,6 @@ static uint64_t faulting_address;
 static uint32_t error_code;
 static uint32_t exception_code;
 static uint64_t bypass_bytes;
-
-bool is_enclave_debug_allowed();
 
 uint64_t test_pfgp_handler(oe_exception_record_t* exception_record)
 {
@@ -45,7 +44,7 @@ int enc_pf_gp_exceptions(int is_misc_region_supported, int is_on_windows)
         return 2;
 
     /* For SGX1 enclaves, the PF simulation is only supported in debug mode */
-    if (!is_misc_region_supported && !is_enclave_debug_allowed())
+    if (!is_misc_region_supported && !oe_is_enclave_debug_allowed())
         return 2;
 
     if (oe_add_vectored_exception_handler(false, test_pfgp_handler) != OE_OK)


### PR DESCRIPTION
This PR does the following:

- Add `oe_sgx_initialize_simulation_mode_cache` and `oe_sgx_is_in_simulation_mode` so that we can check if the enclave is in simulation mode without depending on `oe_sgx_get_td`.
- Removes the existing workaround of `is_enclave_debug_allowed_cached` on getting the cached value directly, which will always be `false` before the `is_enclave_debug_allowed` is made when `oe_sgx_get_td` is available.
- Rename `is_enclave_debug_allowed` to `oe_is_enclave_debug_allowed`


Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>