### PR TITLE
Fix consolefs ioctl and UB in fcntl

### DIFF
--- a/include/openenclave/internal/syscall/sys/ioctl.h
+++ b/include/openenclave/internal/syscall/sys/ioctl.h
@@ -10,6 +10,16 @@
 
 OE_EXTERNC_BEGIN
 
+#define OE_TCGETS 0x5401
+#define OE_TCSETS 0x5402
+#define OE_TCSETSW 0x5403
+#define OE_TCSETSF 0x5404
+#define OE_TCSBRK 0x5409
+#define OE_TCXONC 0x540A
+#define OE_TCFLSH 0x540B
+#define OE_TIOCEXCL 0x540C
+#define OE_TIOCNXCL 0x540D
+#define OE_TIOCSCTTY 0x540E
 #define OE_TIOCGWINSZ 0x5413
 
 int __oe_ioctl(int fd, unsigned long request, uint64_t arg);

--- a/syscall/consolefs.c
+++ b/syscall/consolefs.c
@@ -91,44 +91,75 @@ static int _consolefs_ioctl(oe_fd_t* file_, unsigned long request, uint64_t arg)
 {
     int ret = -1;
     file_t* file = _cast_file(file_);
+    uint64_t argin = 0;
+    void* argout = NULL;
+    uint64_t argsize = 0;
 
     if (!file)
         OE_RAISE_ERRNO(OE_EINVAL);
 
-    /*
-     * MUSL uses the TIOCGWINSZ ioctl request to determine whether the file
-     * descriptor refers to a terminal device (such as stdin, stdout, and
-     * stderr) so that it can use line-bufferred input and output. This check
-     * fails when delegated to the host since this implementation opens the
-     * devices by name (/dev/stdin, /dev/stderr, /dev/stdout). So the following
-     * block works around this problem by implementing TIOCGWINSZ on the
-     * enclave side. Other terminal control ioctls are left unimplemented.
-     */
-    if (request == OE_TIOCGWINSZ)
+    switch (request)
     {
-        struct winsize
+        /*
+         * MUSL uses the TIOCGWINSZ ioctl request to determine whether the file
+         * descriptor refers to a terminal device (such as stdin, stdout, and
+         * stderr) so that it can use line-bufferred input and output. This
+         * check fails when delegated to the host since this implementation
+         * opens the devices by name (/dev/stdin, /dev/stderr, /dev/stdout). So
+         * the following block works around this problem by implementing
+         * TIOCGWINSZ on the enclave side.
+         */
+        case OE_TIOCGWINSZ:
         {
-            unsigned short int ws_row;
-            unsigned short int ws_col;
-            unsigned short int ws_xpixel;
-            unsigned short int ws_ypixel;
-        };
-        struct winsize* p;
+            struct winsize
+            {
+                unsigned short int ws_row;
+                unsigned short int ws_col;
+                unsigned short int ws_xpixel;
+                unsigned short int ws_ypixel;
+            };
+            struct winsize* p;
 
-        if (!(p = (struct winsize*)arg))
-            OE_RAISE_ERRNO(OE_EINVAL);
+            if (!(p = (struct winsize*)arg))
+                OE_RAISE_ERRNO(OE_EINVAL);
 
-        p->ws_row = 24;
-        p->ws_col = 80;
-        p->ws_xpixel = 0;
-        p->ws_ypixel = 0;
+            p->ws_row = 24;
+            p->ws_col = 80;
+            p->ws_xpixel = 0;
+            p->ws_ypixel = 0;
 
-        ret = 0;
-        goto done;
+            ret = 0;
+            goto done;
+        }
+
+        // arg: void
+        case OE_TIOCEXCL:
+        case OE_TIOCNXCL:
+            break;
+
+        // arg: int
+        case OE_TCSBRK:
+        case OE_TCXONC:
+        case OE_TCFLSH:
+        case OE_TIOCSCTTY:
+            argin = arg;
+            break;
+
+        // arg: struct termios*
+        case OE_TCGETS:
+        case OE_TCSETS:
+        case OE_TCSETSW:
+        case OE_TCSETSF:
+            argsize = 60; // sizeof(struct termios)
+            argout = (void*)arg;
+            break;
+
+        default:
+            OE_RAISE_ERRNO(OE_ENOTTY);
     }
 
