### PR TITLE
Add oeutil option --bypass-date-check

### DIFF
--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -114,5 +114,6 @@ endmacro ()
 add_library_oeenclave_wrapper(LIB_NAME oeenclave)
 # This lib should only be used to build oeutil
 add_library_oeenclave_wrapper(LIB_NAME oeenclave_prerelease_test SKIP_INSTALL)
-target_compile_definitions(oeenclave_prerelease_test
-                           PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)
+target_compile_definitions(
+  oeenclave_prerelease_test PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
+                                   OEUTIL_QUOTE_BYPASS_DATE_CHECK)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -587,5 +587,6 @@ include(measure/CMakeLists.txt)
 add_library_oehost_wrapper(LIB_NAME oehost)
 # This lib is only used to build oeutil
 add_library_oehost_wrapper(LIB_NAME oehost_prerelease_test SKIP_INSTALL)
-target_compile_definitions(oehost_prerelease_test
-                           PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)
+target_compile_definitions(
+  oehost_prerelease_test PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
+                                OEUTIL_QUOTE_BYPASS_DATE_CHECK)

--- a/tools/oeutil/host/CMakeLists.txt
+++ b/tools/oeutil/host/CMakeLists.txt
@@ -26,7 +26,8 @@ target_include_directories(oeutil PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
 target_link_libraries(oeutil oehost_prerelease_test OpenSSL::SSL)
 
 # To enable oeutil to load any public key
-target_compile_definitions(oeutil PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)
+target_compile_definitions(oeutil PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
+                                         OEUTIL_QUOTE_BYPASS_DATE_CHECK)
 
 if (WIN32)
   # The X509_print_ex_fp function in OpenSSL requires to include applink.c, which

--- a/tools/oeutil/host/generate_evidence.cpp
+++ b/tools/oeutil/host/generate_evidence.cpp
@@ -67,6 +67,9 @@ extern FILE* log_file;
 #ifdef OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
 #define INPUT_PARAM_OPTION_ROOT_PUB_KEY "--rootkey"
 #endif
+#ifdef OEUTIL_QUOTE_BYPASS_DATE_CHECK
+#define INPUT_PARAM_OPTION_BYPASS_DATE "--bypass-date-check"
+#endif
 #define SHORT_INPUT_PARAM_OPTION_FORMAT "-f"
 #define SHORT_INPUT_PARAM_OPTION_ENDORSEMENTS_FILENAME "-e"
 #define SHORT_INPUT_PARAM_OPTION_QUOTE_PROC "-p"
@@ -98,6 +101,11 @@ OE_EXTERNC const char* _trusted_root_key_pem =
     "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEC6nEwMDIYZOj/iPWsCzaEKi71OiO\n"
     "SLRFhWGjbnBVJfVnkY4u3IjkDYYL0MxO4mqsyYjlBalTVYxFP2sJBK5zlA==\n"
     "-----END PUBLIC KEY-----\n";
+#endif
+
+#ifdef OEUTIL_QUOTE_BYPASS_DATE_CHECK
+// common/sgx/quote.c
+OE_EXTERNC bool _should_skip_date_check = false;
 #endif
 
 // Structure to store input parameters
@@ -320,6 +328,11 @@ static void _display_help(const char* command)
         "\t%s <pub key>: replace hard-coded Intel trusted public key with "
         "given one\n",
         INPUT_PARAM_OPTION_ROOT_PUB_KEY);
+#endif
+#ifdef OEUTIL_QUOTE_BYPASS_DATE_CHECK
+    printf(
+        "\t%s: bypass/ignore quote's date validity check\n",
+        INPUT_PARAM_OPTION_BYPASS_DATE);
 #endif
     printf("Examples:\n");
     printf("\t1. Show the verification results of evidence in SGX_ECDSA "
@@ -1586,6 +1599,13 @@ int _parse_args(int argc, const char* argv[])
 
             _parameters.override_pubkey_filename = argv[i + 1];
             i += 2;
+        }
+#endif
+#ifdef OEUTIL_QUOTE_BYPASS_DATE_CHECK
+        else if (strcasecmp(INPUT_PARAM_OPTION_BYPASS_DATE, argv[i]) == 0)
+        {
+            _should_skip_date_check = true;
+            i++;
         }
 #endif
         else if (


### PR DESCRIPTION
Based on @mingweishih 's work to ignore date-related validity check, this feature is intended only for testing purposes.