### PR TITLE
oe_realpath: Return OE_ENOENT when path is an empty string

### DIFF
--- a/syscall/stdlib.c
+++ b/syscall/stdlib.c
@@ -27,6 +27,9 @@ char* oe_realpath(const char* path, oe_syscall_path_t* resolved_path)
     if (!path)
         OE_RAISE_ERRNO(OE_EINVAL);
 
+    if (path[0] == '\0')
+        OE_RAISE_ERRNO(OE_ENOENT);
+
     /* Allocate variables on the heap since too big for the stack. */
     if (!(v = oe_calloc(1, sizeof(variables_t))))
         OE_RAISE_ERRNO(OE_ENOMEM);

--- a/tests/syscall/fs/enc/enc.cpp
+++ b/tests/syscall/fs/enc/enc.cpp
@@ -611,6 +611,12 @@ static void test_realpath(const char* tmp_dir)
 
     OE_TEST(mount("/", "/", OE_DEVICE_NAME_HOST_FILE_SYSTEM, 0, NULL) == 0);
 
+    OE_TEST(!oe_realpath(NULL, &buf));
+    OE_TEST(oe_errno == EINVAL);
+
+    OE_TEST(!oe_realpath("", &buf));
+    OE_TEST(oe_errno == ENOENT);
+
     OE_TEST(oe_realpath("/../../..", &buf));
     OE_TEST(strcmp(buf.buf, "/") == 0);
 


### PR DESCRIPTION
When `oe_realpath` is called with an empty string, currently Open Enclave will return `/` as the result, since the processing string is initialized with `/` which eventually is copied to the output even if there's nothing else to parse through in an empty string.

However, an empty string is actually a disallowed input and must return ENOENT according to the [Single UNIX Specification v2](https://pubs.opengroup.org/onlinepubs/007908799/xsh/realpath.html). This behavior is also present in [glibc](https://github.com/bminor/glibc/blob/ae612c45efb5e34713859a5facf92368307efb6e/stdlib/canonicalize.c#L206) and [musl](https://github.com/bminor/musl/blob/f47a8cdd250d9163fcfb39bf4e9d813957c0b187/src/misc/realpath.c#L26).

Therefore, let's adopt this behavior here too. 
