### PR TITLE
Publish Docker image versions

### DIFF
--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -1,11 +1,7 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-import java.time.*
-import java.time.format.DateTimeFormatter
-
-OECI_LIB_VERSION = params.OECI_LIB_VERSION ?: "master"
-library "OpenEnclaveJenkinsLibrary@${OECI_LIB_VERSION}"
+library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 
 GLOBAL_TIMEOUT_MINUTES = 480
 
@@ -23,21 +19,6 @@ OS_NAME_MAP = [
     "win2019": "Windows Server 2019",
     "ubuntu":  "Ubuntu",
 ]
-
-def get_image_version() {
-    if (params.IMAGE_VERSION) {
-        return "${params.IMAGE_VERSION}"
-    }
-    def now = LocalDateTime.now()
-    return (now.format(DateTimeFormatter.ofPattern("yyyy")) + "." + \
-            now.format(DateTimeFormatter.ofPattern("MM")) + "." + \
-            now.format(DateTimeFormatter.ofPattern("dd")) + "${BUILD_NUMBER}")
-}
-
-def get_commit_id() {
-    def last_commit_id = sh(script: "git rev-parse --short HEAD", returnStdout: true).tokenize().last()
-    return last_commit_id
-}
 
 def buildLinuxManagedImage(String os_type, String version, String managed_image_name_id, String gallery_image_version) {
     stage('Check Prerequisites') {
@@ -301,11 +282,15 @@ node(params.AGENTS_LABEL) {
                 extensions: [],
                 userRemoteConfigs: [[url: "https://github.com/${params.REPOSITORY_NAME}"]]])
 
-            commit_id = get_commit_id()
-            version = get_image_version()
+            commit_id = helpers.get_commit_id()
 
-            image_version = params.IMAGE_VERSION ?: version
-            image_id = params.IMAGE_ID ?: "${version}-${commit_id}"
+            if (params.IMAGE_VERSION) {
+                image_version = params.IMAGE_VERSION
+            } else {
+                image_version = helpers.get_date(".") + "${BUILD_NUMBER}"
+            }
+            
+            image_id = params.IMAGE_ID ?: "${image_version}-${commit_id}"
 
             println("IMAGE_VERSION: ${image_version}\nIMAGE_ID: ${image_id}")
         }

--- a/.jenkins/infrastructure/build_docker_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_docker_images.Jenkinsfile
@@ -2,39 +2,81 @@
 // Licensed under the MIT License.
 
 GLOBAL_TIMEOUT_MINUTES = 240
