### PR TITLE
Infrastructure - validate Docker installation and remove clang-10 images

### DIFF
--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -356,9 +356,7 @@ node(params.AGENTS_LABEL) {
         stage("Build images") {
             def windows_images = [
                 "Build WS2019 - nonSGX - clang11"       : { buildWindowsManagedImage("win2019", "nonSGX", "SGX1FLC-NoIntelDrivers", "11.1.0", image_id, image_version) },
-                "Build WS2019 - nonSGX - clang10"       : { buildWindowsManagedImage("win2019", "nonSGX", "SGX1FLC-NoIntelDrivers", "10.0.0", image_id, image_version) },
-                "Build WS2019 - SGX1FLC DCAP - clang11" : { buildWindowsManagedImage("win2019", "SGX-DCAP", "SGX1FLC", "11.1.0", image_id, image_version) },
-                "Build WS2019 - SGX1FLC DCAP - clang10" : { buildWindowsManagedImage("win2019", "SGX-DCAP", "SGX1FLC", "10.0.0", image_id, image_version) }
+                "Build WS2019 - SGX1FLC DCAP - clang11" : { buildWindowsManagedImage("win2019", "SGX-DCAP", "SGX1FLC", "11.1.0", image_id, image_version) }
             ]
             def linux_images = [
                 "Build Ubuntu 20.04" : { buildLinuxManagedImage("ubuntu", "20.04", image_id, image_version) }

--- a/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
+++ b/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
@@ -10,9 +10,7 @@ AZURE_IMAGES_MAP = [
     // generated Azure managed image name
     "ubuntu-20.04":      "",
     "nonSGX-clang-11":   "",
-    "nonSGX-clang-10":   "",
     "SGX-DCAP-clang-11": "",
-    "SGX-DCAP-clang-10": ""
 ]
 
 def update_production_azure_gallery_images(String image_name) {

--- a/scripts/ansible/roles/windows/jenkins/vars/windows.yml
+++ b/scripts/ansible/roles/windows/jenkins/vars/windows.yml
@@ -10,3 +10,4 @@ jdk_url: "https://jenkinsprivatestorage.blob.core.windows.net/oraclejdk/jdk-11.0
 
 validation_binaries:
   - "C:\\Program Files\\Java\\jdk-11.0.16.1\\bin\\java.exe"
+  - "C:\\Windows\\System32\\docker.exe"


### PR DESCRIPTION
* Validate Docker is installed by the installer. In 2 occasions Ansible reported Docker installation task was completed - but Docker was not actually installed.
* Remove clang-10 images from image build pipeline as we no longer test with clang-10