### PR TITLE
Propagate verification result for oe_verify_report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated the mbedTLS from 2.28.0 to 2.28.1
 ## Changed
 - Fix the incorrect behavior of pthread_mutex_init() and std::mutex such that they no longer create a recursive lock by default.
+- `oe_verify_report` now reports the verification result in the `parsed_report` output (only valid when the API returns OE_OK or OE_TCB_LEVEL_INVALID). For the SGX case, the definition of the result is based on `oe_sgx_tcb_status_t`.
 
 ### Security
 - Updated openssl to version 1.1.1q. Please refer to release log to find list of CVEs addressed by this version.

--- a/common/sgx/quote.c
+++ b/common/sgx/quote.c
@@ -444,12 +444,14 @@ oe_result_t oe_verify_sgx_quote(
     size_t quote_size,
     const uint8_t* endorsements,
     size_t endorsements_size,
-    oe_datetime_t* input_validation_time)
+    oe_datetime_t* input_validation_time,
+    uint32_t* verification_result)
 {
     oe_result_t result = OE_UNEXPECTED;
     uint8_t* local_endorsements = NULL;
     size_t local_endorsements_size = 0;
     oe_sgx_endorsements_t sgx_endorsements;
+    oe_tcb_info_tcb_level_t tcb_level = {0};
 
     if (quote == NULL)
         OE_RAISE(OE_INVALID_PARAMETER);
@@ -483,16 +485,18 @@ oe_result_t oe_verify_sgx_quote(
         oe_result_str(result));
 
     // Endorsements verification
-    OE_CHECK(oe_verify_quote_with_sgx_endorsements(
+    result = oe_verify_quote_with_sgx_endorsements(
         quote,
         quote_size,
         &sgx_endorsements,
         input_validation_time,
+        &tcb_level,
         NULL,
-        NULL,
-        NULL));
+        NULL);
 
-    result = OE_OK;
+    if (verification_result)
+        *verification_result =
+            oe_tcb_level_status_to_sgx_tcb_status(tcb_level.status);
 
 done:
     if (local_endorsements)

--- a/common/sgx/quote.h
+++ b/common/sgx/quote.h
@@ -47,13 +47,16 @@ oe_result_t oe_get_quote_cert_chain_internal(
  * if the input time is after than the endorsement creation time, then the
  * CRLs might have updated in the period between the input time and the
  * endorsement creation time.
+ * @param[out] verification_result Optional pointer to the verification-specific
+ * return value.
  */
 oe_result_t oe_verify_sgx_quote(
     const uint8_t* quote,
     size_t quote_size,
     const uint8_t* endorsements,
     size_t endorsements_size,
-    oe_datetime_t* input_validation_time);
+    oe_datetime_t* input_validation_time,
+    uint32_t* verification_result);
 
 /*!
  * Verify SGX quote and endorsements.

--- a/enclave/core/sgx/report.c
+++ b/enclave/core/sgx/report.c
@@ -92,7 +92,7 @@ OE_STATIC_ASSERT(OE_REPORT_DATA_SIZE == sizeof(sgx_report_data_t));
 
 OE_STATIC_ASSERT(sizeof(oe_identity_t) == 96);
 
-OE_STATIC_ASSERT(sizeof(oe_report_t) == 144);
+OE_STATIC_ASSERT(sizeof(oe_report_t) == 152);
 
 oe_result_t sgx_create_report(
     const void* report_data,

--- a/enclave/sgx/report.c
+++ b/enclave/sgx/report.c
@@ -101,29 +101,37 @@ oe_result_t oe_verify_report_internal(
     oe_result_t result = OE_UNEXPECTED;
     oe_report_t oe_report = {0};
     oe_report_header_t* header = (oe_report_header_t*)report;
+    uint32_t verification_result = 0;
 
     // Ensure that the report is parseable before using the header.
     OE_CHECK(oe_parse_report(report, report_size, &oe_report));
 
     if (header->report_type == OE_REPORT_TYPE_SGX_REMOTE)
     {
-        OE_CHECK(oe_verify_sgx_quote(
-            header->report, header->report_size, NULL, 0, NULL));
+        result = oe_verify_sgx_quote(
+            header->report,
+            header->report_size,
+            NULL,
+            0,
+            NULL,
+            &verification_result);
     }
     else if (header->report_type == OE_REPORT_TYPE_SGX_LOCAL)
     {
-        OE_CHECK(oe_verify_raw_sgx_report(header->report, header->report_size));
+        result = oe_verify_raw_sgx_report(header->report, header->report_size);
     }
     else
     {
         OE_RAISE(OE_INVALID_PARAMETER);
     }
 
-    // Optionally return parsed report.
+    // Optionally return parsed report and set the verification
+    // result
     if (parsed_report != NULL)
+    {
         *parsed_report = oe_report;
-
-    result = OE_OK;
+        parsed_report->verification_result = verification_result;
+    }
 
 done:
     return result;

--- a/host/sgx/hostverify_report.c
+++ b/host/sgx/hostverify_report.c
@@ -20,6 +20,7 @@ oe_result_t oe_verify_remote_report(
     oe_result_t result = OE_UNEXPECTED;
     oe_report_t oe_report = {0};
     oe_report_header_t* header = (oe_report_header_t*)report;
+    uint32_t verification_result = 0;
 
     if (report == NULL)
         OE_RAISE(OE_INVALID_PARAMETER);
@@ -38,18 +39,20 @@ oe_result_t oe_verify_remote_report(
         OE_RAISE(OE_UNSUPPORTED);
 
     // Quote attestation can be done entirely on the host side.
-    OE_CHECK(oe_verify_sgx_quote(
+    result = oe_verify_sgx_quote(
         header->report,
         header->report_size,
         endorsement,
         endorsement_size,
-        NULL));
+        NULL,
+        &verification_result);
 
-    // Optionally return parsed report.
+    // Optionally return parsed report and set the verification result
     if (parsed_report != NULL)
-        OE_CHECK(oe_parse_report(report, report_size, parsed_report));
-
-    result = OE_OK;
+    {
+        *parsed_report = oe_report;
+        parsed_report->verification_result = verification_result;
+    }
 
 done:
     return result;

--- a/include/openenclave/bits/report.h
+++ b/include/openenclave/bits/report.h
@@ -133,6 +133,10 @@ typedef struct _oe_report
 
     /** Contains the IDs and attributes that are part of oe_identity_t */
     oe_identity_t identity;
+
+    /** Contains the result reported by quote verification logic. The size is
+     * determined based on OE_ENUM_MAX. */
+    uint32_t verification_result;
 } oe_report_t;
 /**< typedef struct _oe_report oe_report_t*/
 

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -696,25 +696,45 @@ static void _test_time(
     oe_datetime_t tmp;
 
     result = oe_verify_sgx_quote(
-        report_body, report_body_size, collaterals, collaterals_size, from);
+        report_body,
+        report_body_size,
+        collaterals,
+        collaterals_size,
+        from,
+        NULL);
     OE_TEST(result == OE_OK || result == OE_TCB_LEVEL_INVALID);
 
     result = oe_verify_sgx_quote(
-        report_body, report_body_size, collaterals, collaterals_size, until);
+        report_body,
+        report_body_size,
+        collaterals,
+        collaterals_size,
+        until,
+        NULL);
     OE_TEST(result == OE_OK || result == OE_TCB_LEVEL_INVALID);
 
     tmp = *from;
     tmp.year--;
     OE_TEST_CODE(
         oe_verify_sgx_quote(
-            report_body, report_body_size, collaterals, collaterals_size, &tmp),
+            report_body,
+            report_body_size,
+            collaterals,
+            collaterals_size,
+            &tmp,
+            NULL),
         OE_VERIFY_FAILED_TO_FIND_VALIDITY_PERIOD);
 
     tmp = *until;
     tmp.year++;
     OE_TEST_CODE(
         oe_verify_sgx_quote(
-            report_body, report_body_size, collaterals, collaterals_size, &tmp),
+            report_body,
+            report_body_size,
+            collaterals,
+            collaterals_size,
+            &tmp,
+            NULL),
         OE_VERIFY_FAILED_TO_FIND_VALIDITY_PERIOD);
 }
 

