### PR TITLE
Add SA_ONSTACK to Linux SGX exception handler.

### DIFF
--- a/host/sgx/linux/exception.c
+++ b/host/sgx/linux/exception.c
@@ -153,17 +153,17 @@ static void _register_signal_handlers(void)
     // Use sa_sigaction instead of sa_handler, allow catching the same signal as
     // the one you're currently handling, and automatically restart the system
     // call that interrupted the signal.
+    sig_action.sa_flags = SA_SIGINFO | SA_NODEFER | SA_RESTART;
     // SA_ONSTACK is required in cases where this signal handler may be
     // registered in a non-C language like Go with alternate stack
-    // implementations.
-    sig_action.sa_flags = SA_SIGINFO | SA_NODEFER | SA_RESTART | SA_ONSTACK;
-    // Set up the alt stack for SA_ONSTACK:
-    static char stack[SIGSTKSZ];
-    stack_t ss = {
-        .ss_size = sizeof(stack),
-        .ss_sp = stack,
-    };
-    sigaltstack(&ss, 0);
+    // implementations.  Those implementations should have already set up an
+    // aleternate stack, so we can check for that and set the flag accordingly.
+    stack_t current_ss = {0};
+    sigaltstack(NULL, &current_ss);
+    if (current_ss.ss_flags & SS_DISABLE)
+    {
+        sig_action.sa_flags |= SA_ONSTACK;
+    }
 
     // Should honor the current signal masks.
     sigemptyset(&sig_action.sa_mask);

--- a/host/sgx/linux/exception.c
+++ b/host/sgx/linux/exception.c
@@ -157,6 +157,13 @@ static void _register_signal_handlers(void)
     // registered in a non-C language like Go with alternate stack
     // implementations.
     sig_action.sa_flags = SA_SIGINFO | SA_NODEFER | SA_RESTART | SA_ONSTACK;
+    // Set up the alt stack for SA_ONSTACK:
+    static char stack[SIGSTKSZ];
+    stack_t ss = {
+        .ss_size = sizeof(stack),
+        .ss_sp = stack,
+    };
+    sigaltstack(&ss, 0);
 
     // Should honor the current signal masks.
     sigemptyset(&sig_action.sa_mask);

--- a/host/sgx/linux/exception.c
+++ b/host/sgx/linux/exception.c
@@ -153,7 +153,10 @@ static void _register_signal_handlers(void)
     // Use sa_sigaction instead of sa_handler, allow catching the same signal as
     // the one you're currently handling, and automatically restart the system
     // call that interrupted the signal.
-    sig_action.sa_flags = SA_SIGINFO | SA_NODEFER | SA_RESTART;
+    // SA_ONSTACK is required in cases where this signal handler may be
+    // registered in a non-C language like Go with alternate stack
+    // implementations.
+    sig_action.sa_flags = SA_SIGINFO | SA_NODEFER | SA_RESTART | SA_ONSTACK;
 
     // Should honor the current signal masks.
     sigemptyset(&sig_action.sa_mask);


### PR DESCRIPTION
This adds the SA_ONSTACK flag to the Linux SGX exception handler, which should better allow OE host-side code to be called via Golang cgo wrapping.

Example Golang error:

```
signal 13 received but handler not on signal stack
fatal error: non-Go code set up signal handler without SA_ONSTACK flag
```