### PR TITLE
Make the OE internal mutex recursive by default

### DIFF
--- a/enclave/core/pthread.c
+++ b/enclave/core/pthread.c
@@ -143,7 +143,17 @@ int oe_pthread_spin_destroy(oe_pthread_spinlock_t* spinlock)
 
 int oe_pthread_mutexattr_init(oe_pthread_mutexattr_t* attr)
 {
-    return _to_errno(oe_mutexattr_init((oe_mutexattr_t*)attr));
+    oe_result_t result = OE_FAILURE;
+
+    result = oe_mutexattr_init((oe_mutexattr_t*)attr);
+    if (result != OE_OK)
+        return _to_errno(result);
+
+    /* Set the type to NORMAL to match the pthread behavior as the
+     * OE's default is RECURSIVE */
+    result = oe_mutexattr_settype((oe_mutexattr_t*)attr, OE_MUTEX_NORMAL);
+
+    return _to_errno(result);
 }
 
 int oe_pthread_mutexattr_settype(oe_pthread_mutexattr_t* attr, int type)
@@ -161,6 +171,15 @@ int oe_pthread_mutex_init(
     oe_pthread_mutex_t* m,
     const oe_pthread_mutexattr_t* attr)
 {
+    if (!attr)
+    {
+        oe_mutexattr_t attr_normal = {0};
+
+        /* If attr is NULL, set the default type to NORMAL (0) to match the
+         * pthread behavior as the OE's default is RECURSIVE (1) */
+        return _to_errno(oe_mutex_init((oe_mutex_t*)m, &attr_normal));
+    }
+
     return _to_errno(oe_mutex_init((oe_mutex_t*)m, (oe_mutexattr_t*)attr));
 }
 

--- a/enclave/core/sgx/thread.c
+++ b/enclave/core/sgx/thread.c
@@ -168,7 +168,7 @@ typedef struct _oe_mutex_impl
     oe_sgx_td_t* owner;
 
     /* The type of mutex (supported types: normal and recursive) */
-    uint32_t type;
+    uint64_t type;
 
     /* Queue of waiting threads (front holds the mutex) */
     Queue queue;
