### PR TITLE
Fix non-prod cert key override

### DIFF
--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -20,15 +20,16 @@
 #define SGX_TCB_STATUS_INVALID "Invalid"
 
 #ifdef OEUTIL_TCB_ALLOW_ANY_ROOT_KEY // allow overrode by oeutil
-const char* _trusted_root_key_pem OE_WEAK = NULL;
-#else  // use hard-coded value
+// Defined by tools/oeutil/host/generate_evidence.cpp
+extern const char* _trusted_root_key_pem;
+#else // use hard-coded value
 // Public key of Intel's root certificate.
 static const char* _trusted_root_key_pem =
     "-----BEGIN PUBLIC KEY-----\n"
     "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEC6nEwMDIYZOj/iPWsCzaEKi71OiO\n"
     "SLRFhWGjbnBVJfVnkY4u3IjkDYYL0MxO4mqsyYjlBalTVYxFP2sJBK5zlA==\n"
     "-----END PUBLIC KEY-----\n";
-#endif // end of OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
+#endif
 
 OE_INLINE uint8_t _is_space(uint8_t c)
 {

--- a/tools/oeutil/host/generate_evidence.cpp
+++ b/tools/oeutil/host/generate_evidence.cpp
@@ -91,8 +91,9 @@ static const oe_uuid_t _sgx_epid_unlinkable_uuid = {
     OE_FORMAT_UUID_SGX_EPID_UNLINKABLE};
 
 #ifdef OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
-// Override weak variable in common/sgx/tcbinfo.c
-const char* _trusted_root_key_pem =
+// Override the root key used in
+// common/sgx/tcbinfo.c:_trusted_root_key_pem
+OE_EXTERNC const char* _trusted_root_key_pem =
     "-----BEGIN PUBLIC KEY-----\n"
     "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEC6nEwMDIYZOj/iPWsCzaEKi71OiO\n"
     "SLRFhWGjbnBVJfVnkY4u3IjkDYYL0MxO4mqsyYjlBalTVYxFP2sJBK5zlA==\n"


### PR DESCRIPTION
Previously it doesn't work on Windows, this PR uses another approach that works on both Win/Linux

Tested on Ubuntu and Windows with following command, all produce expected results.

```
./output/bin/oeutil gen -f SGX_ECDSA -v --rootkey ../good.pub
./output/bin/oeutil gen -f SGX_ECDSA -v --rootkey ../bad.pub
./output/bin/oeutil gen -f SGX_ECDSA -v
```