### PR TITLE
Upgrade pip

### DIFF
--- a/scripts/ansible/install-ansible.sh
+++ b/scripts/ansible/install-ansible.sh
@@ -36,6 +36,7 @@ else
     exit 1
 fi
 
+pip install --upgrade pip
 pip3 install -U -r "$DIR/requirements.txt"
 
 ansible-galaxy collection install community.general


### PR DESCRIPTION
Fixes issue
```
Collecting cryptography==39.0.1 (from -r scripts/ansible/requirements.txt (line 3))

  Downloading https://files.pythonhosted.org/packages/6a/f5/a729774d087e50fffd1438b3877a91e9281294f985bda0fd15bf99016c78/cryptography-39.0.1.tar.gz (603kB)

    Complete output from command python setup.py egg_info:

    Traceback (most recent call last):

      File "<string>", line 1, in <module>

      File "/tmp/pip-build-ch6h9cxk/cryptography/setup.py", line 18, in <module>

        from setuptools_rust import RustExtension

    ModuleNotFoundError: No module named 'setuptools_rust'

    

            =============================DEBUG ASSISTANCE==========================

            If you are seeing an error here please try the following to

            successfully install cryptography:

    

            Upgrade to the latest pip and try again. This will fix errors for most

            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip

            =============================DEBUG ASSISTANCE==========================
```