### PR TITLE
Calculate current frame correctly on Windows

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -198,7 +198,7 @@ if (OE_SGX AND WIN32)
     OUTPUT enter.obj
     DEPENDS sgx/windows/enter.c
     COMMAND
-      clang -c -O2 -fomit-frame-pointer -m64 -I${PROJECT_SOURCE_DIR}/include
+      clang -c -O2 -g -fomit-frame-pointer -m64 -I${PROJECT_SOURCE_DIR}/include
       -I${OE_INCDIR} ${CMAKE_CURRENT_SOURCE_DIR}/sgx/windows/enter.c -o
       enter.obj)
 endif ()

--- a/host/sgx/linux/enter.c
+++ b/host/sgx/linux/enter.c
@@ -65,6 +65,7 @@ oe_result_t _oe_vdso_enter(
 // The following function must not be inlined and must have a frame-pointer
 // so that the frame can be manipulated to stitch the ocall stack.
 // This is ensured by compiling this file with -fno-omit-frame-pointer.
+// Note: The requirements of this function on Windows is different.
 OE_NEVER_INLINE
 int __oe_host_stack_bridge(
     uint64_t arg1,

--- a/host/sgx/windows/enter.c
+++ b/host/sgx/windows/enter.c
@@ -82,8 +82,11 @@
                    "ymm15")
 
 // The following function must not be inlined and must have a frame-pointer
-// so that the frame can be manipulated to stitch the ocall stack.
-// This is ensured by compiling this file with -fno-omit-frame-pointer.
+// Windows can use any register as the frame pointer or omit the frame-pointer
+// altogether. We just a constant offset from the seventh parameter
+// (ecall_context) to fetch the linux style frame-pointer.
+// See OE_FRAME_POINTER_VALUE above.
+// ATTENTION: ENSURE THAT ECALL_CONTEXT IS THE SEVENTH PARAMETER.
 OE_NEVER_INLINE
 int __oe_host_stack_bridge(
     uint64_t arg1,
@@ -101,7 +104,7 @@ int __oe_host_stack_bridge(
     if (debug)
     {
         // Fetch pointer to current frame.
-        current = (oe_host_ocall_frame_t*)__builtin_frame_address(0);
+        current = (oe_host_ocall_frame_t*)((uint64_t)&ecall_context - 0x40);
 
         // Back up current frame.
         backup = *current;


### PR DESCRIPTION
Note: The windows debuggers currently stitch stack on their own. SDK's stack stitching allows the debuggers to relinquish that responsibility.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>