### PR TITLE
Install Intel components from local source only

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -5,7 +5,7 @@
 GLOBAL_BRANCH_NAME = env.BRANCH_NAME ?: params.BRANCH
 
 // Regex that includes directory you want to ignore for CI builds.
-String IGNORED_DIRS = "^(docs|\\.jenkins/infrastructure)|\\.md\$"
+String IGNORED_DIRS = "^docs|^\\.jenkins/infrastructure|\\.md\$|^VERSION\$|^OWNERS\$"
 
 // Load OpenEnclaveJenkinsLibrary version to use in this priority:
 //     1. If this is a bors run, use the bors branch

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -531,12 +531,12 @@ function Install-DCAP-Dependencies {
     }
     if (($LaunchConfiguration -eq "SGX1FLC") -or ($DCAPClientType -eq "Azure"))
     {
-        & nuget.exe install 'DCAP_Components' -Source "$TEMP_NUGET_DIR;nuget.org" -OutputDirectory "$OE_NUGET_DIR" -ExcludeVersion
+        & nuget.exe install 'DCAP_Components' -Source "$TEMP_NUGET_DIR" -OutputDirectory "$OE_NUGET_DIR" -ExcludeVersion
         if($LASTEXITCODE -ne 0) {
             Throw "Failed to install nuget DCAP_Components"
         }
     }
-    & nuget.exe install 'EnclaveCommonAPI' -Source "$TEMP_NUGET_DIR;nuget.org" -OutputDirectory "$OE_NUGET_DIR" -ExcludeVersion
+    & nuget.exe install 'EnclaveCommonAPI' -Source "$TEMP_NUGET_DIR" -OutputDirectory "$OE_NUGET_DIR" -ExcludeVersion
     if($LASTEXITCODE -ne 0) {
         Throw "Failed to install nuget EnclaveCommonAPI"
     }


### PR DESCRIPTION
The Intel zip file has these nuget packages locally, and should only be installed from there anyways rather than from nuget.org

Also add files to ignore files that don't need to be tested in CI: https://github.com/openenclave/openenclave/pull/4739