### PR TITLE
Fix stdout noise and subsequent perf drop when OE_LOG_LEVEL=INFO

### DIFF
--- a/common/sgx/sgxcertextensions.c
+++ b/common/sgx/sgxcertextensions.c
@@ -201,15 +201,6 @@ done:
     return result;
 }
 
-static void _trace_hex_dump(const char* tag, const uint8_t* data, size_t size)
-{
-    if (oe_get_current_logging_level() >= OE_LOG_LEVEL_INFO)
-    {
-        OE_TRACE_INFO("%s = ", tag);
-        oe_hex_dump(data, size);
-    }
-}
-
 /**
  * Read an extension with given oid and data of type octet string.
  */
@@ -225,13 +216,13 @@ static oe_result_t _read_octet_extension(
     uint8_t* data = NULL;
     size_t data_length = 0;
 
+    OE_TRACE_INFO("Reading %s", tag);
     OE_CHECK(_read_extension(
         itr, end, oid, SGX_OCTET_STRING_TAG, &data, &data_length));
     if (data_length != length)
         OE_RAISE(OE_FAILURE);
 
     OE_CHECK(oe_memcpy_s(buffer, length, data, data_length));
-    _trace_hex_dump(tag, buffer, data_length);
     result = OE_OK;
 done:
     return result;

--- a/common/sgx/verifier.c
+++ b/common/sgx/verifier.c
@@ -931,20 +931,6 @@ oe_result_t oe_sgx_verify_evidence(
             &valid_until,
             claims,
             claims_length));
-
-        // Avoid running the loop unless traces are actually generated
-        if (oe_get_current_logging_level() >= OE_LOG_LEVEL_INFO)
-        {
-            OE_TRACE_INFO("extracted %lu claims", *claims_length);
-            for (size_t i = 0; i < *claims_length; i++)
-            {
-                OE_TRACE_INFO(
-                    "claim %s[%lu]: ",
-                    (*claims)[i].name,
-                    (*claims)[i].value_size);
-                oe_hex_dump((*claims)[i].value, (*claims)[i].value_size);
-            }
-        }
     }
 
     result = format_type == SGX_FORMAT_TYPE_LOCAL ? OE_OK : result_verify_quote;


### PR DESCRIPTION
Addresses bug where host call oe_verify_evidence() prints data to stdout, when OE_LOG_LEVEL=INFO.

host/hexdump.c:oe_hex_dump() prints the data as hex to the stdout and is called by common/sgx/sgxcertextensions.c and common/sgx/verifier.c. After discussing with team, determined that these hex dumps create more noise than useful debugging information, hence this PR removes them.

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>