### PR TITLE
Enclave keys: Update header config.h with new name

### DIFF
--- a/samples/file-encryptor/enclave/mbedtls_src/keys.cpp
+++ b/samples/file-encryptor/enclave/mbedtls_src/keys.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include <mbedtls/aes.h>
-#include <mbedtls/config.h>
+#include <mbedtls/mbedtls_config.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/error.h>


### PR DESCRIPTION
The header config.h has a new name, so fixing this is imperative to allow compilation of the sample with the mbedTLS library.

Signed-off-by: Carlos Bilbao bilbao@vt.edu