### PR TITLE
Workaround for Windows agent disconnects

### DIFF
--- a/.jenkins/library/vars/helpers.groovy
+++ b/.jenkins/library/vars/helpers.groovy
@@ -651,3 +651,19 @@ def dockerGetAptPackageVersion(String docker_image, String apt_package) {
     if ( !version ) { version = "N/A" }
     return version
 }
+
+/**
+ * Checks if a retry should be attempted. Returns bool
+ * @param max_try_count  Maximum number of tries
+ * @param try_count      Current try count
+ */
+def check_if_retry(int max_try_count, int try_count) {
+    if (try_count <= max_try_count) {
+        println("Retrying build (Try #${try_count}/3)")
+        return true
+    }
+    else {
+        println("Max retries reached. Aborting build.")
+        return false
+    }
+}

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -3,45 +3,37 @@
 
 library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 GLOBAL_ERROR = globalvars.GLOBAL_ERROR
-globalvars.CTEST_TIMEOUT_SECONDS = 1200
+globalvars.CTEST_TIMEOUT_SECONDS = 1800
 
-try{
-    def testing_stages = [ "Windows 2019 Install Prerequisites Verification" : { tests.windowsPrereqsVerify("acc-win2019-dcap") }]
-    if(FULL_TEST_SUITE == "true") {
-        stage("Full Test Suite") {
-            testing_stages += [
-                "Win2019 Ubuntu2004 clang-11 RelWithDebInfo Linux-Elf-build LVI": { tests.windowsLinuxElfBuild(params.WS2019_DCAP_CFL_LABEL, params.UBUNTU_2004_NONSGX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow') },
-                "Win2019 Ubuntu2004 clang-11 Debug Linux-Elf-build":              { tests.windowsLinuxElfBuild(params.WS2019_DCAP_CFL_LABEL, params.UBUNTU_2004_NONSGX_LABEL, 'clang-11', 'Debug') },
-                "Win2019 Ubuntu1804 clang-11 RelWithDebInfo Linux-Elf-build LVI": { tests.windowsLinuxElfBuild(params.WS2019_DCAP_CFL_LABEL, params.UBUNTU_1804_NONSGX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow') },
-                "Win2019 Sim Debug Cross Compile LVI ":                           { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow', '1') },
-                "Win2019 Sim RelWithDebInfo Cross Compile LVI ":                  { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '1') },
-                "Win2019 Debug Cross Compile DCAP LVI":                           { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow') },
-                "Win2019 RelWithDebInfo Cross Compile DCAP LVI":                  { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow') },
-                "Win2019 clang-10 RelWithDebInfo Cross Compile DCAP LVI":         { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-10', 'RelWithDebInfo', 'ControlFlow') },
-                "Win2019 clang-11 RelWithDebInfo XC DCAP ControlFlow-Clang":      { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang') },
-                "Win2019 ICX RelWithDebInfo Cross Compile DCAP LVI":              { tests.windowsCrossCompile(params.WS2019_DCAP_ICX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow') },
-                "Win2019 Sim Debug Cross Compile LVI snmalloc":                   { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
-                "Win2019 RelWithDebInfo Cross Compile DCAP LVI snmalloc":         { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) },
-                "Win2019 Cross Platform":                                         { tests.windowsCrossPlatform(params.WS2019_DCAP_CFL_LABEL) }
-            ]
-            parallel testing_stages
-        }
-    } else {
-        stage("PR Testing") {
-            testing_stages += [
-                "Win2019 Ubuntu1804 clang-11 RelWithDebInfo Linux-Elf-build LVI":    { tests.windowsLinuxElfBuild(params.WS2019_DCAP_CFL_LABEL, params.UBUNTU_1804_NONSGX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', 'ON') },
-                "Win2019 Sim RelWithDebInfo Cross Compile LVI ":                     { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '1', 'ON') },
-                "Win2019 Debug Cross Compile DCAP LVI":                              { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow', '0', 'ON') },
-                "Win2019 RelWithDebInfo Cross Compile DCAP LVI FULL Tests":          { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow') },
-                "Win2019 RelWithDebInfo Cross Compile DCAP LVI FULL Tests snmalloc": { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) }
-            ]
-            parallel testing_stages
-        }
+def testing_stages = [ "Windows 2019 Install Prerequisites Verification" : { tests.windowsPrereqsVerify("acc-win2019-dcap") }]
+if(FULL_TEST_SUITE == "true") {
+    stage("Full Test Suite") {
+        testing_stages += [
+            "Win2019 Ubuntu2004 clang-11 RelWithDebInfo Linux-Elf-build LVI": { tests.windowsLinuxElfBuild(params.WS2019_DCAP_CFL_LABEL, params.UBUNTU_2004_NONSGX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow') },
+            "Win2019 Ubuntu2004 clang-11 Debug Linux-Elf-build":              { tests.windowsLinuxElfBuild(params.WS2019_DCAP_CFL_LABEL, params.UBUNTU_2004_NONSGX_LABEL, 'clang-11', 'Debug') },
+            "Win2019 Ubuntu1804 clang-11 RelWithDebInfo Linux-Elf-build LVI": { tests.windowsLinuxElfBuild(params.WS2019_DCAP_CFL_LABEL, params.UBUNTU_1804_NONSGX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow') },
+            "Win2019 Sim Debug Cross Compile LVI ":                           { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow', '1') },
+            "Win2019 Sim RelWithDebInfo Cross Compile LVI ":                  { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '1') },
+            "Win2019 Debug Cross Compile DCAP LVI":                           { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow') },
+            "Win2019 RelWithDebInfo Cross Compile DCAP LVI":                  { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow') },
+            "Win2019 clang-10 RelWithDebInfo Cross Compile DCAP LVI":         { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-10', 'RelWithDebInfo', 'ControlFlow') },
+            "Win2019 clang-11 RelWithDebInfo XC DCAP ControlFlow-Clang":      { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang') },
+            "Win2019 ICX RelWithDebInfo Cross Compile DCAP LVI":              { tests.windowsCrossCompile(params.WS2019_DCAP_ICX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow') },
+            "Win2019 Sim Debug Cross Compile LVI snmalloc":                   { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },
+            "Win2019 RelWithDebInfo Cross Compile DCAP LVI snmalloc":         { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) },
+            "Win2019 Cross Platform":                                         { tests.windowsCrossPlatform(params.WS2019_DCAP_CFL_LABEL) }
+        ]
+        parallel testing_stages
     }
-} catch(Exception e) {
-    println "Caught global pipeline exception: " + e
-    GLOBAL_ERROR = e
-    throw e
-} finally {
-    currentBuild.result = (GLOBAL_ERROR != null) ? 'FAILURE' : "SUCCESS"
+} else {
+    stage("PR Testing") {
+        testing_stages += [
+            "Win2019 Ubuntu1804 clang-11 RelWithDebInfo Linux-Elf-build LVI":    { tests.windowsLinuxElfBuild(params.WS2019_DCAP_CFL_LABEL, params.UBUNTU_1804_NONSGX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', 'ON') },
+            "Win2019 Sim RelWithDebInfo Cross Compile LVI ":                     { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '1', 'ON') },
+            "Win2019 Debug Cross Compile DCAP LVI":                              { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow', '0', 'ON') },
+            "Win2019 RelWithDebInfo Cross Compile DCAP LVI FULL Tests":          { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow') },
+            "Win2019 RelWithDebInfo Cross Compile DCAP LVI FULL Tests snmalloc": { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '0', 'OFF', ['-DUSE_SNMALLOC=ON']) }
+        ]
+        parallel testing_stages
+    }
 }


### PR DESCRIPTION
This PR is to work around a known issue with Windows agents disconnecting and not reconnecting, causing entire bors runs to fail. This PR will catch and retry the specific stage again (up to 2 more times).