### PR TITLE
Updating Symcrypt version to v103.1.0

### DIFF
--- a/3rdparty/symcrypt_engine/CMakeLists.txt
+++ b/3rdparty/symcrypt_engine/CMakeLists.txt
@@ -9,13 +9,13 @@ set(SYMCRYPT_ENGINE_DIR
 
 # Use CACHE so that the variables can be globally accessible
 set(SYMCRYPT_VERSION_MAJOR
-    "101"
+    "103"
     CACHE INTERNAL "")
 set(SYMCRYPT_VERSION_MINOR
-    "3"
+    "0"
     CACHE INTERNAL "")
 set(SYMCRYPT_VERSION_PATCH
-    "0"
+    "1"
     CACHE INTERNAL "")
 set(SYMCRYPT_VERSION
     "${SYMCRYPT_VERSION_MAJOR}.${SYMCRYPT_VERSION_MINOR}.${SYMCRYPT_VERSION_PATCH}"
@@ -33,10 +33,11 @@ set(SYMCRYPT_LINK_NAME
 include(FetchContent)
 FetchContent_Declare(
   symcrypt_package
-  SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/SymCrypt
-  URL https://github.com/microsoft/SymCrypt/releases/download/v101.3.0/symcrypt_AMD64_oe_full_v101.3.0-31e06ae.tgz
+  SOURCE_DIR
+  ${CMAKE_CURRENT_BINARY_DIR}/SymCrypt
+  URL https://github.com/microsoft/SymCrypt/releases/download/v103.0.1/symcrypt-linux-oe_full-AMD64-103.0.1-69dbff3.tar.gz
   URL_HASH
-    SHA256=53fcbdbae3925b82e880c102969dc4c646b36dffbca602d2f85f967d54e958e7)
+    SHA256=27C8C1C309B217E74D6055734D305AA86D8CE9E05D6D75AFD12C885F13CEA710)
 
 # Make the downloaded package globally available
 FetchContent_GetProperties(symcrypt_package)
@@ -55,6 +56,7 @@ add_enclave_library(
   ${SYMCRYPT_ENGINE_DIR}/src/scossl_ecc.c
   ${SYMCRYPT_ENGINE_DIR}/src/scossl_helpers.c
   ${SYMCRYPT_ENGINE_DIR}/src/scossl_hkdf.c
+  ${SYMCRYPT_ENGINE_DIR}/src/scossl_hmac.c
   ${SYMCRYPT_ENGINE_DIR}/src/scossl_pkey_meths.c
   ${SYMCRYPT_ENGINE_DIR}/src/scossl_rand.c
   ${SYMCRYPT_ENGINE_DIR}/src/scossl_rsa.c
@@ -89,12 +91,10 @@ elseif (WIN32)
   find_program(
     CLANG_COMPILER clang
     PATHS "C:/Program Files/LLVM/bin"
-    NO_DEFAULT_PATH
-    REQUIRED)
+    NO_DEFAULT_PATH REQUIRED)
   get_filename_component(CLANG_COMPILER_ROOT_DIR ${CLANG_COMPILER} DIRECTORY)
-  file(GLOB 
-    CLANG_INTRINSIC_HEADERS_SEARCH_PATH
-    "${CLANG_COMPILER_ROOT_DIR}/../lib/clang/*/include")
+  file(GLOB CLANG_INTRINSIC_HEADERS_SEARCH_PATH
+       "${CLANG_COMPILER_ROOT_DIR}/../lib/clang/*/include")
 endif ()
 
 # Clang major version should match LLVM version

--- a/samples/attested_tls/CMakeLists.txt
+++ b/samples/attested_tls/CMakeLists.txt
@@ -30,22 +30,21 @@ if (OE_CRYPTO_LIB STREQUAL "openssl_symcrypt_fips")
   # Download the SymCrypt release package at config-time
   include(FetchContent)
   FetchContent_Declare(
-    symcrypt_package
-    SOURCE_DIR
-    ${CMAKE_BINARY_DIR}/SymCrypt
-    URL https://github.com/microsoft/SymCrypt/releases/download/v101.3.0/symcrypt_AMD64_oe_full_v101.3.0-31e06ae.tgz
+    symcrypt_pkg
+    SOURCE_DIR ${CMAKE_BINARY_DIR}/SymCrypt
+    URL https://github.com/microsoft/SymCrypt/releases/download/v103.0.1/symcrypt-linux-oe_full-AMD64-103.0.1-69dbff3.tar.gz
     URL_HASH
-      SHA256=53fcbdbae3925b82e880c102969dc4c646b36dffbca602d2f85f967d54e958e7)
+      SHA256=27C8C1C309B217E74D6055734D305AA86D8CE9E05D6D75AFD12C885F13CEA710)
 
   # Make the downloaded package globally available
-  FetchContent_GetProperties(symcrypt_package)
-  if (NOT symcrypt_package_POPULATED)
-    FetchContent_Populate(symcrypt_package)
+  FetchContent_GetProperties(symcrypt_pkg)
+  if (NOT symcrypt_pkg_POPULATED)
+    FetchContent_Populate(symcrypt_pkg)
   endif ()
 
   # The linker can only resolve up to single number after .so
-  file(COPY_FILE ${CMAKE_BINARY_DIR}/SymCrypt/lib/libsymcrypt.so.101.3.0
-       ${CMAKE_BINARY_DIR}/libsymcrypt.so.101)
+  configure_file(${CMAKE_BINARY_DIR}/SymCrypt/lib/libsymcrypt.so.103.0.1
+                 ${CMAKE_BINARY_DIR}/libsymcrypt.so.103 COPYONLY)
 
   # Option passed in oeedger8r to include entropy.edl (required by
   # SymCrypt FIPS module)

--- a/samples/attested_tls/Makefile
+++ b/samples/attested_tls/Makefile
@@ -10,13 +10,13 @@ export OE_CRYPTO_LIB
 
 TARGETS =
 
-SYMCRYPT_TAR = symcrypt_AMD64_oe_full_v101.3.0-31e06ae.tgz
-SYMCRYPT_URL = https://github.com/microsoft/SymCrypt/releases/download/v101.3.0/${SYMCRYPT_TAR}
-SYMCRYPT_SHA256 = 53fcbdbae3925b82e880c102969dc4c646b36dffbca602d2f85f967d54e958e7
+SYMCRYPT_TAR = symcrypt-linux-oe_full-AMD64-103.0.1-69dbff3.tar.gz
+SYMCRYPT_URL = https://github.com/microsoft/SymCrypt/releases/download/v103.0.1/${SYMCRYPT_TAR}
+SYMCRYPT_SHA256 = 27C8C1C309B217E74D6055734D305AA86D8CE9E05D6D75AFD12C885F13CEA710
 SYMCRYPT_DIR = SymCrypt
-SYMCRYPT_SO = libsymcrypt.so.101.3.0
+SYMCRYPT_SO = libsymcrypt.so.103.0.1
 # The linker can only resolve up to single number after .so
-SYMCRYPT_LINK_SO = libsymcrypt.so.101
+SYMCRYPT_LINK_SO = libsymcrypt.so.103
 
 ifeq (${OE_CRYPTO_LIB}, openssl_symcrypt_fips)
 	TARGETS += symcrypt
@@ -36,6 +36,7 @@ symcrypt:
 	cp ${SYMCRYPT_DIR}/lib/${SYMCRYPT_SO} client/enc/${SYMCRYPT_LINK_SO}
 
 build:
+	make symcrypt
 	echo ${OE_CRYPTO_LIB}
 	$(MAKE) -C server
 	$(MAKE) -C client

--- a/samples/attested_tls/client/enc/CMakeLists.txt
+++ b/samples/attested_tls/client/enc/CMakeLists.txt
@@ -19,8 +19,8 @@ add_custom_command(
     ${CMAKE_SOURCE_DIR}/client/enc/enc.conf -k
     ${CMAKE_SOURCE_DIR}/client/enc/private.pem)
 
-# Cover both openssl and openssl_symcrypt_fips
-if (${OE_CRYPTO_LIB} MATCHES "openssl")
+if (${OE_CRYPTO_LIB} STREQUAL "openssl" OR ${OE_CRYPTO_LIB} STREQUAL
+                                           "openssl_symcrypt_fips")
   add_executable(
     tls_client_enc
     ecalls.cpp
@@ -30,7 +30,7 @@ if (${OE_CRYPTO_LIB} MATCHES "openssl")
     ../../common/utility.cpp
     ../../common/openssl_utility.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/tls_client_t.c)
-elseif (${OE_CRYPTO_LIB} MATCHES "mbedtls")
+elseif (${OE_CRYPTO_LIB} STREQUAL "mbedtls")
   add_executable(
     tls_client_enc
     ecalls.cpp
@@ -67,8 +67,8 @@ elseif (${OE_CRYPTO_LIB} STREQUAL "mbedtls")
 elseif (${OE_CRYPTO_LIB} STREQUAL "openssl_symcrypt_fips")
   add_custom_command(
     TARGET tls_client_enc
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/libsymcrypt.so.101
-            ${CMAKE_CURRENT_BINARY_DIR}/libsymcrypt.so.101)
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/libsymcrypt.so.103
+            ${CMAKE_CURRENT_BINARY_DIR}/libsymcrypt.so.103)
 
   target_link_libraries(
     tls_client_enc
@@ -77,7 +77,7 @@ elseif (${OE_CRYPTO_LIB} STREQUAL "openssl_symcrypt_fips")
     openenclave::oecryptoopenssl
     # Workaround: refer to the root of the build location so that we don't rely on the
     # order of copy
-    ${CMAKE_BINARY_DIR}/libsymcrypt.so.101
+    ${CMAKE_BINARY_DIR}/libsymcrypt.so.103
     openenclave::oelibcxx
     openenclave::oehostsock
     openenclave::oehostresolver)

--- a/samples/attested_tls/client/enc/Makefile
+++ b/samples/attested_tls/client/enc/Makefile
@@ -23,7 +23,7 @@ endif
 EDL_USE_HOST_ENTROPY =
 
 ifeq (${OE_CRYPTO_LIB}, openssl_symcrypt_fips)
-	OBJ_FILES += libsymcrypt.so.101
+	OBJ_FILES += libsymcrypt.so.103
 	EDL_USE_HOST_ENTROPY = -DEDL_USE_HOST_ENTROPY
 endif
 

--- a/samples/attested_tls/server/enc/CMakeLists.txt
+++ b/samples/attested_tls/server/enc/CMakeLists.txt
@@ -25,8 +25,8 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E sleep 1
   COMMAND ${CMAKE_COMMAND} -E remove temp.dmp)
 
