### PR TITLE
Fix: Ubuntu 20.04 getting started driver URL

### DIFF
--- a/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_20.04.md
+++ b/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_20.04.md
@@ -37,7 +37,7 @@ If the output of the above is blank, you should proceed with installing the driv
 ```bash
 sudo apt update
 sudo apt -y install dkms
-wget https://download.01.org/intel-sgx/sgx-linux/2.13.3/linux/distro/ubuntu20.04-server/sgx_linux_x64_driver_1.41.bin -O sgx_linux_x64_driver.bin
+wget https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu20.04-server/sgx_linux_x64_driver_1.41.bin -O sgx_linux_x64_driver.bin
 chmod +x sgx_linux_x64_driver.bin
 sudo ./sgx_linux_x64_driver.bin
 ```


### PR DESCRIPTION
On step 2 (Install the Intel SGX DCAP Driver) of the getting started documentation for Ubuntu 20.04, the URL to the Intel SGX DCAP driver no longer worked. I have updated the documentation with the URL that is stored in variable file `focal.yml` when using the Ansible role "linux\sgx".