### PR TITLE
Change lib search path for windows

### DIFF
--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -127,10 +127,9 @@ typedef struct _supp_ver_t
 #define SGX_DCAP_QL_NAME "sgx_dcap_ql.dll"
 #define SGX_DCAP_QVL_NAME "sgx_dcap_quoteverify.dll"
 
-// Use LOAD_LIBRARY_SEARCH_SYSTEM32 flag since sgx_enclave_common.dll is part of
-// the Intel driver components and should only be loaded from there.
 #define LOAD_SGX_DCAP_LIB(libname) \
-    (void*)LoadLibraryEx((LPCSTR)libname, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    (void*)LoadLibraryEx(          \
+        (LPCSTR)libname, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
 #define LOOKUP_FUNCTION(module, fcn) (void*)GetProcAddress((HANDLE)module, fcn)
 

--- a/host/sgx/windows/sgxquoteproviderloader.c
+++ b/host/sgx/windows/sgxquoteproviderloader.c
@@ -25,7 +25,8 @@ void oe_load_quote_provider()
     if (provider.handle == 0)
     {
         OE_TRACE_INFO("oe_load_quote_provider dcap_quoteprov.dll\n");
-        HMODULE _handle = LoadLibraryEx("dcap_quoteprov.dll", NULL, 0);
+        HMODULE _handle = LoadLibraryEx(
+            "dcap_quoteprov.dll", NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
         if (_handle != 0)
         {
             provider.handle = _handle;


### PR DESCRIPTION
Now on Windows, the following libs can be placed in the same directory as the binary, no need to place under System32.
1. libsgx_dcap_ql
2. libsgx_dcap_quoteverify.dll
3. dcap_quoteprov.dll