### PR TITLE
Wait for VM to be remote ready

### DIFF
--- a/scripts/ansible/requirements.txt
+++ b/scripts/ansible/requirements.txt
@@ -3,4 +3,4 @@
 cryptography==3.3.2
 ansible>=4.10,<=5.2.0
 cmake_format==0.6.9
-pywinrm==0.2.1
+pywinrm>=0.3.0


### PR DESCRIPTION
* Fixes issue where Windows VM image creation was failing as the Jenkins agent could not remote into the VM. This is solved on the infrastructure side and is not reflected in code.
* Creates a separate stage for waiting for VM connection instead of relying on the playbook run.
* Fixes issue where az login command fails to connect and find the subscription.
* Allows toggling building images for either Linux, Windows, or both
* Updates pywinrm to >=0.3.0

Signed-off-by: Chris Yan <chrisyan@microsoft.com>