-    if (oe_syscall_ioctl_ocall(&ret, file->host_fd, request, arg, 0, NULL) !=
-        OE_OK)
+    if (oe_syscall_ioctl_ocall(
+            &ret, file->host_fd, request, argin, argsize, argout) != OE_OK)
         OE_RAISE_ERRNO(OE_EINVAL);
 
 done:

--- a/syscall/devices/hostfs/hostfs.c
+++ b/syscall/devices/hostfs/hostfs.c
@@ -1003,6 +1003,7 @@ static int _hostfs_fcntl(oe_fd_t* desc, int cmd, uint64_t arg)
 {
     int ret = -1;
     file_t* file = _cast_file(desc);
+    uint64_t argin = 0;
     void* argout = NULL;
     uint64_t argsize = 0;
 
@@ -1011,37 +1012,27 @@ static int _hostfs_fcntl(oe_fd_t* desc, int cmd, uint64_t arg)
 
     switch (cmd)
     {
+        // arg: void
         case OE_F_GETFD:
-        case OE_F_SETFD:
         case OE_F_GETFL:
-        case OE_F_SETFL:
             break;
 
-        case OE_F_GETLK64:
+        // arg: int
+        case OE_F_SETFD:
+        case OE_F_SETFL:
+            argin = arg;
+            break;
+
+        // arg: struct flock*
+        case OE_F_GETLK:
         case OE_F_OFD_GETLK:
+        case OE_F_SETLKW:
+        case OE_F_SETLK:
+        case OE_F_OFD_SETLK:
+        case OE_F_OFD_SETLKW:
             argsize = sizeof(struct oe_flock);
             argout = (void*)arg;
             break;
-
-        case OE_F_SETLKW64:
-        case OE_F_SETLK64:
-        {
-            void* srcp = (void*)arg;
-            argsize = sizeof(struct oe_flock64);
-            argout = (void*)arg;
-            memcpy(argout, srcp, argsize);
-            break;
-        }
-
-        case OE_F_OFD_SETLK:
-        case OE_F_OFD_SETLKW:
-        {
-            void* srcp = (void*)arg;
-            argsize = sizeof(struct oe_flock64);
-            argout = (void*)arg;
-            memcpy(argout, srcp, argsize);
-            break;
-        }
 
         // for sockets
         default:
@@ -1057,7 +1048,7 @@ static int _hostfs_fcntl(oe_fd_t* desc, int cmd, uint64_t arg)
     }
 
     if (oe_syscall_fcntl_ocall(
-            &ret, file->host_fd, cmd, arg, argsize, argout) != OE_OK)
+            &ret, file->host_fd, cmd, argin, argsize, argout) != OE_OK)
         OE_RAISE_ERRNO(OE_EINVAL);
 
 done:

--- a/syscall/devices/hostsock/hostsock.c
+++ b/syscall/devices/hostsock/hostsock.c
@@ -945,6 +945,18 @@ static int _hostsock_ioctl(oe_fd_t* sock_, unsigned long request, uint64_t arg)
     if (!sock)
         OE_RAISE_ERRNO(OE_EINVAL);
 
+    /*
+     * MUSL uses the TIOCGWINSZ ioctl request to determine whether the file
+     * descriptor refers to a terminal device. This request cannot be handled
+     * by Windows hosts, so the error is handled on the enclave side. This is
+     * the correct behavior since sockets are not terminal devices.
+     */
+    switch (request)
+    {
+        default:
+            OE_RAISE_ERRNO(OE_ENOTTY);
+    }
+
     if (oe_syscall_ioctl_ocall(&ret, sock->host_fd, request, arg, 0, NULL) !=
         OE_OK)
         OE_RAISE_ERRNO(OE_EINVAL);

--- a/tests/syscall/CMakeLists.txt
+++ b/tests/syscall/CMakeLists.txt
@@ -21,6 +21,7 @@ if (NOT CODE_COVERAGE)
 endif ()
 
 if (UNIX)
+  add_subdirectory(consolefs)
   add_subdirectory(datagram)
   add_subdirectory(epoll)
   add_subdirectory(ids)