@@ -181,6 +181,11 @@ typedef struct _oe_mutexattr_impl
 
 OE_STATIC_ASSERT(sizeof(oe_mutex_impl_t) <= sizeof(oe_mutex_t));
 OE_STATIC_ASSERT(sizeof(oe_mutexattr_impl_t) <= sizeof(oe_mutexattr_t));
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_mutex_impl_t, lock) == 0);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_mutex_impl_t, refs) == 4);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_mutex_impl_t, owner) == 8);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_mutex_impl_t, type) == 16);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_mutex_impl_t, queue) == 24);
 
 static oe_result_t _validate_mutexattr_type(uint32_t type)
 {

--- a/include/openenclave/internal/thread.h
+++ b/include/openenclave/internal/thread.h
@@ -54,17 +54,35 @@ bool oe_thread_equal(oe_thread_t thread1, oe_thread_t thread2);
 
 typedef uint32_t oe_once_t;
 
+/* Match musl's definitions */
+#define OE_MUTEX_NORMAL 0
+#define OE_MUTEX_RECURSIVE 1
+#define OE_MUTEX_ERRORCHECK 2
+/* Make OE's default as recursive */
+#define OE_MUTEX_DEFAULT OE_MUTEX_RECURSIVE
+
 /**
  * @cond DEV
  */
 #define OE_ONCE_INIT 0
 #define OE_ONCE_INITIALIZER 0
 #define OE_SPINLOCK_INITIALIZER 0
-#define OE_MUTEX_INITIALIZER \
-    {                        \
-        {                    \
-            0                \
-        }                    \
+
+/* Default to initialize the mutex as recursive
+ * (the fields are specific for the oe_mutex_impl_t in
+ * enclave/core/sgx/thread.c) */
+#define OE_MUTEX_INITIALIZER             \
+    {                                    \
+        {                                \
+            0, 0, OE_MUTEX_DEFAULT, 0, 0 \
+        }                                \
+    }
+
+#define OE_MUTEX_INITIALIZER_NORMAL \
+    {                               \
+        {                           \
+            0                       \
+        }                           \
     }
 
 #define OE_COND_INITIALIZER \
@@ -210,12 +228,6 @@ typedef struct _oe_mutexattr
 {
     uint32_t _impl;
 } oe_mutexattr_t;
-
-/* Match the definitions of corelibc/pthread.h */
-#define OE_MUTEX_NORMAL 0
-#define OE_MUTEX_DEFAULT 0
-#define OE_MUTEX_RECURSIVE 1
-#define OE_MUTEX_ERRORCHECK 2
 
 /**
  * Initialize a mutex attribute.

--- a/syscall/devices/hostepoll/hostepoll.c
+++ b/syscall/devices/hostepoll/hostepoll.c
@@ -147,6 +147,7 @@ static oe_fd_t* _epoll_create1(oe_device_t* device_, int32_t flags)
     epoll_t* epoll = NULL;
     device_t* device = _cast_device(device_);
     oe_host_fd_t retval;
+    oe_mutexattr_t attr;
 
     oe_errno = 0;
 
@@ -166,6 +167,15 @@ static oe_fd_t* _epoll_create1(oe_device_t* device_, int32_t flags)
     epoll->base.ops.epoll = _get_epoll_ops();
     epoll->magic = EPOLL_MAGIC;
     epoll->host_fd = retval;
+
+    if (oe_mutexattr_init(&attr) != OE_OK)
+        OE_RAISE_ERRNO(OE_EFAULT);
+
+    if (oe_mutexattr_settype(&attr, OE_MUTEX_RECURSIVE) != OE_OK)
+        OE_RAISE_ERRNO(OE_EFAULT);
+
+    if (oe_mutex_init(&epoll->lock, &attr) != OE_OK)
+        OE_RAISE_ERRNO(OE_EFAULT);
 
     ret = &epoll->base;
     epoll = NULL;

--- a/tests/thread/enc/enc.cpp
+++ b/tests/thread/enc/enc.cpp
@@ -15,22 +15,10 @@
 #include <atomic>
 #include "thread_t.h"
 
-static inline oe_mutex_t _mutex_initializer_recursive()
-{
-    oe_mutex_t m;
-    oe_mutexattr_t attr;
-    oe_mutexattr_init(&attr);
-    oe_mutexattr_settype(&attr, OE_MUTEX_RECURSIVE);
-    oe_mutex_init(&m, &attr);
-    return m;
-}
-
-#define OE_MUTEX_INITIALIZER_RECURSIVE _mutex_initializer_recursive()
-
-static oe_mutex_t mutex1 = OE_MUTEX_INITIALIZER;
-static oe_mutex_t mutex2 = OE_MUTEX_INITIALIZER;
-static oe_mutex_t recursive_mutex1 = OE_MUTEX_INITIALIZER_RECURSIVE;
-static oe_mutex_t recursive_mutex2 = OE_MUTEX_INITIALIZER_RECURSIVE;
+static oe_mutex_t mutex1 = OE_MUTEX_INITIALIZER_NORMAL;
+static oe_mutex_t mutex2 = OE_MUTEX_INITIALIZER_NORMAL;
+static oe_mutex_t recursive_mutex1 = OE_MUTEX_INITIALIZER;
+static oe_mutex_t recursive_mutex2 = OE_MUTEX_INITIALIZER;
 static size_t test_mutex_count1 = 0;
 static size_t test_mutex_count2 = 0;
 
@@ -211,9 +199,9 @@ void enc_relinquish_exclusive_access()
     oe_mutex_unlock(&ex_mutex);
 }
 
-static oe_mutex_t mutex_a = OE_MUTEX_INITIALIZER_RECURSIVE;
-static oe_mutex_t mutex_b = OE_MUTEX_INITIALIZER_RECURSIVE;
-static oe_mutex_t mutex_c = OE_MUTEX_INITIALIZER_RECURSIVE;
+static oe_mutex_t mutex_a = OE_MUTEX_INITIALIZER;
+static oe_mutex_t mutex_b = OE_MUTEX_INITIALIZER;
+static oe_mutex_t mutex_c = OE_MUTEX_INITIALIZER;
 
 static oe_thread_t a_owner = 0;
 static oe_thread_t b_owner = 0;

--- a/tests/thread/enc/thread.h
+++ b/tests/thread/enc/thread.h
@@ -19,11 +19,22 @@ static __inline pthread_mutex_t __mutex_initializer_default()
     return m;
 }
 
+static __inline pthread_mutex_t __mutex_initializer_recursive()
+{
+    pthread_mutex_t m;
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&m, &attr);
+    return m;
+}
+
 typedef pthread_t oe_thread_t;
 #define oe_thread_self pthread_self
 
 typedef pthread_mutex_t oe_mutex_t;
-#define OE_MUTEX_INITIALIZER __mutex_initializer_default()
+#define OE_MUTEX_INITIALIZER __mutex_initializer_recursive()
+#define OE_MUTEX_INITIALIZER_NORMAL __mutex_initializer_default()
 #define oe_mutex_init pthread_mutex_init
 #define oe_mutex_lock pthread_mutex_lock
 #define oe_mutex_trylock pthread_mutex_trylock


### PR DESCRIPTION
Update the OE_MUTEX_INITIALIZER that is used to initialize the OE internal mutex, which retain the original behavior: initializing the mutex as recursive.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>