### PR TITLE
Restore backtrace

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -134,15 +134,13 @@ if (OE_SGX)
   # -Wframe-address.
   # -Wno-frame-address is not used for clang-10 as it does not emit such 
   # an error, and does not support the option.
-  if (CMAKE_C_COMPILER_VERSION VERSION_EQUAL 10)
-    set(C_COMPILER_FLAGS "-O2;-fno-omit-frame-pointer;-fno-stack-protector")
-  else ()
-    set(C_COMPILER_FLAGS "-O2;-fno-omit-frame-pointer;-fno-stack-protector;-Wno-frame-address")
+  if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 11)
+    set(C_CALLS_CFLAGS "-Wno-frame-address")
   endif ()
   set_source_files_properties(
     sgx/calls.c
     PROPERTIES
-      COMPILE_OPTIONS "${C_COMPILER_FLAGS}")
+      COMPILE_OPTIONS "${C_CALLS_CFLAGS}")
 
   # To avoid the `unused-command-line-argument` warning, which we treat as an
   # error, we explicitly turn off the warning when compiling these assembly
@@ -362,21 +360,8 @@ if (CODE_COVERAGE)
   set_source_files_properties(once.c sgx/init.c PROPERTIES COMPILE_FLAGS
                                                            "-fno-profile-arcs")
   # Adding "-fno-profile-arcs" for Code Coverage, in addition to existing flags
-  # Don't add -Wno-frame-address for clang-10 as it's not supported
-  if (CMAKE_C_COMPILER_VERSION VERSION_EQUAL 10)
-    set_source_files_properties(
-      sgx/calls.c
-      PROPERTIES
-        COMPILE_FLAGS
-        "-O2 -fno-omit-frame-pointer -fno-stack-protector -fno-profile-arcs")
-  else ()
-    set_source_files_properties(
-      sgx/calls.c
-      PROPERTIES
-        COMPILE_FLAGS
-        "-O2 -fno-omit-frame-pointer -fno-stack-protector -Wno-frame-address -fno-profile-arcs"
-    )
-  endif ()
+  set_source_files_properties(
+    sgx/calls.c PROPERTIES COMPILE_FLAGS "${C_CALLS_CFLAGS} -fno-profile-arcs")
 
 endif ()
 

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -485,11 +485,11 @@ macro (add_library_oehost_wrapper)
     # an error, and does not support the option.
     if (CMAKE_C_COMPILER_VERSION VERSION_EQUAL 10)
       set_source_files_properties(
-        oehost sgx/linux/enter.c PROPERTIES COMPILE_FLAGS
+        ${PARA_LIB_NAME} sgx/linux/enter.c PROPERTIES COMPILE_FLAGS
                                             "-O2 -fno-omit-frame-pointer")
     else ()
       set_source_files_properties(
-        oehost sgx/linux/enter.c
+        ${PARA_LIB_NAME} sgx/linux/enter.c
         PROPERTIES COMPILE_FLAGS "-O2 -fno-omit-frame-pointer -Wno-frame-address")
     endif ()
 

--- a/tests/backtrace/host/host.cpp
+++ b/tests/backtrace/host/host.cpp
@@ -38,6 +38,7 @@ int main(int argc, const char* argv[])
             "ecall_test",
             "oe_handle_call_enclave_function",
             "_handle_ecall",
+            "__oe_handle_main",
             "oe_enter",
         };
         bool rval = false;
@@ -62,6 +63,7 @@ int main(int argc, const char* argv[])
             "ecall_test_unwind",
             "oe_handle_call_enclave_function",
             "_handle_ecall",
+            "__oe_handle_main",
             "oe_enter",
         };
         bool rval = false;


### PR DESCRIPTION
This PR fixes #4704 

I couldn't recall why in the original commit, we are adding `-O2;-fno-omit-frame-pointer;-fno-stack-protector` to `calls.c`, all seems unnecessary.

`make code_coverage` still works after this PR.