### PR TITLE
Added oe_generate_attestation_certificate_v2

### DIFF
--- a/enclave/tls_cert.c
+++ b/enclave/tls_cert.c
@@ -29,48 +29,24 @@ static const unsigned char oid_oe_evidence[] = X509_OID_FOR_NEW_OE_EVIDENCE_EXT;
 // Output: a self-signed certificate embedded critical extension with quote
 // information as its content
 static oe_result_t generate_x509_self_signed_certificate(
-    const unsigned char* oid,
-    size_t oid_size,
-    const unsigned char* subject_name,
-    uint8_t* private_key_buf,
-    size_t private_key_buf_size,
-    uint8_t* public_key_buf,
-    size_t public_key_buf_size,
-    uint8_t* remote_report_buf,
-    size_t remote_report_buf_size,
+    oe_cert_config_t* config,
     uint8_t** output_cert,
     size_t* output_cert_size)
 {
     oe_result_t result = OE_FAILURE;
     size_t bytes_written = 0;
     uint8_t* cert_buf = NULL;
-    oe_cert_config_t config = {0};
     size_t oe_cert_size = 0;
 
-    config.private_key_buf = private_key_buf;
-    config.private_key_buf_size = private_key_buf_size;
-    config.public_key_buf = public_key_buf;
-    config.public_key_buf_size = public_key_buf_size;
-    config.subject_name = (subject_name != NULL)
-                              ? subject_name
-                              : (const unsigned char*)SUBJECT_NAME;
-    config.issuer_name = config.subject_name;
-    config.date_not_valid_before = (unsigned char*)DATE_NOT_VALID_BEFORE;
-    config.date_not_valid_after = (unsigned char*)DATE_NOT_VALID_AFTER;
-    config.ext_data_buf = remote_report_buf;
-    config.ext_data_buf_size = remote_report_buf_size;
-    config.ext_oid = (char*)oid;
-    config.ext_oid_size = oid_size;
-
     // allocate memory for cert output buffer and leave room for paddings
-    oe_cert_size =
-        remote_report_buf_size + public_key_buf_size + OE_MIN_CERT_SIZE;
+    oe_cert_size = config->ext_data_buf_size + config->public_key_buf_size +
+                   OE_MIN_CERT_SIZE;
     cert_buf = (uint8_t*)oe_malloc(oe_cert_size);
     if (cert_buf == NULL)
         goto done;
 
-    result = oe_gen_custom_x509_cert(
-        &config, cert_buf, oe_cert_size, &bytes_written);
+    result =
+        oe_gen_custom_x509_cert(config, cert_buf, oe_cert_size, &bytes_written);
 
     OE_CHECK_MSG(
         result,
@@ -88,7 +64,7 @@ done:
 }
 
 /**
- * oe_generate_attestation_certificate.
+ * oe_generate_attestation_certificate_internal
  *
  * This function generates a self-signed X.509 certificate with an embedded
  * quote from the underlying enclave.
@@ -99,32 +75,39 @@ done:
  * See RFC5280 (https://tools.ietf.org/html/rfc5280) specification for details
  * Example value "CN=Open Enclave SDK,O=OESDK TLS,C=US"
  *
- * @param[in] private_key a private key used to sign this certificate
+ * @param[in] private_key A private key used to sign this certificate
  * @param[in] private_key_size The size of the private_key buffer
- * @param[in] public_key a public key used as the certificate's subject key
+ * @param[in] public_key A public key used as the certificate's subject key
  * @param[in] public_key_size The size of the public_key buffer.
+ * @param[in] date_not_valid_before Cert is not valid before this date, format:
+ * YYYYMMDDHHMMSS
+ * @param[in] date_not_valid_after Cert is not valid after this date, format:
+ * YYYYMMDDHHMMSS
  *
- * @param[out] output_cert a pointer to buffer pointer
- * @param[out] output_cert_size size of the buffer above
+ * @param[out] output_certificate A pointer to buffer pointer
+ * @param[out] output_certificate_size Size of the buffer above
  *
  * @return OE_OK on success
  */
-oe_result_t oe_generate_attestation_certificate(
+static oe_result_t oe_generate_attestation_certificate_internal(
     const unsigned char* subject_name,
     uint8_t* private_key,
     size_t private_key_size,
     uint8_t* public_key,
     size_t public_key_size,
-    uint8_t** output_cert,
-    size_t* output_cert_size)
+    const char* date_not_valid_before,
+    const char* date_not_valid_after,
+    uint8_t** output_certificate,
+    size_t* output_certificate_size)
 {
     oe_result_t result = OE_FAILURE;
     oe_sha256_context_t sha256_ctx = {0};
     OE_SHA256 sha256 = {0};
     uint8_t* remote_report_buf = NULL;
     size_t remote_report_buf_size = OE_MAX_REPORT_SIZE;
+    oe_cert_config_t config = {0};
 
-    OE_TRACE_VERBOSE("Calling oe_generate_attestation_certificate");
+    OE_TRACE_VERBOSE("Calling oe_generate_attestation_certificate_internal");
 
     // generate quote with hash(cert's subject key) and set it as report data
     OE_TRACE_VERBOSE(
@@ -153,58 +136,37 @@ oe_result_t oe_generate_attestation_certificate(
     OE_CHECK_MSG(
         result, "oe_get_report failed with %s\n", oe_result_str(result));
 
+    config.private_key_buf = private_key;
+    config.private_key_buf_size = private_key_size;
+    config.public_key_buf = public_key;
+    config.public_key_buf_size = public_key_size;
+    config.subject_name = (subject_name != NULL)
+                              ? subject_name
+                              : (const unsigned char*)SUBJECT_NAME;
+    config.issuer_name = config.subject_name;
+    config.date_not_valid_before = date_not_valid_before;
+    config.date_not_valid_after = date_not_valid_after;
+    config.ext_data_buf = remote_report_buf;
+    config.ext_data_buf_size = remote_report_buf_size;
+    config.ext_oid = (char*)oid_oe_report;
+    config.ext_oid_size = sizeof(oid_oe_report);
+
     result = generate_x509_self_signed_certificate(
-        oid_oe_report,
-        sizeof(oid_oe_report),
-        subject_name,
-        private_key,
-        private_key_size,
-        public_key,
-        public_key_size,
-        remote_report_buf,
-        remote_report_buf_size,
-        output_cert,
-        output_cert_size);
+        &config, output_certificate, output_certificate_size);
     OE_CHECK_MSG(
         result,
         "generate_x509_self_signed_certificate failed : %s",
         oe_result_str(result));
 
-    OE_TRACE_VERBOSE("self-signed certificate size = %d", *output_cert_size);
+    OE_TRACE_VERBOSE(
+        "self-signed certificate size = %d", *output_certificate_size);
     result = OE_OK;
 done:
     oe_free_report(remote_report_buf);
     return result;
 }
 
-/**
- * oe_get_attestation_certificate_with_evidence.
- *
- * This function generates a self-signed X.509 certificate with embedded
- * evidence generated by an attester plugin for the enclave.
- *
- * @deprecated
- *
- * @param[in] format_id The format ID of the evidence to be generated.
- *
- * @param[in] subject_name A string containing an X.509 distinguished
- * name (DN) for customizing the generated certificate. This name is also used
- * as the issuer name because this is a self-signed certificate.
- * See RFC5280 (https://tools.ietf.org/html/rfc5280) for details.
- * Example value: "CN=Open Enclave SDK,O=OESDK TLS,C=US".
- *
- * @param[in] private_key A private key used to sign this certificate.
- * @param[in] private_key_size The size of the private_key buffer.
- * @param[in] public_key A public key used as the certificate's subject key.
- * @param[in] public_key_size The size of the public_key buffer.
- *
- * @param[out] output_cert A pointer to buffer pointer.
- * @param[out] output_cert_size Size of the buffer above.
- *
- * @return OE_OK on success.
- */
-oe_result_t oe_get_attestation_certificate_with_evidence(
-    const oe_uuid_t* format_id,
+oe_result_t oe_generate_attestation_certificate(
     const unsigned char* subject_name,
     uint8_t* private_key,
     size_t private_key_size,
@@ -213,28 +175,49 @@ oe_result_t oe_get_attestation_certificate_with_evidence(
     uint8_t** output_certificate,
     size_t* output_certificate_size)
 {
-    return oe_get_attestation_certificate_with_evidence_v2(
-        format_id,
+    OE_TRACE_VERBOSE("Calling oe_generate_attestation_certificate");
+    return oe_generate_attestation_certificate_internal(
         subject_name,
         private_key,
         private_key_size,
         public_key,
         public_key_size,
-        NULL,
-        0,
+        DATE_NOT_VALID_BEFORE,
+        DATE_NOT_VALID_AFTER,
+        output_certificate,
+        output_certificate_size);
+}
+
+oe_result_t oe_generate_attestation_certificate_v2(
+    const unsigned char* subject_name,
+    uint8_t* private_key,
+    size_t private_key_size,
+    uint8_t* public_key,
+    size_t public_key_size,
+    const char* date_not_valid_before,
+    const char* date_not_valid_after,
+    uint8_t** output_certificate,
+    size_t* output_certificate_size)
+{
+    OE_TRACE_VERBOSE("Calling oe_generate_attestation_certificate_v2");
+    return oe_generate_attestation_certificate_internal(
+        subject_name,
+        private_key,
+        private_key_size,
+        public_key,
+        public_key_size,
+        date_not_valid_before,
+        date_not_valid_after,
         output_certificate,
         output_certificate_size);
 }
 
 /**
- * oe_get_attestation_certificate_with_evidence_v2
+ * oe_get_attestation_certificate_with_evidence_internal
  *
- * Similar to oe_get_attestation_certificate_with_evidence, this function
- * generates a self-signed X.509 certificate with embedded evidence generated by
- * an attester plugin for the enclave, but it also allows a user to pass in
- * optional parameters.
- *
- * @experimental
+ * This function generates a self-signed X.509 certificate with embedded
+ * evidence generated by an attester plugin for the enclave, it also allows a
+ * user to pass in optional parameters.
  *
  * @param[in] format_id The format id of the evidence to be generated.
  *
@@ -256,7 +239,7 @@ oe_result_t oe_get_attestation_certificate_with_evidence(
  *
  * @return OE_OK on success.
  */
-oe_result_t oe_get_attestation_certificate_with_evidence_v2(
+static oe_result_t oe_get_attestation_certificate_with_evidence_internal(
     const oe_uuid_t* format_id,
     const unsigned char* subject_name,
     uint8_t* private_key,
@@ -271,8 +254,10 @@ oe_result_t oe_get_attestation_certificate_with_evidence_v2(
     oe_result_t result = OE_FAILURE;
     uint8_t* evidence_buffer = NULL;
     size_t evidence_buffer_size = 0;
+    oe_cert_config_t config = {0};
 
-    OE_TRACE_VERBOSE("Calling oe_get_attestation_certificate_with_evidence_v2");
+    OE_TRACE_VERBOSE(
+        "Calling oe_get_attestation_certificate_with_evidence_internal");
     OE_TRACE_VERBOSE(
         "generate evidence with hash from public_key_size=%d public_key key "
         "=\n[%s]\n",
@@ -293,18 +278,23 @@ oe_result_t oe_get_attestation_certificate_with_evidence_v2(
     OE_CHECK_MSG(
         result, "oe_get_evidence failed with %s\n", oe_result_str(result));
 
+    config.private_key_buf = private_key;
+    config.private_key_buf_size = private_key_size;
+    config.public_key_buf = public_key;
+    config.public_key_buf_size = public_key_size;
+    config.subject_name = (subject_name != NULL)
+                              ? subject_name
+                              : (const unsigned char*)SUBJECT_NAME;
+    config.issuer_name = config.subject_name;
+    config.date_not_valid_before = DATE_NOT_VALID_BEFORE;
+    config.date_not_valid_after = DATE_NOT_VALID_AFTER;
+    config.ext_data_buf = evidence_buffer;
+    config.ext_data_buf_size = evidence_buffer_size;
+    config.ext_oid = (char*)oid_oe_evidence;
+    config.ext_oid_size = sizeof(oid_oe_evidence);
+
     result = generate_x509_self_signed_certificate(
-        oid_oe_evidence,
-        sizeof(oid_oe_evidence),
-        subject_name,
-        private_key,
-        private_key_size,
-        public_key,
-        public_key_size,
-        evidence_buffer,
-        evidence_buffer_size,
-        output_certificate,
-        output_certificate_size);
+        &config, output_certificate, output_certificate_size);
     OE_CHECK_MSG(
         result,
         "generate_x509_self_signed_certificate failed : %s",
@@ -316,6 +306,56 @@ oe_result_t oe_get_attestation_certificate_with_evidence_v2(
 done:
     oe_free_evidence(evidence_buffer);
     return result;
+}
+
+oe_result_t oe_get_attestation_certificate_with_evidence(
+    const oe_uuid_t* format_id,
+    const unsigned char* subject_name,
+    uint8_t* private_key,
+    size_t private_key_size,
+    uint8_t* public_key,
+    size_t public_key_size,
+    uint8_t** output_certificate,
+    size_t* output_certificate_size)
+{
+    OE_TRACE_VERBOSE("Calling oe_get_attestation_certificate_with_evidence");
+    return oe_get_attestation_certificate_with_evidence_internal(
+        format_id,
+        subject_name,
+        private_key,
+        private_key_size,
+        public_key,
+        public_key_size,
+        NULL,
+        0,
+        output_certificate,
+        output_certificate_size);
+}
+
+oe_result_t oe_get_attestation_certificate_with_evidence_v2(
+    const oe_uuid_t* format_id,
+    const unsigned char* subject_name,
+    uint8_t* private_key,
+    size_t private_key_size,
+    uint8_t* public_key,
+    size_t public_key_size,
+    const void* optional_parameters,
+    size_t optional_parameters_size,
+    uint8_t** output_certificate,
+    size_t* output_certificate_size)
+{
+    OE_TRACE_VERBOSE("Calling oe_get_attestation_certificate_with_evidence_v2");
+    return oe_get_attestation_certificate_with_evidence_internal(
+        format_id,
+        subject_name,
+        private_key,
+        private_key_size,
+        public_key,
+        public_key_size,
+        optional_parameters,
+        optional_parameters_size,
+        output_certificate,
+        output_certificate_size);
 }
 
 void oe_free_attestation_certificate(uint8_t* cert)

--- a/include/openenclave/enclave.h
+++ b/include/openenclave/enclave.h
@@ -95,7 +95,7 @@ oe_result_t oe_remove_vectored_exception_handler(
  * portion of the buffer lies outside the enclave's memory, return false.
  *
  * @param[in] ptr The pointer pointer to buffer.
- * @param[in] size The size of buffer
+ * @param[in] size The size of buffer.
  *
  * @retval true The buffer is strictly within the enclave.
  * @retval false At least some part of the buffer is outside the enclave, or
@@ -603,15 +603,15 @@ oe_enclave_t* oe_get_enclave(void);
  *
  * This function generates a sequence of random bytes.
  *
- * @param[out] data the buffer that will be filled with random bytes
- * @param[in] size the size of the buffer
+ * @param[out] data The buffer that will be filled with random bytes
+ * @param[in] size Size of the buffer
  *
  * @return OE_OK on success
  */
 oe_result_t oe_random(void* data, size_t size);
 
 /**
- * oe_generate_attestation_certificate.
+ * oe_generate_attestation_certificate
  *
  * This function generates a self-signed x.509 certificate with an embedded
  * quote from the underlying enclave.
@@ -622,13 +622,13 @@ oe_result_t oe_random(void* data, size_t size);
  * See RFC5280 (https://tools.ietf.org/html/rfc5280) specification for details
  * Example value "CN=Open Enclave SDK,O=OESDK TLS,C=US"
  *
- * @param[in] private_key a private key used to sign this certificate
+ * @param[in] private_key The private key used to sign this certificate
  * @param[in] private_key_size The size of the private_key buffer
- * @param[in] public_key a public key used as the certificate's subject key
+ * @param[in] public_key The public key used as the certificate's subject key
  * @param[in] public_key_size The size of the public_key buffer.
  *
- * @param[out] output_cert a pointer to buffer pointer
- * @param[out] output_cert_size size of the buffer above
+ * @param[out] output_certificate A pointer to buffer pointer
+ * @param[out] output_certificate_size Size of the buffer above
  *
  * @return OE_OK on success
  */
@@ -638,8 +638,47 @@ oe_result_t oe_generate_attestation_certificate(
     size_t private_key_size,
     uint8_t* public_key,
     size_t public_key_size,
-    uint8_t** output_cert,
-    size_t* output_cert_size);
+    uint8_t** output_certificate,
+    size_t* output_certificate_size);
+
+/**
+ * oe_generate_attestation_certificate_v2
+ *
+ * Similar to oe_generate_attestation_certificate
+ * this function generates a self-signed x.509 certificate with embedded
+ * quote from the underlying enclave. It also allows the caller to pass in
+ * an expiration date for the certificate.
+ *
+ * @param[in] subject_name a string contains an X.509 distinguished
+ * name (DN) for customizing the generated certificate. This name is also used
+ * as the issuer name because this is a self-signed certificate.
+ * See RFC5280 (https://tools.ietf.org/html/rfc5280) for details.
+ * Example value: "CN=Open Enclave SDK,O=OESDK TLS,C=US"
+ *
+ * @param[in] private_key The private key used to sign this certificate
+ * @param[in] private_key_size The size of the private_key buffer
+ * @param[in] public_key The public key used as the certificate's subject key
+ * @param[in] public_key_size The size of the public_key buffer.
+ * @param[in] date_not_valid_before Cert is not valid before this date, format:
+ * YYYYMMDDHHMMSS
+ * @param[in] date_not_valid_after Cert is not valid after this date, format:
+ * YYYYMMDDHHMMSS
+ *
+ * @param[out] output_certificate A pointer to buffer pointer
+ * @param[out] output_certificate_size Size of the buffer above
+ *
+ * @return OE_OK on success
+ */
+oe_result_t oe_generate_attestation_certificate_v2(
+    const unsigned char* subject_name,
+    uint8_t* private_key,
+    size_t private_key_size,
+    uint8_t* public_key,
+    size_t public_key_size,
+    const char* date_not_valid_before,
+    const char* date_not_valid_after,
+    uint8_t** output_certificate,
+    size_t* output_certificate_size);
 
 /**
  * Free the given cert
@@ -649,8 +688,8 @@ void oe_free_attestation_certificate(uint8_t* cert);
 
 /**
  * identity validation callback type
- * @param[in] identity a pointer to an enclave's identity information
- * @param[in] arg caller defined context
+ * @param[in] identity A pointer to an enclave's identity information
+ * @param[in] arg Caller defined context
  */
 typedef oe_result_t (
     *oe_identity_verify_callback_t)(oe_identity_t* identity, void* arg);
@@ -665,12 +704,12 @@ typedef oe_result_t (
  * validate the identity of the enclave creating the quote.
  * OE_FAILURE is returned if the expected certificate extension OID is not
  * found.
- * @param[in] cert_in_der a pointer to buffer holding certificate contents
+ * @param[in] cert_in_der A pointer to buffer holding certificate contents
  *  in DER format
- * @param[in] cert_in_der_len size of certificate buffer above
- * @param[in] enclave_identity_callback callback routine for custom identity
+ * @param[in] cert_in_der_len Size of certificate buffer above
+ * @param[in] enclave_identity_callback Callback routine for custom identity
  * checking
- * @param[in] arg an optional context pointer argument specified by the caller
+ * @param[in] arg An optional context pointer argument specified by the caller
  * when setting callback
  * @retval OE_OK on a successful validation
  * @retval OE_VERIFY_FAILED on quote failure

--- a/include/openenclave/internal/crypto/cert.h
+++ b/include/openenclave/internal/crypto/cert.h
@@ -367,8 +367,8 @@ typedef struct _oe_cert_config
     size_t public_key_buf_size;
     const unsigned char* subject_name;
     const unsigned char* issuer_name;
-    unsigned char* date_not_valid_before;
-    unsigned char* date_not_valid_after;
+    const char* date_not_valid_before;
+    const char* date_not_valid_after;
     uint8_t* ext_data_buf;
     size_t ext_data_buf_size;
     char* ext_oid;

--- a/tests/attestation_cert_apis/README.md
+++ b/tests/attestation_cert_apis/README.md
@@ -1,4 +1,4 @@
-oe_generate_attestation_cert, oe_free_attestation_cert, and oe_verify_attestation_cert API tests
+oe_generate_attestation_certificate_v2, oe_free_attestation_cert, and oe_verify_attestation_cert API tests
 =====================
 
 Test scenario:

--- a/tests/attestation_cert_apis/enc/enc.cpp
+++ b/tests/attestation_cert_apis/enc/enc.cpp
@@ -211,12 +211,14 @@ oe_result_t get_tls_cert_signed_with_key(
     OE_TRACE_INFO("private key:[%s]\n", private_key);
     OE_TRACE_INFO("public key:[%s]\n", public_key);
 
-    result = oe_generate_attestation_certificate(
+    result = oe_generate_attestation_certificate_v2(
         (const unsigned char*)"CN=Open Enclave SDK,O=OESDK TLS,C=US",
         private_key,
         private_key_size,
         public_key,
         public_key_size,
+        "20190501000000",
+        "20501231235959",
         &output_certificate,
         &output_certificate_size);
     if (result != OE_OK)

--- a/tests/attestation_cert_apis/host/host.cpp
+++ b/tests/attestation_cert_apis/host/host.cpp
@@ -64,6 +64,9 @@ done:
     return result;
 }
 
+// test_type can be one of the following:
+//  TEST_EC_KEY: test with EC key
+//  TEST_RSA_KEY: test with RSA key
 void run_test(oe_enclave_t* enclave, int test_type)
 {
     oe_result_t result = OE_FAILURE;


### PR DESCRIPTION
Created a new API inside enclave `oe_generate_attestation_certificate_v2 `

It's similar to `oe_generate_attestation_certificate`, but it takes two additional datetime arguments that determine the cert's valid date.