### PR TITLE
Use azure-cli Ansible role

### DIFF
--- a/.jenkins/infrastructure/docker/dockerfiles/linux/Dockerfile
+++ b/.jenkins/infrastructure/docker/dockerfiles/linux/Dockerfile
@@ -75,12 +75,6 @@ RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bioni
     wget https://packages.microsoft.com/keys/microsoft.asc && \
     apt-key add microsoft.asc
 
-# Install Azure CLI
-RUN apt-get update && \
-    apt-get -y install azure-cli && \
-    apt-get clean && \
-    rm -rf rm /var/lib/apt/lists/*
-
 # Install packer
 RUN wget https://releases.hashicorp.com/packer/1.5.5/packer_1.5.5_linux_amd64.zip && \
     unzip packer_1.5.5_linux_amd64.zip -d /usr/sbin && \

--- a/scripts/ansible/roles/linux/azure-cli/tasks/main.yml
+++ b/scripts/ansible/roles/linux/azure-cli/tasks/main.yml
@@ -1,0 +1,34 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+
+- name: Install via APT
+  block:
+    - name: Install prerequisite APT packages
+      ansible.builtin.apt:
+        name: "{{ prerequisite_apt_packages }}"
+        state: latest
+
+    - name: Create keyring directory
+      ansible.builtin.file:
+        path: /etc/apt/keyrings/
+        owner: root
+        mode: '0744'
+        state: directory
+
+    - name: Import APT repository key
+      ansible.builtin.apt_key:
+        url: "{{ apt_key_url }}"
+        state: present
+    
+    - name: Add APT repository
+      ansible.builtin.apt_repository:
+        repo: "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ {{ ansible_distribution_release }} main"
+        state: present
+        update_cache: yes
+    
+    - name: Install AzCLI
+      ansible.builtin.apt:
+        name: "azure-cli"
+        state: present

--- a/scripts/ansible/roles/linux/azure-cli/vars/main.yml
+++ b/scripts/ansible/roles/linux/azure-cli/vars/main.yml
@@ -1,0 +1,11 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+---
+
+prerequisite_apt_packages:
+  - ca-certificates
+  - apt-transport-https
+  - gnupg
+
+apt_key_url: https://packages.microsoft.com/keys/microsoft.asc

--- a/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
@@ -42,3 +42,7 @@
   ansible.builtin.import_role:
     name: linux/az-dcap-client
     tasks_from: stable-install.yml
+
+- name: Install Azure CLI
+  ansible.builtin.import_role:
+    name: linux/azure-cli


### PR DESCRIPTION
This fixes an issue with installing azure-cli on Ubuntu 20.04 oetools Docker image
```
#10 3.186 The following packages have unmet dependencies:
#10 3.238  azure-cli : Depends: libffi6 (>= 3.0.10~rc8) but it is not installable
#10 3.246 E: Unable to correct problems, you have held broken packages.
```