### PR TITLE
Updating CI builds

### DIFF
--- a/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
+++ b/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
@@ -8,10 +8,12 @@ GLOBAL_TIMEOUT_MINUTES = 240
 AZURE_IMAGES_MAP = [
     // Mapping between shared gallery image definition name and
     // generated Azure managed image name
-    "ubuntu-18.04":    "${params.IMAGE_ID}-ubuntu-18.04-SGX",
-    "ubuntu-20.04":    "${params.IMAGE_ID}-ubuntu-20.04-SGX",
-    "ws2019-nonSGX":   "${params.IMAGE_ID}-ws2019-nonSGX",
-    "ws2019-SGX-DCAP": "${params.IMAGE_ID}-ws2019-SGX-DCAP"
+    "ubuntu-18.04":      "",
+    "ubuntu-20.04":      "",
+    "nonSGX-clang-11":   "",
+    "nonSGX-clang-10":   "",
+    "SGX-DCAP-clang-11": "",
+    "SGX-DCAP-clang-10": ""
 ]
 
 def update_production_azure_gallery_images(String image_name) {

--- a/.jenkins/library/vars/tests.groovy
+++ b/.jenkins/library/vars/tests.groovy
@@ -395,12 +395,12 @@ def ACCHostVerificationPackageTest(String version, String build_type) {
     }
 }
 
-def OEReleaseTest(String label, String release_version, String oe_package = "open-enclave", String source = "Azure", boolean lvi_mitigation = false) {
+def OEReleaseTest(String label, String release_version, String oe_package = "open-enclave", String source = "Azure", String storage_credentials_id, String storage_blob, boolean lvi_mitigation = false) {
     stage("OE Release Test ${label}") {
         node(label) {
             timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
-                helpers.releaseInstall(release_version, oe_package, source)
+                helpers.releaseInstall(release_version, oe_package, source, storage_credentials_id, storage_blob)
                 helpers.TestSamplesCommand(lvi_mitigation, oe_package)
             }
         }

--- a/.jenkins/pipelines/OpenEnclave/releases/tests/Jenkinsfile
+++ b/.jenkins/pipelines/OpenEnclave/releases/tests/Jenkinsfile
@@ -1,32 +1,10 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
 
-properties(
-    [
-        buildDiscarder(
-            logRotator(
-                artifactDaysToKeepStr: '90',
-                artifactNumToKeepStr: '180',
-                daysToKeepStr: '90',
-                numToKeepStr: '180'
-            )
-        ),
-        [$class: 'JobRestrictionProperty'],
-        parameters(
-            [
-                string(name: "OECI_LIB_VERSION", defaultValue: 'master', description: 'Version of OE Libraries to use'),
-                string(name: "OE_RELEASE_VERSION", description: "Open Enclave Release Version"),
-                choice(name: "OE_PACKAGE", choices: ["open-enclave", "open-enclave-hostverify"], description: "Open Enclave package type to install"),
-                choice(name: "RELEASE_SOURCE", choices: ["Azure", "GitHub"], description: "Source to download the OE Release from")
-            ]
-        )
-    ]
-)
-
 library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 
-parallel "Ubuntu 20.04":        { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, false) },
-         "Ubuntu 18.04":        { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, false) },
-         "Ubuntu 20.04 w/ LVI": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, true)  },
-         "Ubuntu 18.04 w/ LVI": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, true)  },
-         "Windows Server 2019": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-win2019-dcap"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, false) }
+parallel "Ubuntu 20.04":        { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, params.STORAGE_CREDENTIALS_ID, params.STORAGE_BLOB, false) },
+         "Ubuntu 18.04":        { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, params.STORAGE_CREDENTIALS_ID, params.STORAGE_BLOB, false) },
+         "Ubuntu 20.04 w/ LVI": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, params.STORAGE_CREDENTIALS_ID, params.STORAGE_BLOB, true)  },
+         "Ubuntu 18.04 w/ LVI": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-18.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, params.STORAGE_CREDENTIALS_ID, params.STORAGE_BLOB, true)  },
+         "Windows Server 2019": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-win2019-dcap"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, params.STORAGE_CREDENTIALS_ID, params.STORAGE_BLOB, false) }


### PR DESCRIPTION
This adds the following:
* Open Enclave release tests to use different Azure blob storage sources to download the release.
* CI to start using new clang-11 and clang-10 image definitions