### PR TITLE
Reverse upgrade to libcxx11

### DIFF
--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -5,9 +5,9 @@ include(FetchContent)
 FetchContent_Declare(
   libcxx_sources
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libcxx"
-  URL https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/libcxx-11.1.0.src.tar.xz
+  URL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/libcxx-10.0.1.src.tar.xz
   URL_HASH
-    SHA256=bb233d250ed7eaa05c73eaf81ef0f9ee3fac9d8fc0c3d38a7a7383f82ed6f8e5)
+    SHA256=def674535f22f83131353b3c382ccebfef4ba6a35c488bdb76f10b68b25be86c)
 
 FetchContent_GetProperties(libcxx_sources)
 if (NOT libcxx_sources_POPULATED)

--- a/tests/libcxx/tests.broken
+++ b/tests/libcxx/tests.broken
@@ -19,3 +19,5 @@
 # The following C++17 tests fail.
 ../../3rdparty/libcxx/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new_align_val_t_nothrow_replace.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new_align_val_t_nothrow_replace.pass.cpp
+# Using null conversion that is rejected in clang 11
+../../3rdparty/libcxx/libcxx/test/std/language.support/support.types/nullptr_t.pass.cpp

--- a/tests/libcxx/tests.supported
+++ b/tests/libcxx/tests.supported
@@ -2454,7 +2454,6 @@
 ../../3rdparty/libcxx/libcxx/test/std/language.support/support.types/byteops/xor.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/language.support/support.types/max_align_t.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/language.support/support.types/null.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/language.support/support.types/nullptr_t.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/language.support/support.types/nullptr_t_integral_cast.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/language.support/support.types/offsetof.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/language.support/support.types/ptrdiff_t.pass.cpp


### PR DESCRIPTION
Unblock the pipeline for now. Related to #4705

This libcxx 11 upgrade needs bigger effort than expected to triage what new features are added to libcxx11, and what are supported in Open Enclave, etc.

For example, one of the new source files libcxx 11 introduce is `src/atomic.cpp`, 