### PR TITLE
Fix OCALL dependencies

### DIFF
--- a/syscall/hostcalls.c
+++ b/syscall/hostcalls.c
@@ -48,7 +48,11 @@ OE_WEAK_ALIAS(_oe_syscall_epoll_wake_ocall, oe_syscall_epoll_wake_ocall);
 **==============================================================================
 */
 
-static oe_result_t _oe_syscall_read_ocall(
+/* The following symbols are the dependencies to the fdtable implementation and
+ * are pulled in by default and therefore will not be eliminated by the linker.
+ * Theses stubs are necessary to support the ocall opt-out. */
+
+oe_result_t _oe_syscall_read_ocall(
     ssize_t* _retval,
     oe_host_fd_t fd,
     void* buf,
@@ -62,7 +66,7 @@ static oe_result_t _oe_syscall_read_ocall(
 }
 OE_WEAK_ALIAS(_oe_syscall_read_ocall, oe_syscall_read_ocall);
 
-static oe_result_t _oe_syscall_write_ocall(
+oe_result_t _oe_syscall_write_ocall(
     ssize_t* _retval,
     oe_host_fd_t fd,
     const void* buf,
@@ -93,6 +97,54 @@ static oe_result_t _oe_syscall_fcntl_ocall(
     return OE_UNSUPPORTED;
 }
 OE_WEAK_ALIAS(_oe_syscall_fcntl_ocall, oe_syscall_fcntl_ocall);
+
+oe_result_t _oe_syscall_readv_ocall(
+    ssize_t* _retval,
+    oe_host_fd_t fd,
+    void* iov_buf,
+    int iovcnt,
+    size_t iov_buf_size)
+{
+    OE_UNUSED(_retval);
+    OE_UNUSED(fd);
+    OE_UNUSED(iov_buf);
+    OE_UNUSED(iovcnt);
+    OE_UNUSED(iov_buf_size);
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_syscall_readv_ocall, oe_syscall_readv_ocall);
+
+oe_result_t _oe_syscall_writev_ocall(
+    ssize_t* _retval,
+    oe_host_fd_t fd,
+    const void* iov_buf,
+    int iovcnt,
+    size_t iov_buf_size)
+{
+    OE_UNUSED(_retval);
+    OE_UNUSED(fd);
+    OE_UNUSED(iov_buf);
+    OE_UNUSED(iovcnt);
+    OE_UNUSED(iov_buf_size);
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_syscall_writev_ocall, oe_syscall_writev_ocall);
+
+oe_result_t _oe_syscall_close_ocall(int* _retval, oe_host_fd_t fd)
+{
+    OE_UNUSED(_retval);
+    OE_UNUSED(fd);
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_syscall_close_ocall, oe_syscall_close_ocall);
+
+oe_result_t _oe_syscall_dup_ocall(oe_host_fd_t* _retval, oe_host_fd_t oldfd)
+{
+    OE_UNUSED(_retval);
+    OE_UNUSED(oldfd);
+    return OE_UNSUPPORTED;
+}
+OE_WEAK_ALIAS(_oe_syscall_dup_ocall, oe_syscall_dup_ocall);
 
 /*
 **==============================================================================

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,10 @@ if (OE_SGX)
   set(DEFINE_OE_SGX "-DOE_SGX")
 endif ()
 
+if (CODE_COVERAGE)
+  set(DEFINE_OE_CODE_COVERAGE "-DOE_CODE_COVERAGE")
+endif ()
+
 if (UNIX)
   # On Linux prefer python3 since python may not be available.
   find_program(PYTHON NAMES python3 python)

--- a/tests/edl_opt_out/edl/edl_opt_out.edl
+++ b/tests/edl_opt_out/edl/edl_opt_out.edl
@@ -3,6 +3,7 @@
 
 enclave {
     from "openenclave/edl/logging.edl" import oe_write_ocall; // Support OE_TEST
+#ifdef OE_CODE_COVERAGE
     from "openenclave/edl/fcntl.edl" import // Support code coverage analysis
         oe_syscall_open_ocall,
         oe_syscall_close_ocall,
@@ -11,6 +12,7 @@ enclave {
         oe_syscall_lseek_ocall,
         oe_syscall_dup_ocall,
         oe_syscall_flock_ocall;
+#endif
 #ifdef OE_SGX
     from "openenclave/edl/sgx/cpu.edl" import *;
 #else

--- a/tests/edl_opt_out/enc/CMakeLists.txt
+++ b/tests/edl_opt_out/enc/CMakeLists.txt
@@ -8,7 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} ${DEFINE_OE_CODE_COVERAGE} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(PLATFORM_EDL_FILE ../edl/header.edl)
 add_custom_command(
@@ -32,6 +33,10 @@ add_enclave(
   ${CMAKE_CURRENT_BINARY_DIR}/edl_opt_out_t.c)
 
 add_enclave_dependencies(edl_opt_out_enc trusted_header)
+
+if (CODE_COVERAGE)
+  enclave_compile_definitions(edl_opt_out_enc PRIVATE CODE_COVERAGE)
+endif ()
 
 enclave_include_directories(edl_opt_out_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 enclave_link_libraries(edl_opt_out_enc oelibc)

--- a/tests/edl_opt_out/enc/enc.c
+++ b/tests/edl_opt_out/enc/enc.c
@@ -12,6 +12,16 @@ void enc_edl_opt_out()
     /* logging.edl */
     OE_TEST(oe_log_ocall(0, NULL) == OE_UNSUPPORTED);
 
+#ifndef CODE_COVERAGE
+    /* fcntl.edl */
+    OE_TEST(oe_syscall_read_ocall(NULL, 0, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_write_ocall(NULL, 0, NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_readv_ocall(NULL, 0, NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_writev_ocall(NULL, 0, NULL, 0, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_close_ocall(NULL, 0) == OE_UNSUPPORTED);
+    OE_TEST(oe_syscall_dup_ocall(NULL, 0) == OE_UNSUPPORTED);
+#endif
+
     /* ioctl.edl */
     OE_TEST(oe_syscall_ioctl_ocall(NULL, 0, 0, 0, 0, NULL) == OE_UNSUPPORTED);
 

--- a/tests/edl_opt_out/host/CMakeLists.txt
+++ b/tests/edl_opt_out/host/CMakeLists.txt
@@ -8,7 +8,8 @@ add_custom_command(
   DEPENDS ${EDL_FILE} edger8r
   COMMAND
     edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
-    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+    ${DEFINE_OE_SGX} ${DEFINE_OE_CODE_COVERAGE} --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(PLATFORM_EDL_FILE ../edl/header.edl)
 add_custom_command(


### PR DESCRIPTION
Few OCALLs referenced by fdtable are pulled in by default and cannot be eliminated by the linker. Add stubs back so the developers can still opt out those OCALLs.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>