### PR TITLE
update instructions related to PCCS

### DIFF
--- a/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md
@@ -162,11 +162,15 @@ Get the value of your primary key, which will be used during PCCS service bring 
 
 ### 4.2 Install and Config PCCS
 
-Install nodejs and npm if you haven't
+Install nodejs and npm if you haven't (The minimum node.js version required by PCCS is v14.20.0)
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash
 sudo apt-get install -y nodejs
+```
+Install the required library
+```
+sudo apt install cracklib-runtime 
 ```
 
 To install PCCS, you can choose to install it from the Intel SGX repository (recommended), or install it manually with dpkg.

--- a/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md
+++ b/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md
@@ -221,12 +221,13 @@ Then check the status of your service.
 ```bash
 pm2 status
 ```
+
 You should be able to see the service is running.
 ![nodejs](/docs/GettingStartedDocs/images/nodejs.png)
 
 Run the following command to verify if it can actually fetch the root CA CRL from the Intel PCK service
 ```bash
-curl --noproxy "*" -v -k -G "https://localhost:8081/sgx/certification/v2/rootcacrl"
+curl --noproxy "*" -v -k -G "https://localhost:8081/sgx/certification/v3/rootcacrl"
 ```
 
 To learn more about PCCS, please refer to the [PCCS GitHub repository](https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/QuoteGeneration/pccs).


### PR DESCRIPTION
updates related to PCCS instructions
- node version (required is 14)
- missing dependency
- new API version