### PR TITLE
Update snmalloc to 0.6.2

### DIFF
--- a/3rdparty/snmalloc/allocator.cpp
+++ b/3rdparty/snmalloc/allocator.cpp
@@ -17,7 +17,7 @@
 
 namespace snmalloc
 {
-using Globals = snmalloc::FixedGlobals<snmalloc::PALOpenEnclave>;
+using Globals = snmalloc::FixedRangeConfig<snmalloc::PALOpenEnclave>;
 using Alloc = snmalloc::LocalAllocator<Globals>;
 
 class ThreadAllocExternal

--- a/tests/stack_overflow_exception/enc/enc.c
+++ b/tests/stack_overflow_exception/enc/enc.c
@@ -12,7 +12,7 @@
 
 #define PAGE_SIZE 4096
 #define EXCEPTION_HANDLER_STACK_SIZE 16384
-#define STACK_PAGE_NUMBER 4
+#define STACK_PAGE_NUMBER 16
 #define STACK_SIZE (STACK_PAGE_NUMBER * PAGE_SIZE)
 void* td_to_tcs(const oe_sgx_td_t* td);
 

--- a/tests/stack_overflow_exception/enc/sign.conf
+++ b/tests/stack_overflow_exception/enc/sign.conf
@@ -5,7 +5,7 @@
 Debug=1
 CapturePFGPExceptions=1
 NumHeapPages=1024
-NumStackPages=4
+NumStackPages=16
 NumTCS=1
 ProductID=1
 SecurityVersion=1


### PR DESCRIPTION
This updates snmalloc to the latest version.

The release includes the updates that remove some levels of thread caching for small heaps.