### PR TITLE
Add debugger hook to detect non-debug enclaves

### DIFF
--- a/debugger/gdb-extension/gdb_sgx_plugin.py
+++ b/debugger/gdb-extension/gdb_sgx_plugin.py
@@ -284,6 +284,17 @@ class EnclaveCreationBreakpoint(gdb.Breakpoint):
         enable_oeenclave_debug(enclave_addr)
         return False
 
+class NonDebugEnclaveBreakpoint(gdb.Breakpoint):
+    def __init__(self):
+        gdb.Breakpoint.__init__ (self, spec="_debug_non_debug_enclave_created_hook", internal=1)
+
+    def stop(self):
+        print ("oegdb: The enclave is not debuggable." +
+               " Debugging non-debug enclaves using oegdb is unreliable and unstable." +
+               " To make the enclave debuggable, set Debug=1 in the enclave's configuration and" +
+               " add OE_ENCLAVE_FLAG_DEBUG to enclave creation flags.")
+        return True
+
 class EnclaveTerminationBreakpoint(gdb.Breakpoint):
     def __init__(self):
         gdb.Breakpoint.__init__ (self, spec="oe_debug_enclave_terminated_hook", internal=1)
@@ -380,6 +391,7 @@ def oe_debugger_init():
     EnclaveTerminationBreakpoint()
     ModuleLoadedBreakpoint()
     ModuleUnloadedBreakpoint()
+    NonDebugEnclaveBreakpoint()
     return
 
 def oe_debugger_cleanup():

--- a/debugger/lldb-extension/lldb_sgx_plugin.py
+++ b/debugger/lldb-extension/lldb_sgx_plugin.py
@@ -296,6 +296,19 @@ class EnclaveCreationBreakpoint:
             g_enclave = enclave_addr
         return False
 
+class NonDebugEnclaveBreakpoint:
+    def __init__(self, target):
+        breakpoint  = target.BreakpointCreateByName("_debug_non_debug_enclave_created_hook")
+        breakpoint.SetScriptCallbackFunction('lldb_sgx_plugin.NonDebugEnclaveBreakpoint.onHit')
+
+    @staticmethod
+    def onHit(frame, bp_loc, dict):
+        print ("oelldb: The enclave is not debuggable." +
+               " Debugging non-debug enclaves using oelldb is unreliable and unstable." +
+               " To make the enclave debuggable, set Debug=1 in the enclave's configuration and" +
+               " add OE_ENCLAVE_FLAG_DEBUG to enclave creation flags.")
+        return True
+
 class EnclaveTerminationBreakpoint:
     def __init__(self, target):
         breakpoint  = target.BreakpointCreateByName("oe_debug_enclave_terminated_hook")
@@ -359,6 +372,7 @@ def oe_debugger_init(debugger):
     EnclaveTerminationBreakpoint(debugger.GetSelectedTarget())
     ModuleLoadedBreakpoint(debugger.GetSelectedTarget())
     ModuleUnloadedBreakpoint(debugger.GetSelectedTarget())
+    NonDebugEnclaveBreakpoint(debugger.GetSelectedTarget())
 
 # Invoked when `command script import lldb_sgx_plugin' is called.
 def __lldb_init_module(debugger, dict):

--- a/tests/debugger/CMakeLists.txt
+++ b/tests/debugger/CMakeLists.txt
@@ -5,6 +5,7 @@ if (NOT UNIX OR BUILD_TYPE_UPPER STREQUAL "RELEASE")
   return()
 endif ()
 
+add_subdirectory(non_debug)
 add_subdirectory(host)
 add_subdirectory(enc)
 

--- a/tests/debugger/non_debug/CMakeLists.txt
+++ b/tests/debugger/non_debug/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_test(
+  NAME oegdb-non-debug-enclave-test
+  COMMAND
+    ${OE_BINDIR}/oegdb --batch -nh # Do not use user's gdbinit
+    --command=${CMAKE_CURRENT_SOURCE_DIR}/commands.gdb
+    --return-child-result # This fails the test in case of any error.
+    -arg host/non_debug_host enc/non_debug_enc --simulation-mode)
+
+set_tests_properties(
+  oegdb-non-debug-enclave-test
+  PROPERTIES PASS_REGULAR_EXPRESSION "The enclave is not debuggable"
+             FAIL_REGULAR_EXPRESSION "This should not be hit")
+
+add_test(
+  NAME oelldb-test
+  COMMAND
+    ${OE_BINDIR}/oelldb -o
+    "command script import ${CMAKE_CURRENT_SOURCE_DIR}/commands.py" -o "quit"
+    -- host/non_debug_host enc/non_debug_enc --simulation-mode)
+
+set_tests_properties(
+  oelldb-test
+  PROPERTIES PASS_REGULAR_EXPRESSION "The enclave is not debuggable"
+             FAIL_REGULAR_EXPRESSION "This should not be hit")

--- a/tests/debugger/non_debug/commands.gdb
+++ b/tests/debugger/non_debug/commands.gdb
@@ -1,0 +1,19 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# Enable pending breakpoints
+set breakpoint pending on
+
+# Set a breakpoint in enclave function
+# This should not get hit.
+b enc_foo
+commands
+    printf "This should not be hit\n"
+end
+
+# Run the program. This will cause GDB to detect that
+# it is a non debug enclave and stop execution.
+run
+
+# Now that GDB is stopped, execute program till end.
+c

