### PR TITLE
Increase alstack size for the stack overflow test

### DIFF
--- a/tests/stack_overflow_exception/enc/enc.c
+++ b/tests/stack_overflow_exception/enc/enc.c
@@ -11,7 +11,7 @@
 #include "stack_overflow_exception_t.h"
 
 #define PAGE_SIZE 4096
-#define EXCEPTION_HANDLER_STACK_SIZE 8192
+#define EXCEPTION_HANDLER_STACK_SIZE 16384
 #define STACK_PAGE_NUMBER 4
 #define STACK_SIZE (STACK_PAGE_NUMBER * PAGE_SIZE)
 void* td_to_tcs(const oe_sgx_td_t* td);


### PR DESCRIPTION
The 2-page stack size can be insufficient (in my local environment) when the secure ocall unserialization return value is enabled. Increasing the stack size to fix the issue.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>