### PR TITLE
Avoid use of freopen on stdin and stdout

### DIFF
--- a/tests/tools/oeapkman/zlib/enc/enc.c
+++ b/tests/tools/oeapkman/zlib/enc/enc.c
@@ -18,22 +18,28 @@ int main(int argc, const char** argv);
 
 int enc_test(bool decompress, const char* in_file, const char* out_file)
 {
-    const char* argv[2] = {
-        "zpipe",
-        decompress ? "-d" : NULL,
-    };
+    bool use_freopen = false;
+    int ret = 0;
 
-    if (in_file && out_file)
+    OE_TEST(oe_load_module_host_file_system() == OE_OK);
+    OE_TEST(oe_mount("/", "/", OE_DEVICE_NAME_HOST_FILE_SYSTEM, 0, NULL) == 0);
+
+    if (!use_freopen)
     {
-        OE_TEST(oe_load_module_host_file_system() == OE_OK);
-        OE_TEST(
-            oe_mount("/", "/", OE_DEVICE_NAME_HOST_FILE_SYSTEM, 0, NULL) == 0);
+        const char* argv[5] = {
+            "zpipe", in_file, out_file, decompress ? "-d" : NULL, NULL};
 
+        ret = main(decompress ? 4 : 3, argv);
+    }
+    else
+    {
         OE_TEST(freopen(in_file, "rb", stdin) != NULL);
         OE_TEST(freopen(out_file, "wb", stdout) != NULL);
-    }
 
-    int ret = main(decompress ? 2 : 1, argv);
+        const char* argv[3] = {"zpipe", decompress ? "-d" : NULL, NULL};
+
+        ret = main(decompress ? 2 : 1, argv);
+    }
 
     oe_umount("/");
     return ret;

--- a/tests/tools/oeapkman/zlib/enc/zpipe.c
+++ b/tests/tools/oeapkman/zlib/enc/zpipe.c
@@ -185,6 +185,52 @@ void zerr(int ret)
 /* compress or decompress from stdin to stdout */
 int main(int argc, char** argv)
 {
+    if (argc == 3 || (argc == 4 && strcmp(argv[3], "-d") == 0))
+    {
+        FILE* in = NULL;
+        FILE* out = NULL;
+        int ret = -1;
+
+        in = fopen(argv[1], "rb");
+        if (in == NULL)
+        {
+            fprintf(stderr, "zpipe: could not open %s", argv[1]);
+            goto done;
+        }
+
+        out = fopen(argv[2], "wb");
+        if (in == NULL)
+        {
+            fprintf(stderr, "zpipe: could not open %s", argv[2]);
+            goto done;
+        }
+
+        /* do compression if no arguments */
+        if (argc == 3)
+        {
+            ret = def(in, out, Z_DEFAULT_COMPRESSION);
+            if (ret != Z_OK)
+                zerr(ret);
+            goto done;
+        }
+
+        /* do decompression if -d specified */
+        else if (argc == 4 && strcmp(argv[3], "-d") == 0)
+        {
+            ret = inf(in, out);
+            if (ret != Z_OK)
+                zerr(ret);
+            goto done;
+        }
+    done:
+        if (in)
+            fclose(in);
+        if (out)
+            fclose(out);
+
+        return ret;
+    }
+
     int ret;
 
     /* avoid end-of-line conversions */


### PR DESCRIPTION
These functions likely behave incorrectly, causing deflate error with zlib.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>