-# Cover both openssl and openssl_symcrypt_fips
-if (${OE_CRYPTO_LIB} MATCHES "openssl")
+if (${OE_CRYPTO_LIB} STREQUAL "openssl" OR ${OE_CRYPTO_LIB} STREQUAL
+                                           "openssl_symcrypt_fips")
   add_executable(
     tls_server_enc
     ecalls.cpp
@@ -36,7 +36,7 @@ if (${OE_CRYPTO_LIB} MATCHES "openssl")
     ../../common/utility.cpp
     ../../common/openssl_utility.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/tls_server_t.c)
-elseif (${OE_CRYPTO_LIB} MATCHES "mbedtls")
+elseif (${OE_CRYPTO_LIB} STREQUAL "mbedtls")
   add_executable(
     tls_server_enc
     ecalls.cpp
@@ -71,8 +71,8 @@ elseif (${OE_CRYPTO_LIB} STREQUAL "mbedtls")
 elseif (${OE_CRYPTO_LIB} STREQUAL "openssl_symcrypt_fips")
   add_custom_command(
     TARGET tls_server_enc
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/libsymcrypt.so.101
-            ${CMAKE_CURRENT_BINARY_DIR}/libsymcrypt.so.101)
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/libsymcrypt.so.103
+            ${CMAKE_CURRENT_BINARY_DIR}/libsymcrypt.so.103)
 
   target_link_libraries(
     tls_server_enc
@@ -81,7 +81,7 @@ elseif (${OE_CRYPTO_LIB} STREQUAL "openssl_symcrypt_fips")
     openenclave::oecryptoopenssl
     # Workaround: refer to the root of the build location so that we don't rely on the
     # order of copy
-    ${CMAKE_BINARY_DIR}/libsymcrypt.so.101
+    ${CMAKE_BINARY_DIR}/libsymcrypt.so.103
     openenclave::oelibcxx
     openenclave::oehostsock
     openenclave::oehostresolver)

