### PR TITLE
Update pyOpenSSL version

### DIFF
--- a/scripts/ansible/requirements.txt
+++ b/scripts/ansible/requirements.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
 cryptography==41.0.0
-pyOpenSSL==23.0.0
+pyOpenSSL==23.2.0
 ansible>=4.10,<=5.2.0
 cmake_format==0.6.9
 pywinrm>=0.3.0


### PR DESCRIPTION
This fixes a version conflict between cryptography 41.0.0 and pyopenssl 23.0.0