### PR TITLE
Remove dependency on libsgx-dcap-ql-dev

### DIFF
--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -14,7 +14,7 @@ set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 
 # CPack variables for Debian packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "libsgx-enclave-common (>=2.3.100.46354-1), libsgx-dcap-ql (>=1.0.100.46460-1.0), libsgx-dcap-ql-dev (>=1.0.100.46460-1.0)"
+    "libsgx-enclave-common (>=2.3.100.46354-1), libsgx-dcap-ql (>=1.0.100.46460-1.0)"
 )
 set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "pkg-config")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -111,8 +111,8 @@ static quote3_error_t (*_sgx_qv_verify_quote)(
 
 #include <dlfcn.h>
 
-#define SGX_DCAP_QL_NAME "libsgx_dcap_ql.so"
-#define SGX_DCAP_QVL_NAME "libsgx_dcap_quoteverify.so"
+#define SGX_DCAP_QL_NAME "libsgx_dcap_ql.so.1"
+#define SGX_DCAP_QVL_NAME "libsgx_dcap_quoteverify.so.1"
 
 // Use best practices
 // - RTLD_NOW  Bind all undefined symbols before dlopen returns.


### PR DESCRIPTION
Choose the .1 version of the library. This is in line with enclave-common and quote-ex.