### PR TITLE
Update NonAccMachineSGXLinuxGettingStarted.md

### DIFF
--- a/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md
@@ -222,7 +222,7 @@ You should be able to see the service is running.
 
 Run the following command to verify if it can actually fetch the root CA CRL from the Intel PCK service
 ```bash
-curl --noproxy "*" -v -k -G "https://localhost:8081/sgx/certification/v2/rootcacrl"
+curl --noproxy "*" -v -k -G "https://localhost:8081/sgx/certification/v3/rootcacrl"
 ```
 
 To learn more about PCCS, please refer to the [PCCS GitHub repository](https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/QuoteGeneration/pccs).


### PR DESCRIPTION
Changed PCCS server's test URL from v2 to v3. V2 no longer works.