+library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 
-OETOOLS_REPO = "https://oejenkinscidockerregistry.azurecr.io"
-OETOOLS_REPO_CREDENTIAL_ID = "oejenkinscidockerregistry"
-OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID = "oeciteamdockerhub"
-
-parallel "Windows Stage": {
-        stage("Build Windows Docker Containers") {
-          build job: '/Private/Infrastructure/Windows-Docker-Container-Build',
-          parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY_NAME),
-                       string(name: 'BRANCH_NAME', value: env.BRANCH_NAME),
-                       string(name: 'INTERNAL_REPO', value: OETOOLS_REPO),
-                       string(name: 'INTERNAL_REPO_CREDS', value: OETOOLS_REPO_CREDENTIAL_ID),
-                       string(name: 'DOCKERHUB_REPO_CREDS', value: OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID),
-                       string(name: 'DOCKER_TAG', value: env.DOCKER_TAG),
-                       string(name: 'AGENTS_LABEL', value: env.WINDOWS_AGENTS_LABEL),
-                       string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
-                       booleanParam(name: 'PUBLISH_DOCKER_HUB', value: env.PUBLISH_DOCKER_HUB),
-                       booleanParam(name: 'TAG_LATEST', value: env.TAG_LATEST)]
+pipeline {
+    agent {
+        label globalvars.AGENTS_LABELS["shared"]
+    }
+    parameters {
+        string(name: "SGX_VERSION", description: "[REQUIRED] Intel SGX version to install (Ex: 2.15.100). For versions see: https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/")
+        string(name: "REPOSITORY_NAME", defaultValue: "openenclave/openenclave", description: "GitHub repository to checkout")
+        string(name: "BRANCH_NAME", defaultValue: "master", description: "The branch used to checkout the repository")
+        string(name: "BASE_DOCKER_TAG", defaultValue: "", description: "[OPTIONAL] Specify the tag for the new Base Docker images.")
+        string(name: "DOCKER_TAG", defaultValue: "", description: "[OPTIONAL] Specify the tag for the new Docker images.")
+        string(name: "OECI_LIB_VERSION", defaultValue: 'master', description: 'Version of OE Libraries to use')
+        string(name: "INTERNAL_REPO", defaultValue: "https://oejenkinscidockerregistry.azurecr.io", description: "Url for internal Docker repository")
+        string(name: "INTERNAL_REPO_CRED_ID", defaultValue: "oejenkinscidockerregistry", description: "Credential ID for internal Docker repository")
+        string(name: "IMAGES_BUILD_LABEL", defaultValue: "acc-ubuntu-18.04", description: "Label of the agent to use to run Linux container builds")
+        string(name: "WINDOWS_AGENTS_LABEL", defaultValue: "windows-nonsgx", description: "Label of the agent to use to run Windows container builds")
+        booleanParam(name: "PUBLISH_DOCKER_HUB", defaultValue: false, description: "Publish container to OECITeam Docker Hub?")
+        booleanParam(name: "TAG_LATEST", defaultValue: false, description: "Update the latest tag to the currently built DOCKER_TAG")
+        booleanParam(name: "PUBLISH_VERSION_FILE", defaultValue: false, description: "Publish versioning information?")
+    }
+    stages {
+        stage('Set dynamic default parameters') {
+            steps {
+                script {
+                    if ( ! params.DOCKER_TAG ) {
+                        DOCKER_TAG = helpers.get_date(".") + "${BUILD_NUMBER}"
+                    }
+                    if ( ! params.BASE_DOCKER_TAG ) {
+                        BASE_DOCKER_TAG = helpers.get_date(".") + "${BUILD_NUMBER}"
+                    }
+                }
+                println("DOCKER_TAG = " + DOCKER_TAG)
+                println("BASE_DOCKER_TAG = " + BASE_DOCKER_TAG)
+            }
         }
-    }, "Linux Stage": {
-        stage("Build Linux Docker Containers") {
-          build job: '/Private/Infrastructure/Linux-Docker-Container-Build',
-          parameters: [string(name: 'REPOSITORY_NAME', value: env.REPOSITORY_NAME),
-                       string(name: 'BRANCH_NAME', value: env.BRANCH_NAME),
-                       string(name: 'INTERNAL_REPO', value: OETOOLS_REPO),
-                       string(name: 'INTERNAL_REPO_CREDS', value: OETOOLS_REPO_CREDENTIAL_ID),
-                       string(name: 'DOCKERHUB_REPO_CREDS', value: OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID),
-                       string(name: 'DOCKER_TAG', value: env.DOCKER_TAG),
-                       string(name: 'AGENTS_LABEL', value: env.AGENTS_LABEL),
-                       string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
-                       string(name: 'SGX_VERSION', value: params.SGX_VERSION),
-                       string(name: 'BASE_DOCKER_TAG', value: "SGX-${params.SGX_VERSION}"),
-                       booleanParam(name: 'PUBLISH_DOCKER_HUB', value: env.PUBLISH_DOCKER_HUB),
-                       booleanParam(name: 'TAG_LATEST', value: env.TAG_LATEST)]
+        stage('Parallel') {
+            parallel {
+                stage("Build Windows Docker Containers") {
+                    steps {
+                        build job: '/Private/Infrastructure/Windows-Docker-Container-Build',
+                            parameters: [
+                                string(name: 'REPOSITORY_NAME', value: params.REPOSITORY_NAME),
+                                string(name: 'BRANCH_NAME', value: params.BRANCH_NAME),
+                                string(name: 'INTERNAL_REPO', value: params.INTERNAL_REPO),
+                                string(name: 'INTERNAL_REPO_CRED_ID', value: params.INTERNAL_REPO_CRED_ID),
+                                string(name: 'DOCKER_TAG', value: DOCKER_TAG),
+                                string(name: 'OECI_LIB_VERSION', value: params.OECI_LIB_VERSION),
+                                string(name: 'AGENTS_LABEL', value: params.WINDOWS_AGENTS_LABEL),
+                                booleanParam(name: 'PUBLISH_DOCKER_HUB', value: params.PUBLISH_DOCKER_HUB),
+                                booleanParam(name: 'TAG_LATEST', value: params.TAG_LATEST),
+                                booleanParam(name: 'PUBLISH_VERSION_FILE', value: params.PUBLISH_VERSION_FILE)
+                            ]
+                    }
+                }
+                stage("Build Linux Docker Containers") {
+                    steps {
+                        build job: '/Private/Infrastructure/Linux-Docker-Container-Build',
+                            parameters: [
+                                string(name: 'REPOSITORY_NAME', value: params.REPOSITORY_NAME),
+                                string(name: 'BRANCH_NAME', value: params.BRANCH_NAME),
+                                string(name: 'INTERNAL_REPO', value: params.INTERNAL_REPO),
+                                string(name: 'INTERNAL_REPO_CRED_ID', value: params.INTERNAL_REPO_CRED_ID),
+                                string(name: 'DOCKER_TAG', value: DOCKER_TAG),
+                                string(name: 'AGENTS_LABEL', value: params.IMAGES_BUILD_LABEL),
+                                string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
+                                string(name: 'SGX_VERSION', value: params.SGX_VERSION),
+                                string(name: 'BASE_DOCKER_TAG', value: BASE_DOCKER_TAG),
+                                booleanParam(name: 'PUBLISH_DOCKER_HUB', value: params.PUBLISH_DOCKER_HUB),
+                                booleanParam(name: 'TAG_LATEST', value: params.TAG_LATEST),
+                                booleanParam(name: 'PUBLISH_VERSION_FILE', value: params.PUBLISH_VERSION_FILE)
+                            ]
+                    }
+                }
+            }
         }
     }
+}

--- a/.jenkins/infrastructure/docker/build_linux_docker_images.Jenkinsfile
+++ b/.jenkins/infrastructure/docker/build_linux_docker_images.Jenkinsfile
@@ -3,9 +3,12 @@
 
 library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 
+TAG_BASE_IMAGE = params.BASE_DOCKER_TAG ?: helpers.get_date(".") + "${BUILD_NUMBER}"
+TAG_FULL_IMAGE = params.DOCKER_TAG ?: helpers.get_date(".") + "${BUILD_NUMBER}"
+
 pipeline {
     agent {
-        label globalvars.AGENTS_LABELS["acc-ubuntu-18.04"]
+        label globalvars.AGENTS_LABELS[params.AGENTS_LABEL]
     }
     options {
         timeout(time: 240, unit: 'MINUTES')
@@ -14,16 +17,18 @@ pipeline {
         string(name: "SGX_VERSION", description: "Intel SGX version to install (Ex: 2.15.100). For versions see: https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/")
         string(name: "REPOSITORY_NAME", defaultValue: "openenclave/openenclave", description: "GitHub repository to checkout")
         string(name: "BRANCH_NAME", defaultValue: "master", description: "The branch used to checkout the repository")
-        string(name: "DOCKER_TAG", defaultValue: "standalone-linux-build", description: "The tag for the new Docker images")
-        string(name: "BASE_DOCKER_TAG", defaultValue: "SGX-${params.SGX_VERSION}", description: "The tag for the new Base Docker images. Use SGX-<version> for releases. Example: SGX-2.15.100")
+        string(name: "DOCKER_TAG", defaultValue: "", description: "[OPTIONAL] Specify the tag for the new Docker images.")
+        string(name: "BASE_DOCKER_TAG", defaultValue: "", description: "[OPTIONAL] Specify the tag for the new Base Docker images.")
         string(name: "INTERNAL_REPO", defaultValue: "https://oejenkinscidockerregistry.azurecr.io", description: "Url for internal Docker repository")
+        string(name: "INTERNAL_REPO_CRED_ID", defaultValue: "oejenkinscidockerregistry", description: "Credential ID for internal Docker repository")
         string(name: "OECI_LIB_VERSION", defaultValue: 'master', description: 'Version of OE Libraries to use')
         string(name: "DEVKITS_URI", defaultValue: 'https://oejenkins.blob.core.windows.net/oejenkins/OE-CI-devkits-d1634ce8.tar.gz', description: "Uri for downloading the OECI Devkit")
+        string(name: "AGENTS_LABEL", defaultValue: 'acc-ubuntu-18.04', description: "Label of the agent to use to run this job")
         booleanParam(name: "PUBLISH_DOCKER_HUB", defaultValue: false, description: "Publish container to OECITeam Docker Hub?")
         booleanParam(name: "TAG_LATEST", defaultValue: false, description: "Update the latest tag to the currently built DOCKER_TAG")
+        booleanParam(name: "PUBLISH_VERSION_FILE", defaultValue: false, description: "Publish versioning information?")
     }
     environment {
-        INTERNAL_REPO_CREDS = 'oejenkinscidockerregistry'
         // Docker plugin cannot seem to use credentials from Azure Key Vault
         DOCKERHUB_REPO_CREDS = 'oeciteamdockerhub'
         BASE_DOCKERFILE_DIR = ".jenkins/infrastructure/docker/dockerfiles/linux/base/"
@@ -48,8 +53,8 @@ pipeline {
                                 chmod +x ./build.sh
                                 mkdir build
                                 cd build
-                                ../build.sh -v "${params.SGX_VERSION}" -u "18.04" -t "${params.BASE_DOCKER_TAG}"
-                                ../build.sh -v "${params.SGX_VERSION}" -u "20.04" -t "${params.BASE_DOCKER_TAG}"
+                                ../build.sh -v "${params.SGX_VERSION}" -u "18.04" -t "${TAG_BASE_IMAGE}"
+                                ../build.sh -v "${params.SGX_VERSION}" -u "20.04" -t "${TAG_BASE_IMAGE}"
                             """
                         }
                     }
@@ -59,7 +64,7 @@ pipeline {
                         stage("Test Base - 18.04") {
                             steps {
                                 script {
-                                    base_1804_image = docker.image("oeciteam/openenclave-base-ubuntu-18.04:${params.BASE_DOCKER_TAG}")
+                                    base_1804_image = docker.image("openenclave-base-ubuntu-18.04:${TAG_BASE_IMAGE}")
                                     base_1804_image.inside("--user root:root --cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket") {
                                         sh """
                                             apt update
@@ -73,7 +78,7 @@ pipeline {
                         stage("Test Base - 20.04") {
                             steps {
                                 script {
-                                    base_2004_image = docker.image("oeciteam/openenclave-base-ubuntu-20.04:${params.BASE_DOCKER_TAG}")
+                                    base_2004_image = docker.image("openenclave-base-ubuntu-20.04:${TAG_BASE_IMAGE}")
                                     base_2004_image.inside("--user root:root --cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket") {
                                         sh """
                                             apt update
@@ -89,7 +94,7 @@ pipeline {
                 stage('Push to internal repository') {
                     steps {
                         script {
-                            docker.withRegistry(params.INTERNAL_REPO, env.INTERNAL_REPO_CREDS) {
+                            docker.withRegistry(params.INTERNAL_REPO, params.INTERNAL_REPO_CRED_ID) {
                                 base_1804_image.push()
                                 base_2004_image.push()
                                 if ( params.TAG_LATEST ) {
@@ -97,7 +102,7 @@ pipeline {
                                     base_2004_image.push('latest')
                                 }
                             }
-                            sh "docker logout"
+                            sh "docker logout ${params.INTERNAL_REPO}"
                         }
                     }
                 }
@@ -109,12 +114,16 @@ pipeline {
                     }
                     steps {
                         script {
+                            sh("docker tag openenclave-base-ubuntu-20.04:${TAG_BASE_IMAGE} oeciteam/openenclave-base-ubuntu-20.04:${TAG_BASE_IMAGE}")
+                            sh("docker tag openenclave-base-ubuntu-18.04:${TAG_BASE_IMAGE} oeciteam/openenclave-base-ubuntu-18.04:${TAG_BASE_IMAGE}")
+                            dockerhub_base_2004_image = docker.image("oeciteam/openenclave-base-ubuntu-20.04:${TAG_BASE_IMAGE}")
+                            dockerhub_base_1804_image = docker.image("oeciteam/openenclave-base-ubuntu-18.04:${TAG_BASE_IMAGE}")
                             docker.withRegistry('', DOCKERHUB_REPO_CREDS) {
-                                base_1804_image.push()
-                                base_2004_image.push()
+                                dockerhub_base_2004_image.push()
+                                dockerhub_base_1804_image.push()
                                 if ( params.TAG_LATEST ) {
-                                    base_1804_image.push('latest')
-                                    base_2004_image.push('latest')
+                                    dockerhub_base_2004_image.push('latest')
+                                    dockerhub_base_1804_image.push('latest')
                                 }
                             }
                             sh "docker logout"
@@ -130,17 +139,22 @@ pipeline {
                         stage("Ubuntu 18.04") {
                             steps {
                                 script {
-                                    buildArgs = common.dockerBuildArgs("UID=\$(id -u)", "UNAME=\$(id -un)",
-                                                                       "GID=\$(id -g)", "GNAME=\$(id -gn)")
-                                    oe1804 = common.dockerImage("oetools-18.04:${DOCKER_TAG}", LINUX_DOCKERFILE, "${buildArgs} --build-arg ubuntu_version=18.04 --build-arg devkits_uri=${params.DEVKITS_URI}")
-                                    oe1804.inside("--user root:root --cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket") {
+                                    buildArgs = common.dockerBuildArgs(
+                                        "ubuntu_version=18.04",
+                                        "devkits_uri=${params.DEVKITS_URI}"
+                                    )
+                                    oe1804 = common.dockerImage("oetools-18.04:${TAG_FULL_IMAGE}", LINUX_DOCKERFILE, "${buildArgs}")
+                                    oe1804.inside("--user root:root \
+                                                   --cap-add=SYS_PTRACE \
+                                                   --device /dev/sgx:/dev/sgx \
+                                                   --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket") {
                                         sh """
                                             apt update
                                             apt install -y build-essential open-enclave libssl-dev
                                         """
                                         helpers.TestSamplesCommand(false, "open-enclave")
                                     }
-                                    docker.withRegistry(params.INTERNAL_REPO, env.INTERNAL_REPO_CREDS) {
+                                    docker.withRegistry(params.INTERNAL_REPO, params.INTERNAL_REPO_CRED_ID) {
                                         common.exec_with_retry { oe1804.push() }
                                         if ( params.TAG_LATEST ) {
                                             common.exec_with_retry { oe1804.push('latest') }
@@ -150,22 +164,25 @@ pipeline {
                             }
                         }
                         stage("Ubuntu 20.04") {
-                            agent {
-                                label globalvars.AGENTS_LABELS["acc-ubuntu-20.04"]
-                            }
                             steps {
                                 script {
-                                    buildArgs = common.dockerBuildArgs("UID=\$(id -u)", "UNAME=\$(id -un)",
-                                                                       "GID=\$(id -g)", "GNAME=\$(id -gn)")
-                                    oe2004 = common.dockerImage("oetools-20.04:${DOCKER_TAG}", LINUX_DOCKERFILE, "${buildArgs} --build-arg ubuntu_version=20.04 --build-arg devkits_uri=${params.DEVKITS_URI}")
-                                    oe2004.inside("--user root:root --cap-add=SYS_PTRACE --device /dev/sgx/provision:/dev/sgx/provision --device /dev/sgx/enclave:/dev/sgx/enclave --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket") {
+                                    buildArgs = common.dockerBuildArgs(
+                                        "ubuntu_version=20.04",
+                                        "devkits_uri=${params.DEVKITS_URI}"
+                                    )
+                                    oe2004 = common.dockerImage("oetools-20.04:${TAG_FULL_IMAGE}", LINUX_DOCKERFILE, "${buildArgs}")
+                                    oe2004.inside("--user root:root \
+                                                   --cap-add=SYS_PTRACE \
+                                                   --device /dev/sgx/provision:/dev/sgx/provision \
+                                                   --device /dev/sgx/enclave:/dev/sgx/enclave \
+                                                   --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket") {
                                         sh """
                                             apt update
                                             apt install -y build-essential open-enclave libssl-dev
                                         """
                                         helpers.TestSamplesCommand(false, "open-enclave")
                                     }
-                                    docker.withRegistry(params.INTERNAL_REPO, env.INTERNAL_REPO_CREDS) {
+                                    docker.withRegistry(params.INTERNAL_REPO, params.INTERNAL_REPO_CRED_ID) {
                                         common.exec_with_retry { oe2004.push() }
                                         if ( params.TAG_LATEST ) {
                                             common.exec_with_retry { oe2004.push('latest') }
@@ -175,6 +192,74 @@ pipeline {
                             }
                         }
                     }
+                }
+                stage('Publish oetools') {
+                    when {
+                        expression {
+                            return params.PUBLISH_DOCKER_HUB
+                        }
+                    }
+                    steps {
+                        script {
+                            sh("docker tag oetools-20.04:${TAG_BASE_IMAGE} oeciteam/oetools-20.04:${TAG_BASE_IMAGE}")
+                            sh("docker tag oetools-18.04:${TAG_BASE_IMAGE} oeciteam/oetools-18.04:${TAG_BASE_IMAGE}")
+                            dockerhub_full_2004_image = docker.image("oeciteam/oetools-20.04:${TAG_BASE_IMAGE}")
+                            dockerhub_full_1804_image = docker.image("oeciteam/oetools-18.04:${TAG_BASE_IMAGE}")
+                            docker.withRegistry('', DOCKERHUB_REPO_CREDS) {
+                                dockerhub_full_2004_image.push()
+                                dockerhub_full_1804_image.push()
+                                if ( params.TAG_LATEST ) {
+                                    dockerhub_full_2004_image.push('latest')
+                                    dockerhub_full_1804_image.push('latest')
+                                }
+                            }
+                            sh "docker logout"
+                        }
+                    }
+                }
+            }
+        }
+        stage('Publish info') {
+            when {
+                expression {
+                    return params.PUBLISH_VERSION_FILE
+                }
+            }
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'github-oeciteam-user-pat',
+                                 usernameVariable: 'GIT_USERNAME',
+                                 passwordVariable: 'GIT_PASSWORD')]) {
+                    script {
+                        sh '''
+                            git config --global user.email "${GIT_USERNAME}@microsoft.com"
+                            git config --global user.name ${GIT_USERNAME}
+                            git checkout --force "oeciteam/publish-docker"
+                            git pull
+                        '''
+                        BASE_2004_PSW  = helpers.dockerGetAptPackageVersion("openenclave-base-ubuntu-20.04:${TAG_BASE_IMAGE}", "libsgx-enclave-common")
+                        BASE_2004_DCAP = helpers.dockerGetAptPackageVersion("openenclave-base-ubuntu-20.04:${TAG_BASE_IMAGE}", "libsgx-ae-id-enclave")
+                        BASE_1804_PSW  = helpers.dockerGetAptPackageVersion("openenclave-base-ubuntu-18.04:${TAG_BASE_IMAGE}", "libsgx-enclave-common")
+                        BASE_1804_DCAP = helpers.dockerGetAptPackageVersion("openenclave-base-ubuntu-18.04:${TAG_BASE_IMAGE}", "libsgx-ae-id-enclave")
+                        FULL_2004_PSW  = helpers.dockerGetAptPackageVersion("oetools-20.04:${TAG_FULL_IMAGE}", "libsgx-enclave-common")
+                        FULL_2004_DCAP = helpers.dockerGetAptPackageVersion("oetools-20.04:${TAG_FULL_IMAGE}", "libsgx-ae-id-enclave")
+                        FULL_1804_PSW  = helpers.dockerGetAptPackageVersion("oetools-18.04:${TAG_FULL_IMAGE}", "libsgx-enclave-common")
+                        FULL_1804_DCAP = helpers.dockerGetAptPackageVersion("oetools-18.04:${TAG_FULL_IMAGE}", "libsgx-ae-id-enclave")
+                        REPOSITORY = params.INTERNAL_REPO - ~"^https://"
+                        sh """#!/bin/bash
+                            OE_VERSION=\$(grep --max-count=1 --only-matching --perl-regexp 'v\\d+\\.\\d+\\.\\d+(?=_log)' CHANGELOG.md)
+                            cat <<EOF >>DOCKER_IMAGES.md
+| Base Ubuntu 20.04 | ${REPOSITORY}/openenclave-base-ubuntu-20.04:${TAG_BASE_IMAGE} | \${OE_VERSION} | ${BASE_2004_PSW} | ${BASE_2004_DCAP} |
+| Base Ubuntu 18.04 | ${REPOSITORY}/openenclave-base-ubuntu-18.04:${TAG_BASE_IMAGE} | \${OE_VERSION} | ${BASE_1804_PSW} | ${BASE_1804_DCAP} |
+| Full Ubuntu 20.04 | ${REPOSITORY}/oetools-20.04:${TAG_FULL_IMAGE} | \${OE_VERSION} | ${FULL_2004_PSW} | ${FULL_2004_DCAP} |
+| Full Ubuntu 18.04 | ${REPOSITORY}/oetools-18.04:${TAG_FULL_IMAGE} | \${OE_VERSION} | ${FULL_1804_PSW} | ${FULL_1804_DCAP} |
+EOF
+                        """
+                    }
+                    sh '''
+                        git add DOCKER_IMAGES.md
+                        git commit -sm "Publish Docker Images"
+                        git push --force https://${GIT_PASSWORD}@github.com/openenclave/openenclave.git HEAD:oeciteam/publish-docker
+                    '''
                 }
             }
         }

--- a/.jenkins/infrastructure/docker/build_windows_docker_images.Jenkinsfile
+++ b/.jenkins/infrastructure/docker/build_windows_docker_images.Jenkinsfile
@@ -1,47 +1,113 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-OECI_LIB_VERSION = env.OECI_LIB_VERSION ?: "master"
-oe = library("OpenEnclaveCommon@${OECI_LIB_VERSION}").jenkins.common.Openenclave.new()
+library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 
-AGENTS_LABEL = params.AGENTS_LABEL
-TIMEOUT_MINUTES = params.TIMEOUT_MINUTES ?: 240
+TAG_FULL_IMAGE = params.DOCKER_TAG ?: helpers.get_date(".") + "${BUILD_NUMBER}"
 
-INTERNAL_REPO = params.INTERNAL_REPO ?: "https://oejenkinscidockerregistry.azurecr.io"
-INTERNAL_REPO_CREDS = params.INTERNAL_REPO_CREDS ?: "oejenkinscidockerregistry"
-DOCKERHUB_REPO_CREDS = params.DOCKERHUB_REPO_CREDS ?: "oeciteamdockerhub"
+TIMEOUT_MINUTES = 240
+DOCKERHUB_REPO_CREDS = "oeciteamdockerhub"
 
-def buildWindowsDockerContainers() {
-    node(AGENTS_LABEL) {
-        timeout(TIMEOUT_MINUTES) {
-            stage("Checkout") {
+pipeline {
+    agent {
+        label globalvars.AGENTS_LABELS[params.AGENTS_LABEL]
+    }
+    options {
+        timeout(time: 240, unit: 'MINUTES')
+    }
+    parameters {
+        string(name: "REPOSITORY_NAME", defaultValue: "openenclave/openenclave", description: "GitHub repository to checkout")
+        string(name: "BRANCH_NAME", defaultValue: "master", description: "The branch used to checkout the repository")
+        string(name: "DOCKER_TAG", defaultValue: "", description: "[OPTIONAL] Specify the tag for the new Docker images.")
+        string(name: "INTERNAL_REPO", defaultValue: "https://oejenkinscidockerregistry.azurecr.io", description: "Url for internal Docker repository")
+        string(name: "INTERNAL_REPO_CRED_ID", defaultValue: "oejenkinscidockerregistry", description: "Credential ID for internal Docker repository")
+        string(name: "OECI_LIB_VERSION", defaultValue: 'master', description: 'Version of OE Libraries to use')
+        string(name: "AGENTS_LABEL", defaultValue: 'windows-nonsgx', description: "Label of the agent to use to run this job")
+        booleanParam(name: "PUBLISH_DOCKER_HUB", defaultValue: false, description: "Publish container to OECITeam Docker Hub?")
+        booleanParam(name: "TAG_LATEST", defaultValue: false, description: "Update the latest tag to the currently built DOCKER_TAG")
+        booleanParam(name: "PUBLISH_VERSION_FILE", defaultValue: false, description: "Publish versioning information?")
+    }
+    stages {
+        stage("Checkout") {
+            steps {
                 cleanWs()
-                checkout scm
+                checkout([$class: 'GitSCM',
+                    branches: [[name: BRANCH_NAME]],
+                    extensions: [],
+                    userRemoteConfigs: [[url: "https://github.com/${params.REPOSITORY_NAME}"]]])
             }
-            stage("Build Windows Server 2019 Docker Image") {
-                oe2019 = oe.dockerImage("oetools-ws2019:${DOCKER_TAG}", ".jenkins/infrastructure/docker/dockerfiles/windows/Dockerfile")
-                puboe2019 = oe.dockerImage("oeciteam/oetools-ws2019:${DOCKER_TAG}", ".jenkins/infrastructure/docker/dockerfiles/windows/Dockerfile")
-            }
-            stage("Push to OE Docker Registry") {
-                docker.withRegistry(INTERNAL_REPO, INTERNAL_REPO_CREDS) {
-                    oe.exec_with_retry { oe2019.push() }
-                    if(TAG_LATEST == "true") {
-                        oe.exec_with_retry { oe2019.push('latest') }
-                    }
+        }
+        stage("Build Windows Server 2019 Docker Image") {
+            steps {
+                script {
+                    oe2019 = common.dockerImage("oetools-ws2019:${TAG_FULL_IMAGE}", ".jenkins/infrastructure/docker/dockerfiles/windows/Dockerfile")
                 }
             }
-            stage("Push to OE Docker Hub Registry") {
-                docker.withRegistry('', DOCKERHUB_REPO_CREDS) {
-                    if(PUBLISH_DOCKER_HUB == "true") {
-                        oe.exec_with_retry { puboe2019.push() }
-                        if(TAG_LATEST == "true") {
-                            oe.exec_with_retry { puboe2019.push('latest') }
+        }
+        stage("Push to OE Docker Registry") {
+            steps {
+                script {
+                    docker.withRegistry(params.INTERNAL_REPO, params.INTERNAL_REPO_CRED_ID) {
+                        common.exec_with_retry { oe2019.push() }
+                        if ( TAG_LATEST ) {
+                            common.exec_with_retry { oe2019.push('latest') }
                         }
                     }
                 }
             }
         }
+        stage("Push to OE Docker Hub Registry") {
+            when {
+                expression {
+                    return params.PUBLISH_DOCKER_HUB
+                }
+            }
+            steps {
+                script {
+                    docker.withRegistry('', DOCKERHUB_REPO_CREDS) {
+                        if ( PUBLISH_DOCKER_HUB ) {
+                            common.exec_with_retry { oe2019.push() }
+                            if( TAG_LATEST ) {
+                                common.exec_with_retry { oe2019.push('latest') }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Publish info') {
+            when {
+                expression {
+                    return params.PUBLISH_VERSION_FILE
+                }
+            }
+            agent {
+                label globalvars.AGENTS_LABELS["shared"]
+            }
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'github-oeciteam-user-pat',
+                                 usernameVariable: 'GIT_USERNAME',
+                                 passwordVariable: 'GIT_PASSWORD')]) {
+                    sh '''
+                        git config --global user.email "${GIT_USERNAME}@microsoft.com"
+                        git config --global user.name ${GIT_USERNAME}
+                        git checkout --force "oeciteam/publish-docker"
+                        git pull
+                    '''
+                    script {
+                    REPOSITORY = params.INTERNAL_REPO - ~"^https://"
+                        sh """#!/bin/bash
+                            OE_VERSION=\$(grep --max-count=1 --only-matching --perl-regexp 'v\\d+\\.\\d+\\.\\d+(?=_log)' CHANGELOG.md)
+                            echo "| Windows Server 2019 | ${REPOSITORY}/oetools-ws2019:${TAG_FULL_IMAGE} | \${OE_VERSION} | None | None |" >> DOCKER_IMAGES.md
+                        """
+                    }
+                    sh '''
+                        git add DOCKER_IMAGES.md
+                        git commit -sm "Publish Docker Images"
+                        git push --force https://${GIT_PASSWORD}@github.com/openenclave/openenclave.git HEAD:oeciteam/publish-docker
+                    '''
+                }
+            }
+        }
     }
 }
-
-buildWindowsDockerContainers()

--- a/.jenkins/infrastructure/docker/dockerfiles/linux/base/README.md
+++ b/.jenkins/infrastructure/docker/dockerfiles/linux/base/README.md
@@ -21,12 +21,9 @@ This image supports out-of-proc attestation using Intel SGX. To allow this, the 
 
 ## Versions
 
-All base images available are:  
-[oeciteam/openenclave-base-ubuntu-18.04](https://hub.docker.com/r/oeciteam/openenclave-base-ubuntu-18.04) for Ubuntu 18.04  
-[oeciteam/openenclave-base-ubuntu-20.04](https://hub.docker.com/r/oeciteam/openenclave-base-ubuntu-20.04) for Ubuntu 20.04
+All Docker images offered are available in [this table](https://github.com/openenclave/openenclave/blob/master/DOCKER_IMAGES.md).
 
 The base Docker images can be pulled from Dockerhub like so:
-```docker pull oeciteam/openenclave-base-ubuntu-18.04```
+```docker pull oejenkinscidockerregistry.azurecr.io/openenclave-base-ubuntu-20.04:2022.06.0931```
 
-Tags are versioned by the Intel SGX version that are used to build it. For example: `SGX-2.15.100`.
-Alternatively, you can use the `latest` tag to pull in the container with the latest Intel SGX version. 
+Tags correspond to different Open Enclave or Intel SGX PSW/DCAP versions. You can use the `latest` tag to pull in the container with the latest component versions.

--- a/.jenkins/infrastructure/docker/dockerfiles/linux/base/build.sh
+++ b/.jenkins/infrastructure/docker/dockerfiles/linux/base/build.sh
@@ -119,5 +119,5 @@ DOCKER_BUILDKIT=1 docker build \
   --build-arg UBUNTU_CODENAME="${UBUNTU_CODENAME}" \
   --no-cache \
   --file "${SOURCE_DIR}/Dockerfile" \
-  --tag "oeciteam/openenclave-base-ubuntu-${UBUNTU_VERSION}:${IMAGE_TAG}" \
+  --tag "openenclave-base-ubuntu-${UBUNTU_VERSION}:${IMAGE_TAG}" \
   "${BUILD_DIR}"

--- a/.jenkins/infrastructure/e2e_testing.Jenkinsfile
+++ b/.jenkins/infrastructure/e2e_testing.Jenkinsfile
@@ -39,7 +39,6 @@ pipeline {
          string(name: 'WINDOWS_2019_DCAP_LABEL', defaultValue: 'e2e-SGXFLC-Windows-2019-DCAP', description: 'Label to use for image testing and promotion', trim: true)
          string(name: 'WINDOWS_NONSGX_CUSTOM_LABEL', defaultValue: 'e2e-nonsgx-windows', description: 'Label to use for image testing and promotion', trim: true)
          string(name: 'IMAGES_BUILD_LABEL', defaultValue: 'vanilla-ubuntu-2004', description: 'Agent label used to run Azure Managed Image builds', trim: true)
-         string(name: 'WINDOWS_IMAGES_BUILD_LABEL', defaultValue: 'nonSGX-Windows-2019', description: 'Agent label used to run image builds (Windows)', trim: true)
          string(name: 'OECI_LIB_VERSION', defaultValue: 'master', description: 'Version of OE Libraries to use', trim: true)
     }
     stages {
@@ -50,11 +49,11 @@ pipeline {
                         string(name: 'REPOSITORY_NAME', value: env.REPOSITORY),
                         string(name: 'BRANCH_NAME', value: env.BRANCH),
                         string(name: 'DOCKER_TAG', value: DOCKER_TAG),
-                        string(name: 'AGENTS_LABEL', value: env.IMAGES_BUILD_LABEL),
-                        string(name: 'WINDOWS_AGENTS_LABEL', value: env.WINDOWS_IMAGES_BUILD_LABEL),
                         string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
                         string(name: 'SGX_VERSION', value: params.SGX_VERSION),
+                        booleanParam(name: 'PUBLISH_DOCKER_HUB', value: false)
                         booleanParam(name: 'TAG_LATEST', value: false)
+                        booleanParam(name: 'PUBLISH', value: false)
                     ]
             }
         }

--- a/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
+++ b/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
@@ -5,12 +5,6 @@ OECI_LIB_VERSION = params.OECI_LIB_VERSION ?: "master"
 library "OpenEnclaveJenkinsLibrary@${OECI_LIB_VERSION}"
 
 GLOBAL_TIMEOUT_MINUTES = 240
-
-OETOOLS_REPO_NAME = "oejenkinscidockerregistry.azurecr.io"
-OETOOLS_REPO_CREDENTIAL_ID = "oejenkinscidockerregistry"
-OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID = "oeciteamdockerhub"
-
-DOCKER_IMAGES_NAMES = ["oetools-18.04", "oetools-20.04"]
 AZURE_IMAGES_MAP = [
     // Mapping between shared gallery image definition name and
     // generated Azure managed image name
@@ -19,40 +13,6 @@ AZURE_IMAGES_MAP = [
     "ws2019-nonSGX":   "${params.IMAGE_ID}-ws2019-nonSGX",
     "ws2019-SGX-DCAP": "${params.IMAGE_ID}-ws2019-SGX-DCAP"
 ]
-
-// def update_production_docker_images() {
-//     node("nonSGX-ubuntu-2004") {
-//         timeout(GLOBAL_TIMEOUT_MINUTES) {
-//             stage("Backup current production Docker images") {
-//                 docker.withRegistry("https://${OETOOLS_REPO_NAME}", OETOOLS_REPO_CREDENTIAL_ID) {
-//                     for (image_name in DOCKER_IMAGES_NAMES) {
-//                         def image = docker.image("${OETOOLS_REPO_NAME}/${image_name}:latest")
-//                         oe.exec_with_retry { image.pull() }
-//                         oe.exec_with_retry { image.push("latest-backup") }
-//                     }
-//                 }
-//             }
-//         }
-//     }
-//     node(IMAGES_BUILD_LABEL) {
-//         timeout(GLOBAL_TIMEOUT_MINUTES) {
-//             stage("Update production Docker images") {
-//                 for (image_name in DOCKER_IMAGES_NAMES) {
-//                     docker.withRegistry("https://${OETOOLS_REPO_NAME}", OETOOLS_REPO_CREDENTIAL_ID) {
-//                         def image = docker.image("${OETOOLS_REPO_NAME}/${image_name}:${env.DOCKER_TAG}")
-//                         oe.exec_with_retry { image.pull() }
-//                         oe.exec_with_retry { image.push("latest") }
-//                     }
-//                     sh("docker tag ${OETOOLS_REPO_NAME}/${image_name}:${env.DOCKER_TAG} oeciteam/${image_name}:latest")
-//                     docker.withRegistry('', OETOOLS_DOCKERHUB_REPO_CREDENTIAL_ID) {
-//                         def image = docker.image("oeciteam/${image_name}:latest")
-//                         oe.exec_with_retry { image.push("latest") }
-//                     }
-//                 }
-//             }
-//         }
-//     }
-// }
 
 def update_production_azure_gallery_images(String image_name) {
     timeout(GLOBAL_TIMEOUT_MINUTES) {
@@ -91,7 +51,6 @@ def update_production_azure_gallery_images(String image_name) {
     }
 }
 
-// def parallel_steps = [ "Update Docker images": { update_production_docker_images() } ]
 def parallel_steps = [:]
 AZURE_IMAGES_MAP.keySet().each {
     image_name -> parallel_steps["Update Azure gallery ${image_name} image"] = { update_production_azure_gallery_images(image_name) }

--- a/.jenkins/library/vars/globalvars.groovy
+++ b/.jenkins/library/vars/globalvars.groovy
@@ -22,6 +22,7 @@ import groovy.transform.Field
     "acc-ubuntu-20.04-vanilla": env.UBUNTU_VANILLA_2004_CUSTOM_LABEL ?: "vanilla-ubuntu-2004",
     "acc-ubuntu-18.04-vanilla": env.UBUNTU_VANILLA_1804_CUSTOM_LABEL ?: "vanilla-ubuntu-1804",
     "acc-win2019-dcap":         env.WINDOWS_2019_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2019-DCAP",
-    "acc-v3-win2019-dcap":      env.WINDOWS_2019_DCAP_ICX_CUSTOM_LABEL ?: "ACC-v3-SGXFLC-Windows-2019-DCAP"
+    "acc-v3-win2019-dcap":      env.WINDOWS_2019_DCAP_ICX_CUSTOM_LABEL ?: "ACC-v3-SGXFLC-Windows-2019-DCAP",
+    "shared":                   "Jenkins-Shared-DC2"
 ]
 @Field COMPILER = "clang-10"

--- a/.jenkins/library/vars/helpers.groovy
+++ b/.jenkins/library/vars/helpers.groovy
@@ -554,3 +554,25 @@ def getUbuntuReleaseVer() {
         script: 'lsb_release -rs'
     ).trim()
 }
+
+/**
+ * Returns current git commit id
+ */
+def get_commit_id() {
+    return sh(script: "git rev-parse --short HEAD", returnStdout: true).tokenize().last()
+}
+
+/**
+ * Returns apt package versions inside Docker container, or None
+ *
+ * @param docker_image  Docker image[:tag]
+ * @param package       Apt package name
+ */
+def dockerGetAptPackageVersion(String docker_image, String apt_package) {
+    version = sh(
+        script: "docker run ${docker_image} apt list --installed 2>/dev/null | grep ${apt_package} | awk \'{print \$2}\'",
+        returnStdout: true
+    ).trim()
+    if ( !version ) { version = "N/A" }
+    return version
+}

--- a/DOCKER_IMAGES.md
+++ b/DOCKER_IMAGES.md
@@ -1,0 +1,2 @@
+| Docker Image | Version | Open Enclave version | Intel SGX PSW version | Intel SGX DCAP version |
+| ------------ | ------- | -------------------- | --------------------- | ---------------------- |

--- a/docs/GettingStartedDocs/Contributors/BuildingInADockerContainer.md
+++ b/docs/GettingStartedDocs/Contributors/BuildingInADockerContainer.md
@@ -15,8 +15,10 @@
     - To install this driver, simply run it as root like this:
         - `sudo bash ./sgx_linux_x64_driver_1.35.bin`
 
-3. Pull the latest oetools image for Open Enclave from this distribution:
-    - https://hub.docker.com/r/oeciteam/oetools-18.04 or https://hub.docker.com/r/oeciteam/oetools-20.04
+3. Pull the latest "Full" image for Open Enclave for your appropriate distribution from [this table](https://github.com/openenclave/openenclave/blob/master/DOCKER_IMAGES.md). Example:
+```bash
+docker pull oejenkinscidockerregistry.azurecr.io/oetools-20.04:2022.06.0931
+```
 
 4. Run an interactive container of one of these images. If you're using the Intel SGX DCAP driver, for example, you'll want to expose the /dev/sgx device to the container:
 ```bash


### PR DESCRIPTION
Docker versions now have the same versioning scheme which will be published in `DOCKER_IMAGES.md` which will look like the following example

| Docker Image | Version | Open Enclave version | Intel SGX PSW version | Intel SGX DCAP version |
| ------------ | ------- | -------------------- | --------------------- | ---------------------- |
| Windows Server 2019 | openenclavedockerregistry.azurecr.io/oetools-ws2019:2022.06.0931 | v0.17.7 | None | None |
| Base Ubuntu 20.04 | openenclavedockerregistry.azurecr.io/openenclave-base-ubuntu-20.04:2022.06.0931 | v0.17.7 | 2.16.100.4-focal1 | 1.13.100.4-focal1 |
| Base Ubuntu 18.04 | openenclavedockerregistry.azurecr.io/openenclave-base-ubuntu-18.04:2022.06.0931 | v0.17.7 | 2.16.100.4-bionic1 | 1.13.100.4-bionic1 |
| Full Ubuntu 20.04 | openenclavedockerregistry.azurecr.io/oetools-20.04:2022.06.0931 | v0.17.7 | 2.16.100.4-focal1 | 1.13.100.4-focal1 |
| Full Ubuntu 18.04 | openenclavedockerregistry.azurecr.io/oetools-18.04:2022.06.0931 | v0.17.7 | 2.16.100.4-bionic1 | 1.13.100.4-bionic1 |


Signed-off-by: Chris Yan <chrisyan@microsoft.com>