### PR TITLE
Bump sgx sdk version and handle new error codes

### DIFF
--- a/3rdparty/sgxsdk/include/sgx_dcap_quoteverify.h
+++ b/3rdparty/sgxsdk/include/sgx_dcap_quoteverify.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,157 +31,282 @@
 /**
  * File: sgx_dcap_quoteverify.h
  *
- * Description: Definitions and prototypes for the DCAP Verification Library
+ * Description: Definitions and prototypes for Intel(R) SGX/TDX DCAP Quote Verification Library
  *
  */
 
 #ifndef _SGX_DCAP_QV_H_
 #define _SGX_DCAP_QV_H_
 
-#include "sgx_ql_quote.h"
 #include "sgx_qve_header.h"
+#include "sgx_ql_quote.h"
 
 #if defined(__cplusplus)
-extern "C"
-{
+extern "C" {
 #endif
 
-    /**
-     * When the Quoting Verification Library is linked to a process, it needs to
-     *know the proper enclave loading policy. The library may be linked with a
-     *long lived process, such as a service, where it can load the enclaves and
-     *leave them loaded (persistent). This better ensures that the enclaves will
-     *be available upon quote requests and not subject to EPC limitations if
-     *loaded on demand. However, if the Quoting library is linked with an
-     *application process, there may be many applications with the Quoting
-     *library and a better utilization of EPC is to load and unloaded the
-     *quoting enclaves on demand (ephemeral).  The library will be shipped with
-     *a default policy of loading enclaves and leaving them loaded until the
-     *library is unloaded (PERSISTENT). If the policy is set to EPHEMERAL, then
-     *the QE and PCE will be loaded and unloaded on-demand.  If either enclave
-     *is already loaded when the policy is change to EPHEMERAL, the enclaves
-     *will be unloaded before returning.
-     *
-     * @param policy Sets the requested enclave loading policy to either
-     *SGX_QL_PERSISTENT, SGX_QL_EPHEMERAL or SGX_QL_DEFAULT.
-     *
-     * @return SGX_QL_SUCCESS Successfully set the enclave loading policy for
-     *the quoting library's enclaves.
-     * @return SGX_QL_UNSUPPORTED_LOADING_POLICY The selected policy is not
-     *support by the quoting library.
-     * @return SGX_QL_ERROR_UNEXPECTED Unexpected internal error.
-     *
-     **/
-    quote3_error_t sgx_qv_set_enclave_load_policy(
-        sgx_ql_request_policy_t policy);
+/**
+ * When the Quoting Verification Library is linked to a process, it needs to know the proper enclave loading policy.
+ * The library may be linked with a long lived process, such as a service, where it can load the enclaves and leave
+ * them loaded (persistent). This better ensures that the enclaves will be available upon quote requests and not subject
+ * to EPC limitations if loaded on demand. However, if the Quoting library is linked with an application process, there
+ * may be many applications with the Quoting library and a better utilization of EPC is to load and unloaded the quoting
+ * enclaves on demand (ephemeral).  The library will be shipped with a default policy of loading enclaves and leaving
+ * them loaded until the library is unloaded (PERSISTENT). If the policy is set to EPHEMERAL, then the QE and PCE will
+ * be loaded and unloaded on-demand.  If either enclave is already loaded when the policy is change to EPHEMERAL, the
+ * enclaves will be unloaded before returning.
+ *
+ * @param policy Sets the requested enclave loading policy to either SGX_QL_PERSISTENT, SGX_QL_EPHEMERAL or SGX_QL_DEFAULT.
+ *
+ * @return SGX_QL_SUCCESS Successfully set the enclave loading policy for the quoting library's enclaves.
+ * @return SGX_QL_UNSUPPORTED_LOADING_POLICY The selected policy is not support by the quoting library.
+ * @return SGX_QL_ERROR_UNEXPECTED Unexpected internal error.
+ *
+ **/
+quote3_error_t sgx_qv_set_enclave_load_policy(sgx_ql_request_policy_t policy);
 
-    /**
-     * Get supplemental data required size.
-     * @param p_data_size[OUT] - Pointer to hold the size of the buffer in bytes
-     *required to contain all of the supplemental data.
-     *
-     * @return Status code of the operation, one of:
-     *      - SGX_QL_SUCCESS
-     *      - SGX_QL_ERROR_INVALID_PARAMETER
-     *      - SGX_QL_ERROR_QVL_QVE_MISMATCH
-     *      - SGX_QL_ENCLAVE_LOAD_ERROR
-     **/
-    quote3_error_t sgx_qv_get_quote_supplemental_data_size(
-        uint32_t* p_data_size);
 
-    /**
-     * Perform quote verification.
-     *
-     * @param p_quote[IN] - Pointer to SGX Quote.
-     * @param quote_size[IN] - Size of the buffer pointed to by p_quote (in
-     *bytes).
-     * @param p_quote_collateral[IN] - This is a pointer to the Quote
-     *Certification Collateral provided by the caller.
-     * @param expiration_check_date[IN] - This is the date that the QvE will use
-     *to determine if any of the inputted collateral have expired.
-     * @param p_collateral_expiration_status[OUT] - Address of the outputted
-     *expiration status.  This input must not be NULL.
-     * @param p_quote_verification_result[OUT] - Address of the outputted quote
-     *verification result.
-     * @param p_qve_report_info[IN/OUT] - This parameter can be used in 2 ways.
-     *        If p_qve_report_info is NOT NULL, the API will use Intel QvE to
-     *perform quote verification, and QvE will generate a report using the
-     *target_info in sgx_ql_qe_report_info_t structure. if p_qve_report_info is
-     *NULL, the API will use QVL library to perform quote verification, not that
-     *the results can not be cryptographically authenticated in this mode.
-     * @param supplemental_data_size[IN] - Size of the buffer pointed to by
-     *p_quote (in bytes).
-     * @param p_supplemental_data[OUT] - The parameter is optional.  If it is
-     *NULL, supplemental_data_size must be 0.
-     *
-     * @return Status code of the operation, one of:
-     *      - SGX_QL_SUCCESS
-     *      - SGX_QL_ERROR_INVALID_PARAMETER
-     *      - SGX_QL_QUOTE_FORMAT_UNSUPPORTED
-     *      - SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED
-     *      - SGX_QL_UNABLE_TO_GENERATE_REPORT
-     *      - SGX_QL_ERROR_UNEXPECTED
-     **/
-    quote3_error_t sgx_qv_verify_quote(
-        const uint8_t* p_quote,
-        uint32_t quote_size,
-        const struct _sgx_ql_qve_collateral_t* p_quote_collateral,
-        const time_t expiration_check_date,
-        uint32_t* p_collateral_expiration_status,
-        sgx_ql_qv_result_t* p_quote_verification_result,
-        sgx_ql_qe_report_info_t* p_qve_report_info,
-        uint32_t supplemental_data_size,
-        uint8_t* p_supplemental_data);
+/**
+ * Get supplemental data required size.
+ * @param p_data_size[OUT] - Pointer to hold the size of the buffer in bytes required to contain all of the supplemental data.
+ *
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ *      - SGX_QL_ERROR_QVL_QVE_MISMATCH
+ *      - SGX_QL_ENCLAVE_LOAD_ERROR
+ **/
+quote3_error_t sgx_qv_get_quote_supplemental_data_size(uint32_t *p_data_size);
 
-    /**
-     * Call quote provider library to get QvE identity.
-     *
-     * @param pp_qveid[OUT] - Pointer to the pointer of QvE identity
-     * @param p_qveid_size[OUT] -  Pointer to the size of QvE identity
-     * @param pp_qveid_issue_chain[OUT] - Pointer to the pointer QvE identity
-     *certificate chain
-     * @param p_qveid_issue_chain_size[OUT] - Pointer to the QvE identity
-     *certificate chain size
-     * @param pp_root_ca_crl[OUT] - Pointer to the pointer of Intel Root CA CRL
-     * @param p_root_ca_crl_size[OUT] - Pointer to the Intel Root CA CRL size
-     *
-     * @return Status code of the operation, one of:
-     *      - SGX_QL_SUCCESS
-     *      - SGX_QL_ERROR_INVALID_PARAMETER
-     *      - SGX_QL_NO_QVE_IDENTITY_DATA
-     *      - SGX_QL_ERROR_OUT_OF_MEMORY
-     *      - SGX_QL_NETWORK_ERROR
-     *      - SGX_QL_MESSAGE_ERROR
-     *      - SGX_QL_ERROR_UNEXPECTED
-     **/
-    quote3_error_t sgx_qv_get_qve_identity(
-        uint8_t** pp_qveid,
-        uint32_t* p_qveid_size,
-        uint8_t** pp_qveid_issue_chain,
-        uint32_t* p_qveid_issue_chain_size,
-        uint8_t** pp_root_ca_crl,
-        uint16_t* p_root_ca_crl_size);
 
-    /**
-     * Call quote provider library to free the p_qve_id, p_qveid_issuer_chain
-     *buffer and p_root_ca_crl allocated by sgx_qv_get_qve_identity
-     **/
-    quote3_error_t sgx_qv_free_qve_identity(
-        uint8_t* p_qveid,
-        uint8_t* p_qveid_issue_chain,
-        uint8_t* p_root_ca_crl);
+/**
+ * Perform ECDSA quote verification.
+ *
+ * @param p_quote[IN] - Pointer to SGX Quote.
+ * @param quote_size[IN] - Size of the buffer pointed to by p_quote (in bytes).
+ * @param p_quote_collateral[IN] - This is a pointer to the Quote Certification Collateral provided by the caller.
+ * @param expiration_check_date[IN] - This is the date that the QvE will use to determine if any of the inputted collateral have expired.
+ * @param p_collateral_expiration_status[OUT] - Address of the outputted expiration status.  This input must not be NULL.
+ * @param p_quote_verification_result[OUT] - Address of the outputted quote verification result.
+ * @param p_qve_report_info[IN/OUT] - This parameter can be used in 2 ways.
+ *        If p_qve_report_info is NOT NULL, the API will use Intel QvE to perform quote verification, and QvE will generate a report using the target_info in sgx_ql_qe_report_info_t structure.
+ *        if p_qve_report_info is NULL, the API will use QVL library to perform quote verification, note that the results can not be cryptographically authenticated in this mode.
+ * @param supplemental_data_size[IN] - Size of the buffer pointed to by p_quote (in bytes).
+ * @param p_supplemental_data[OUT] - The parameter is optional.  If it is NULL, supplemental_data_size must be 0.
+ *
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ *      - SGX_QL_QUOTE_FORMAT_UNSUPPORTED
+ *      - SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED
+ *      - SGX_QL_UNABLE_TO_GENERATE_REPORT
+ *      - SGX_QL_CRL_UNSUPPORTED_FORMAT
+ *      - SGX_QL_ERROR_UNEXPECTED
+ **/
+quote3_error_t sgx_qv_verify_quote(
+    const uint8_t *p_quote,
+    uint32_t quote_size,
+    const sgx_ql_qve_collateral_t *p_quote_collateral,
+    const time_t expiration_check_date,
+    uint32_t *p_collateral_expiration_status,
+    sgx_ql_qv_result_t *p_quote_verification_result,
+    sgx_ql_qe_report_info_t *p_qve_report_info,
+    uint32_t supplemental_data_size,
+    uint8_t *p_supplemental_data);
+
+
+
+/**
+ * Call quote provider library to get QvE identity.
+ *
+ * @param pp_qveid[OUT] - Pointer to the pointer of QvE identity
+ * @param p_qveid_size[OUT] -  Pointer to the size of QvE identity
+ * @param pp_qveid_issue_chain[OUT] - Pointer to the pointer QvE identity certificate chain
+ * @param p_qveid_issue_chain_size[OUT] - Pointer to the QvE identity certificate chain size
+ * @param pp_root_ca_crl[OUT] - Pointer to the pointer of Intel Root CA CRL
+ * @param p_root_ca_crl_size[OUT] - Pointer to the Intel Root CA CRL size
+ *
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ *      - SGX_QL_NO_QVE_IDENTITY_DATA
+ *      - SGX_QL_ERROR_OUT_OF_MEMORY
+ *      - SGX_QL_NETWORK_ERROR
+ *      - SGX_QL_MESSAGE_ERROR
+ *      - SGX_QL_ERROR_UNEXPECTED
+ **/
+quote3_error_t sgx_qv_get_qve_identity(
+        uint8_t **pp_qveid,
+        uint32_t *p_qveid_size,
+        uint8_t **pp_qveid_issue_chain,
+        uint32_t *p_qveid_issue_chain_size,
+        uint8_t **pp_root_ca_crl,
+        uint16_t *p_root_ca_crl_size);
+
+/**
+ * Call quote provider library to free the p_qve_id, p_qveid_issuer_chain buffer and p_root_ca_crl allocated by sgx_qv_get_qve_identity
+ **/
+quote3_error_t sgx_qv_free_qve_identity(uint8_t *p_qveid,
+                                        uint8_t *p_qveid_issue_chain,
+                                        uint8_t *p_root_ca_crl);
+
 
 #ifndef _MSC_VER
-    typedef enum
-    {
-        SGX_QV_QVE_PATH,
-        SGX_QV_QPL_PATH
-    } sgx_qv_path_type_t;
+typedef enum
+{
+    SGX_QV_QVE_PATH,
+    SGX_QV_QPL_PATH
+} sgx_qv_path_type_t;
 
-    quote3_error_t sgx_qv_set_path(
-        sgx_qv_path_type_t path_type,
-        const char* p_path);
+quote3_error_t sgx_qv_set_path(sgx_qv_path_type_t path_type,
+                                   const char *p_path);
 #endif
+
+
+/**
+ * Get TDX supplemental data required size.
+ * @param p_data_size[OUT] - Pointer to hold the size of the buffer in bytes required to contain all of the supplemental data.
+ *
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ *      - SGX_QL_ERROR_QVL_QVE_MISMATCH
+ *      - SGX_QL_ENCLAVE_LOAD_ERROR
+ **/
+quote3_error_t tdx_qv_get_quote_supplemental_data_size(uint32_t *p_data_size);
+
+
+/**
+ * Perform TDX ECDSA quote verification.
+ *
+ * @param p_quote[IN] - Pointer to TDX Quote.
+ * @param quote_size[IN] - Size of the buffer pointed to by p_quote (in bytes).
+ * @param p_quote_collateral[IN] - This is a pointer to the Quote Certification Collateral provided by the caller.
+ * @param expiration_check_date[IN] - This is the date that the QvE will use to determine if any of the inputted collateral have expired.
+ * @param p_collateral_expiration_status[OUT] - Address of the outputted expiration status.  This input must not be NULL.
+ * @param p_quote_verification_result[OUT] - Address of the outputted quote verification result.
+ * @param p_qve_report_info[IN/OUT] - This parameter can be used in 2 ways.
+ *        If p_qve_report_info is NOT NULL, the API will use Intel QvE to perform quote verification, and QvE will generate a report using the target_info in sgx_ql_qe_report_info_t structure.
+ *        if p_qve_report_info is NULL, the API will use QVL library to perform quote verification, not that the results can not be cryptographically authenticated in this mode.
+ * @param supplemental_data_size[IN] - Size of the buffer pointed to by p_quote (in bytes).
+ * @param p_supplemental_data[OUT] - The parameter is optional.  If it is NULL, supplemental_data_size must be 0.
+ *
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ *      - SGX_QL_QUOTE_FORMAT_UNSUPPORTED
+ *      - SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED
+ *      - SGX_QL_UNABLE_TO_GENERATE_REPORT
+ *      - SGX_QL_CRL_UNSUPPORTED_FORMAT
+ *      - SGX_QL_ERROR_UNEXPECTED
+ **/
+quote3_error_t tdx_qv_verify_quote(
+    const uint8_t *p_quote,
+    uint32_t quote_size,
+    const tdx_ql_qve_collateral_t *p_quote_collateral,
+    const time_t expiration_check_date,
+    uint32_t *p_collateral_expiration_status,
+    sgx_ql_qv_result_t *p_quote_verification_result,
+    sgx_ql_qe_report_info_t *p_qve_report_info,
+    uint32_t supplemental_data_size,
+    uint8_t *p_supplemental_data);
+
+
+/**
+ * Get quote verification collateral.
+ *
+ * @param p_quote[IN] - Pointer to TDX/SGX Quote.
+ * @param quote_size[IN] - Size of the buffer pointed to by p_quote (in bytes).
+ * @param p_quote_collateral[OUT] - This is a pointer to the Quote Certification Collateral retrieved based on Quote
+ * @param p_collateral_size[OUT] - This is the sizeof collateral including the size of nested fileds
+ *
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ *      - SGX_QL_PLATFORM_LIB_UNAVAILABLE
+ *      - SGX_QL_PCK_CERT_CHAIN_ERROR
+ *      - SGX_QL_PCK_CERT_UNSUPPORTED_FORMAT
+ *      - SGX_QL_QUOTE_FORMAT_UNSUPPORTED
+ *      - SGX_QL_OUT_OF_MEMORY
+ *      - SGX_QL_NO_QUOTE_COLLATERAL_DATA
+ *      - SGX_QL_ERROR_UNEXPECTED
+ **/
+quote3_error_t tee_qv_get_collateral(
+    const uint8_t *p_quote,
+    uint32_t quote_size,
+    uint8_t **pp_quote_collateral,
+    uint32_t *p_collateral_size);
+
+
+/**
+ * Free quote verification collateral buffer, which returned by `tee_qv_get_collateral`
+ *
+ * @param p_quote_collateral[IN] - Pointer to collateral
+ *
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ *      - SGX_QL_QUOTE_FORMAT_UNSUPPORTED
+ **/
+quote3_error_t tee_qv_free_collateral(uint8_t *p_quote_collateral);
+
+
+/**
+ * Get supplemental data latest version and required size, support both SGX and TDX
+ *
+ * @param p_quote[IN] - Pointer to SGX or TDX Quote.
+ * @param quote_size[IN] - Size of the buffer pointed to by p_quote (in bytes).
+ * @param p_version[OUT] - Optional. Pointer to hold latest version of the supplemental data.
+ * @param p_data_size[OUT] - Optional. Pointer to hold the size of the buffer in bytes required to contain all of the supplemental data.
+ **/
+quote3_error_t tee_get_supplemental_data_version_and_size(
+    const uint8_t *p_quote,
+    uint32_t quote_size,
+    uint32_t *p_version,
+    uint32_t *p_data_size);
+
+
+/**
+ * Perform quote verification for SGX and TDX
+ * This API works the same as the old one, but takes a new parameter to describe the supplemental data (p_supp_data_descriptor)
+ *
+ * @param p_quote[IN] - Pointer to SGX or TDX Quote.
+ * @param quote_size[IN] - Size of the buffer pointed to by p_quote (in bytes).
+ * @param p_quote_collateral[IN] - This is a pointer to the Quote Certification Collateral provided by the caller.
+ * @param expiration_check_date[IN] - This is the date that the QvE will use to determine if any of the inputted collateral have expired.
+ * @param p_collateral_expiration_status[OUT] - Address of the outputted expiration status.  This input must not be NULL.
+ * @param p_quote_verification_result[OUT] - Address of the outputted quote verification result.
+ * @param p_qve_report_info[IN/OUT] - This parameter can be used in 2 ways.
+ *        If p_qve_report_info is NOT NULL, the API will use Intel QvE to perform quote verification, and QvE will generate a report using the target_info in sgx_ql_qe_report_info_t structure.
+ *        if p_qve_report_info is NULL, the API will use QVL library to perform quote verification, not that the results can not be cryptographically authenticated in this mode.
+ * @param p_supp_datal_descriptor[IN/OUT] - Pointer to tee_supp_data_descriptor_t structure
+ *        You can specify the major version of supplemental data by setting p_supp_datal_descriptor->major_version
+ *        If p_supp_datal_descriptor == NULL, no supplemental data is returned
+ *        If p_supp_datal_descriptor->major_version == 0, then return the latest version of the sgx_ql_qv_supplemental_t structure
+ *        If p_supp_datal_descriptor <= latest supported version, return the latest minor version associated with that major version
+ *        If p_supp_datal_descriptor > latest supported version, return an error SGX_QL_SUPPLEMENTAL_DATA_VERSION_NOT_SUPPORTED
+ *
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ *      - SGX_QL_QUOTE_FORMAT_UNSUPPORTED
+ *      - SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED
+ *      - SGX_QL_UNABLE_TO_GENERATE_REPORT
+ *      - SGX_QL_CRL_UNSUPPORTED_FORMAT
+ *      - SGX_QL_SUPPLEMENTAL_DATA_VERSION_NOT_SUPPORTED
+ *      - SGX_QL_ERROR_UNEXPECTED
+ **/
+quote3_error_t tee_verify_quote(
+    const uint8_t *p_quote,
+    uint32_t quote_size,
+    const uint8_t *p_quote_collateral,
+    const time_t expiration_check_date,
+    uint32_t *p_collateral_expiration_status,
+    sgx_ql_qv_result_t *p_quote_verification_result,
+    sgx_ql_qe_report_info_t *p_qve_report_info,
+    tee_supp_data_descriptor_t *p_supp_data_descriptor);
+
+
 #if defined(__cplusplus)
 }
 #endif

--- a/3rdparty/sgxsdk/include/sgx_defs.h
+++ b/3rdparty/sgxsdk/include/sgx_defs.h
@@ -46,7 +46,7 @@
 # define SGX_FASTCALL
 
 # define SGX_DLLIMPORT
-//# define SGX_UBRIDGE(attr, fname, args...) attr fname args
+// # define SGX_UBRIDGE(attr, fname, args...) attr fname args
 
 # define SGX_DEPRECATED __attribute__((deprecated))
 

--- a/3rdparty/sgxsdk/include/sgx_pce.h
+++ b/3rdparty/sgxsdk/include/sgx_pce.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/3rdparty/sgxsdk/include/sgx_ql_lib_common.h
+++ b/3rdparty/sgxsdk/include/sgx_ql_lib_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,7 +68,7 @@ typedef enum _quote3_error_t {
     SGX_QL_ERROR_REPORT = SGX_QL_MK_ERROR(0x0013),                   ///< There was a problem verifying an SGX REPORT.
     SGX_QL_ENCLAVE_LOST = SGX_QL_MK_ERROR(0x0014),                   ///< Interfacing to the enclave failed due to a power transition.
     SGX_QL_INVALID_REPORT = SGX_QL_MK_ERROR(0x0015),                 ///< Error verifying the application enclave's report.
-    SGX_QL_ENCLAVE_LOAD_ERROR = SGX_QL_MK_ERROR(0x0016),             ///< Unable to load the enclaves.  Could be due to file I/O error, loading infrastructure error.
+    SGX_QL_ENCLAVE_LOAD_ERROR = SGX_QL_MK_ERROR(0x0016),             ///< Unable to load the enclaves. Could be due to file I/O error, loading infrastructure error, or non-SGX capable system
     SGX_QL_UNABLE_TO_GENERATE_QE_REPORT = SGX_QL_MK_ERROR(0x0017),   ///< The QE was unable to generate its own report targeting the application enclave either
                                                                      ///< because the QE doesn't support this feature there is an enclave compatibility issue.
                                                                      ///< Please call again with the p_qe_report_info to NULL.
@@ -126,8 +126,18 @@ typedef enum _quote3_error_t {
     SGX_QL_CERTS_UNAVAILABLE  = SGX_QL_MK_ERROR(0x0049),             /// Certificates are not available for this platform
 
     SGX_QL_QVEIDENTITY_MISMATCH = SGX_QL_MK_ERROR(0x0050),          ///< QvE Identity is NOT match to Intel signed QvE identity
-    SGX_QL_QVE_OUT_OF_DATE = SGX_QL_MK_ERROR(0x0051),               ///< QvE ISVSVN is smaller then the ISVSVN threshold
+    SGX_QL_QVE_OUT_OF_DATE = SGX_QL_MK_ERROR(0x0051),               ///< QvE ISVSVN is smaller than the ISVSVN threshold, or input QvE ISVSVN is too small
     SGX_QL_PSW_NOT_AVAILABLE = SGX_QL_MK_ERROR(0x0052),             ///< SGX PSW library cannot be loaded, could be due to file I/O error
+    SGX_QL_COLLATERAL_VERSION_NOT_SUPPORTED = SGX_QL_MK_ERROR(0x0053),  ///< SGX quote verification collateral version not supported by QVL/QvE
+    SGX_QL_TDX_MODULE_MISMATCH = SGX_QL_MK_ERROR(0x0060),            ///< TDX SEAM module identity is NOT match to Intel signed TDX SEAM module
+
+    SGX_QL_QEIDENTITY_NOT_FOUND = SGX_QL_MK_ERROR(0x0061),            ///< QE identity was not found 
+    SGX_QL_TCBINFO_NOT_FOUND = SGX_QL_MK_ERROR(0x0062),               ///< TCB Info was not found 
+    SGX_QL_INTERNAL_SERVER_ERROR = SGX_QL_MK_ERROR(0x0063),           ///< Internal server error
+
+    SGX_QL_SUPPLEMENTAL_DATA_VERSION_NOT_SUPPORTED = SGX_QL_MK_ERROR(0x0064),       ///< The supplemental data version is not supported
+
+    SGX_QL_ROOT_CA_UNTRUSTED = SGX_QL_MK_ERROR(0x0065),              ///< The certificate used to establish SSL session is untrusted
 
     SGX_QL_ERROR_MAX = SGX_QL_MK_ERROR(0x00FF),                      ///< Indicate max error to allow better translation.
 
@@ -163,19 +173,41 @@ typedef enum _sgx_ql_config_version_t
 typedef struct _sgx_ql_config_t
 {
     sgx_ql_config_version_t version;
-    sgx_cpu_svn_t cert_cpu_svn;            ///< The CPUSVN used to generate the PCK Signature used to certify the attestation key.
-    sgx_isv_svn_t cert_pce_isv_svn;        ///< The PCE ISVSVN used to generate the PCK Signature used to certify the attestation key.
-    uint32_t cert_data_size;               ///< The size of the buffer pointed to by p_cert_data
-    uint8_t* p_cert_data;                  ///< The certificaton data used for the quote.
-                                           ///todo: It is the assumed to be the PCK Cert Chain.  May want to change to support other cert types.
-}sgx_ql_config_t;
+    sgx_cpu_svn_t cert_cpu_svn;     ///< The CPUSVN used to generate the PCK Signature used to certify the attestation key.
+    sgx_isv_svn_t cert_pce_isv_svn; ///< The PCE ISVSVN used to generate the PCK Signature used to certify the attestation key.
+    uint32_t cert_data_size;        ///< The size of the buffer pointed to by p_cert_data
+    uint8_t *p_cert_data;           ///< The certificaton data used for the quote.
+                                    ///todo: It is the assumed to be the PCK Cert Chain.  May want to change to support other cert types.
+} sgx_ql_config_t;
+
 #pragma pack(pop)
+
+#define MAX_PARAM_STRING_SIZE (256)
+typedef struct _sgx_ql_qve_collateral_param_t {
+    uint8_t key[MAX_PARAM_STRING_SIZE + 1];
+    uint8_t value[MAX_PARAM_STRING_SIZE + 1];
+} sgx_ql_qve_collateral_param_t;
+
+// Nameless struct generates C4201 warning in MS compiler, but it is allowed in c++ 11 standard
+// Should remove the pragma after Microsoft fixes this issue
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4201)
+#endif
 
 #ifndef __sgx_ql_qve_collateral_t          // The __sgx_ql_qve_collateral_t can also be defined in QvE _t/_u.h
 #define __sgx_ql_qve_collateral_t
 typedef struct _sgx_ql_qve_collateral_t
 {
-    uint32_t version;                      /// version = 1.  PCK Cert chain is in the Quote.
+    union {
+        uint32_t version;           ///< 'version' is the backward compatible legacy representation
+        struct {                    ///< For PCS V1 and V2 APIs, the major_version = 1 and minor_version = 0 and
+            uint16_t major_version; ///< the CRLs will be formatted in PEM. For PCS V3 APIs, the major_version = 3 and the
+            uint16_t minor_version; ///< minor_version can be either 0 or 1. minor_verion of 0 indicates the CRL’s are formatted
+                                    ///< in Base16 encoded DER.  A minor version of 1 indicates the CRL’s are formatted in raw binary DER.
+        };
+    };
+    uint32_t tee_type;                     ///<  0x00000000: SGX or 0x00000081: TDX
     char *pck_crl_issuer_chain;
     uint32_t pck_crl_issuer_chain_size;
     char *root_ca_crl;                     /// Root CA CRL
@@ -191,8 +223,31 @@ typedef struct _sgx_ql_qve_collateral_t
     char *qe_identity;                     /// QE Identity Structure
     uint32_t qe_identity_size;
 } sgx_ql_qve_collateral_t;
-#endif  //__sgx_ql_qve_collateral_t
+#endif //__sgx_ql_qve_collateral_t
 
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+typedef enum _sgx_ql_log_level_t
+{
+    SGX_QL_LOG_ERROR,
+    SGX_QL_LOG_INFO
+} sgx_ql_log_level_t;
+
+typedef void (*sgx_ql_logging_callback_t)(sgx_ql_log_level_t level, const char* message);
+
+#ifndef tdx_ql_qve_collateral_t
+typedef sgx_ql_qve_collateral_t tdx_ql_qve_collateral_t;
+#endif
+
+typedef enum _sgx_prod_type_t {
+    SGX_PROD_TYPE_SGX = 0,
+    SGX_PROD_TYPE_TDX = 1,
+} sgx_prod_type_t;
+
+#ifndef tdx_ql_qve_collateral_t
+typedef sgx_ql_qve_collateral_t tdx_ql_qve_collateral_t;
+#endif
 
 #endif //_SGX_QL_LIB_COMMON_H_
-

--- a/3rdparty/sgxsdk/include/sgx_ql_quote.h
+++ b/3rdparty/sgxsdk/include/sgx_ql_quote.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,11 +29,11 @@
  *
  */
 /**
- * File: sgx_ql_quote.h
- *
- * Description: Generic SGX quote reference code definitions.
- *
- */
+* File: sgx_ql_quote.h
+*
+* Description: Generic SGX quote reference code definitions.
+*
+*/
 
 /* User defined types */
 #ifndef _SGX_QL_QUOTE_H_
@@ -43,82 +43,67 @@
 #include "sgx_quote.h"
 #include "sgx_quote_3.h"
 
+
 #pragma pack(push, 1)
-/** Describes the algorithm parameters needed to generate the given algorithm's
- * signature.  Used for quote generation APIs. */
-typedef struct _sgx_ql_att_key_id_param_t
-{
-    uint32_t algorithm_param_size; ///< Size of additional attestation key
-                                   ///< information.  0 is valid.
+/** Describes the algorithm parameters needed to generate the given algorithm's signature.  Used for quote generation
+ *  APIs. */
+typedef struct _sgx_ql_att_key_id_param_t {
+    uint32_t    algorithm_param_size;               ///< Size of additional attestation key information.  0 is valid.
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4200)
+#pragma warning ( disable:4200 )
 #endif
-    uint8_t algorithm_param[]; ///< Additional attestation algorithm
-                               ///< information.For example, SigRL for EPID.
+    uint8_t     algorithm_param[];                  ///< Additional attestation algorithm information.For example, SigRL for EPID.
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-} sgx_ql_att_key_id_param_t;
+}sgx_ql_att_key_id_param_t;
 
