### PR TITLE
Update Docker publishing workflow

### DIFF
--- a/.jenkins/infrastructure/docker/build_windows_docker_images.Jenkinsfile
+++ b/.jenkins/infrastructure/docker/build_windows_docker_images.Jenkinsfile
@@ -6,7 +6,6 @@ library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 TAG_FULL_IMAGE = params.DOCKER_TAG ?: helpers.get_date(".") + "${BUILD_NUMBER}"
 
 TIMEOUT_MINUTES = 240
-DOCKERHUB_REPO_CREDS = "oeciteamdockerhub"
 
 pipeline {
     agent {
@@ -23,9 +22,7 @@ pipeline {
         string(name: "INTERNAL_REPO_CRED_ID", defaultValue: "oejenkinscidockerregistry", description: "Credential ID for internal Docker repository")
         string(name: "OECI_LIB_VERSION", defaultValue: 'master', description: 'Version of OE Libraries to use')
         string(name: "AGENTS_LABEL", defaultValue: 'windows-nonsgx', description: "Label of the agent to use to run this job")
-        booleanParam(name: "PUBLISH_DOCKER_HUB", defaultValue: false, description: "Publish container to OECITeam Docker Hub?")
         booleanParam(name: "TAG_LATEST", defaultValue: false, description: "Update the latest tag to the currently built DOCKER_TAG")
-        booleanParam(name: "PUBLISH_VERSION_FILE", defaultValue: false, description: "Publish versioning information?")
     }
     stages {
         stage("Checkout") {
@@ -53,59 +50,6 @@ pipeline {
                             common.exec_with_retry { oe2019.push('latest') }
                         }
                     }
-                }
-            }
-        }
-        stage("Push to OE Docker Hub Registry") {
-            when {
-                expression {
-                    return params.PUBLISH_DOCKER_HUB
-                }
-            }
-            steps {
-                script {
-                    docker.withRegistry('', DOCKERHUB_REPO_CREDS) {
-                        if ( PUBLISH_DOCKER_HUB ) {
-                            common.exec_with_retry { oe2019.push() }
-                            if( TAG_LATEST ) {
-                                common.exec_with_retry { oe2019.push('latest') }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        stage('Publish info') {
-            when {
-                expression {
-                    return params.PUBLISH_VERSION_FILE
-                }
-            }
-            agent {
-                label globalvars.AGENTS_LABELS["shared"]
-            }
-            steps {
-                withCredentials([usernamePassword(credentialsId: 'github-oeciteam-user-pat',
-                                 usernameVariable: 'GIT_USERNAME',
-                                 passwordVariable: 'GIT_PASSWORD')]) {
-                    sh '''
-                        git config --global user.email "${GIT_USERNAME}@microsoft.com"
-                        git config --global user.name ${GIT_USERNAME}
-                        git checkout --force "oeciteam/publish-docker"
-                        git pull
-                    '''
-                    script {
-                    REPOSITORY = params.INTERNAL_REPO - ~"^https://"
-                        sh """#!/bin/bash
-                            OE_VERSION=\$(grep --max-count=1 --only-matching --perl-regexp 'v\\d+\\.\\d+\\.\\d+(?=_log)' CHANGELOG.md)
-                            echo "| Windows Server 2019 | ${REPOSITORY}/oetools-ws2019:${TAG_FULL_IMAGE} | \${OE_VERSION} | None | None |" >> DOCKER_IMAGES.md
-                        """
-                    }
-                    sh '''
-                        git add DOCKER_IMAGES.md
-                        git commit -sm "Publish Docker Images"
-                        git push --force https://${GIT_PASSWORD}@github.com/openenclave/openenclave.git HEAD:oeciteam/publish-docker
-                    '''
                 }
             }
         }

--- a/.jenkins/infrastructure/docker/publish_docker_images.Jenkinsfile
+++ b/.jenkins/infrastructure/docker/publish_docker_images.Jenkinsfile
@@ -27,6 +27,9 @@ pipeline {
         booleanParam(name: "TAG_LATEST", defaultValue: true, description: "Update the latest tag to the currently built DOCKER_TAG")
         booleanParam(name: "PUBLISH_VERSION_FILE", defaultValue: true, description: "Publish versioning information?")
     }
+    environment {
+        OECITEAM_BRANCH = "oeciteam/publish-docker"
+    }
     stages {
         stage('Push to public repo') {
             parallel {
@@ -49,7 +52,7 @@ pipeline {
                                 }
                             }
                         }
-                        stage('Push tag') {
+                        stage('Push tag to public repo') {
                             steps {
                                 script {
                                     docker.withRegistry(params.PUBLIC_REPO, params.PUBLIC_REPO_CRED_ID) {
@@ -67,7 +70,10 @@ pipeline {
                                 }
                             }
                         }
-                        stage('Push latest') {
+                        stage('Push latest to public repo') {
+                            when {
+                                expression { return params.TAG_LATEST }
+                            }
                             steps {
                                 script {
                                     docker.withRegistry(params.PUBLIC_REPO, params.PUBLIC_REPO_CRED_ID) {
@@ -80,6 +86,48 @@ pipeline {
                                             docker push ${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-18.04:latest
                                             docker push ${PUBLIC_REPO_NAME}/oetools-20.04:latest
                                             docker push ${PUBLIC_REPO_NAME}/oetools-18.04:latest
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        stage('Push tag to internal repo') {
+                            when {
+                                expression { return params.INTERNAL_LINUX_TAG != params.PUBLIC_LINUX_TAG }
+                            }
+                            steps {
+                                script {
+                                    docker.withRegistry(params.INTERNAL_REPO, params.INTERNAL_REPO_CRED_ID) {
+                                        sh """
+                                            docker tag ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-20.04:${params.PUBLIC_LINUX_TAG} ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-20.04:${params.PUBLIC_LINUX_TAG}
+                                            docker tag ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-18.04:${params.PUBLIC_LINUX_TAG} ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-18.04:${params.PUBLIC_LINUX_TAG}
+                                            docker tag ${INTERNAL_REPO_NAME}/oetools-20.04:${params.PUBLIC_LINUX_TAG} ${INTERNAL_REPO_NAME}/oetools-20.04:${params.PUBLIC_LINUX_TAG}
+                                            docker tag ${INTERNAL_REPO_NAME}/oetools-18.04:${params.PUBLIC_LINUX_TAG} ${INTERNAL_REPO_NAME}/oetools-18.04:${params.PUBLIC_LINUX_TAG}
+                                            docker push ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-20.04:${params.PUBLIC_LINUX_TAG}
+                                            docker push ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-18.04:${params.PUBLIC_LINUX_TAG}
+                                            docker push ${INTERNAL_REPO_NAME}/oetools-20.04:${params.PUBLIC_LINUX_TAG}
+                                            docker push ${INTERNAL_REPO_NAME}/oetools-18.04:${params.PUBLIC_LINUX_TAG}
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        stage('Push latest to internal repo') {
+                            when {
+                                expression { return params.TAG_LATEST }
+                            }
+                            steps {
+                                script {
+                                    docker.withRegistry(params.INTERNAL_REPO, params.INTERNAL_REPO_CRED_ID) {
+                                        sh """
+                                            docker tag ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-20.04:${params.PUBLIC_LINUX_TAG} ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-20.04:latest
+                                            docker tag ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-18.04:${params.PUBLIC_LINUX_TAG} ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-18.04:latest
+                                            docker tag ${INTERNAL_REPO_NAME}/oetools-20.04:${params.PUBLIC_LINUX_TAG} ${INTERNAL_REPO_NAME}/oetools-20.04:latest
+                                            docker tag ${INTERNAL_REPO_NAME}/oetools-18.04:${params.PUBLIC_LINUX_TAG} ${INTERNAL_REPO_NAME}/oetools-18.04:latest
+                                            docker push ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-20.04:latest
+                                            docker push ${INTERNAL_REPO_NAME}/openenclave-base-ubuntu-18.04:latest
+                                            docker push ${INTERNAL_REPO_NAME}/oetools-20.04:latest
+                                            docker push ${INTERNAL_REPO_NAME}/oetools-18.04:latest
                                         """
                                     }
                                 }
@@ -107,7 +155,7 @@ pipeline {
                                 }
                             }
                         }
-                        stage('Push tag') {
+                        stage('Push tag to public repo') {
                             steps {
                                 script {
                                     docker.withRegistry(params.PUBLIC_REPO, params.PUBLIC_REPO_CRED_ID) {
@@ -119,7 +167,7 @@ pipeline {
                                 }
                             }
                         }
-                        stage('Push latest') {
+                        stage('Push latest to public repo') {
                             when {
                                 expression { return params.TAG_LATEST }
                             }
@@ -134,17 +182,70 @@ pipeline {
                                 }
                             }
                         }
+                        stage('Push tag to internal repo') {
+                            when {
+                                expression { return params.INTERNAL_WINDOWS_TAG != params.PUBLIC_WINDOWS_TAG }
+                            }
+                            steps {
+                                script {
+                                    docker.withRegistry(params.INTERNAL_REPO, params.INTERNAL_REPO_CRED_ID) {
+                                        powershell """
+                                            docker tag ${INTERNAL_REPO_NAME}/oetools-ws2019:${params.INTERNAL_WINDOWS_TAG} ${INTERNAL_REPO_NAME}/oetools-ws2019:${params.PUBLIC_WINDOWS_TAG}
+                                            docker push ${INTERNAL_REPO_NAME}/oetools-ws2019:${params.PUBLIC_WINDOWS_TAG}
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        stage('Push latest to internal repo') {
+                            when {
+                                expression { return params.TAG_LATEST }
+                            }
+                            steps {
+                                script {
+                                    docker.withRegistry(params.INTERNAL_REPO, params.INTERNAL_REPO_CRED_ID) {
+                                        powershell """
+                                            docker tag ${INTERNAL_REPO_NAME}/oetools-ws2019:${params.INTERNAL_WINDOWS_TAG} ${INTERNAL_REPO_NAME}/oetools-ws2019:latest
+                                            docker push ${INTERNAL_REPO_NAME}/oetools-ws2019:latest
+                                        """
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
-        stage('Publish') {
+        stage('Publish version file') {
+            when {
+                anyOf {
+                    expression { return params.PUBLISH_LINUX }
+                    expression { return params.PUBLISH_WINDOWS }
+                }
+                expression { return params.PUBLISH_VERSION_FILE }
+            }
             stages {   
                 stage('Init') {
                     steps {
+                        checkout([$class: 'GitSCM',
+                            branches: [[name: 'master']],
+                            extensions: [
+                                [
+                                    $class: 'PruneStaleBranch',
+                                    $class: 'SubmoduleOption',
+                                    disableSubmodules: true,
+                                    recursiveSubmodules: false,
+                                    trackingSubmodules: false
+                                ]
+                            ], 
+                            userRemoteConfigs: [[url: "https://github.com/openenclave/openenclave"]]])
                         sh """
-                            git fetch origin oeciteam/publish-docker || true
-                            git checkout oeciteam/publish-docker || git checkout -f master && git checkout -B oeciteam/publish-docker
+                            if git fetch origin ${OECITEAM_BRANCH}; then
+                                git checkout ${OECITEAM_BRANCH} --force
+                            else
+                                git fetch origin master
+                                git checkout -b ${OECITEAM_BRANCH} --track remotes/origin/master --force
+                            fi
                         """
                         script {
                             OE_VERSION = sh(script: "grep --max-count=1 --only-matching --perl-regexp 'v\\d+\\.\\d+\\.\\d+(?=_log)' CHANGELOG.md", returnStdout: true).trim()
@@ -154,22 +255,32 @@ pipeline {
                 stage('Add details') {
                     steps {
                         script {
-                            BASE_2004_PSW  = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-20.04:${params.PUBLIC_LINUX_TAG}", "libsgx-enclave-common")
-                            BASE_2004_DCAP = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-20.04:${params.PUBLIC_LINUX_TAG}", "libsgx-ae-id-enclave")
-                            BASE_1804_PSW  = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-18.04:${params.PUBLIC_LINUX_TAG}", "libsgx-enclave-common")
-                            BASE_1804_DCAP = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-18.04:${params.PUBLIC_LINUX_TAG}", "libsgx-ae-id-enclave")
-                            FULL_2004_PSW  = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/oetools-20.04:${params.PUBLIC_LINUX_TAG}", "libsgx-enclave-common")
-                            FULL_2004_DCAP = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/oetools-20.04:${params.PUBLIC_LINUX_TAG}", "libsgx-ae-id-enclave")
-                            FULL_1804_PSW  = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/oetools-18.04:${params.PUBLIC_LINUX_TAG}", "libsgx-enclave-common")
-                            FULL_1804_DCAP = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/oetools-18.04:${params.PUBLIC_LINUX_TAG}", "libsgx-ae-id-enclave")
+                            sh """
+                                echo "\$(head -n 2 DOCKER_IMAGES.md)" > DOCKER_IMAGES_new.md
+                            """
+                            if (params.PUBLISH_WINDOWS) {
+                                sh """
+                                    echo "| Windows Server 2019 | ${PUBLIC_REPO_NAME}/oetools-ws2019:${PUBLIC_WINDOWS_TAG} | ${OE_VERSION} | None | None |" >> DOCKER_IMAGES_new.md
+                                """
+                            }
+                            if (params.PUBLISH_LINUX) {
+                                BASE_2004_PSW  = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-20.04:${params.PUBLIC_LINUX_TAG}", "libsgx-enclave-common")
+                                BASE_2004_DCAP = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-20.04:${params.PUBLIC_LINUX_TAG}", "libsgx-ae-id-enclave")
+                                BASE_1804_PSW  = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-18.04:${params.PUBLIC_LINUX_TAG}", "libsgx-enclave-common")
+                                BASE_1804_DCAP = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-18.04:${params.PUBLIC_LINUX_TAG}", "libsgx-ae-id-enclave")
+                                FULL_2004_PSW  = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/oetools-20.04:${params.PUBLIC_LINUX_TAG}", "libsgx-enclave-common")
+                                FULL_2004_DCAP = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/oetools-20.04:${params.PUBLIC_LINUX_TAG}", "libsgx-ae-id-enclave")
+                                FULL_1804_PSW  = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/oetools-18.04:${params.PUBLIC_LINUX_TAG}", "libsgx-enclave-common")
+                                FULL_1804_DCAP = helpers.dockerGetAptPackageVersion("${PUBLIC_REPO_NAME}/oetools-18.04:${params.PUBLIC_LINUX_TAG}", "libsgx-ae-id-enclave")
+                                sh """
+                                    echo "| Base Ubuntu 20.04 | ${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-20.04:${PUBLIC_LINUX_TAG} | ${OE_VERSION} | ${BASE_2004_PSW} | ${BASE_2004_DCAP} |" >> DOCKER_IMAGES_new.md
+                                    echo "| Base Ubuntu 18.04 | ${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-18.04:${PUBLIC_LINUX_TAG} | ${OE_VERSION} | ${BASE_1804_PSW} | ${BASE_1804_DCAP} |" >> DOCKER_IMAGES_new.md
+                                    echo "| Full Ubuntu 20.04 | ${PUBLIC_REPO_NAME}/oetools-20.04:${PUBLIC_LINUX_TAG} | ${OE_VERSION} | ${FULL_2004_PSW} | ${FULL_2004_DCAP} |" >> DOCKER_IMAGES_new.md
+                                    echo "| Full Ubuntu 18.04 | ${PUBLIC_REPO_NAME}/oetools-18.04:${PUBLIC_LINUX_TAG} | ${OE_VERSION} | ${FULL_1804_PSW} | ${FULL_1804_DCAP} |" >> DOCKER_IMAGES_new.md
+                                """
+                            }
                         }
                         sh """
-                            echo "\$(head -n 2 DOCKER_IMAGES.md)" > DOCKER_IMAGES_new.md
-                            echo "| Base Ubuntu 20.04 | ${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-20.04:${PUBLIC_LINUX_TAG} | ${OE_VERSION} | ${BASE_2004_PSW} | ${BASE_2004_DCAP} |" >> DOCKER_IMAGES_new.md
-                            echo "| Base Ubuntu 18.04 | ${PUBLIC_REPO_NAME}/openenclave-base-ubuntu-18.04:${PUBLIC_LINUX_TAG} | ${OE_VERSION} | ${BASE_1804_PSW} | ${BASE_1804_DCAP} |" >> DOCKER_IMAGES_new.md
-                            echo "| Full Ubuntu 20.04 | ${PUBLIC_REPO_NAME}/oetools-20.04:${PUBLIC_LINUX_TAG} | ${OE_VERSION} | ${FULL_2004_PSW} | ${FULL_2004_DCAP} |" >> DOCKER_IMAGES_new.md
-                            echo "| Full Ubuntu 18.04 | ${PUBLIC_REPO_NAME}/oetools-18.04:${PUBLIC_LINUX_TAG} | ${OE_VERSION} | ${FULL_1804_PSW} | ${FULL_1804_DCAP} |" >> DOCKER_IMAGES_new.md
-                            echo "| Windows Server 2019 | ${PUBLIC_REPO_NAME}/oetools-ws2019:${PUBLIC_WINDOWS_TAG} | ${OE_VERSION} | None | None |" >> DOCKER_IMAGES_new.md
                             echo "\$(tail -n +3 DOCKER_IMAGES.md)" >> DOCKER_IMAGES_new.md
                             mv DOCKER_IMAGES_new.md DOCKER_IMAGES.md
                         """
@@ -185,7 +296,7 @@ pipeline {
                                 git config --global user.email "${GIT_USERNAME}@microsoft.com"
                                 git config --global user.name ${GIT_USERNAME}
                                 git commit -sm "Publish Docker Images"
-                                git push --force https://${GIT_PASSWORD}@github.com/openenclave/openenclave.git HEAD:oeciteam/publish-docker
+                                git push --force https://${GIT_PASSWORD}@github.com/openenclave/openenclave.git HEAD:${OECITEAM_BRANCH}
                             '''
                         }
                     }

--- a/.jenkins/infrastructure/e2e_testing.Jenkinsfile
+++ b/.jenkins/infrastructure/e2e_testing.Jenkinsfile
@@ -50,7 +50,6 @@ pipeline {
                         string(name: 'DOCKER_TAG', value: DOCKER_TAG),
                         string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
                         string(name: 'SGX_VERSION', value: params.SGX_VERSION),
-                        booleanParam(name: 'PUBLISH_DOCKER_HUB', value: false),
                         booleanParam(name: 'TAG_LATEST', value: false),
                         booleanParam(name: 'PUBLISH', value: false)
                     ]


### PR DESCRIPTION
* Removes DockerHub publishing
* Toggles building images for Linux, Windows, or both
* Publishing images are now completely done by a separate job
* Adds a check to make sure the pushed tag exists in all repositories
* Adds curl so oeapkman can install sqlite3 for running samples.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>