### PR TITLE
Enable oeutil to load and replace trusted pub root key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,8 @@ if (WIN32)
     # OpenSSL relies on Perl to generate files (e.g., headers, assembly files, and test cases).
     find_program(
       OE_PERL perl
-      PATHS "C:/Program Files/Git/bin" "C:/Program Files/Git/usr/bin" "${GIT_DIR}/../usr/bin"
+      PATHS "C:/Program Files/Git/bin" "C:/Program Files/Git/usr/bin"
+            "${GIT_DIR}/../usr/bin"
       NO_DEFAULT_PATH)
     if (NOT OE_PERL)
       message(FATAL_ERROR "Perl not found!")
@@ -226,7 +227,8 @@ if (WIN32)
     # OpenSSL tests.
     find_program(
       OE_DOS2UNIX dos2unix
-      PATHS "C:/Program Files/Git/bin" "C:/Program Files/Git/usr/bin" "${GIT_DIR}/../usr/bin"
+      PATHS "C:/Program Files/Git/bin" "C:/Program Files/Git/usr/bin"
+            "${GIT_DIR}/../usr/bin"
       NO_DEFAULT_PATH)
     if (NOT OE_DOS2UNIX)
       message(FATAL_ERROR "Dos2unix not found!")

--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -19,12 +19,17 @@
     "ConfigurationAndSWHardeningNeeded"
 #define SGX_TCB_STATUS_INVALID "Invalid"
 
+#ifdef OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
+// Should be overrode by oeutil
+const char* _trusted_root_key_pem __attribute__((weak));
+#else
 // Public key of Intel's root certificate.
 static const char* _trusted_root_key_pem =
     "-----BEGIN PUBLIC KEY-----\n"
     "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEC6nEwMDIYZOj/iPWsCzaEKi71OiO\n"
     "SLRFhWGjbnBVJfVnkY4u3IjkDYYL0MxO4mqsyYjlBalTVYxFP2sJBK5zlA==\n"
     "-----END PUBLIC KEY-----\n";