--- a/tests/host_verify/host/host.cpp
+++ b/tests/host_verify/host/host.cpp
@@ -240,6 +240,7 @@ static int _verify_report(
             report_file_size,
             endorsements_data,
             endorsements_file_size,
+            NULL,
             NULL);
 
         if (pass)

--- a/tools/oeutil/host/generate_evidence.cpp
+++ b/tools/oeutil/host/generate_evidence.cpp
@@ -1151,11 +1151,25 @@ oe_result_t generate_oe_report(
 
         oe_report_t parsed_report;
 
-        OE_CHECK_MSG(
-            oe_verify_report(
-                nullptr, remote_report, report_size, &parsed_report),
-            "Failed to verify report. Error: (%s)\n",
-            oe_result_str(result));
+        result = oe_verify_report(
+            nullptr, remote_report, report_size, &parsed_report);
+
+        if (result == OE_OK)
+        {
+            log("========== TCB is up-to-date\n");
+        }
+        else if (result == OE_TCB_LEVEL_INVALID)
+        {
+            log("========== Non-terminal TCB: 0x:%0x\n",
+                parsed_report.verification_result);
+        }
+        else
+        {
+            OE_CHECK_MSG(
+                result,
+                "Failed to verify report. Error: (%s)\n",
+                oe_result_str(result));
+        }
 
         // verify signer id
         OE_CHECK_MSG(


### PR DESCRIPTION
The PR adds a new field, `verification_result` to the `oe_report_t`, which allows `oe_verify_report` to propagate the verification result as part of the `parsed_report` out parameter. For the SGX case, the value can be interpreted based on `oe_sgx_tcb_status_t`. 

Side note: `oe_report_t` is only used as an out parameter, which is the OE-defined data structure that holds the raw report and some information extracted from it (e.g., enclave identity). The report verification APIs only take the raw report as input.