### PR TITLE
De-duplicate input validation for sgx_verify_quote

### DIFF
--- a/enclave/sgx/verifier.c
+++ b/enclave/sgx/verifier.c
@@ -377,6 +377,7 @@ oe_result_t sgx_verify_quote(
     const void* p_qe_identity_issuer_chain,
     uint32_t qe_identity_issuer_chain_size)
 {
+    // delegate input validation to host/sgx/sgxquote.c:oe_sgx_verify_quote
     oe_result_t result = OE_UNEXPECTED;
     sgx_nonce_t nonce = {0};
     uint8_t* p_self_report = NULL;
@@ -387,16 +388,6 @@ oe_result_t sgx_verify_quote(
     oe_result_t retval = OE_UNEXPECTED;
 
     sgx_ql_qe_report_info_t* p_qve_report_info_internal = p_qve_report_info;
-
-    // Add format_id for forward compatibility
-    if (!format_id || !supplemental_data_size ||
-        (!opt_params && opt_params_size > 0))
-        OE_RAISE(OE_INVALID_PARAMETER);
-
-    if ((p_qve_report_info &&
-         (qve_report_info_size != sizeof(sgx_ql_qe_report_info_t))) ||
-        (!p_qve_report_info && qve_report_info_size != 0))
-        OE_RAISE(OE_INVALID_PARAMETER);
 
     if (!p_qve_report_info)
     {
@@ -444,8 +435,8 @@ oe_result_t sgx_verify_quote(
     OE_CHECK(oe_verify_quote_ocall(
         &retval,
         format_id,
-        NULL,
-        0,
+        opt_params,
+        opt_params_size,
         p_quote,
         quote_size,
         expiration_check_date,

--- a/host/sgx/quote.c
+++ b/host/sgx/quote.c
@@ -180,13 +180,8 @@ oe_result_t sgx_verify_quote(
     const void* p_qe_identity_issuer_chain,
     uint32_t qe_identity_issuer_chain_size)
 {
+    // delegate input validation to host/sgx/sgxquote.c:oe_sgx_verify_quote
     oe_result_t result = OE_UNEXPECTED;
-
-    /* Reject null parameters */
-    if (!p_quote || !p_collateral_expiration_status ||
-        !p_quote_verification_result ||
-        (!p_supplemental_data && supplemental_data_size > 0))
-        OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Try to get supplemental data size if needed */
     if (p_supplemental_data)

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -1111,24 +1111,25 @@ oe_result_t oe_sgx_verify_quote(
     oe_result_t result = OE_UNEXPECTED;
     quote3_error_t error = SGX_QL_ERROR_UNEXPECTED;
 
+    // Input validation
     // Add format_id for forward compatibility
     // Only support ECDSA-p256 now
     if (memcmp(format_id, &_ecdsa_p256_uuid, sizeof(_ecdsa_p256_uuid)) != 0)
         OE_RAISE(OE_INVALID_PARAMETER);
 
     if (!p_quote || quote_size > OE_MAX_UINT32 ||
-        !p_collateral_expiration_status || !p_quote_verification_result ||
-        (!p_supplemental_data && supplemental_data_size > 0) ||
-        (!opt_params && opt_params_size > 0))
+        !p_collateral_expiration_status || !p_quote_verification_result)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    if ((p_qve_report_info &&
-         qve_report_info_size != sizeof(sgx_ql_qe_report_info_t)) ||
-        (!p_qve_report_info && qve_report_info_size > 0))
+    if ((!opt_params && opt_params_size > 0) ||
+        (!p_qve_report_info && qve_report_info_size > 0) ||
+        (!p_supplemental_data && supplemental_data_size > 0))
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    if (quote_size > OE_MAX_UINT32)
+    if (p_qve_report_info &&
+        qve_report_info_size != sizeof(sgx_ql_qe_report_info_t))
         OE_RAISE(OE_INVALID_PARAMETER);
+    // End of Input validation
 
     if (TRY_TO_USE_SGX_DCAP_QVL() && _load_sgx_dcap_qvl())
     {


### PR DESCRIPTION

Call chain:
* enclave/sgx/verifier.c:`sgx_verify_quote` -> `oe_verify_quote_ocall` -> host/sgx/quote.c:`sgx_verify_quote`
* host/sgx/quote.c:`sgx_verify_quote` -> host/sgx/sgxquote.c:`oe_sgx_verify_quote`
* host/sgx/sgxquote.c:`oe_sgx_verify_quote` <- all input validation moved to here