+#endif
 
 OE_INLINE uint8_t _is_space(uint8_t c)
 {

--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -19,17 +19,16 @@
     "ConfigurationAndSWHardeningNeeded"
 #define SGX_TCB_STATUS_INVALID "Invalid"
 
-#ifdef OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
-// Should be overrode by oeutil
-const char* _trusted_root_key_pem __attribute__((weak));
-#else
+#ifdef OEUTIL_TCB_ALLOW_ANY_ROOT_KEY // allow overrode by oeutil
+const char* _trusted_root_key_pem OE_WEAK = NULL;
+#else  // use hard-coded value
 // Public key of Intel's root certificate.
 static const char* _trusted_root_key_pem =
     "-----BEGIN PUBLIC KEY-----\n"
     "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEC6nEwMDIYZOj/iPWsCzaEKi71OiO\n"
     "SLRFhWGjbnBVJfVnkY4u3IjkDYYL0MxO4mqsyYjlBalTVYxFP2sJBK5zlA==\n"
     "-----END PUBLIC KEY-----\n";
-#endif
+#endif // end of OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
 
 OE_INLINE uint8_t _is_space(uint8_t c)
 {

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -32,61 +32,74 @@ elseif (OE_TRUSTZONE)
   message("TODO: ADD ARM files.")
 endif ()
 
-add_enclave_library(
-  oeenclave
-  STATIC
-  attest_plugin.c
-  ../common/attest_plugin.c
-  ../common/custom_claims.c
-  ../common/datetime.c
-  ../common/sha.c
-  asym_keys.c
-  link.c
-  tls_cert.c
-  ${PLATFORM_SRC})
+macro (add_library_oeenclave_wrapper lib_name)
 
-maybe_build_using_clangw(oeenclave)
+  add_enclave_library(
+    ${lib_name}
+    STATIC
+    attest_plugin.c
+    ../common/attest_plugin.c
+    ../common/custom_claims.c
+    ../common/datetime.c
+    ../common/sha.c
+    asym_keys.c
+    link.c
+    tls_cert.c
+    ${PLATFORM_SRC})
 
-if (CMAKE_C_COMPILER_ID MATCHES GNU)
-  enclave_compile_options(oeenclave PRIVATE -Wjump-misses-init)
+  maybe_build_using_clangw(${lib_name})
+
+  if (CMAKE_C_COMPILER_ID MATCHES GNU)
+    enclave_compile_options(${lib_name} PRIVATE -Wjump-misses-init)
+
+    if (OE_TRUSTZONE)
+      target_compile_options(${lib_name} PUBLIC ${OE_TZ_TA_C_FLAGS})
+    endif ()
+  endif ()
+
+  enclave_enable_code_coverage(${lib_name})
+
+  # Add location of the oeedger8r-generated trusted headers for internal
+  # functions implemented via EDL files.
+  enclave_include_directories(${lib_name} PRIVATE
+                              ${CMAKE_CURRENT_BINARY_DIR}/core)
+
+  enclave_link_libraries(${lib_name} PUBLIC oelibc)
 
   if (OE_TRUSTZONE)
-    target_compile_options(oeenclave PUBLIC ${OE_TZ_TA_C_FLAGS})
+    enclave_link_libraries(${lib_name} PUBLIC oelibutee)
   endif ()
-endif ()
 
-enclave_enable_code_coverage(oeenclave)
+  # Skip install if ends with _loophole
+  if (NOT "${lib_name}" MATCHES "_loophole$")
+    set_enclave_property(TARGET ${lib_name} PROPERTY ARCHIVE_OUTPUT_DIRECTORY
+                         ${OE_LIBDIR}/openenclave/enclave)
+    install_enclaves(
+      TARGETS
+      ${lib_name}
+      EXPORT
+      openenclave-targets
+      ARCHIVE
+      DESTINATION
+      ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+  endif ()
 
-# Add location of the oeedger8r-generated trusted headers for internal
-# functions implemented via EDL files.
-enclave_include_directories(oeenclave PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/core)
+  if (WITH_EEID)
+    enclave_compile_definitions(${lib_name} PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+    # oeenclave currently does not link against the oecrypto* library by default.
+    # Consequently, it does not inherit the include paths of the crypto (e.g., mbedtls)
+    # headers, which are needed by eeid.c. Therefore, we add the paths here.
+    enclave_include_directories(
+      ${lib_name} PRIVATE
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include>
+      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/3rdparty/mbedtls>)
+  endif ()
 
-enclave_link_libraries(oeenclave PUBLIC oelibc)
+  enclave_enable_fuzzing(${lib_name})
+endmacro ()
 
-if (OE_TRUSTZONE)
-  enclave_link_libraries(oeenclave PUBLIC oelibutee)
-endif ()
-
-set_enclave_property(TARGET oeenclave PROPERTY ARCHIVE_OUTPUT_DIRECTORY
-                     ${OE_LIBDIR}/openenclave/enclave)
-install_enclaves(
-  TARGETS
-  oeenclave
-  EXPORT
-  openenclave-targets
-  ARCHIVE
-  DESTINATION
-  ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
-
-if (WITH_EEID)
-  enclave_compile_definitions(oeenclave PRIVATE OE_WITH_EXPERIMENTAL_EEID)
-  # oeenclave currently does not link against the oecrypto* library by default.
-  # Consequently, it does not inherit the include paths of the crypto (e.g., mbedtls)
-  # headers, which are needed by eeid.c. Therefore, we add the paths here.
-  enclave_include_directories(
-    oeenclave PRIVATE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/3rdparty/mbedtls>)
-endif ()
-
-enclave_enable_fuzzing(oeenclave)
+add_library_oeenclave_wrapper(oeenclave)
+# This lib should only be used to build oeutil
+add_library_oeenclave_wrapper(oeenclave_loophole)
+target_compile_definitions(oeenclave_loophole
+                           PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -32,10 +32,19 @@ elseif (OE_TRUSTZONE)
   message("TODO: ADD ARM files.")
 endif ()
 
-macro (add_library_oeenclave_wrapper lib_name)
+# build oeenclave
+# Usage:
+# add_library_oeenclave_wrapper(<LIB_NAME name of lib> [SKIP_INSTALL])
+macro (add_library_oeenclave_wrapper)
+  set(options SKIP_INSTALL)
+  set(oneValueArgs LIB_NAME)
+  set(multiValueArgs)
+
+  cmake_parse_arguments(PARA "${options}" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
 
   add_enclave_library(
-    ${lib_name}
+    ${PARA_LIB_NAME}
     STATIC
     attest_plugin.c
     ../common/attest_plugin.c
@@ -47,36 +56,36 @@ macro (add_library_oeenclave_wrapper lib_name)
     tls_cert.c
     ${PLATFORM_SRC})
 
-  maybe_build_using_clangw(${lib_name})
+  maybe_build_using_clangw(${PARA_LIB_NAME})
 
   if (CMAKE_C_COMPILER_ID MATCHES GNU)
-    enclave_compile_options(${lib_name} PRIVATE -Wjump-misses-init)
+    enclave_compile_options(${PARA_LIB_NAME} PRIVATE -Wjump-misses-init)
 
     if (OE_TRUSTZONE)
-      target_compile_options(${lib_name} PUBLIC ${OE_TZ_TA_C_FLAGS})
+      target_compile_options(${PARA_LIB_NAME} PUBLIC ${OE_TZ_TA_C_FLAGS})
     endif ()
   endif ()
 
-  enclave_enable_code_coverage(${lib_name})
+  enclave_enable_code_coverage(${PARA_LIB_NAME})
 
   # Add location of the oeedger8r-generated trusted headers for internal
   # functions implemented via EDL files.
-  enclave_include_directories(${lib_name} PRIVATE
+  enclave_include_directories(${PARA_LIB_NAME} PRIVATE
                               ${CMAKE_CURRENT_BINARY_DIR}/core)
 
-  enclave_link_libraries(${lib_name} PUBLIC oelibc)
+  enclave_link_libraries(${PARA_LIB_NAME} PUBLIC oelibc)
 
   if (OE_TRUSTZONE)
-    enclave_link_libraries(${lib_name} PUBLIC oelibutee)
+    enclave_link_libraries(${PARA_LIB_NAME} PUBLIC oelibutee)
   endif ()
 
-  # Skip install if ends with _loophole
-  if (NOT "${lib_name}" MATCHES "_loophole$")
-    set_enclave_property(TARGET ${lib_name} PROPERTY ARCHIVE_OUTPUT_DIRECTORY
-                         ${OE_LIBDIR}/openenclave/enclave)
+  if (NOT PARA_SKIP_INSTALL)
+    set_enclave_property(
+      TARGET ${PARA_LIB_NAME} PROPERTY ARCHIVE_OUTPUT_DIRECTORY
+      ${OE_LIBDIR}/openenclave/enclave)
     install_enclaves(
       TARGETS
-      ${lib_name}
+      ${PARA_LIB_NAME}
       EXPORT
       openenclave-targets
       ARCHIVE
@@ -85,21 +94,22 @@ macro (add_library_oeenclave_wrapper lib_name)
   endif ()
 
   if (WITH_EEID)
-    enclave_compile_definitions(${lib_name} PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+    enclave_compile_definitions(${PARA_LIB_NAME} PRIVATE
+                                OE_WITH_EXPERIMENTAL_EEID)
     # oeenclave currently does not link against the oecrypto* library by default.
     # Consequently, it does not inherit the include paths of the crypto (e.g., mbedtls)
     # headers, which are needed by eeid.c. Therefore, we add the paths here.
     enclave_include_directories(
-      ${lib_name} PRIVATE
+      ${PARA_LIB_NAME} PRIVATE
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include>
       $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/3rdparty/mbedtls>)
   endif ()
 
-  enclave_enable_fuzzing(${lib_name})
+  enclave_enable_fuzzing(${PARA_LIB_NAME})
 endmacro ()
 
-add_library_oeenclave_wrapper(oeenclave)
+add_library_oeenclave_wrapper(LIB_NAME oeenclave)
 # This lib should only be used to build oeutil
-add_library_oeenclave_wrapper(oeenclave_loophole)
-target_compile_definitions(oeenclave_loophole
+add_library_oeenclave_wrapper(LIB_NAME oeenclave_prerelease_test SKIP_INSTALL)
+target_compile_definitions(oeenclave_prerelease_test
                            PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -426,26 +426,36 @@ install(
           COMPONENT OEHOSTVERIFY)
 
 # Build oehost
-macro (add_library_oehost_wrapper lib_name)
+# Usage:
+# add_library_oehost_wrapper(<LIB_NAME name of lib> [SKIP_INSTALL])
+macro (add_library_oehost_wrapper)
+  set(options SKIP_INSTALL)
+  set(oneValueArgs LIB_NAME)
+  set(multiValueArgs)
+
+  cmake_parse_arguments(PARA "${options}" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
+
   # Combine the following common code along with the platform specific code and
   # host verification code to get the full oehost target provided by the OE SDK.
-  add_library(${lib_name} STATIC ${PLATFORM_HOST_ONLY_SRC}
-                                 ${PLATFORM_SDK_ONLY_SRC})
+  add_library(${PARA_LIB_NAME} STATIC ${PLATFORM_HOST_ONLY_SRC}
+                                      ${PLATFORM_SDK_ONLY_SRC})
 
-  add_dependencies(${lib_name} syscall_untrusted_edl)
-  add_dependencies(${lib_name} core_untrusted_edl)
+  add_dependencies(${PARA_LIB_NAME} syscall_untrusted_edl)
+  add_dependencies(${PARA_LIB_NAME} core_untrusted_edl)
   if (OE_SGX)
-    add_dependencies(${lib_name} platform_untrusted_edl)
+    add_dependencies(${PARA_LIB_NAME} platform_untrusted_edl)
   endif ()
 
   # For including edge routines.
-  target_include_directories(${lib_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+  target_include_directories(${PARA_LIB_NAME}
+                             PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-  target_link_libraries(${lib_name} PUBLIC oe_includes)
+  target_link_libraries(${PARA_LIB_NAME} PUBLIC oe_includes)
 
   # Compile definitions and options for oehost
   target_compile_definitions(
-    ${lib_name}
+    ${PARA_LIB_NAME}
     PUBLIC # NOTE: This definition is public to the rest of our project's
            # targets, but should not yet be exposed to consumers of our
            # package.
@@ -455,71 +465,75 @@ macro (add_library_oehost_wrapper lib_name)
 
   if (OE_SGX)
     target_include_directories(
-      ${lib_name} PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include
-                          ${CMAKE_CURRENT_BINARY_DIR})
+      ${PARA_LIB_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include
+                               ${CMAKE_CURRENT_BINARY_DIR})
   endif ()
 
   if (OE_SGX AND UNIX)
     # Link oedebugrt static library.
-    target_link_libraries(${lib_name} PRIVATE oedebugrt)
+    target_link_libraries(${PARA_LIB_NAME} PRIVATE oedebugrt)
 
     # enter.c must be forced to retain the frame-pointer
     # for ocall stack-stitching by using the -fno-omit-frame-pointer flag.
     # It is compiled with -O2 flag to retain the same generated assembly
     # code in both debug and release builds.
     set_source_files_properties(
-      ${lib_name} sgx/linux/enter.c PROPERTIES COMPILE_FLAGS
-                                               "-O2 -fno-omit-frame-pointer")
+      ${PARA_LIB_NAME} sgx/linux/enter.c
+      PROPERTIES COMPILE_FLAGS "-O2 -fno-omit-frame-pointer")
   endif ()
 
   if (UNIX)
-    target_link_libraries(${lib_name} PRIVATE openenclave::crypto
-                                              openenclave::dl Threads::Threads)
+    target_link_libraries(
+      ${PARA_LIB_NAME} PRIVATE openenclave::crypto openenclave::dl
+                               Threads::Threads)
     target_compile_options(
-      ${lib_name}
+      ${PARA_LIB_NAME}
       PRIVATE -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS}
       PUBLIC -fstack-protector-strong)
     target_compile_definitions(
-      ${lib_name}
+      ${PARA_LIB_NAME}
       PRIVATE _GNU_SOURCE
       PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
-    target_link_libraries(${lib_name} INTERFACE -Wl,-z,noexecstack)
+    target_link_libraries(${PARA_LIB_NAME} INTERFACE -Wl,-z,noexecstack)
 
     if (OE_TRUSTZONE)
-      target_include_directories(${lib_name} PRIVATE ${OE_TZ_OPTEE_CLIENT_INC})
-      target_link_libraries(${lib_name} PRIVATE teec)
+      target_include_directories(${PARA_LIB_NAME}
+                                 PRIVATE ${OE_TZ_OPTEE_CLIENT_INC})
+      target_link_libraries(${PARA_LIB_NAME} PRIVATE teec)
     endif ()
   elseif (WIN32)
-    target_link_libraries(${lib_name} PUBLIC ws2_32 shlwapi)
+    target_link_libraries(${PARA_LIB_NAME} PUBLIC ws2_32 shlwapi)
     target_include_directories(
-      ${lib_name}
+      ${PARA_LIB_NAME}
       PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include)
     # Synchronization library is needed for WaitOnAddress/WakeByAddress functions
     # used by switchless ocalls worker threads.
-    target_link_libraries(${lib_name} PRIVATE bcrypt Crypt32 Synchronization)
+    target_link_libraries(${PARA_LIB_NAME} PRIVATE bcrypt Crypt32
+                                                   Synchronization)
     # TODO: Handle TrustZone on Windows.
   endif ()
 
   if (WITH_EEID)
-    target_compile_definitions(${lib_name} PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+    target_compile_definitions(${PARA_LIB_NAME}
+                               PRIVATE OE_WITH_EXPERIMENTAL_EEID)
   endif ()
 
   if (CMAKE_C_COMPILER_ID MATCHES GNU)
-    target_compile_options(${lib_name} PRIVATE -Wjump-misses-init)
+    target_compile_options(${PARA_LIB_NAME} PRIVATE -Wjump-misses-init)
   endif ()
 
-  if (NOT "${lib_name}" MATCHES "_loophole$")
+  if (NOT PARA_SKIP_INSTALL)
     # TODO: Remove this hard coded output directory.
-    set_property(TARGET ${lib_name} PROPERTY ARCHIVE_OUTPUT_DIRECTORY
-                                             ${OE_LIBDIR}/openenclave/host)
+    set_property(TARGET ${PARA_LIB_NAME} PROPERTY ARCHIVE_OUTPUT_DIRECTORY
+                                                  ${OE_LIBDIR}/openenclave/host)
 
     # Install targets
     install(
-      TARGETS ${lib_name}
+      TARGETS ${PARA_LIB_NAME}
       EXPORT openenclave-targets
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host)
   endif ()
-  host_enable_fuzzing(${lib_name})
+  host_enable_fuzzing(${PARA_LIB_NAME})
 endmacro ()
 
 # TODO: Replace these with `find_package` and add as dependencies to
@@ -554,7 +568,8 @@ find_package(Threads REQUIRED)
 
 include(measure/CMakeLists.txt)
 
-add_library_oehost_wrapper(oehost)
+add_library_oehost_wrapper(LIB_NAME oehost)
 # This lib is only used to build oeutil
-add_library_oehost_wrapper(oehost_loophole)
-target_compile_definitions(oehost_loophole PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)
+add_library_oehost_wrapper(LIB_NAME oehost_prerelease_test SKIP_INSTALL)
+target_compile_definitions(oehost_prerelease_test
+                           PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -359,45 +359,168 @@ list(
   strings.c
   traceh_enclave.c)
 
-# Combine the following common code along with the platform specific code and
-# host verification code to get the full oehost target provided by the OE SDK.
-add_library(oehost STATIC ${PLATFORM_HOST_ONLY_SRC} ${PLATFORM_SDK_ONLY_SRC})
-
+# Build oehostverify
 add_library(oehostverify STATIC ${PLATFORM_HOST_ONLY_SRC})
-
 target_link_libraries(oehostverify PUBLIC oe_includes)
-target_link_libraries(oehost PUBLIC oe_includes)
+target_compile_definitions(oehostverify PUBLIC OE_BUILD_HOST_VERIFY)
+target_compile_definitions(
+  oehostverify
+  PUBLIC # NOTE: This definition is public to the rest of our project's
+         # targets, but should not be exposed to consumers of our
+         # package.
+         $<BUILD_INTERFACE:OE_API_VERSION=2>
+  PRIVATE OE_BUILD_UNTRUSTED OE_REPO_BRANCH_NAME="${GIT_BRANCH}"
+          OE_REPO_LAST_COMMIT="${GIT_COMMIT}")
 
 if (OE_SGX)
-  target_include_directories(
-    oehost PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include
-                   ${CMAKE_CURRENT_BINARY_DIR})
   target_include_directories(
     oehostverify PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include)
 endif ()
 
+if (UNIX)
+  target_link_libraries(oehostverify PRIVATE openenclave::crypto
+                                             openenclave::dl Threads::Threads)
+  target_compile_options(
+    oehostverify
+    PRIVATE -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS}
+    PUBLIC -fstack-protector-strong)
+  target_compile_definitions(
+    oehostverify
+    PRIVATE _GNU_SOURCE
+    PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
+  target_link_libraries(oehostverify INTERFACE -Wl,-z,noexecstack -rdynamic)
+elseif (WIN32)
+  target_include_directories(
+    oehostverify PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include)
+  target_link_libraries(oehostverify PRIVATE bcrypt Crypt32)
+endif ()
+
+if (WITH_EEID)
+  target_compile_definitions(oehostverify PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+endif ()
+
+if (CMAKE_C_COMPILER_ID MATCHES GNU)
+  target_compile_options(oehostverify PRIVATE -Wjump-misses-init)
+endif ()
+
+# Install oehostverify
 if (WIN32)
-  target_link_libraries(oehost PUBLIC ws2_32 shlwapi)
+  # Install .pdb files to enable stepping into oehost srcs for Debug
+  # and RelWithDebInfo builds.
+  # Note: PDB_OUTPUT_DIRECTORY is defined only for shared library and
+  # executable targets.
+  string(FIND "${CMAKE_BUILD_TYPE}" "Deb" BUILD_TYPE_DEBUG)
+  if (${BUILD_TYPE_DEBUG} GREATER_EQUAL 0)
+    install(
+      FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/oehost.dir/oehost.pdb
+        ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/oehostverify.dir/oehostverify.pdb
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host)
+  endif ()
 endif ()
 
-if (OE_SGX AND UNIX)
-  # Link oedebugrt static library.
-  target_link_libraries(oehost PRIVATE oedebugrt)
+install(
+  TARGETS oehostverify
+  EXPORT openenclave-hostverify-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host
+          COMPONENT OEHOSTVERIFY)
 
-  # enter.c must be forced to retain the frame-pointer
-  # for ocall stack-stitching by using the -fno-omit-frame-pointer flag.
-  # It is compiled with -O2 flag to retain the same generated assembly
-  # code in both debug and release builds.
-  set_source_files_properties(
-    oehost sgx/linux/enter.c PROPERTIES COMPILE_FLAGS
-                                        "-O2 -fno-omit-frame-pointer")
-endif ()
+# Build oehost
+macro (add_library_oehost_wrapper lib_name)
+  # Combine the following common code along with the platform specific code and
+  # host verification code to get the full oehost target provided by the OE SDK.
+  add_library(${lib_name} STATIC ${PLATFORM_HOST_ONLY_SRC}
+                                 ${PLATFORM_SDK_ONLY_SRC})
 
-add_dependencies(oehost syscall_untrusted_edl)
-add_dependencies(oehost core_untrusted_edl)
-if (OE_SGX)
-  add_dependencies(oehost platform_untrusted_edl)
-endif ()
+  add_dependencies(${lib_name} syscall_untrusted_edl)
+  add_dependencies(${lib_name} core_untrusted_edl)
+  if (OE_SGX)
+    add_dependencies(${lib_name} platform_untrusted_edl)
+  endif ()
+
+  # For including edge routines.
+  target_include_directories(${lib_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+  target_link_libraries(${lib_name} PUBLIC oe_includes)
+
+  # Compile definitions and options for oehost
+  target_compile_definitions(
+    ${lib_name}
+    PUBLIC # NOTE: This definition is public to the rest of our project's
+           # targets, but should not yet be exposed to consumers of our
+           # package.
+           $<BUILD_INTERFACE:OE_API_VERSION=2>
+    PRIVATE OE_BUILD_UNTRUSTED OE_REPO_BRANCH_NAME="${GIT_BRANCH}"
+            OE_REPO_LAST_COMMIT="${GIT_COMMIT}")
+
+  if (OE_SGX)
+    target_include_directories(
+      ${lib_name} PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include
+                          ${CMAKE_CURRENT_BINARY_DIR})
+  endif ()
+
+  if (OE_SGX AND UNIX)
+    # Link oedebugrt static library.
+    target_link_libraries(${lib_name} PRIVATE oedebugrt)
+
+    # enter.c must be forced to retain the frame-pointer
+    # for ocall stack-stitching by using the -fno-omit-frame-pointer flag.
+    # It is compiled with -O2 flag to retain the same generated assembly
+    # code in both debug and release builds.
+    set_source_files_properties(
+      ${lib_name} sgx/linux/enter.c PROPERTIES COMPILE_FLAGS
+                                               "-O2 -fno-omit-frame-pointer")
+  endif ()
+
+  if (UNIX)
+    target_link_libraries(${lib_name} PRIVATE openenclave::crypto
+                                              openenclave::dl Threads::Threads)
+    target_compile_options(
+      ${lib_name}
+      PRIVATE -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS}
+      PUBLIC -fstack-protector-strong)
+    target_compile_definitions(
+      ${lib_name}
+      PRIVATE _GNU_SOURCE
+      PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
+    target_link_libraries(${lib_name} INTERFACE -Wl,-z,noexecstack)
+
+    if (OE_TRUSTZONE)
+      target_include_directories(${lib_name} PRIVATE ${OE_TZ_OPTEE_CLIENT_INC})
+      target_link_libraries(${lib_name} PRIVATE teec)
+    endif ()
+  elseif (WIN32)
+    target_link_libraries(${lib_name} PUBLIC ws2_32 shlwapi)
+    target_include_directories(
+      ${lib_name}
+      PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include)
+    # Synchronization library is needed for WaitOnAddress/WakeByAddress functions
+    # used by switchless ocalls worker threads.
+    target_link_libraries(${lib_name} PRIVATE bcrypt Crypt32 Synchronization)
+    # TODO: Handle TrustZone on Windows.
+  endif ()
+
+  if (WITH_EEID)
+    target_compile_definitions(${lib_name} PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+  endif ()
+
+  if (CMAKE_C_COMPILER_ID MATCHES GNU)
+    target_compile_options(${lib_name} PRIVATE -Wjump-misses-init)
+  endif ()
+
+  if (NOT "${lib_name}" MATCHES "_loophole$")
+    # TODO: Remove this hard coded output directory.
+    set_property(TARGET ${lib_name} PROPERTY ARCHIVE_OUTPUT_DIRECTORY
+                                             ${OE_LIBDIR}/openenclave/host)
+
+    # Install targets
+    install(
+      TARGETS ${lib_name}
+      EXPORT openenclave-targets
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host)
+  endif ()
+  host_enable_fuzzing(${lib_name})
+endmacro ()
 
 # TODO: Replace these with `find_package` and add as dependencies to
 # the CMake package.
@@ -429,116 +552,9 @@ endif ()
 
 find_package(Threads REQUIRED)
 
-if (UNIX)
-  target_link_libraries(oehost PRIVATE openenclave::crypto openenclave::dl
-                                       Threads::Threads)
-  target_link_libraries(oehostverify PRIVATE openenclave::crypto
-                                             openenclave::dl Threads::Threads)
-
-  if (OE_TRUSTZONE)
-    target_include_directories(oehost PRIVATE ${OE_TZ_OPTEE_CLIENT_INC})
-    target_link_libraries(oehost PRIVATE teec)
-  endif ()
-elseif (WIN32)
-  target_include_directories(
-    oehost PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include)
-  # Synchronization library is needed for WaitOnAddress/WakeByAddress functions
-  # used by switchless ocalls worker threads.
-  target_link_libraries(oehost PRIVATE bcrypt Crypt32 Synchronization)
-  target_include_directories(
-    oehostverify PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include)
-  target_link_libraries(oehostverify PRIVATE bcrypt Crypt32)
-
-  # TODO: Handle TrustZone on Windows.
-endif ()
-
-# For including edge routines.
-target_include_directories(oehost PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
-# Compile definitions and options for oehost and oehostverify
-target_compile_definitions(
-  oehost
-  PUBLIC # NOTE: This definition is public to the rest of our project's
-         # targets, but should not yet be exposed to consumers of our
-         # package.
-         $<BUILD_INTERFACE:OE_API_VERSION=2>
-  PRIVATE OE_BUILD_UNTRUSTED OE_REPO_BRANCH_NAME="${GIT_BRANCH}"
-          OE_REPO_LAST_COMMIT="${GIT_COMMIT}")
-target_compile_definitions(
-  oehostverify
-  PUBLIC # NOTE: This definition is public to the rest of our project's
-         # targets, but should not be exposed to consumers of our
-         # package.
-         $<BUILD_INTERFACE:OE_API_VERSION=2>
-  PRIVATE OE_BUILD_UNTRUSTED OE_REPO_BRANCH_NAME="${GIT_BRANCH}"
-          OE_REPO_LAST_COMMIT="${GIT_COMMIT}")
-
-if (WITH_EEID)
-  target_compile_definitions(oehost PRIVATE OE_WITH_EXPERIMENTAL_EEID)
-  target_compile_definitions(oehostverify PRIVATE OE_WITH_EXPERIMENTAL_EEID)
-endif ()
-
-if (UNIX)
-  target_compile_options(
-    oehost
-    PRIVATE -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS}
-    PUBLIC -fstack-protector-strong)
-  target_compile_definitions(
-    oehost
-    PRIVATE _GNU_SOURCE
-    PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
-  target_compile_options(
-    oehostverify
-    PRIVATE -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS}
-    PUBLIC -fstack-protector-strong)
-  target_compile_definitions(
-    oehostverify
-    PRIVATE _GNU_SOURCE
-    PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
-endif ()
-
-if (CMAKE_C_COMPILER_ID MATCHES GNU)
-  target_compile_options(oehost PRIVATE -Wjump-misses-init)
-  target_compile_options(oehostverify PRIVATE -Wjump-misses-init)
-endif ()
-
-target_compile_definitions(oehostverify PUBLIC OE_BUILD_HOST_VERIFY)
-
-# TODO: Remove this hard coded output directory.
-set_property(TARGET oehost PROPERTY ARCHIVE_OUTPUT_DIRECTORY
-                                    ${OE_LIBDIR}/openenclave/host)
-
-if (UNIX)
-  target_link_libraries(oehost INTERFACE -Wl,-z,noexecstack)
-  target_link_libraries(oehostverify INTERFACE -Wl,-z,noexecstack -rdynamic)
-endif ()
-
-# Install targets
-install(
-  TARGETS oehost
-  EXPORT openenclave-targets
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host)
-if (WIN32)
-  # Install .pdb files to enable stepping into oehost srcs for Debug
-  # and RelWithDebInfo builds.
-  # Note: PDB_OUTPUT_DIRECTORY is defined only for shared library and
-  # executable targets.
-  string(FIND "${CMAKE_BUILD_TYPE}" "Deb" BUILD_TYPE_DEBUG)
-  if (${BUILD_TYPE_DEBUG} GREATER_EQUAL 0)
-    install(
-      FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/oehost.dir/oehost.pdb
-        ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/oehostverify.dir/oehostverify.pdb
-      DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host)
-  endif ()
-endif ()
-
-install(
-  TARGETS oehostverify
-  EXPORT openenclave-hostverify-targets
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/host
-          COMPONENT OEHOSTVERIFY)
-
 include(measure/CMakeLists.txt)
 
-host_enable_fuzzing(oehost)
+add_library_oehost_wrapper(oehost)
+# This lib is only used to build oeutil
+add_library_oehost_wrapper(oehost_loophole)
+target_compile_definitions(oehost_loophole PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)

--- a/tools/oeutil/enc/CMakeLists.txt
+++ b/tools/oeutil/enc/CMakeLists.txt
@@ -24,7 +24,7 @@ add_enclave_dependencies(oeutil_enc enclave_key_pair)
 # Need for the generated file oeutil_t.h
 enclave_include_directories(oeutil_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-enclave_link_libraries(oeutil_enc oeenclave_loophole oelibc)
+enclave_link_libraries(oeutil_enc oeenclave_prerelease_test oelibc)
 
 # Generate the enclave binary in the the same directory with the oeutil binary
 set_enclave_properties(oeutil_enc PROPERTIES RUNTIME_OUTPUT_DIRECTORY

--- a/tools/oeutil/enc/CMakeLists.txt
+++ b/tools/oeutil/enc/CMakeLists.txt
@@ -24,7 +24,7 @@ add_enclave_dependencies(oeutil_enc enclave_key_pair)
 # Need for the generated file oeutil_t.h
 enclave_include_directories(oeutil_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-enclave_link_libraries(oeutil_enc oeenclave oelibc)
+enclave_link_libraries(oeutil_enc oeenclave_loophole oelibc)
 
 # Generate the enclave binary in the the same directory with the oeutil binary
 set_enclave_properties(oeutil_enc PROPERTIES RUNTIME_OUTPUT_DIRECTORY

--- a/tools/oeutil/host/CMakeLists.txt
+++ b/tools/oeutil/host/CMakeLists.txt
@@ -23,7 +23,7 @@ add_dependencies(oeutil enclave_key_pair)
 target_include_directories(oeutil PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                           -I/usr/include/openssl)
 
-target_link_libraries(oeutil oehost_loophole OpenSSL::SSL)
+target_link_libraries(oeutil oehost_prerelease_test OpenSSL::SSL)
 
 # To enable oeutil to load any public key
 target_compile_definitions(oeutil PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)

--- a/tools/oeutil/host/CMakeLists.txt
+++ b/tools/oeutil/host/CMakeLists.txt
@@ -23,7 +23,10 @@ add_dependencies(oeutil enclave_key_pair)
 target_include_directories(oeutil PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                           -I/usr/include/openssl)
 
-target_link_libraries(oeutil oehost OpenSSL::SSL)
+target_link_libraries(oeutil oehost_loophole OpenSSL::SSL)
+
+# To enable oeutil to load any public key
+target_compile_definitions(oeutil PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)
 
 if (WIN32)
   # The X509_print_ex_fp function in OpenSSL requires to include applink.c, which


### PR DESCRIPTION
The hard-coded trusted public root key is in 2 places: `common/sgx/quote.c` and `common/sgx/tcbinfo.c`. This PR makes the second occurrence override-able only when using `oeutil` tool. **THIS CHANGE IS TO FACILITATE TESTING ONLY.**

### Implement Details:
Everything below is put behind the CMake flag `BUILD_OEUTIL_WITH_LOOPHOLE`, which defaults to OFF.
`tcbinfo.c` is used to build libraries `oehost` and `oeenclave` only, these 2 libs are then linked to `oeutil`. This PR created 2 additional lib `oehost_loophole` and `oeenclave_loophole`, they allow the pub key variable to be re-assign at run-time. Only `oeutil` uses these 2 libs, other part of OE is not affected, even with `BUILD_OEUTIL_WITH_LOOPHOLE` set to ON



Signed-off-by: Zijie Wu <zijiewu@microsoft.com>