### PR TITLE
Update TDX claims based Intel TDX Module 1.0 Specification Feb 2023 edition

### DIFF
--- a/common/tdx/verifier.c
+++ b/common/tdx/verifier.c
@@ -240,11 +240,11 @@ static oe_result_t _fill_with_known_tdx_claims(
         &flag,
         sizeof(flag)));
 
-    flag = !!attributes->tud.d.sysprof;
+    flag = !!attributes->sec.d.sept_ve_disable;
     OE_CHECK(_add_claim(
         &claims[claims_index++],
-        OE_CLAIM_TDX_TD_ATTRIBUTES_SYSPROF,
-        sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_SYSPROF),
+        OE_CLAIM_TDX_TD_ATTRIBUTES_SEPT_VE_DISABLE,
+        sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_SEPT_VE_DISABLE),
         &flag,
         sizeof(flag)));
 

--- a/include/openenclave/attestation/tdx/evidence.h
+++ b/include/openenclave/attestation/tdx/evidence.h
@@ -24,7 +24,8 @@ OE_EXTERNC_BEGIN
 #define OE_CLAIM_TDX_SEAM_ATTRIBUTES "tdx_seam_attributes"
 #define OE_CLAIM_TDX_TD_ATTRIBUTES "tdx_td_attributes"
 #define OE_CLAIM_TDX_TD_ATTRIBUTES_DEBUG "tdx_td_attributes_debug"
-#define OE_CLAIM_TDX_TD_ATTRIBUTES_SYSPROF "tdx_td_attributes_sysprof"
+#define OE_CLAIM_TDX_TD_ATTRIBUTES_SEPT_VE_DISABLE \
+    "tdx_td_attributes_septve_disable"
 #define OE_CLAIM_TDX_TD_ATTRIBUTES_PROTECTION_KEYS \
     "tdx_td_attributes_protection_keys"
 #define OE_CLAIM_TDX_TD_ATTRIBUTES_KEY_LOCKER "tdx_td_attributes_key_locker"

--- a/include/openenclave/bits/tdx/tdxquote.h
+++ b/include/openenclave/bits/tdx/tdxquote.h
@@ -24,8 +24,7 @@ typedef struct _tdx_attributes_t
         struct
         {
             uint8_t debug : 1;
-            uint8_t sysprof : 1;
-            uint8_t reserved : 6;
+            uint8_t reserved : 7;
         } d;
         uint8_t u;
     } tud;
@@ -34,7 +33,9 @@ typedef struct _tdx_attributes_t
         struct
         {
             uint8_t reserved0[2];
-            uint8_t reserved1 : 6;
+            uint8_t reserved1 : 4;
+            uint8_t sept_ve_disable : 1;
+            uint8_t reserved2 : 1;
             uint8_t pks : 1;
             uint8_t kl : 1;
         } d;


### PR DESCRIPTION
According to the latest specification, `SYSPROF` bit (`ATTRIBUTES.TUD[1]`) is dropped and a `SEPT_VE_DISABLE` bit is added ( `ATTRIBUTES.SEC[28]`).