### PR TITLE
Distinguish between in-enclave and host exceptions for SGX

### DIFF
--- a/host/sgx/exception.c
+++ b/host/sgx/exception.c
@@ -50,7 +50,7 @@ uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
         // OE_AEP_ADDRESS. Otherwise, skip the check given that
         // the AEP is set by the kernel.
         if (!oe_sgx_is_vdso_enabled && exit_address != OE_AEP_ADDRESS)
-            return OE_EXCEPTION_CONTINUE_SEARCH;
+            return OE_SGX_EXCEPTION_HOST; /* Not an in-enclave exception */
 
         // Check if the enclave exception happens inside the first pass
         // exception handler.
@@ -58,7 +58,7 @@ uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
         if (thread_data->flags & _OE_THREAD_HANDLING_EXCEPTION)
         {
             // Return directly.
-            return OE_EXCEPTION_CONTINUE_EXECUTION;
+            return OE_SGX_EXCEPTION_ENCLAVE_NOT_HANDLED;
         }
 
         // Call-in enclave to handle the exception.
@@ -97,7 +97,7 @@ uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
         if (result == OE_OK && arg_out == OE_EXCEPTION_CONTINUE_EXECUTION)
         {
             // This exception has been handled by the enclave. Let's resume.
-            return OE_EXCEPTION_CONTINUE_EXECUTION;
+            return OE_SGX_EXCEPTION_ENCLAVE_HANDLED;
         }
         else
         {
@@ -109,13 +109,12 @@ uint64_t oe_host_handle_exception(oe_host_exception_context_t* context)
 
             // We continue the exception handler search as if it were a
             // non-enclave exception.
-            return OE_EXCEPTION_CONTINUE_SEARCH;
+            return OE_SGX_EXCEPTION_ENCLAVE_NOT_HANDLED;
         }
     }
     else
     {
         // Not an exclave exception.
-        // Continue searching for other handlers.
-        return OE_EXCEPTION_CONTINUE_SEARCH;
+        return OE_SGX_EXCEPTION_HOST;
     }
 }

--- a/host/sgx/exception.h
+++ b/host/sgx/exception.h
@@ -7,6 +7,12 @@
 #include <openenclave/bits/exception.h>
 #include <openenclave/internal/calls.h>
 
+/* Compatiblie with OE_EXCEPTION_CONTINUE_EXECUTION */
+#define OE_SGX_EXCEPTION_ENCLAVE_HANDLED 0xFFFFFFFF
+/* Compatible with OE_EXCEPTION_CONTINUE_SEARCH */
+#define OE_SGX_EXCEPTION_ENCLAVE_NOT_HANDLED 0x0
+#define OE_SGX_EXCEPTION_HOST 0x1
+
 typedef struct _host_exception_context
 {
     uint64_t rax;

--- a/host/sgx/linux/exception.c
+++ b/host/sgx/linux/exception.c
@@ -74,7 +74,7 @@ static void _host_signal_handler(
     // Call platform neutral handler.
     uint64_t action = oe_host_handle_exception(&host_context);
 
-    if (action == OE_EXCEPTION_CONTINUE_EXECUTION)
+    if (action == OE_SGX_EXCEPTION_ENCLAVE_HANDLED)
     {
         // Exception has been handled.
         return;
@@ -94,10 +94,11 @@ static void _host_signal_handler(
                 return;
         }
 
-        OE_TRACE_ERROR("Unhandled in-enclave exception. To get more "
-                       "information, configure the enclave with "
-                       "CapturePFGPExceptions=1 and enable the in-enclave "
-                       "logging.");
+        if (action == OE_SGX_EXCEPTION_ENCLAVE_NOT_HANDLED)
+            OE_TRACE_ERROR("Unhandled in-enclave exception. To get more "
+                           "information, configure the enclave with "
+                           "CapturePFGPExceptions=1 and enable the in-enclave "
+                           "logging.");
 
         // If not an enclave exception, and no valid previous signal handler is
         // set, raise it again, and let the default signal handler handle it.

--- a/host/sgx/linux/vdso.c
+++ b/host/sgx/linux/vdso.c
@@ -132,6 +132,7 @@ static int oe_vdso_user_handler(
             /* Hardware exceptions occur */
 
             oe_host_exception_context_t host_context = {0};
+            uint64_t action = 0;
 
             host_context.rax = ENCLU_ERESUME;
             host_context.rbx = run->tcs;
@@ -154,16 +155,18 @@ static int oe_vdso_user_handler(
 
             OE_TRACE_INFO("vDSO: exception occurred");
 
-            if (oe_host_handle_exception(&host_context) ==
-                OE_EXCEPTION_CONTINUE_EXECUTION)
+            action = oe_host_handle_exception(&host_context);
+            if (action == OE_SGX_EXCEPTION_ENCLAVE_HANDLED)
                 result = ENCLU_ERESUME;
             else
             {
-                OE_TRACE_ERROR(
-                    "Unhanded in-enclave exception. To get more "
-                    "information, configure the enclave with "
-                    "CapturePFGPExceptions=1 and enable the in-enclave "
-                    "logging.");
+                /* Should always be this case */
+                if (action == OE_SGX_EXCEPTION_ENCLAVE_NOT_HANDLED)
+                    OE_TRACE_ERROR(
+                        "Unhanded in-enclave exception. To get more "
+                        "information, configure the enclave with "
+                        "CapturePFGPExceptions=1 and enable the in-enclave "
+                        "logging.");
                 result = -1;
             }
 

--- a/host/sgx/windows/exception.c
+++ b/host/sgx/windows/exception.c
@@ -72,17 +72,18 @@ _host_exception_handler(struct _EXCEPTION_POINTERS* exception_pointers)
     // Call platform neutral handler.
     uint64_t action = oe_host_handle_exception(&host_context);
 
-    if (action == OE_EXCEPTION_CONTINUE_EXECUTION)
+    if (action == OE_SGX_EXCEPTION_ENCLAVE_HANDLED)
     {
         // Exception has been handled.
         return EXCEPTION_CONTINUE_EXECUTION;
     }
     else
     {
-        OE_TRACE_ERROR("Unhandled in-enclave exception. To get more "
-                       "information, configure the enclave with "
-                       "CapturePFGPExceptions=1 and enable the in-enclave "
-                       "logging.");
+        if (action == OE_SGX_EXCEPTION_ENCLAVE_NOT_HANDLED)
+            OE_TRACE_ERROR("Unhandled in-enclave exception. To get more "
+                           "information, configure the enclave with "
+                           "CapturePFGPExceptions=1 and enable the in-enclave "
+                           "logging.");
 
         // Exception has not been handled.
         return EXCEPTION_CONTINUE_SEARCH;


### PR DESCRIPTION
Add return code so that the host exception handler can distinguish the following exception types
- In-enclave exception, handled
- In-enclave exception, not handled
- Host exception

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>