### PR TITLE
Fixed CMake configuration for test case openssl_3_tls_e2e

### DIFF
--- a/tests/tls_e2e/CMakeLists.txt
+++ b/tests/tls_e2e/CMakeLists.txt
@@ -18,9 +18,8 @@ if (BUILD_OPENSSL)
                    openssl_tls_server_enc $<TARGET_FILE:openssl_tls_client_enc>)
   set_enclave_tests_properties(tests/openssl_tls_e2e PROPERTIES
                                SKIP_RETURN_CODE 2)
-
   add_enclave_test(tests/openssl_3_tls_e2e openssl_tls_e2e_host
-                   openssl_tls_server_enc $<TARGET_FILE:openssl_tls_client_enc>)
+                   openssl_3_tls_server_enc $<TARGET_FILE:openssl_3_tls_client_enc>)
   set_enclave_tests_properties(tests/openssl_3_tls_e2e PROPERTIES
                                SKIP_RETURN_CODE 2)
 endif ()

--- a/tests/tls_e2e/server_enc/CMakeLists.txt
+++ b/tests/tls_e2e/server_enc/CMakeLists.txt
@@ -46,4 +46,20 @@ if (BUILD_OPENSSL)
                               ${CMAKE_CURRENT_BINARY_DIR})
 
   enclave_link_libraries(openssl_tls_server_enc oehostsock oehostresolver)
+
+  add_enclave(
+    TARGET
+    openssl_3_tls_server_enc
+    CRYPTO_LIB
+    openssl_3
+    SOURCES
+    openssl_server.cpp
+    ../common/utility.cpp
+    ../common/openssl_utility.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/tls_e2e_t.c)
+
+  enclave_include_directories(openssl_3_tls_server_enc PRIVATE
+                              ${CMAKE_CURRENT_BINARY_DIR})
+
+  enclave_link_libraries(openssl_3_tls_server_enc oehostsock oehostresolver)
 endif ()


### PR DESCRIPTION
This test case was misconfigured, which led to openssl being used and openssl_3 not being tested in the enclave side. This PR fixes this problem.