-/** The full data structure passed to the platform by the verifier. It will list
- * all of the attestation algorithms and QE's supported by the verifier */
-typedef struct _sgx_ql_att_id_list_t
-{
-    sgx_ql_att_key_id_list_header_t
-        header; ///< Header for the attestation key ID list provided by the
-                ///< quote verifier.
+/** The full data structure passed to the platform by the verifier. It will list all of the attestation algorithms and
+ *  QE's supported by the verifier */
+typedef struct _sgx_ql_att_id_list_t {
+    sgx_ql_att_key_id_list_header_t   header;       ///< Header for the attestation key ID list provided by the quote verifier.
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4200)
+#pragma warning ( disable:4200 )
 #endif
-    sgx_att_key_id_ext_t
-        ext_id_list[]; ///< Place holder for the extended attestation ID list.
+    sgx_att_key_id_ext_t              ext_id_list[];///< Place holder for the extended attestation ID list.
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-} sgx_ql_att_key_id_list_t;
+}sgx_ql_att_key_id_list_t;
 
-typedef struct _sgx_ql_qe_report_info_t
-{
+typedef struct _sgx_ql_qe_report_info_t {
     sgx_quote_nonce_t nonce;
     sgx_target_info_t app_enclave_target_info;
     sgx_report_t qe_report;
-} sgx_ql_qe_report_info_t;
+}sgx_ql_qe_report_info_t;
 
 #pragma pack(pop)
 
 #ifdef __cplusplus