--- a/samples/attested_tls/server/enc/Makefile
+++ b/samples/attested_tls/server/enc/Makefile
@@ -23,7 +23,7 @@ endif
 EDL_USE_HOST_ENTROPY =
 
 ifeq (${OE_CRYPTO_LIB}, openssl_symcrypt_fips)
-	OBJ_FILES += libsymcrypt.so.101
+	OBJ_FILES += libsymcrypt.so.103
 	EDL_USE_HOST_ENTROPY = -DEDL_USE_HOST_ENTROPY
 endif
 

--- a/samples/test-samples.cmake
+++ b/samples/test-samples.cmake
@@ -135,10 +135,14 @@ foreach (i RANGE ${len})
   set(CMAKE_CRYPTO_LIB_DEFINE "")
   set(MAKE_CRYPTO_LIB_DEFINE "")
 
-  if (CRYPTO_LIB MATCHES "openssl")
+  if (CRYPTO_LIB STREQUAL "openssl")
     set(SAMPLE_BUILD_DIR "${SAMPLE_BUILD_DIR}_openssl")
     set(CMAKE_CRYPTO_LIB_DEFINE "-DOE_CRYPTO_LIB=openssl")
     set(MAKE_CRYPTO_LIB_DEFINE "OE_CRYPTO_LIB=openssl")
+  elseif (CRYPTO_LIB STREQUAL "openssl_symcrypt_fips")
+    set(SAMPLE_BUILD_DIR "${SAMPLE_BUILD_DIR}_symcrypt_fips")
+    set(CMAKE_CRYPTO_LIB_DEFINE "-DOE_CRYPTO_LIB=openssl_symcrypt_fips")
+    set(MAKE_CRYPTO_LIB_DEFINE "OE_CRYPTO_LIB=openssl_symcrypt_fips")
   endif ()
 
   execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory

--- a/tests/openssl/tests.unsupported.symcrypt
+++ b/tests/openssl/tests.unsupported.symcrypt
@@ -8,3 +8,5 @@ rsa_mp_test
 evp_test-evpciph
 # Inconsistent implementation between OpenSSL and SymCrypt
 evp_test-evppkey
+# SCOSSL v1.3.0 only supports HMAC with SHA1, SHA256, SHA384, or SHA512
+evp_test-evpmac


### PR DESCRIPTION
This updates Symcrypt version to this release:
https://github.com/microsoft/SymCrypt/releases/tag/v103.0.1

We needed to remove evp_test-evpmac_symcrypt test because SCOSSL v1.3.0 added support for HMAC, but only support for digests with SHA1, SHA256, SHA384, or SHA512.