### PR TITLE
[Attestation] Enable logging dcap_quoteprov logs for all OE_LOG_LEVELs

### DIFF
--- a/host/sgx/linux/sgxquoteproviderloader.c
+++ b/host/sgx/linux/sgxquoteproviderloader.c
@@ -29,18 +29,15 @@ void oe_load_quote_provider()
             dlopen("libdcap_quoteprov.so", RTLD_LAZY | RTLD_LOCAL);
         if (provider.handle != 0)
         {
-            if (oe_get_current_logging_level() >= OE_LOG_LEVEL_INFO)
+            if (oe_sgx_set_quote_provider_logger(oe_quote_provider_log) ==
+                OE_OK)
             {
-                if (oe_sgx_set_quote_provider_logger(oe_quote_provider_log) ==
-                    OE_OK)
-                {
-                    OE_TRACE_INFO("sgxquoteprovider: Installed log function\n");
-                }
-                else
-                {
-                    OE_TRACE_WARNING(
-                        "sgxquoteprovider: Not able to install log function\n");
-                }
+                OE_TRACE_INFO("sgxquoteprovider: Installed log function\n");
+            }
+            else
+            {
+                OE_TRACE_WARNING(
+                    "sgxquoteprovider: Not able to install log function\n");
             }
 
             provider.get_sgx_quote_verification_collateral = dlsym(

--- a/host/sgx/platformquoteprovider.h
+++ b/host/sgx/platformquoteprovider.h
@@ -81,7 +81,9 @@ typedef void (*sgx_free_quote_verification_collateral_t)(
 typedef enum _sgx_ql_log_level_t
 {
     SGX_QL_LOG_ERROR,
-    SGX_QL_LOG_INFO
+    SGX_QL_LOG_WARNING,
+    SGX_QL_LOG_INFO,
+    SGX_QL_LOG_NONE
 } sgx_ql_log_level_t;
 
 /// Function signature used for logging from within the library

--- a/host/sgx/sgxquoteprovider.c
+++ b/host/sgx/sgxquoteprovider.c
@@ -27,14 +27,23 @@ extern oe_sgx_quote_provider_t provider;
 
 void oe_quote_provider_log(sgx_ql_log_level_t level, const char* message)
 {
-    const char* level_string = level == 0 ? "ERROR" : "INFO";
-    char formatted[1024];
+    char formatted[OE_LOG_MESSAGE_LEN_MAX] = {0};
+    oe_log_level_t oe_log_level[] = {
+        OE_LOG_LEVEL_ERROR,
+        OE_LOG_LEVEL_WARNING,
+        OE_LOG_LEVEL_INFO,
+        OE_LOG_LEVEL_NONE};
+    const char* dcap_level_strings[] = {"ERROR", "WARN", "INFO", "NONE"};
 
-    snprintf(formatted, sizeof(formatted), "[%s]: %s\n", level_string, message);
+    snprintf(
+        formatted,
+        sizeof(formatted),
+        "dcap_quoteprov: [%s]: %s\n",
+        dcap_level_strings[level],
+        message);
+    formatted[OE_LOG_MESSAGE_LEN_MAX - 1] = 0;
 
-    formatted[sizeof(formatted) - 1] = 0;
-
-    OE_TRACE_INFO("dcap_quoteprov: %s", formatted);
+    OE_TRACE(oe_log_level[level], "%s", formatted);
 }
 
 oe_result_t oe_initialize_quote_provider()

--- a/host/sgx/windows/sgxquoteproviderloader.c
+++ b/host/sgx/windows/sgxquoteproviderloader.c
@@ -29,18 +29,15 @@ void oe_load_quote_provider()
         if (_handle != 0)
         {
             provider.handle = _handle;
-            if (oe_get_current_logging_level() >= OE_LOG_LEVEL_INFO)
+            if (oe_sgx_set_quote_provider_logger(oe_quote_provider_log) ==
+                OE_OK)
             {
-                if (oe_sgx_set_quote_provider_logger(oe_quote_provider_log) ==
-                    OE_OK)
-                {
-                    OE_TRACE_INFO("sgxquoteprovider: Installed log function\n");
-                }
-                else
-                {
-                    OE_TRACE_WARNING(
-                        "sgxquoteprovider: Not able to install log function\n");
-                }
+                OE_TRACE_INFO("sgxquoteprovider: Installed log function\n");
+            }
+            else
+            {
+                OE_TRACE_WARNING(
+                    "sgxquoteprovider: Not able to install log function\n");
             }
 
             provider.get_sgx_quote_verification_collateral =

--- a/samples/attestation/CMakeLists.txt
+++ b/samples/attestation/CMakeLists.txt
@@ -31,7 +31,7 @@ add_subdirectory(enclave_b)
 add_subdirectory(host)
 
 # Remove previously built CMakeFiles directory, if any. This avoids build
-# failures due to stale object files in CMakeFiles/. 
+# failures due to stale object files in CMakeFiles/.
 file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/enclave_a/CMakeFiles)
 file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/enclave_b/CMakeFiles)
 
@@ -41,16 +41,20 @@ if ((NOT DEFINED ENV{OE_SIMULATION}) OR (NOT $ENV{OE_SIMULATION}))
   add_custom_target(run DEPENDS runsgxlocal runsgxremote)
 
   add_custom_target(
+    runsgxremote
+    DEPENDS attestation_host sign
+    BYPRODUCTS sgxremote_log.txt
+    COMMAND
+      OE_LOG_LEVEL=INFO AZDCAP_DEBUG_LOG_LEVEL=ERROR host/attestation_host
+      sgxremote ${CMAKE_BINARY_DIR}/enclave_a/enclave_a.signed
+      ${CMAKE_BINARY_DIR}/enclave_b/enclave_b.signed sgxremote_log.txt
+    COMMAND grep -q "dcap_quoteprov:" ${CMAKE_BINARY_DIR}/sgxremote_log.txt)
+
+  add_custom_target(
     runsgxlocal
     DEPENDS attestation_host sign
     COMMAND
-      attestation_host sgxlocal ${CMAKE_BINARY_DIR}/enclave_a/enclave_a.signed
-      ${CMAKE_BINARY_DIR}/enclave_b/enclave_b.signed)
-
-  add_custom_target(
-    runsgxremote
-    DEPENDS attestation_host sign
-    COMMAND
-      attestation_host sgxremote ${CMAKE_BINARY_DIR}/enclave_a/enclave_a.signed
+      host/attestation_host sgxlocal
+      ${CMAKE_BINARY_DIR}/enclave_a/enclave_a.signed
       ${CMAKE_BINARY_DIR}/enclave_b/enclave_b.signed)
 endif ()

--- a/samples/attestation/attestation.edl
+++ b/samples/attestation/attestation.edl
@@ -3,6 +3,7 @@
 
 enclave {
     from "openenclave/edl/attestation.edl" import *;
+    from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
 

--- a/samples/attestation/host/host.cpp
+++ b/samples/attestation/host/host.cpp
@@ -3,6 +3,7 @@
 
 #include <openenclave/attestation/sgx/evidence.h>
 #include <openenclave/host.h>
+#include <openenclave/trace.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "attestation_u.h"
@@ -116,6 +117,39 @@ exit:
     return ret;
 }
 
+void host_logging_callback(
+    void* context,
+    bool is_enclave,
+    const struct tm* t,
+    long int usecs,
+    oe_log_level_t level,
+    uint64_t host_thread_id,
+    const char* message)
+{
+    char time[25];
+    FILE* log_file = NULL;
+    strftime(time, sizeof(time), "%Y-%m-%dT%H:%M:%S%z", t);
+
+    if (level == OE_LOG_LEVEL_ERROR)
+    {
+        log_file = stderr;
+    }
+    else
+    {
+        log_file = (FILE*)context;
+    }
+
+    fprintf(
+        log_file,
+        "%s.%06ld, %s, %s, %lx, %s",
+        time,
+        usecs,
+        (is_enclave ? "E" : "H"),
+        oe_log_level_strings[level],
+        host_thread_id,
+        message);
+}
+
 int main(int argc, const char* argv[])
 {
     oe_enclave_t* enclave_a = NULL;
@@ -127,9 +161,12 @@ int main(int argc, const char* argv[])
     oe_uuid_t* format_id = nullptr;
 
     /* Check argument count */
-    if (argc != 4)
+    if (argc != 4 && argc != 5)
     {
-        printf("Usage: %s <tee> ENCLAVE_PATH1 ENCLAVE_PATH2\n", argv[0]);
+        printf(
+            "Usage: %s <tee> ENCLAVE_PATH1 ENCLAVE_PATH2 "
+            "<optional:log_file_name>\n",
+            argv[0]);
         printf("       where <tee> is one of:\n");
         printf("           sgxlocal  : for SGX local attestation\n");
         printf("           sgxremote : for SGX remote attestation\n");
@@ -148,6 +185,13 @@ int main(int argc, const char* argv[])
     {
         printf("Unrecognized TEE type\n");
         return 1;
+    }
+
+    if (argc == 5)
+    {
+        /* Set logging callback */
+        FILE* out_file = fopen(argv[4], "w");
+        oe_log_set_callback((void*)out_file, host_logging_callback);
     }
 
     printf("Host: Creating two enclaves\n");
@@ -172,7 +216,7 @@ int main(int argc, const char* argv[])
     {
         printf("Host: environment variable SGX_AESM_ADDR is not set\n");
     }
-#endif
+#endif //__linux__
 
     // attest enclave A to enclave B
     ret = attest_one_enclave_to_the_other(


### PR DESCRIPTION
In current implementation of dcap_quoteprov logging callback, the logs from dcap_quoteprov are only logged when OE_LOG_LEVEL >= INFO. This PR enables logging for all OE_LOG_LEVELs accordingly.

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>