### PR TITLE
[WIP] struct changes per Intel attestation collateral v4

### DIFF
--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -631,6 +631,20 @@ done:
  *    "tcbEvaluationDataNumber" : integer
  *    "tcbLevels" : [ objects of type oe_tcb_info_tcb_level_t ]
  * }
+ *
+ * V3 Schema:
+ * {
+ *    "id" : string, ("SGX"/"TDX")
+ *    "version" : integer,
+ *    "issueDate" : string,
+ *    "nextUpdate" : string,
+ *    "fmspc" : "hex string (12 nibbles)"
+ *    "pceId" : "hex string (4 nibbles)"
+ *    "tcbType" : integer
+ *    "tcbEvaluationDataNumber" : integer
+ *    "tdxModule" : TDX module object,
+ *    "tcbLevels" : [ objects of type oe_tcb_info_tcb_level_t ]
+ * }
  */
 static oe_result_t _read_tcb_info(
     const uint8_t* tcb_info_json,
@@ -1129,7 +1143,7 @@ done:
  * type = enclaveIdentity
  * V2 Schema:
  * {
- *    "id" : string ("QE" | "QVE")
+ *    "id" : string ("QE" | "QVE" | "TD QE")
  *    "version" : integer,
  *    "issueDate" : string,
  *    "nextUpdate" : string,
@@ -1176,6 +1190,8 @@ static oe_result_t _read_qe_identity_info_v2(
         parsed_info->id = QE_IDENTITY_ID_QE;
     else if (_json_str_equal(str, size, "QVE"))
         parsed_info->id = QE_IDENTITY_ID_QVE;
+    else if (_json_str_equal(str, size, "TD_QE"))
+        parsed_info->id = QE_IDENTITY_ID_TD_QE;
     else
         OE_RAISE_MSG(OE_JSON_INFO_PARSE_ERROR, "Invalid id %s", str);
     OE_CHECK(_read(',', itr, end));

--- a/tests/report/host/tcbinfo.cpp
+++ b/tests/report/host/tcbinfo.cpp
@@ -113,7 +113,9 @@ void TestVerifyTCBInfo(oe_enclave_t* enclave, const char* test_filename)
 {
     const uint32_t version = 1;
     oe_tcb_info_tcb_level_t platform_tcb_level = {
-        {4, 4, 2, 4, 1, 128, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 8};
+        {4, 4, 2, 4, 1, 128, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        8};
     oe_parsed_tcb_info_t parsed_info = {0};
 
     // ./data/tcbInfo.json contains 4 tcb levels.
@@ -229,7 +231,9 @@ void TestVerifyTCBInfoV2(oe_enclave_t* enclave, const char* test_filename)
 {
     const uint32_t version = 2;
     oe_tcb_info_tcb_level_t platform_tcb_level = {
-        {4, 4, 2, 4, 1, 128, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 8};
+        {4, 4, 2, 4, 1, 128, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        8};
     oe_parsed_tcb_info_t parsed_info = {0};
 
     printf("TCB Info Version 2 tests:\n");
@@ -390,7 +394,9 @@ void TestVerifyTCBInfo_AdvisoryIDs(
     OE_TEST(FileToBytes(test_filename, &tcbInfo) == 0);
 
     oe_tcb_info_tcb_level_t platform_tcb_level = {
-        {4, 4, 2, 4, 1, 128, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 8};
+        {4, 4, 2, 4, 1, 128, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        8};
     oe_parsed_tcb_info_t parsed_info = {0};
 
     // Set platform pce svn to 8 and assert that


### PR DESCRIPTION
This PR make OE compatible with Intel collaterals version v4.

This document captures the changes introduced to collateral structures - https://api.trustedservices.intel.com/documents/PCS_V3-V4_migration_guide.pdf

Signed-off-by: Rathna Ramesh <rathna1993@gmail.com>