-/** Describes the generic Quoting API used by all attestation keys/algorithms.
-   A particular quoting implementer will implement this interface. Application
-   can use this interface to remain agnostic to the attestation key used to
-   generate a quote. */
-class IQuote
-{
-  public:
-    virtual ~IQuote()
-    {
-    }
+/** Describes the generic Quoting API used by all attestation keys/algorithms.  A particular quoting implementer will implement this interface.
+    Application can use this interface to remain agnostic to the attestation key used to generate a quote. */
+class IQuote {
+public:
+    virtual ~IQuote() {}
 
-    virtual quote3_error_t init_quote(
-        sgx_ql_att_key_id_t* p_att_key_id,
-        sgx_ql_cert_key_type_t certification_key_type,
-        sgx_target_info_t* p_target_info,
-        bool refresh_att_key,
-        size_t* p_pub_key_id_size,
-        uint8_t* p_pub_key_id) = 0;
+    virtual quote3_error_t init_quote(sgx_ql_att_key_id_t* p_att_key_id,
+                                      sgx_ql_cert_key_type_t certification_key_type,
+                                      sgx_target_info_t *p_target_info,
+                                      bool refresh_att_key,
+                                      size_t* p_pub_key_id_size,
+                                      uint8_t* p_pub_key_id) = 0;
 
-    virtual quote3_error_t get_quote_size(
-        sgx_ql_att_key_id_t* p_att_key_id,
-        sgx_ql_cert_key_type_t certification_key_type,
-        uint32_t* p_quote_size) = 0;
+    virtual quote3_error_t get_quote_size(sgx_ql_att_key_id_t* p_att_key_id,
+                                          sgx_ql_cert_key_type_t certification_key_type,
+                                          uint32_t* p_quote_size) = 0;
 
-    virtual quote3_error_t get_quote(
-        const sgx_report_t* p_app_report,
-        sgx_ql_att_key_id_t* p_att_key_id,
-        sgx_ql_qe_report_info_t* p_qe_report_info,
-        sgx_quote3_t* p_quote,
-        uint32_t quote_size) = 0;
+    virtual quote3_error_t get_quote(const sgx_report_t *p_app_report,
+                                     sgx_ql_att_key_id_t* p_att_key_id,
+                                     sgx_ql_qe_report_info_t *p_qe_report_info,
+                                     sgx_quote3_t *p_quote,
+                                     uint32_t quote_size) = 0;
 };
 #endif //#ifdef __cplusplus
 #endif //_SGX_QL_QUOTE_H_

--- a/3rdparty/sgxsdk/include/sgx_quote_3.h
+++ b/3rdparty/sgxsdk/include/sgx_quote_3.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,7 +60,7 @@ typedef enum {
     PPID_RSA2048_ENCRYPTED = 2, ///< RSA-2048-OAEP Encrypted PPID + CPU_SVN, PvE_SVN, PCE_SVN, PCE_ID
     PPID_RSA3072_ENCRYPTED = 3, ///< RSA-3072-OAEP Encrypted PPID + CPU_SVN, PvE_SVN, PCE_SVN, PCE_ID
     PCK_CLEARTEXT = 4,          ///< Clear PCK Leaf Cert
-    PCK_CERT_CHAIN = 5,         ///< Full PCK Cert chain (trustedRootCaCert||intermediateCa||pckCert)
+    PCK_CERT_CHAIN = 5,         ///< Full PCK Cert chain (PCK Leaf Cert|| Intermediate CA Cert || Root CA Cert)
     ECDSA_SIG_AUX_DATA = 6,     ///< Indicates the contents of the CERTIFICATION_INFO_DATA contains the ECDSA_SIG_AUX_DATA of another Quote.
     QL_CERT_KEY_TYPE_MAX = 16,
 } sgx_ql_cert_key_type_t;
@@ -149,8 +149,8 @@ typedef struct _sgx_ql_certification_data_t {
 typedef struct _sgx_ql_ecdsa_sig_data_t {
     uint8_t               sig[32*2];            ///< Signature over the Quote using the ECDSA Att key. Big Endian.
     uint8_t               attest_pub_key[32*2]; ///< ECDSA Att Public Key.  Hash in QE3Report.ReportData.  Big Endian
-    sgx_report_body_t     qe3_report;           ///< QE3 Report of the QE when the Att key was generated.  The ReportData will contain the ECDSA_ID
-    uint8_t               qe3_report_sig[32*2]; ///< Signature of QE3 Report using the Certification Key (PCK for root signing). Big Endian
+    sgx_report_body_t     qe_report;            ///< QE3 Report of the QE when the Att key was generated.  The ReportData will contain the ECDSA_ID
+    uint8_t               qe_report_sig[32*2];  ///< Signature of QE Report using the Certification Key (PCK for root signing). Big Endian
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning ( disable:4200 )

--- a/3rdparty/sgxsdk/include/sgx_qve_header.h
+++ b/3rdparty/sgxsdk/include/sgx_qve_header.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,104 +36,112 @@
 #include "time.h"
 
 #ifndef SGX_QL_QV_MK_ERROR
-#define SGX_QL_QV_MK_ERROR(x) (0x0000A000 | (x))
-#endif // SGX_QL_QV_MK_ERROR
+#define SGX_QL_QV_MK_ERROR(x)              (0x0000A000|(x))
+#endif //SGX_QL_QV_MK_ERROR
 /** Contains the possible values of the quote verification result. */
 typedef enum _sgx_ql_qv_result_t
 {
-    SGX_QL_QV_RESULT_OK = 0x0000, ///< The Quote verification passed and is at
-                                  ///< the latest TCB level
-    SGX_QL_QV_RESULT_MIN = SGX_QL_QV_MK_ERROR(0x0001),
-    SGX_QL_QV_RESULT_CONFIG_NEEDED = SGX_QL_QV_MK_ERROR(
-        0x0001), ///< The Quote verification passed and the platform is patched
-                 ///< to the latest TCB level but additional configuration of
-                 ///< the SGX platform may be needed
-    SGX_QL_QV_RESULT_OUT_OF_DATE = SGX_QL_QV_MK_ERROR(
-        0x0002), ///< The Quote is good but TCB level of the platform is out of
-                 ///< date. The platform needs patching to be at the latest TCB
-                 ///< level
-    SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED = SGX_QL_QV_MK_ERROR(
-        0x0003), ///< The Quote is good but the TCB level of the platform is out
-                 ///< of date and additional configuration of the SGX Platform
-                 ///< at its current patching level may be needed. The platform
-                 ///< needs patching to be at the latest TCB level
-    SGX_QL_QV_RESULT_INVALID_SIGNATURE = SGX_QL_QV_MK_ERROR(
-        0x0004), ///< The signature over the application report is invalid
-    SGX_QL_QV_RESULT_REVOKED = SGX_QL_QV_MK_ERROR(
-        0x0005), ///< The attestation key or platform has been revoked
-    SGX_QL_QV_RESULT_UNSPECIFIED =
-        SGX_QL_QV_MK_ERROR(0x0006), ///< The Quote verification failed due to an
-                                    ///< error in one of the input
-    SGX_QL_QV_RESULT_SW_HARDENING_NEEDED =
-        SGX_QL_QV_MK_ERROR(0x0007), ///< The TCB level of the platform is up to
-                                    ///< date, but SGX SW Hardening is needed
-    SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED = SGX_QL_QV_MK_ERROR(
-        0x0008), ///< The TCB level of the platform is up to date, but
-                 ///< additional configuration of the platform at its current
-                 ///< patching level may be needed. Moreove, SGX SW Hardening is
-                 ///< also needed
+   SGX_QL_QV_RESULT_OK = 0x0000,                                            ///< The Quote verification passed and is at the latest TCB level
+   SGX_QL_QV_RESULT_MIN = SGX_QL_QV_MK_ERROR(0x0001),
+   SGX_QL_QV_RESULT_CONFIG_NEEDED = SGX_QL_QV_MK_ERROR(0x0001),             ///< The Quote verification passed and the platform is patched to
+                                                                            ///< the latest TCB level but additional configuration of the SGX
+                                                                            ///< platform may be needed
+   SGX_QL_QV_RESULT_OUT_OF_DATE = SGX_QL_QV_MK_ERROR(0x0002),               ///< The Quote is good but TCB level of the platform is out of date.
+                                                                            ///< The platform needs patching to be at the latest TCB level
+   SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED = SGX_QL_QV_MK_ERROR(0x0003), ///< The Quote is good but the TCB level of the platform is out of
+                                                                            ///< date and additional configuration of the SGX Platform at its
+                                                                            ///< current patching level may be needed. The platform needs
+                                                                            ///< patching to be at the latest TCB level
+   SGX_QL_QV_RESULT_INVALID_SIGNATURE = SGX_QL_QV_MK_ERROR(0x0004),         ///< The signature over the application report is invalid
+   SGX_QL_QV_RESULT_REVOKED = SGX_QL_QV_MK_ERROR(0x0005),                   ///< The attestation key or platform has been revoked
+   SGX_QL_QV_RESULT_UNSPECIFIED = SGX_QL_QV_MK_ERROR(0x0006),               ///< The Quote verification failed due to an error in one of the input
+   SGX_QL_QV_RESULT_SW_HARDENING_NEEDED = SGX_QL_QV_MK_ERROR(0x0007),       ///< The TCB level of the platform is up to date, but SGX SW Hardening
+                                                                            ///< is needed
+   SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED = SGX_QL_QV_MK_ERROR(0x0008),   ///< The TCB level of the platform is up to date, but additional
+                                                                                   ///< configuration of the platform at its current patching level
+                                                                                   ///< may be needed. Moreove, SGX SW Hardening is also needed
 
-    SGX_QL_QV_RESULT_MAX = SGX_QL_QV_MK_ERROR(
-        0x00FF), ///< Indicate max result to allow better translation
+   SGX_QL_QV_RESULT_MAX = SGX_QL_QV_MK_ERROR(0x00FF),                              ///< Indicate max result to allow better translation
 
 } sgx_ql_qv_result_t;
 
-typedef enum _pck_cert_flag_enum_t
-{
+
+typedef enum _pck_cert_flag_enum_t {
     PCK_FLAG_FALSE = 0,
     PCK_FLAG_TRUE,
     PCK_FLAG_UNDEFINED
 } pck_cert_flag_enum_t;
 
-#define ROOT_KEY_ID_SIZE 48
-#define PLATFORM_INSTANCE_ID_SIZE 16
+
+#define ROOT_KEY_ID_SIZE    48
+#define PLATFORM_INSTANCE_ID_SIZE   16
+
+// Each Intel Advisory size is ~16 bytes
+// Assume each TCB level has 10 advisoryIDs at the very most
+#define MAX_SA_LIST_SIZE   160
+
+// Nameless struct generates C4201 warning in MS compiler, but it is allowed in c++ 11 standard
+// Should remove the pragma after Microsoft fixes this issue
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4201)
+#endif
 
 /** Contains data that will allow an alternative quote verification policy. */
 typedef struct _sgx_ql_qv_supplemental_t
 {
-    uint32_t version;           ///< Supplemental data version
-    time_t earliest_issue_date; ///< Earliest issue date of all the collateral
-                                ///< (UTC)
-    time_t latest_issue_date; ///< Latest issue date of all the collateral (UTC)
-    time_t earliest_expiration_date; ///< Earliest expiration date of all the
-                                     ///< collateral (UTC)
-    time_t tcb_level_date_tag; ///< The SGX TCB of the platform that generated
-                               ///< the quote is not vulnerable to any Security
-                               ///< Advisory with an SGX TCB impact released on
-                               ///< or before this date. See Intel Security
-                               ///< Center Advisories
-    uint32_t pck_crl_num;      ///< CRL Num from PCK Cert CRL
-    uint32_t root_ca_crl_num;  ///< CRL Num from Root CA CRL
-    uint32_t tcb_eval_ref_num; ///< Lower number of the TCBInfo and QEIdentity
-    uint8_t root_key_id[ROOT_KEY_ID_SIZE]; ///< ID of the collateral's root
-                                           ///< signer (hash of Root CA's public
-                                           ///< key SHA-384)
-    sgx_key_128bit_t pck_ppid; ///< PPID from remote platform.  Can be used for
-                               ///< platform ownership checks
-    sgx_cpu_svn_t tcb_cpusvn;  ///< CPUSVN of the remote platform's PCK Cert
-    sgx_isv_svn_t
-        tcb_pce_isvsvn; ///< PCE_ISVNSVN of the remote platform's PCK Cert
-    uint16_t pce_id;    ///< PCE_ID of the remote platform
-    uint8_t sgx_type;   ///< Indicate the type of memory protection available on
-                        ///< the platform, it should be one of Standard (0) and
-                        ///< Scalable (1)
+    union {
+        uint32_t version;                       ///< 'version' is the backward compatible legacy representation
+        struct {
+            uint16_t major_version;             ///< If this major version doesn't change, the size of the structure may change and new fields appended to the end but old minor version structure can still be 'cast'
+                                                ///< If this major version does change, then the structure has been modified in a way that makes the older definitions non-backwards compatible. i.e. You cannot 'cast' older definitions
+            uint16_t minor_version;             ///< If this version changes, new fields have been appended to the end of the previous minor version definition of the structure
+                                                ///< Set to 1 to support SA_List.  Set to 0 to support everything except the SA List
+        };
+    };
+    time_t earliest_issue_date;           ///< Earliest issue date of all the collateral (UTC)
+    time_t latest_issue_date;             ///< Latest issue date of all the collateral (UTC)
+    time_t earliest_expiration_date;      ///< Earliest expiration date of all the collateral (UTC)
+    time_t tcb_level_date_tag;            ///< The SGX TCB of the platform that generated the quote is not vulnerable
+                                          ///< to any Security Advisory with an SGX TCB impact released on or before this date.
+                                          ///< See Intel Security Center Advisories
+    uint32_t pck_crl_num;                 ///< CRL Num from PCK Cert CRL
+    uint32_t root_ca_crl_num;             ///< CRL Num from Root CA CRL
+    uint32_t tcb_eval_ref_num;            ///< Lower number of the TCBInfo and QEIdentity
+    uint8_t root_key_id[ROOT_KEY_ID_SIZE];              ///< ID of the collateral's root signer (hash of Root CA's public key SHA-384)
+    sgx_key_128bit_t pck_ppid;            ///< PPID from remote platform.  Can be used for platform ownership checks
+    sgx_cpu_svn_t tcb_cpusvn;             ///< CPUSVN of the remote platform's PCK Cert
+    sgx_isv_svn_t tcb_pce_isvsvn;         ///< PCE_ISVNSVN of the remote platform's PCK Cert
+    uint16_t pce_id;                      ///< PCE_ID of the remote platform
+    uint32_t tee_type;                    ///< 0x00000000: SGX or 0x00000081: TDX
+    uint8_t sgx_type;                     ///< Indicate the type of memory protection available on the platform, it should be one of
+                                          ///< Standard (0), Scalable (1) and Scalable with Integrity (2)
 
-    // Multi-Package PCK cert related flags, they are only relevant to PCK
-    // Certificates issued by PCK Platform CA
-    uint8_t
-        platform_instance_id[PLATFORM_INSTANCE_ID_SIZE]; ///< Value of Platform
-                                                         ///< Instance ID, 16
-                                                         ///< bytes
-    pck_cert_flag_enum_t
-        dynamic_platform; ///< Indicate whether a platform can be extended with
-                          ///< additional packages - via Package Add calls to
-                          ///< SGX Registration Backend
-    pck_cert_flag_enum_t
-        cached_keys; ///< Indicate whether platform root keys are cached by SGX
-                     ///< Registration Backend
-    pck_cert_flag_enum_t smt_enabled; ///< Indicate whether a plat form has SMT
-                                      ///< (simultaneous multithreading) enabled
+    // Multi-Package PCK cert related flags, they are only relevant to PCK Certificates issued by PCK Platform CA
+    uint8_t platform_instance_id[PLATFORM_INSTANCE_ID_SIZE];           ///< Value of Platform Instance ID, 16 bytes
+    pck_cert_flag_enum_t dynamic_platform;      ///< Indicate whether a platform can be extended with additional packages - via Package Add calls to SGX Registration Backend
+    pck_cert_flag_enum_t cached_keys;           ///< Indicate whether platform root keys are cached by SGX Registration Backend
+    pck_cert_flag_enum_t smt_enabled;           ///< Indicate whether a plat form has SMT (simultaneous multithreading) enabled
+
+    char sa_list[MAX_SA_LIST_SIZE];             ///< String of comma separated list of Security Advisory IDs
 
 } sgx_ql_qv_supplemental_t;
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+/** Descriptor of the supplemental data requestor structure. Used when requesting supplemental data from the DCAP quote verification API */
+typedef struct _tee_supp_data_descriptor_t
+{
+    uint16_t major_version;             ///< Input. Major version of supplemental data
+                                        ///< If == 0, then return latest version of the sgx_ql_qv_supplemental_t structure
+                                        ///< If <= latest supported, return the latest minor version associated with that major version
+                                        ///< > latest supported, return an error (SGX_QL_SUPPLEMENTAL_DATA_VERSION_NOT_SUPPORTED)
+
+    uint32_t data_size;                 ///< Input. Supplemental data size of `p_data`, which returned by API `tee_get_supplemental_data_version_and_size()`
+    uint8_t *p_data;                    ///< Output. Pointer to supplemental data
+}tee_supp_data_descriptor_t;
+
 
 #endif //_QVE_HEADER_H_

--- a/3rdparty/sgxsdk/update.make
+++ b/3rdparty/sgxsdk/update.make
@@ -4,10 +4,10 @@
 # Licensed under the MIT License.
 
 SDK_VERSION=sgx_2.10_reproducible
-DCAP_VERSION=dcap_1.7_reproducible
+DCAP_VERSION=DCAP_1.15
 
 all: update-sgxsdk-headers
-	echo All done - please review changes
+	echo "All done - please review changes"
 
 update-sgxsdk-headers:
 	rm -rf include

--- a/common/sgx/quote.c
+++ b/common/sgx/quote.c
@@ -609,7 +609,7 @@ oe_result_t oe_verify_quote_with_sgx_endorsements(
         result = OE_OK;
     }
 
-    // DCAP QVL doesn't exist or system env `SGX_DCAP_QVL` doesn't set
+    // DCAP QVL doesn't exist or system env `SGX_DCAP_QVL` isn't set
     if (result == OE_PLATFORM_ERROR)
     {
         OE_CHECK_MSG(

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -221,6 +221,14 @@ static const char* get_quote3_error_t_string(quote3_error_t error)
         CASE_ERROR_RETURN_ERROR_STRING(SGX_QL_QVEIDENTITY_MISMATCH);
         CASE_ERROR_RETURN_ERROR_STRING(SGX_QL_QVE_OUT_OF_DATE);
         CASE_ERROR_RETURN_ERROR_STRING(SGX_QL_PSW_NOT_AVAILABLE);
+        CASE_ERROR_RETURN_ERROR_STRING(SGX_QL_COLLATERAL_VERSION_NOT_SUPPORTED);
+        CASE_ERROR_RETURN_ERROR_STRING(SGX_QL_TDX_MODULE_MISMATCH);
+        CASE_ERROR_RETURN_ERROR_STRING(SGX_QL_QEIDENTITY_NOT_FOUND);
+        CASE_ERROR_RETURN_ERROR_STRING(SGX_QL_TCBINFO_NOT_FOUND);
+        CASE_ERROR_RETURN_ERROR_STRING(SGX_QL_INTERNAL_SERVER_ERROR);
+        CASE_ERROR_RETURN_ERROR_STRING(
+            SGX_QL_SUPPLEMENTAL_DATA_VERSION_NOT_SUPPORTED);
+        CASE_ERROR_RETURN_ERROR_STRING(SGX_QL_ROOT_CA_UNTRUSTED);
 
         // return the error number as is in the default case
         default:
@@ -1043,6 +1051,8 @@ static oe_result_t sgx_qvl_error_to_oe(quote3_error_t error)
         case SGX_QL_SGX_PCK_CERT_CHAIN_EXPIRED:
         case SGX_QL_SGX_SIGNING_CERT_CHAIN_EXPIRED:
         case SGX_QL_SGX_ENCLAVE_IDENTITY_EXPIRED:
+        case SGX_QL_QEIDENTITY_NOT_FOUND:
+        case SGX_QL_NO_QVE_IDENTITY_DATA:
             return OE_INVALID_ENDORSEMENT;
 
         case SGX_QL_QUOTE_FORMAT_UNSUPPORTED:
@@ -1061,6 +1071,7 @@ static oe_result_t sgx_qvl_error_to_oe(quote3_error_t error)
         case SGX_QL_TCB_CONFIGURATION_NEEDED:
         case SGX_QL_TCB_OUT_OF_DATE_CONFIGURATION_NEEDED:
         case SGX_QL_TCB_CONFIGURATION_AND_SW_HARDENING_NEEDED:
+        case SGX_QL_TCBINFO_NOT_FOUND:
             return OE_TCB_LEVEL_INVALID;
 
         default:
@@ -1190,17 +1201,17 @@ oe_result_t oe_sgx_verify_quote(
         if (result != OE_OK)
         {
             OE_RAISE_MSG(
-                OE_PLATFORM_ERROR,
+                result,
                 "SGX ECDSA QVL-based quote verificaton error "
-                "quote3_error_t=0x%x\n",
-                error);
+                "quote3_error_t=%s\n",
+                get_quote3_error_t_string(error));
         }
 
         OE_TRACE_INFO("verfication status=%d", *p_quote_verification_result);
     }
     else
     {
-        // SGX_DCAP_QVL env doesn't set or QVL doesn't exist
+        // SGX_DCAP_QVL env isn't set or QVL doesn't exist
         result = OE_PLATFORM_ERROR;
     }
 


### PR DESCRIPTION
This PR surfaces/unmask the `quote3_error_t` received from underlying service, so end users should have a better understanding of the failure, if happens.

This PR also updated the lib used to bring in new error codes.