### PR TITLE
Remove size check for tdx supplemental data

### DIFF
--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -1336,9 +1336,6 @@ oe_result_t oe_tdx_get_supplemental_data_size(
             get_quote3_error_t_string(error));
     }
 
-    if (*p_data_size != sizeof(sgx_ql_qv_supplemental_t))
-        OE_RAISE(OE_UNEXPECTED);
-
     OE_TRACE_INFO(
         "tdx supplemental data size=%u, major version=%u, minor version=%u",
         *p_data_size,


### PR DESCRIPTION
The sgx_ql_qv_supplemental_t is not stable, which could be changed when QVL/QvE update. Remove this size check to avoid the requirement of re-building the enclaves when updating Intel Components.