### PR TITLE
Remove docker setup on Windows

### DIFF
--- a/scripts/ansible/roles/windows/openenclave/tasks/main.yml
+++ b/scripts/ansible/roles/windows/openenclave/tasks/main.yml
@@ -22,7 +22,6 @@
       -DCAPClientType      "Azure"
       -ClangUrl            "{{ clang_url }}"
       -ClangHash           "{{ clang_hash }}"
-      -InstallDocker
 
   - name: Check installed Intel PSW version
     ansible.windows.win_powershell:

--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -566,9 +566,7 @@ function Install-NSIS {
 }
 
 function Install-Docker {
-    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-    Install-Module -Name DockerMsftProvider -Repository PSGallery -Force
-    Install-Package -Name docker -ProviderName DockerMsftProvider -Force
+    Write-Output '[WARNING] Docker is no longer a prerequisite and installation thereof is deprecated.'
 }
 
 try {


### PR DESCRIPTION
dockermsftprovider was [deprecated last month](https://github.com/OneGet/MicrosoftDockerProvider), so Docker installations through install-windows-prereqs.ps1 are failing. Currently there is no use-case for Docker on Windows, so this change will remove the option to install it.

Instead of removing the parameter, it will be kept for now to avoid breaking changes.