### PR TITLE
Removing clang-10 case from Jenkins files

### DIFF
--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -22,7 +22,6 @@ try{
             "Host verification 2004 Debug":                          { tests.ACCHostVerificationTest('20.04', 'Debug', 'clang-11') },
             "Host verification package 2004 Debug":                  { tests.ACCHostVerificationPackageTest('20.04', 'Debug', 'clang-11') },
             "ACC2004 Package RelWithDebInfo ControlFlow snmalloc":   { tests.ACCPackageTest('20.04', ['-DLVI_MITIGATION=ControlFlow', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON']) },
-            "ACC2004 clang-10 RelWithDebInfo ControlFlow":           { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-10', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow',       '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
             "ACC2004 clang-11 RelWithDebInfo ControlFlow":           { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-11', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow',       '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },
             "ACC2004 clang-11 RelWithDebInfo ControlFlow EEID":      { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-11', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow',       '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DWITH_EEID=ON']) },
             "ACC2004 clang-11 RelWithDebInfo ControlFlow-Clang":     { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], 'clang-11', 'RelWithDebInfo', ['-DLVI_MITIGATION=ControlFlow-Clang', '-DLVI_MITIGATION_SKIP_TESTS=OFF']) },

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -16,7 +16,6 @@ def testing_stages = [
 if(FULL_TEST_SUITE == "true") {
     testing_stages += [
         "ELF Win2019 Ubuntu2004 clang-11 Debug":                                 { tests.windowsLinuxElfBuild(params.WS2019_DCAP_CFL_LABEL, params.UBUNTU_2004_NONSGX_LABEL, 'clang-11', 'Debug') },
-        "XC Win2019 v2 clang-10 RelWithDebInfo ControlFlow":                     { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-10', 'RelWithDebInfo', 'ControlFlow') },
         "XC Win2019 v2 clang-11 RelWithDebInfo ControlFlow-Clang":               { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang') },
         "XC Win2019 v2 clang-11 Debug ControlFlow Sim":                          { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow', '1') },
         "XC Win2019 v2 clang-11 Debug ControlFlow Sim snmalloc":                 { tests.windowsCrossCompile(params.WS2019_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow', '1', 'OFF', ['-DUSE_SNMALLOC=ON']) },


### PR DESCRIPTION
The change to add OpenSSL3 causes build issues when using clang-10.
Most users should be updating to clang-11, this removes clang-10 runs from our CI files.