### PR TITLE
Fix ControlFlow default

### DIFF
--- a/cmake/apply_lvi_mitigation.cmake
+++ b/cmake/apply_lvi_mitigation.cmake
@@ -16,6 +16,10 @@ macro (get_glibc_version)
 endmacro ()
 
 function (apply_lvi_mitigation NAME)
+  # alias ControlFlow to ControlFlow-GNU
+  if (LVI_MITIGATION STREQUAL "ControlFlow")
+    set(LVI_MITIGATION "ControlFlow-GNU")
+  endif ()
   # Add LVI mitigation compliation options.
   if (UNIX)
     if (LVI_MITIGATION STREQUAL ControlFlow-Clang)


### PR DESCRIPTION
This fix ensures when LVI_MITIGATION=ControlFlow it will default to ControlFlow-GNU and apply the necessary compiler options.