### PR TITLE
Ignore OpenSSL update in dependbot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,5 @@ updates:
     allow:
       - dependency-name: "snmalloc"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+    ignore:
+      - dependency-name: "3rdparty/openssl/openssl"


### PR DESCRIPTION
This PR disables the OpenSSL update tracking by the dependbot. We will still manually update the repository before figuring out if the dependbot can track the update based on release tags.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>