### PR TITLE
De-duplicate input validation for TDX quote verify

### DIFF
--- a/enclave/sgx/tdx_verifier.c
+++ b/enclave/sgx/tdx_verifier.c
@@ -113,22 +113,14 @@ oe_result_t tdx_verify_quote(
     uint32_t supplemental_data_size,
     uint32_t* p_supplemental_data_size_out)
 {
+    // delegate input validation to host/sgx/sgxquote.c:oe_tdx_verify_quote
+
     oe_result_t result = OE_UNEXPECTED;
     sgx_nonce_t nonce = {0};
     uint16_t qve_isvsvn_threshold = 3;
     oe_result_t retval = OE_UNEXPECTED;
 
     sgx_ql_qe_report_info_t* p_qve_report_info_internal = p_qve_report_info;
-
-    // Add format_id for forward compatibility
-    if (!format_id || !supplemental_data_size ||
-        (!opt_params && opt_params_size > 0))
-        OE_RAISE(OE_INVALID_PARAMETER);
-
-    if ((p_qve_report_info &&
-         (qve_report_info_size != sizeof(sgx_ql_qe_report_info_t))) ||
-        (!p_qve_report_info && qve_report_info_size != 0))
-        OE_RAISE(OE_INVALID_PARAMETER);
 
     if (!p_qve_report_info)
         OE_CHECK(oe_create_qve_report_info(
@@ -137,8 +129,8 @@ oe_result_t tdx_verify_quote(
     OE_CHECK(oe_verify_tdx_quote_ocall(
         &retval,
         format_id,
-        NULL,
-        0,
+        opt_params,
+        opt_params_size,
         p_quote,
         quote_size,
         p_endorsements,

--- a/host/sgx/quote.c
+++ b/host/sgx/quote.c
@@ -183,6 +183,9 @@ oe_result_t sgx_verify_quote(
     // delegate input validation to host/sgx/sgxquote.c:oe_sgx_verify_quote
     oe_result_t result = OE_UNEXPECTED;
 
+    if (p_supplemental_data && !p_supplemental_data_size_out)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
     /* Try to get supplemental data size if needed */
     if (p_supplemental_data)
     {

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -1453,26 +1453,25 @@ oe_result_t oe_tdx_verify_quote(
     uint8_t* endorsements_unserialized = NULL;
     oe_result_t result = OE_UNEXPECTED;
 
+    // Input validation
     // Only support ECDSA-p256 now
     if (memcmp(
             format_id, &_tdx_ecdsa_p256_uuid, sizeof(_tdx_ecdsa_p256_uuid)) !=
         0)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    if (!p_quote || quote_size > OE_MAX_UINT32 ||
+    if (!p_collateral_expiration_status || !p_quote_verification_result ||
+        !p_quote || quote_size > OE_MAX_UINT32 ||
+        (!opt_params && opt_params_size > 0) ||
         (!p_endorsements && endorsements_size > 0) ||
-        !p_collateral_expiration_status || !p_quote_verification_result ||
-        (!p_supplemental_data && supplemental_data_size > 0) ||
-        (!opt_params && opt_params_size > 0))
+        (!p_qve_report_info && qve_report_info_size > 0) ||
+        (!p_supplemental_data && supplemental_data_size > 0))
         OE_RAISE(OE_INVALID_PARAMETER);
 
     if ((p_qve_report_info &&
-         qve_report_info_size != sizeof(sgx_ql_qe_report_info_t)) ||
-        (!p_qve_report_info && qve_report_info_size > 0))
+         qve_report_info_size != sizeof(sgx_ql_qe_report_info_t)))
         OE_RAISE(OE_INVALID_PARAMETER);
-
-    if (quote_size > OE_MAX_UINT32)
-        OE_RAISE(OE_INVALID_PARAMETER);
+    // End of input validation
 
     // Always use QvE/QVL for TDX verification
     if (!_load_tdx_dcap_qvl())

--- a/host/tdx/quote.c
+++ b/host/tdx/quote.c
@@ -22,13 +22,10 @@ oe_result_t tdx_verify_quote(
     uint32_t supplemental_data_size,
     uint32_t* p_supplemental_data_size_out)
 {
+    // delegate input validation to host/sgx/sgxquote.c:oe_tdx_verify_quote
     oe_result_t result = OE_UNEXPECTED;
 
-    /* Reject null parameters */
-    if (!p_quote || !p_collateral_expiration_status ||
-        !p_quote_verification_result ||
-        (!p_endorsements && endorsements_size > 0) ||
-        (!p_supplemental_data && supplemental_data_size > 0))
+    if (p_supplemental_data && !p_supplemental_data_size_out)
         OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Try to get supplemental data size if needed */


### PR DESCRIPTION
Also, is there a reason to not pass `opt_params` when calling quote verify inside the enclave? Like this:
https://github.com/openenclave/openenclave/commit/a0effaeff190403a39d2d7394762388145b576eb#diff-ecdcce87ae0a03957ad675de436ae71b2b80876fed167f31dbf09f423657da2fL473