--- a/tests/syscall/consolefs/CMakeLists.txt
+++ b/tests/syscall/consolefs/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(host)
+
+if (BUILD_ENCLAVES)
+  add_subdirectory(enc)
+endif ()
+
+add_enclave_test(tests/consolefs consolefs_host consolefs_enc)

--- a/tests/syscall/consolefs/consolefs.edl
+++ b/tests/syscall/consolefs/consolefs.edl
@@ -1,0 +1,17 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+    from "openenclave/edl/logging.edl" import oe_write_ocall;
+    from "openenclave/edl/fcntl.edl" import *;
+    from "openenclave/edl/ioctl.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+
+    trusted {
+        public void test_consolefs();
+    };
+};

--- a/tests/syscall/consolefs/enc/CMakeLists.txt
+++ b/tests/syscall/consolefs/enc/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../consolefs.edl)
+
+add_custom_command(
+  OUTPUT consolefs_t.h consolefs_t.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --trusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_enclave(TARGET consolefs_enc SOURCES enc.c
+            ${CMAKE_CURRENT_BINARY_DIR}/consolefs_t.c)
+enclave_include_directories(consolefs_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+maybe_build_using_clangw(consolefs_enc)
+enclave_link_libraries(consolefs_enc oelibc oeenclave)

--- a/tests/syscall/consolefs/enc/enc.c
+++ b/tests/syscall/consolefs/enc/enc.c
@@ -1,0 +1,36 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/tests.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <unistd.h>
+#include "consolefs_t.h"
+
+static bool _termios_flags_equal(
+    const struct termios* a,
+    const struct termios* b)
+{
+    return a->c_iflag == b->c_iflag && a->c_oflag == b->c_oflag &&
+           a->c_cflag == b->c_cflag && a->c_lflag == b->c_lflag;
+}
+
+void test_consolefs()
+{
+    // test ioctl
+    struct termios t1 = {0};
+    struct termios t2 = {0};
+    OE_TEST(ioctl(STDIN_FILENO, TCGETS, &t1) == 0);
+    OE_TEST(!_termios_flags_equal(&t1, &t2));
+    OE_TEST(ioctl(STDIN_FILENO, TCSETS, &t1) == 0);
+    OE_TEST(ioctl(STDIN_FILENO, TCGETS, &t2) == 0);
+    OE_TEST(_termios_flags_equal(&t1, &t2));
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* Debug */
+    1024, /* NumHeapPages */
+    512,  /* NumStackPages */
+    1);   /* NumTCS */

--- a/tests/syscall/consolefs/host/CMakeLists.txt
+++ b/tests/syscall/consolefs/host/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set(EDL_FILE ../consolefs.edl)
+
+add_custom_command(
+  OUTPUT consolefs_u.h consolefs_u.c
+  DEPENDS ${EDL_FILE} edger8r
+  COMMAND
+    edger8r --untrusted ${EDL_FILE} --search-path ${PROJECT_SOURCE_DIR}/include
+    ${DEFINE_OE_SGX} --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(consolefs_host host.c consolefs_u.c)
+
+target_include_directories(consolefs_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(consolefs_host oehost)

--- a/tests/syscall/consolefs/host/host.c
+++ b/tests/syscall/consolefs/host/host.c
@@ -1,0 +1,38 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include "consolefs_u.h"
+
+int main(int argc, const char* argv[])
+{
+    oe_result_t result = OE_UNEXPECTED;
+    oe_enclave_t* enclave = NULL;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    const uint32_t flags = oe_get_create_flags();
+
+    result = oe_create_consolefs_enclave(
+        argv[1], OE_ENCLAVE_TYPE_AUTO, flags, NULL, 0, &enclave);
+    if (result != OE_OK)
+        oe_put_err("oe_create_enclave(): result=%u", result);
+
+    result = test_consolefs(enclave);
+    if (result != OE_OK)
+        oe_put_err("oe_call_enclave() failed: result=%u", result);
+
+    result = oe_terminate_enclave(enclave);
+    OE_TEST(result == OE_OK);
+
+    printf("=== passed all tests (consolefs)\n");
+
+    return 0;
+}


### PR DESCRIPTION
First commit removes a memcpy with src==dst and also sanitizes args to the ocall a bit.

Second commit prevents calling the ioctl ocall for arbitrary requests and instead implements arg adjustments for selected requests similar to the current fcntl implementations.