--- a/tests/debugger/non_debug/commands.py
+++ b/tests/debugger/non_debug/commands.py
@@ -1,0 +1,39 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+import lldb
+import sys
+
+def bp_enc_foo(frame, bp_loc, dict):
+    print("This should not be hit")
+    return True
+
+def run_test():
+    lldb.debugger.SetAsync(False)
+    target = lldb.debugger.GetSelectedTarget()
+
+    # Set breakpoint in enclave function. It should not be hit.
+    bp = target.BreakpointCreateByName("enc_foo")
+    bp.SetScriptCallbackFunction('commands.bp_enc_foo')
+
+    # The `personality` syscall is used by lldb to turn off ASLR.
+    # This syscall may not be permitted within containers.
+    # Therefore, turn off disable-aslr.
+    lldb.debugger.HandleCommand("settings set target.disable-aslr false")
+
+
+    # Run the program. This will cause lldb to detect that a release-mode
+    # enclave is being debugged and stop execution.
+    lldb.debugger.HandleCommand("run")
+
+    # Continue execution till end.
+    lldb.debugger.HandleCommand("continue")
+
+    retval = lldb.debugger.GetSelectedTarget().GetProcess().exit_state
+    if int(retval) == 0:
+        print("oelldb non debug enclave test passed")
+    else:
+        print("oelldb non debug enclave test failed")
+
+def __lldb_init_module(debugger, dict):
+    run_test()

--- a/tests/debugger/non_debug/enc/CMakeLists.txt
+++ b/tests/debugger/non_debug/enc/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../non_debug.edl)
+
+add_custom_command(
+  OUTPUT non_debug_t.h non_debug_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(
+  TARGET
+  non_debug_enc
+  UUID
+  ff375399-0b06-4189-9ddc-df5e38612e6d
+  # The test would fail with the OpenSSL-based crypto wrapper
+  # because the invocations of cpuid is not handled properly
+  # (i.e., the SIGILL signal).
+  CRYPTO_LIB
+  mbedtls
+  SOURCES
+  enc.c
+  ${CMAKE_CURRENT_BINARY_DIR}/non_debug_t.c)
+
+enclave_include_directories(non_debug_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+enclave_link_libraries(non_debug_enc oelibc)

--- a/tests/debugger/non_debug/enc/enc.c
+++ b/tests/debugger/non_debug/enc/enc.c
@@ -1,0 +1,33 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// The line numbers in this file are referenced by the gdb
+// test script commands.gdb. If you edit this file, update the
+// test script as well.
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include "non_debug_t.h"
+#include "openenclave/bits/defs.h"
+
+OE_NEVER_INLINE
+void enc_foo(void)
+{
+}
+
+void enc_fcn(void)
+{
+    enc_foo();
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug: Enclave will however be created without
+             OE_ENCLAVE_FLAG_DEBUG */
+    1024, /* NumHeapPages */
+    1024, /* NumStackPages */
+    2);   /* NumTCS */

--- a/tests/debugger/non_debug/host/CMakeLists.txt
+++ b/tests/debugger/non_debug/host/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../non_debug.edl)
+
+add_custom_command(
+  OUTPUT non_debug_u.h non_debug_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(non_debug_host host.c non_debug_u.c)
+
+target_include_directories(non_debug_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(non_debug_host oehost)

--- a/tests/debugger/non_debug/host/host.c
+++ b/tests/debugger/non_debug/host/host.c
@@ -1,0 +1,55 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <limits.h>
+#include <openenclave/bits/sgx/sgxtypes.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "non_debug_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result;
+    oe_enclave_t* enclave = NULL;
+    bool simulation_mode = false;
+
+    if (argc < 2)
+    {
+        fprintf(
+            stderr, "Usage: %s ENCLAVE_PATH [--simulation-mode]\n", argv[0]);
+        return 1;
+    }
+
+    uint32_t flags = oe_get_create_flags();
+
+    simulation_mode =
+        (argc == 3 && (strcmp(argv[2], "--simulation-mode") == 0));
+
+    if (simulation_mode)
+    {
+        // Force simulation mode if --simulation-mode is specified.
+        flags |= OE_ENCLAVE_FLAG_SIMULATE;
+    }
+
+    // Remove debug flag.
+    flags = flags & (~OE_ENCLAVE_FLAG_DEBUG);
+
+    if ((result = oe_create_non_debug_enclave(
+             argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    OE_TEST(enc_fcn(enclave) == OE_OK);
+
+    OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+    OE_TEST(result == OE_OK);
+
+    printf(
+        "=== ran non debug enclave in %s mode\n",
+        simulation_mode ? "-simulation" : "hardware");
+
+    return 0;
+}

--- a/tests/debugger/non_debug/non_debug.edl
+++ b/tests/debugger/non_debug/non_debug.edl
@@ -1,0 +1,16 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public void enc_fcn();
+    };
+};


### PR DESCRIPTION
oegedb and oelldb will set internal breakpoints on this hook
and warn the user that the enclave is not debuggable.

fixes #4558

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>