### PR TITLE
Handle new error code from DCAP 1.16

### DIFF
--- a/3rdparty/sgxsdk/include/sgx_dcap_quoteverify.h
+++ b/3rdparty/sgxsdk/include/sgx_dcap_quoteverify.h
@@ -306,7 +306,23 @@ quote3_error_t tee_verify_quote(
     sgx_ql_qe_report_info_t *p_qve_report_info,
     tee_supp_data_descriptor_t *p_supp_data_descriptor);
 
-
+/**
+ * Extrace FMSPC from a given quote 
+ * @param p_quote[IN] - Pointer to a quote buffer.
+ * @param quote_size[IN] - Size of input quote buffer.
+ * @param p_fmspc_from_quote[IN/OUT] - Pointer to a buffer to write fmspc to.
+ * @param fmspc_from_quote_size[IN] - Size of fmspc buffer.
+ * 
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ *      - SGX_QL_ERROR_UNEXPECTED
+ *      - SGX_QL_PCK_CERT_CHAIN_ERROR
+ *      - SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED
+ */
+quote3_error_t tee_get_fmspc_from_quote(const uint8_t* p_quote, uint32_t quote_size,
+    uint8_t* p_fmspc_from_quote, uint32_t fmspc_from_quote_size);
+    
 #if defined(__cplusplus)
 }
 #endif

--- a/3rdparty/sgxsdk/include/sgx_defs.h
+++ b/3rdparty/sgxsdk/include/sgx_defs.h
@@ -46,6 +46,7 @@
 # define SGX_FASTCALL
 
 # define SGX_DLLIMPORT
+// Comment out this so it compiles on Windows
 // # define SGX_UBRIDGE(attr, fname, args...) attr fname args
 
 # define SGX_DEPRECATED __attribute__((deprecated))

--- a/3rdparty/sgxsdk/include/sgx_ql_lib_common.h
+++ b/3rdparty/sgxsdk/include/sgx_ql_lib_common.h
@@ -131,13 +131,15 @@ typedef enum _quote3_error_t {
     SGX_QL_COLLATERAL_VERSION_NOT_SUPPORTED = SGX_QL_MK_ERROR(0x0053),  ///< SGX quote verification collateral version not supported by QVL/QvE
     SGX_QL_TDX_MODULE_MISMATCH = SGX_QL_MK_ERROR(0x0060),            ///< TDX SEAM module identity is NOT match to Intel signed TDX SEAM module
 
-    SGX_QL_QEIDENTITY_NOT_FOUND = SGX_QL_MK_ERROR(0x0061),            ///< QE identity was not found 
-    SGX_QL_TCBINFO_NOT_FOUND = SGX_QL_MK_ERROR(0x0062),               ///< TCB Info was not found 
+    SGX_QL_QEIDENTITY_NOT_FOUND = SGX_QL_MK_ERROR(0x0061),            ///< QE identity was not found
+    SGX_QL_TCBINFO_NOT_FOUND = SGX_QL_MK_ERROR(0x0062),               ///< TCB Info was not found
     SGX_QL_INTERNAL_SERVER_ERROR = SGX_QL_MK_ERROR(0x0063),           ///< Internal server error
 
     SGX_QL_SUPPLEMENTAL_DATA_VERSION_NOT_SUPPORTED = SGX_QL_MK_ERROR(0x0064),       ///< The supplemental data version is not supported
 
     SGX_QL_ROOT_CA_UNTRUSTED = SGX_QL_MK_ERROR(0x0065),              ///< The certificate used to establish SSL session is untrusted
+
+    SGX_QL_TCB_NOT_SUPPORTED = SGX_QL_MK_ERROR(0x0066),              ///< Current TCB level cannot be found in platform/enclave TCB info
 
     SGX_QL_ERROR_MAX = SGX_QL_MK_ERROR(0x00FF),                      ///< Indicate max error to allow better translation.
 
@@ -236,10 +238,6 @@ typedef enum _sgx_ql_log_level_t
 } sgx_ql_log_level_t;
 
 typedef void (*sgx_ql_logging_callback_t)(sgx_ql_log_level_t level, const char* message);
-
-#ifndef tdx_ql_qve_collateral_t
-typedef sgx_ql_qve_collateral_t tdx_ql_qve_collateral_t;
-#endif
 
 typedef enum _sgx_prod_type_t {
     SGX_PROD_TYPE_SGX = 0,

--- a/3rdparty/sgxsdk/update.make
+++ b/3rdparty/sgxsdk/update.make
@@ -3,8 +3,8 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 
-SDK_VERSION=sgx_2.10_reproducible
-DCAP_VERSION=DCAP_1.15
+SDK_VERSION=sgx_2.10
+DCAP_VERSION=DCAP_1.16
 
 all: update-sgxsdk-headers
 	echo "All done - please review changes"


### PR DESCRIPTION
DCAP new version (1.15 -> 1.16) introduces a new error code:
https://github.com/intel/SGXDataCenterAttestationPrimitives/blame/925499dffaf8fbef52c0bbc57204632d15cc84bf/QuoteGeneration/quote_wrapper/common/inc/sgx_ql_lib_common.h#L142

This PR is similar to #4689 