### PR TITLE
Make in-enclave pthread_mutex not recursive by default and support pthread_mutexattr APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ## Changed
-
+- Fix the incorrect behavior of pthread_mutex_init() and std::mutex such that they no longer create a recursive lock by default.
 
 [v0.18.0][v0.18.0_log]
 --------------

--- a/enclave/core/optee/thread.c
+++ b/enclave/core/optee/thread.c
@@ -72,10 +72,25 @@ typedef struct _oe_mutex_impl
 
 OE_STATIC_ASSERT(sizeof(oe_mutex_impl_t) <= sizeof(oe_mutex_t));
 
-oe_result_t oe_mutex_init(oe_mutex_t* mutex)
+oe_result_t oe_mutexattr_init(oe_mutexattr_t* attr)
+{
+    OE_UNUSED(attr);
+    return OE_OK;
+}
+
+oe_result_t oe_mutexattr_settype(oe_mutexattr_t* attr, int type)
+{
+    OE_UNUSED(attr);
+    OE_UNUSED(type);
+    return OE_OK;
+}
+
+oe_result_t oe_mutex_init(oe_mutex_t* mutex, oe_mutexattr_t* attr)
 {
     oe_mutex_impl_t* m = (oe_mutex_impl_t*)mutex;
     oe_result_t result = OE_UNEXPECTED;
+
+    OE_UNUSED(attr);
 
     if (!m)
         return OE_INVALID_PARAMETER;

--- a/enclave/core/pthread.c
+++ b/enclave/core/pthread.c
@@ -5,11 +5,13 @@
 #include <openenclave/corelibc/pthread.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/defs.h>
+#include <openenclave/internal/raise.h>
 #include <openenclave/internal/thread.h>
 
 OE_STATIC_ASSERT(sizeof(oe_pthread_once_t) == sizeof(oe_once_t));
 OE_STATIC_ASSERT(sizeof(oe_pthread_spinlock_t) == sizeof(oe_spinlock_t));
 OE_STATIC_ASSERT(sizeof(oe_pthread_mutex_t) >= sizeof(oe_mutex_t));
+OE_STATIC_ASSERT(sizeof(oe_pthread_mutexattr_t) >= sizeof(oe_mutexattr_t));
 OE_STATIC_ASSERT(sizeof(oe_pthread_cond_t) >= sizeof(oe_cond_t));
 OE_STATIC_ASSERT(sizeof(oe_pthread_rwlock_t) >= sizeof(oe_rwlock_t));
 
@@ -141,15 +143,12 @@ int oe_pthread_spin_destroy(oe_pthread_spinlock_t* spinlock)
 
 int oe_pthread_mutexattr_init(oe_pthread_mutexattr_t* attr)
 {
-    OE_UNUSED(attr);
-    return 0;
+    return _to_errno(oe_mutexattr_init((oe_mutexattr_t*)attr));
 }
 
 int oe_pthread_mutexattr_settype(oe_pthread_mutexattr_t* attr, int type)
 {
-    OE_UNUSED(attr);
-    OE_UNUSED(type);
-    return 0;
+    return _to_errno(oe_mutexattr_settype((oe_mutexattr_t*)attr, type));
 }
 
 int oe_pthread_mutexattr_destroy(oe_pthread_mutexattr_t* attr)
@@ -162,8 +161,7 @@ int oe_pthread_mutex_init(
     oe_pthread_mutex_t* m,
     const oe_pthread_mutexattr_t* attr)
 {
-    OE_UNUSED(attr);
-    return _to_errno(oe_mutex_init((oe_mutex_t*)m));
+    return _to_errno(oe_mutex_init((oe_mutex_t*)m, (oe_mutexattr_t*)attr));
 }
 
 int oe_pthread_mutex_lock(oe_pthread_mutex_t* m)

--- a/include/openenclave/internal/thread.h
+++ b/include/openenclave/internal/thread.h
@@ -203,23 +203,62 @@ oe_result_t oe_spin_destroy(oe_spinlock_t* spinlock);
  */
 typedef struct _oe_mutex
 {
-    uint64_t __impl[4]; /**< Internal private implementation */
+    uint64_t __impl[5]; /**< Internal private implementation */
 } oe_mutex_t;
 
+typedef struct _oe_mutexattr
+{
+    uint32_t _impl;
+} oe_mutexattr_t;
+
+/* Match the definitions of corelibc/pthread.h */
+#define OE_MUTEX_NORMAL 0
+#define OE_MUTEX_DEFAULT 0
+#define OE_MUTEX_RECURSIVE 1
+#define OE_MUTEX_ERRORCHECK 2
+
 /**
- * Initialize a mutex.
+ * Initialize a mutex attribute.
  *
- * This function initializes a mutex. All mutexes are recursive. Once
- * initialized, multiple threads can use this mutex to synchronize access
- * to data. See oe_mutex_lock() and oe_mutex_unlock().
+ * This function initializes a mutex attribute, which can be by oe_mutex_init().
  *
- * @param mutex Initialize this mutex.
+ * @param attr The mutex attribute.
+ *
+ * @return OE_OK the operation was successful
+ * @return OE_INVALID_PARAMETER the parameter is invalid
+ *
+ */
+oe_result_t oe_mutexattr_init(oe_mutexattr_t* attr);
+
+/**
+ * Set the mutex attribute.
+ *
+ * This function sets the mutex attribute with the given type.
+ *
+ * @param attr The mutex attribute.
+ * @param type The type to be set.
  *
  * @return OE_OK the operation was successful
  * @return OE_INVALID_PARAMETER one or more parameters is invalid
  *
  */
-oe_result_t oe_mutex_init(oe_mutex_t* mutex);
+oe_result_t oe_mutexattr_settype(oe_mutexattr_t* attr, int type);
+
+/**
+ * Initialize a mutex.
+ *
+ * This function initializes a mutex. Once initialized, multiple threads can use
+ * this mutex to synchronize access to data. See oe_mutex_lock() and
+ * oe_mutex_unlock().
+ *
+ * @param mutex Initialize this mutex.
+ * @param attr The mutex attribute.
+ *
+ * @return OE_OK the operation was successful
+ * @return OE_INVALID_PARAMETER one or more parameters is invalid
+ *
+ */
+oe_result_t oe_mutex_init(oe_mutex_t* mutex, oe_mutexattr_t* attr);
 
 /**
  * Acquire a lock on a mutex.

--- a/tests/thread/enc/enc.cpp
+++ b/tests/thread/enc/enc.cpp
@@ -15,8 +15,22 @@
 #include <atomic>
 #include "thread_t.h"
 
+static inline oe_mutex_t _mutex_initializer_recursive()
+{
+    oe_mutex_t m;
+    oe_mutexattr_t attr;
+    oe_mutexattr_init(&attr);
+    oe_mutexattr_settype(&attr, OE_MUTEX_RECURSIVE);
+    oe_mutex_init(&m, &attr);
+    return m;
+}
+
+#define OE_MUTEX_INITIALIZER_RECURSIVE _mutex_initializer_recursive()
+
 static oe_mutex_t mutex1 = OE_MUTEX_INITIALIZER;
 static oe_mutex_t mutex2 = OE_MUTEX_INITIALIZER;
+static oe_mutex_t recursive_mutex1 = OE_MUTEX_INITIALIZER_RECURSIVE;
+static oe_mutex_t recursive_mutex2 = OE_MUTEX_INITIALIZER_RECURSIVE;
 static size_t test_mutex_count1 = 0;
 static size_t test_mutex_count2 = 0;
 
@@ -40,18 +54,18 @@ static void _test_parallel_mallocs()
     }
 }
 
-void enc_test_mutex()
+void enc_test_recursive_mutex()
 {
-    OE_TEST(oe_mutex_lock(&mutex1) == 0);
-    OE_TEST(oe_mutex_lock(&mutex1) == 0);
+    OE_TEST(oe_mutex_lock(&recursive_mutex1) == 0);
+    OE_TEST(oe_mutex_lock(&recursive_mutex1) == 0);
     ++test_mutex_count1;
-    OE_TEST(oe_mutex_lock(&mutex2) == 0);
-    OE_TEST(oe_mutex_lock(&mutex2) == 0);
+    OE_TEST(oe_mutex_lock(&recursive_mutex2) == 0);
+    OE_TEST(oe_mutex_lock(&recursive_mutex2) == 0);
     ++test_mutex_count2;
-    OE_TEST(oe_mutex_unlock(&mutex1) == 0);
-    OE_TEST(oe_mutex_unlock(&mutex1) == 0);
-    OE_TEST(oe_mutex_unlock(&mutex2) == 0);
-    OE_TEST(oe_mutex_unlock(&mutex2) == 0);
+    OE_TEST(oe_mutex_unlock(&recursive_mutex1) == 0);
+    OE_TEST(oe_mutex_unlock(&recursive_mutex1) == 0);
+    OE_TEST(oe_mutex_unlock(&recursive_mutex2) == 0);
+    OE_TEST(oe_mutex_unlock(&recursive_mutex2) == 0);
 
     oe_host_printf("enc_test_mutex: %lld\n", OE_LLU(oe_thread_self()));
 }
@@ -197,9 +211,9 @@ void enc_relinquish_exclusive_access()
     oe_mutex_unlock(&ex_mutex);
 }
 
-static oe_mutex_t mutex_a = OE_MUTEX_INITIALIZER;
-static oe_mutex_t mutex_b = OE_MUTEX_INITIALIZER;
-static oe_mutex_t mutex_c = OE_MUTEX_INITIALIZER;
+static oe_mutex_t mutex_a = OE_MUTEX_INITIALIZER_RECURSIVE;
+static oe_mutex_t mutex_b = OE_MUTEX_INITIALIZER_RECURSIVE;
+static oe_mutex_t mutex_c = OE_MUTEX_INITIALIZER_RECURSIVE;
 
 static oe_thread_t a_owner = 0;
 static oe_thread_t b_owner = 0;

--- a/tests/thread/enc/thread.h
+++ b/tests/thread/enc/thread.h
@@ -10,13 +10,11 @@
 
 #include <pthread.h>
 
-/* Unlike OE threads, pthreads are not recursive by default */
-static __inline pthread_mutex_t __mutex_initializer_recursive()
+static __inline pthread_mutex_t __mutex_initializer_default()
 {
     pthread_mutex_t m;
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
     pthread_mutex_init(&m, &attr);
     return m;
 }
@@ -25,9 +23,16 @@ typedef pthread_t oe_thread_t;
 #define oe_thread_self pthread_self
 
 typedef pthread_mutex_t oe_mutex_t;
-#define OE_MUTEX_INITIALIZER __mutex_initializer_recursive()
+#define OE_MUTEX_INITIALIZER __mutex_initializer_default()
+#define oe_mutex_init pthread_mutex_init
 #define oe_mutex_lock pthread_mutex_lock
+#define oe_mutex_trylock pthread_mutex_trylock
 #define oe_mutex_unlock pthread_mutex_unlock
+
+typedef pthread_mutexattr_t oe_mutexattr_t;
+#define OE_MUTEX_RECURSIVE PTHREAD_MUTEX_RECURSIVE
+#define oe_mutexattr_init pthread_mutexattr_init
+#define oe_mutexattr_settype pthread_mutexattr_settype
 
 typedef pthread_spinlock_t oe_spinlock_t;
 #define OE_SPINLOCK_INITIALIZER 0

--- a/tests/thread/host/host.cpp
+++ b/tests/thread/host/host.cpp
@@ -20,7 +20,7 @@ const size_t NUM_THREADS = 8;
 
 void* test_mutex_thread(oe_enclave_t* enclave)
 {
-    oe_result_t result = enc_test_mutex(enclave);
+    oe_result_t result = enc_test_recursive_mutex(enclave);
     OE_TEST(result == OE_OK);
 
     return NULL;

--- a/tests/thread/thread.edl
+++ b/tests/thread/thread.edl
@@ -15,7 +15,7 @@ enclave {
 
         public void cb_test_signal_thread_impl();
 
-        public void enc_test_mutex();
+        public void enc_test_recursive_mutex();
 
         public void enc_test_mutex_counts(
             [out] size_t* count1,


### PR DESCRIPTION
Previously, the oe_mutex implementation supports only the recursive mutex type by default and there is no way to opt out.
This PR updates the internal oe_mutex implementation so that the mutex is not recursive by default. In addition, the PR implements the oe_mutexattr* APIs (will be used by pthread_mutexattr* APIs), allowing for initializing mutex with normal or recursive type.

Note that with the PR, consecutive oe_mutex_lock on a non-recursive lock will result in a deadlock. OE additionally provides logging to help debugging.

Fixes #4555

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>