### PR TITLE
Fixed code coverage for crypto tests

### DIFF
--- a/tests/crypto/asn1_tests.c
+++ b/tests/crypto/asn1_tests.c
@@ -327,7 +327,7 @@ done:
     return result;
 }
 
-static void _test_asn1_parsing(void)
+static void _test_asn1_parsing(char* path)
 {
     oe_cert_t cert;
     uint8_t* data = NULL;
@@ -336,7 +336,7 @@ static void _test_asn1_parsing(void)
     oe_result_t r;
 
     printf("=== begin %s()\n", __FUNCTION__);
-    OE_TEST(read_cert("../data/asn1.cert.pem", _CERT) == OE_OK);
+    OE_TEST(read_cert(path, "../data/asn1.cert.pem", _CERT) == OE_OK);
     OE_TEST(oe_cert_read_pem(&cert, _CERT, strlen(_CERT) + 1) == OE_OK);
 
     /* Find the SGX_EXTENSION */
@@ -367,7 +367,7 @@ static void _test_asn1_parsing(void)
     printf("=== passed %s()\n", __FUNCTION__);
 }
 
-void TestASN1(void)
+void TestASN1(char* path)
 {
-    _test_asn1_parsing();
+    _test_asn1_parsing(path);
 }

--- a/tests/crypto/crl_tests.c
+++ b/tests/crypto/crl_tests.c
@@ -279,27 +279,30 @@ static void _test_verify_with_two_crls(
     printf("=== passed %s()\n", __FUNCTION__);
 }
 
-void TestCRL(void)
+void TestCRL(char* path)
 {
-    OE_TEST(read_cert("../data/intermediate.cert.pem", _CERT1) == OE_OK);
-    OE_TEST(read_cert("../data/leaf.cert.pem", _CERT2) == OE_OK);
+    OE_TEST(read_cert(path, "../data/intermediate.cert.pem", _CERT1) == OE_OK);
+    OE_TEST(read_cert(path, "../data/leaf.cert.pem", _CERT2) == OE_OK);
 
     OE_TEST(
         read_chain(
+            path,
             "../data/leaf.cert.pem",
             "../data/root.cert.pem",
             _CHAIN1,
             OE_COUNTOF(_CHAIN1)) == OE_OK);
     OE_TEST(
         read_chain(
+            path,
             "../data/intermediate.cert.pem",
             "../data/root.cert.pem",
             _CHAIN2,
             OE_COUNTOF(_CHAIN2)) == OE_OK);
 
     OE_TEST(
-        read_crl("../data/intermediate.crl.der", _CRL1, &crl_size1) == OE_OK);
-    OE_TEST(read_crl("../data/root.crl.der", _CRL2, &crl_size2) == OE_OK);
+        read_crl(path, "../data/intermediate.crl.der", _CRL1, &crl_size1) ==
+        OE_OK);
+    OE_TEST(read_crl(path, "../data/root.crl.der", _CRL2, &crl_size2) == OE_OK);
 
     _test_verify_without_crl(_CERT1, _CHAIN1);
     _test_verify_without_crl(_CERT2, _CHAIN2);
@@ -312,6 +315,6 @@ void TestCRL(void)
     _test_verify_with_two_crls(
         _CERT2, _CHAIN2, _CRL1, crl_size1, _CRL2, crl_size2, true);
 
-    OE_TEST(read_dates("../data/time.txt", &_time) == OE_OK);
+    OE_TEST(read_dates(path, "../data/time.txt", &_time) == OE_OK);
     _test_get_dates();
 }

--- a/tests/crypto/ec_tests.c
+++ b/tests/crypto/ec_tests.c
@@ -934,16 +934,18 @@ static void _test_crl_distribution_points(void)
     printf("=== passed %s()\n", __FUNCTION__);
 }
 
-void TestEC()
+void TestEC(char* path)
 {
-    OE_TEST(read_cert("../data/ec_cert_with_ext.pem", _CERT) == OE_OK);
+    OE_TEST(read_cert(path, "../data/ec_cert_with_ext.pem", _CERT) == OE_OK);
     OE_TEST(
-        read_cert("../data/leaf.ec.cert.pem", _CERT_WITHOUT_EXTENSIONS) ==
+        read_cert(path, "../data/leaf.ec.cert.pem", _CERT_WITHOUT_EXTENSIONS) ==
         OE_OK);
     OE_TEST(
-        read_cert("../data/ec_cert_crl_distribution.pem", _SGX_CERT) == OE_OK);
+        read_cert(path, "../data/ec_cert_crl_distribution.pem", _SGX_CERT) ==
+        OE_OK);
     OE_TEST(
         read_chains(
+            path,
             "../data/leaf.ec.cert.pem",
             "../data/intermediate.ec.cert.pem",
             "../data/root.ec.cert.pem",
@@ -951,23 +953,29 @@ void TestEC()
             OE_COUNTOF(_CHAIN)) == OE_OK);
     OE_TEST(
         read_pem_key(
+            path,
             "../data/root.ec.key.pem",
             _PRIVATE_KEY,
             sizeof(_PRIVATE_KEY),
             &private_key_size) == OE_OK);
     OE_TEST(
         read_pem_key(
+            path,
             "../data/root.ec.public.key.pem",
             _PUBLIC_KEY,
             sizeof(_PUBLIC_KEY),
             &public_key_size) == OE_OK);
     OE_TEST(
-        read_sign("../data/test_ec_signature", _SIGNATURE, &sign_size) ==
+        read_sign(path, "../data/test_ec_signature", _SIGNATURE, &sign_size) ==
         OE_OK);
     OE_TEST(
         read_coordinates(
-            "../data/coordinates.bin", x_data, y_data, &x_size, &y_size) ==
-        OE_OK);
+            path,
+            "../data/coordinates.bin",
+            x_data,
+            y_data,
+            &x_size,
+            &y_size) == OE_OK);
 
     _test_cert_with_extensions();
     _test_cert_without_extensions();

--- a/tests/crypto/enclave/CMakeLists.txt
+++ b/tests/crypto/enclave/CMakeLists.txt
@@ -10,12 +10,20 @@ add_subdirectory(host)
 # Disable because this test would fail with code coverage
 # Output: ***Exception: SegFault
 if (NOT CODE_COVERAGE)
-  add_enclave_test(tests/crypto/enclave_mbedtls cryptohost crypto_mbedtls_enc)
+  add_enclave_test(tests/crypto/enclave_mbedtls cryptohost crypto_mbedtls_enc
+                   ${CMAKE_CURRENT_BINARY_DIR})
+endif ()
+
+set(TEST_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+if (WIN32)
+  string(REPLACE "C:/" "" TEST_DIR "${TEST_DIR}")
 endif ()
 
 if (BUILD_OPENSSL)
-  add_enclave_test(tests/crypto/enclave_openssl cryptohost crypto_openssl_enc)
+  add_enclave_test(tests/crypto/enclave_openssl cryptohost crypto_openssl_enc
+                   ${TEST_DIR})
 
   add_enclave_test(tests/crypto/enclave_openssl_3 cryptohost
-                   crypto_openssl_3_enc)
+                   crypto_openssl_3_enc ${TEST_DIR})
 endif ()

--- a/tests/crypto/enclave/crypto.edl
+++ b/tests/crypto/enclave/crypto.edl
@@ -11,7 +11,8 @@ enclave {
 #endif
 
     trusted {
-        public void test();
+        public void test(
+            [string, in]char* abspath);
     };
 
     untrusted {

--- a/tests/crypto/enclave/enc/CMakeLists.txt
+++ b/tests/crypto/enclave/enc/CMakeLists.txt
@@ -49,6 +49,8 @@ endif ()
 enclave_include_directories(crypto_mbedtls_enc PRIVATE
                             ${CMAKE_CURRENT_BINARY_DIR})
 
+enclave_link_libraries(crypto_mbedtls_enc)
+
 if (BUILD_OPENSSL)
   add_enclave(
     TARGET
@@ -71,6 +73,8 @@ if (BUILD_OPENSSL)
     crypto_openssl_enc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR})
 
+  enclave_link_libraries(crypto_openssl_enc oehostfs)
+
   add_enclave(
     TARGET
     crypto_openssl_3_enc
@@ -91,4 +95,6 @@ if (BUILD_OPENSSL)
   enclave_include_directories(
     crypto_openssl_3_enc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR})
+
+  enclave_link_libraries(crypto_openssl_3_enc oehostfs)
 endif ()

--- a/tests/crypto/enclave/enc/enc.c
+++ b/tests/crypto/enclave/enc/enc.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mount.h>
 #include <sys/syscall.h>
 #include <sys/uio.h>
 #include <unistd.h>
@@ -41,6 +42,7 @@ char* oe_host_strdup(const char* str)
 
 // Tests need these syscall overrides.
 
+#if !defined(OE_USE_OPENSSL)
 OE_DEFINE_SYSCALL2_M(SYS_openat)
 {
     oe_va_list ap;
@@ -145,63 +147,26 @@ OE_DEFINE_SYSCALL1_M(SYS_close)
     OE_TEST(OE_OK == f_close(&rval, (int)arg1));
     return rval;
 }
-
-static long _syscall_dispatch(
-    long number,
-    long arg1,
-    long arg2,
-    long arg3,
-    long arg4,
-    long arg5,
-    long arg6)
-{
-    OE_UNUSED(arg5);
-    OE_UNUSED(arg6);
-
-    switch (number)
-    {
-        OE_SYSCALL_DISPATCH(SYS_openat, arg1, arg2, arg3, arg4);
-#if defined(__x86_64__) || defined(_M_X64)
-        OE_SYSCALL_DISPATCH(SYS_open, arg1, arg2, arg3);
 #endif
-        OE_SYSCALL_DISPATCH(SYS_read, arg1, arg2, arg3);
-        OE_SYSCALL_DISPATCH(SYS_readv, arg1, arg2, arg3);
-        OE_SYSCALL_DISPATCH(SYS_close, arg1);
-        default:
-            return -1;
-    }
-}
 
-static oe_result_t _syscall_hook(
-    long number,
-    long arg1,
-    long arg2,
-    long arg3,
-    long arg4,
-    long arg5,
-    long arg6,
-    long* ret)
+void test(char* abspath)
 {
-    oe_result_t result = OE_UNEXPECTED;
-    if (ret)
-        *ret = -1;
+#if !defined(CODE_COVERAGE) && defined(OE_USE_OPENSSL)
+    /*
+     * When enabling code coverage analysis, libgcov should initialize the host
+     * fs already so we do not do it again here. Otherwise, the
+     * oe_load_module_host_file_system will fail.
+     */
+    if (oe_load_module_host_file_system() != OE_OK)
+        goto done;
+    if (mount("/", "/", OE_HOST_FILE_SYSTEM, 0, NULL))
+        goto done;
+#endif
+    TestAll(abspath);
 
-    if (!ret)
-        OE_RAISE(OE_INVALID_PARAMETER);
-
-    *ret = _syscall_dispatch(number, arg1, arg2, arg3, arg4, arg5, arg6);
-    result = OE_OK;
+#if !defined(CODE_COVERAGE) && defined(OE_USE_OPENSSL)
 done:
-    return result;
-}
-
-void test()
-{
-    oe_register_syscall_hook(_syscall_hook);
-    TestAll();
-
-#ifdef CODE_COVERAGE // For code coverage tests.
-    oe_register_syscall_hook(NULL);
+    umount("/");
 #endif
 }
 

--- a/tests/crypto/enclave/host/host.c
+++ b/tests/crypto/enclave/host/host.c
@@ -79,7 +79,7 @@ int main(int argc, const char* argv[])
     oe_result_t result;
     oe_enclave_t* enclave = NULL;
 
-    if (argc != 2)
+    if (argc != 3)
     {
         fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
         return 1;
@@ -93,7 +93,7 @@ int main(int argc, const char* argv[])
         oe_put_err("oe_create_crypto_enclave(): result=%u", result);
     }
 
-    if ((result = test(enclave)) != OE_OK)
+    if ((result = test(enclave, (char*)argv[2])) != OE_OK)
     {
         oe_put_err("test() failed: result=%u", result);
     }

--- a/tests/crypto/host/main.c
+++ b/tests/crypto/host/main.c
@@ -13,7 +13,7 @@ int main(int argc, const char* argv[])
     arg0 = argv[0];
 
     /* Run the tests */
-    TestAll();
+    TestAll(".");
 
     printf("=== passed all tests (%s)\n", arg0);
 

--- a/tests/crypto/read_file.c
+++ b/tests/crypto/read_file.c
@@ -22,10 +22,16 @@ FILE* read_file(const char* filename, const char* mode)
     return file;
 }
 
-oe_result_t read_cert(char* filename, char* cert)
+oe_result_t read_cert(char* dir, char* filename, char* cert)
 {
     size_t len_cert;
-    FILE* cfp = read_file(filename, "rb");
+    char* abspath = NULL;
+
+    abspath = (char*)malloc(strlen(dir) + strlen(filename) + 2);
+    snprintf(
+        abspath, strlen(dir) + strlen(filename) + 2, "%s/%s", dir, filename);
+
+    FILE* cfp = read_file(abspath, "rb");
     if (cfp != NULL)
     {
         len_cert = fread(cert, sizeof(char), max_cert_size, cfp);
@@ -36,10 +42,12 @@ oe_result_t read_cert(char* filename, char* cert)
     }
     cert[len_cert] = '\0';
     fclose(cfp);
+    free(abspath);
     return OE_OK;
 }
 
 oe_result_t read_chain(
+    char* dir,
     char* filename1,
     char* filename2,
     char* chain,
@@ -47,8 +55,17 @@ oe_result_t read_chain(
 {
     size_t len_cert1 = 0, len_cert2 = 0;
     char chain_temp[max_cert_size];
-    FILE* cfp1 = read_file(filename1, "rb");
-    FILE* cfp2 = read_file(filename2, "rb");
+    char* abspath1 = NULL;
+    char* abspath2 = NULL;
+
+    abspath1 = (char*)malloc(strlen(dir) + strlen(filename1) + 2);
+    abspath2 = (char*)malloc(strlen(dir) + strlen(filename2) + 2);
+    snprintf(
+        abspath1, strlen(dir) + strlen(filename1) + 2, "%s/%s", dir, filename1);
+    snprintf(
+        abspath2, strlen(dir) + strlen(filename2) + 2, "%s/%s", dir, filename2);
+    FILE* cfp1 = read_file(abspath1, "rb");
+    FILE* cfp2 = read_file(abspath2, "rb");
 
     if (cfp1 != NULL && cfp2 != NULL)
     {
@@ -63,12 +80,15 @@ oe_result_t read_chain(
         return OE_FAILURE;
     }
 
+    free(abspath1);
+    free(abspath2);
     fclose(cfp1);
     fclose(cfp2);
     return OE_OK;
 }
 
 oe_result_t read_chains(
+    char* dir,
     char* filename1,
     char* filename2,
     char* filename3,
@@ -78,9 +98,22 @@ oe_result_t read_chains(
     size_t len_cert1 = 0, len_cert2 = 0, len_cert3 = 0;
     char chain_temp1[max_cert_size];
     char chain_temp2[max_cert_size];
-    FILE* cfp1 = read_file(filename1, "rb");
-    FILE* cfp2 = read_file(filename2, "rb");
-    FILE* cfp3 = read_file(filename3, "rb");
+    char* abspath1 = NULL;
+    char* abspath2 = NULL;
+    char* abspath3 = NULL;
+
+    abspath1 = (char*)malloc(strlen(dir) + strlen(filename1) + 2);
+    abspath2 = (char*)malloc(strlen(dir) + strlen(filename2) + 2);
+    abspath3 = (char*)malloc(strlen(dir) + strlen(filename3) + 2);
+    snprintf(
+        abspath1, strlen(dir) + strlen(filename1) + 2, "%s/%s", dir, filename1);
+    snprintf(
+        abspath2, strlen(dir) + strlen(filename2) + 2, "%s/%s", dir, filename2);
+    snprintf(
+        abspath3, strlen(dir) + strlen(filename3) + 2, "%s/%s", dir, filename3);
+    FILE* cfp1 = read_file(abspath1, "rb");
+    FILE* cfp2 = read_file(abspath2, "rb");
+    FILE* cfp3 = read_file(abspath3, "rb");
 
     if (cfp1 != NULL && cfp2 != NULL && cfp3 != NULL)
     {
@@ -97,16 +130,24 @@ oe_result_t read_chains(
     {
         return OE_FAILURE;
     }
+    free(abspath1);
+    free(abspath2);
+    free(abspath3);
     fclose(cfp1);
     fclose(cfp2);
     fclose(cfp3);
     return OE_OK;
 }
 
-oe_result_t read_crl(char* filename, uint8_t* crl, size_t* crl_size)
+oe_result_t read_crl(char* dir, char* filename, uint8_t* crl, size_t* crl_size)
 {
     size_t len_crl = 0;
-    FILE* cfp = read_file(filename, "rb");
+    char* abspath = NULL;
+
+    abspath = (char*)malloc(strlen(dir) + strlen(filename) + 2);
+    snprintf(
+        abspath, strlen(dir) + strlen(filename) + 2, "%s/%s", dir, filename);
+    FILE* cfp = read_file(abspath, "rb");
 
     if (cfp != NULL)
     {
@@ -119,14 +160,20 @@ oe_result_t read_crl(char* filename, uint8_t* crl, size_t* crl_size)
     crl[len_crl] = '\0';
     *crl_size = len_crl;
     fclose(cfp);
+    free(abspath);
     return OE_OK;
 }
 
-oe_result_t read_dates(char* filename, oe_datetime_t* time)
+oe_result_t read_dates(char* dir, char* filename, oe_datetime_t* time)
 {
     size_t len_date = 0;
     char buffer[max_date_size];
-    FILE* dfp = read_file(filename, "rb");
+    char* abspath = NULL;
+
+    abspath = (char*)malloc(strlen(dir) + strlen(filename) + 2);
+    snprintf(
+        abspath, strlen(dir) + strlen(filename) + 2, "%s/%s", dir, filename);
+    FILE* dfp = read_file(abspath, "rb");
 
     if (dfp != NULL)
     {
@@ -149,6 +196,7 @@ oe_result_t read_dates(char* filename, oe_datetime_t* time)
         &(time->seconds));
 
     fclose(dfp);
+    free(abspath);
     return OE_OK;
 }
 
@@ -209,14 +257,18 @@ static uint8_t hexval(char c)
 }
 
 // Assume a series of hex digits in the file.
-oe_result_t read_mod(char* filename, uint8_t* mod, size_t* mod_size)
+oe_result_t read_mod(char* dir, char* filename, uint8_t* mod, size_t* mod_size)
 {
     size_t len_mod;
     size_t numchars = 0;
     char buffer[(max_mod_size * 2) + 1];
     char* bufp = buffer;
+    char* abspath = NULL;
 
-    FILE* mfp = read_file(filename, "rb");
+    abspath = (char*)malloc(strlen(dir) + strlen(filename) + 2);
+    snprintf(
+        abspath, strlen(dir) + strlen(filename) + 2, "%s/%s", dir, filename);
+    FILE* mfp = read_file(abspath, "rb");
     if (mfp != NULL)
     {
         numchars = fread(buffer, sizeof(char), max_mod_size * 2, mfp);
@@ -246,6 +298,7 @@ oe_result_t read_mod(char* filename, uint8_t* mod, size_t* mod_size)
 
     *mod_size = len_mod;
     fclose(mfp);
+    free(abspath);
     return OE_OK;
 }
 
@@ -260,10 +313,19 @@ oe_result_t read_mixed_chain(
     return OE_OK;
 }
 
-oe_result_t read_sign(char* filename, uint8_t* sign, size_t* sign_size)
+oe_result_t read_sign(
+    char* dir,
+    char* filename,
+    uint8_t* sign,
+    size_t* sign_size)
 {
     size_t len_sign;
-    FILE* sfp = read_file(filename, "rb");
+    char* abspath = NULL;
+
+    abspath = (char*)malloc(strlen(dir) + strlen(filename) + 2);
+    snprintf(
+        abspath, strlen(dir) + strlen(filename) + 2, "%s/%s", dir, filename);
+    FILE* sfp = read_file(abspath, "rb");
     if (sfp != NULL)
     {
         len_sign = fread(sign, sizeof(char), max_sign_size, sfp);
@@ -276,10 +338,12 @@ oe_result_t read_sign(char* filename, uint8_t* sign, size_t* sign_size)
     sign[len_sign] = '\0';
     *sign_size = len_sign;
     fclose(sfp);
+    free(abspath);
     return OE_OK;
 }
 
 oe_result_t read_pem_key(
+    char* dir,
     const char* filename,
     char* data,
     size_t data_size,
@@ -289,6 +353,7 @@ oe_result_t read_pem_key(
     size_t size = 0;
     FILE* stream = NULL;
     int c;
+    char* abspath = NULL;
 
     if (!filename || !data)
     {
@@ -296,8 +361,11 @@ oe_result_t read_pem_key(
         goto done;
     }
 
+    abspath = (char*)malloc(strlen(dir) + strlen(filename) + 2);
+    snprintf(
+        abspath, strlen(dir) + strlen(filename) + 2, "%s/%s", dir, filename);
     /* Open file in binary mode. */
-    if (!(stream = read_file(filename, "rb")))
+    if (!(stream = read_file(abspath, "rb")))
     {
         result = OE_FAILURE;
         goto done;
@@ -325,6 +393,8 @@ oe_result_t read_pem_key(
 
 done:
 
+    free(abspath);
+
     if (stream)
         fclose(stream);
 
@@ -332,6 +402,7 @@ done:
 }
 
 oe_result_t read_coordinates(
+    char* dir,
     char* filename,
     uint8_t* x,
     uint8_t* y,
@@ -339,7 +410,12 @@ oe_result_t read_coordinates(
     size_t* y_size)
 {
     size_t len_x, len_y;
-    FILE* cfp = read_file(filename, "rb");
+    char* abspath = NULL;
+
+    abspath = (char*)malloc(strlen(dir) + strlen(filename) + 2);
+    snprintf(
+        abspath, strlen(dir) + strlen(filename) + 2, "%s/%s", dir, filename);
+    FILE* cfp = read_file(abspath, "rb");
     if (cfp != NULL)
     {
         len_x = fread(x, sizeof(char), max_coordinates_size, cfp);
@@ -350,6 +426,7 @@ oe_result_t read_coordinates(
         return OE_FAILURE;
     }
     fclose(cfp);
+    free(abspath);
     *x_size = len_x;
     *y_size = len_y;
     return OE_OK;

--- a/tests/crypto/readfile.h
+++ b/tests/crypto/readfile.h
@@ -26,28 +26,30 @@
 #define sscanf_s sscanf
 #endif
 
-oe_result_t read_cert(char* filename, char* cert);
+oe_result_t read_cert(char* dir, char* filename, char* cert);
 
 oe_result_t read_chain(
+    char* dir,
     char* filename1,
     char* filename2,
     char* chain,
     size_t chain_size);
 
 oe_result_t read_chains(
+    char* dir,
     char* filename1,
     char* filename2,
     char* filename3,
     char* chain,
     size_t chain_size);
 
-oe_result_t read_crl(char* filename, uint8_t* crl, size_t* crl_size);
+oe_result_t read_crl(char* dir, char* filename, uint8_t* crl, size_t* crl_size);
 
-oe_result_t read_dates(char* filename, oe_datetime_t* time);
+oe_result_t read_dates(char* dir, char* filename, oe_datetime_t* time);
 
 FILE* read_file(const char* filename, const char* mode);
 
-oe_result_t read_mod(char* filename, uint8_t* mod, size_t* mod_size);
+oe_result_t read_mod(char* dir, char* filename, uint8_t* mod, size_t* mod_size);
 
 oe_result_t read_mixed_chain(
     char* chain1,
@@ -55,15 +57,21 @@ oe_result_t read_mixed_chain(
     char* chain,
     size_t chain_size);
 
-oe_result_t read_sign(char* filename, uint8_t* sign, size_t* sign_size);
+oe_result_t read_sign(
+    char* dir,
+    char* filename,
+    uint8_t* sign,
+    size_t* sign_size);
 
 oe_result_t read_pem_key(
+    char* dir,
     const char* filename,
     char* data,
     size_t data_size,
     size_t* data_size_out);
 
 oe_result_t read_coordinates(
+    char* dir,
     char* filename,
     uint8_t* x,
     uint8_t* y,

--- a/tests/crypto/rsa_tests.c
+++ b/tests/crypto/rsa_tests.c
@@ -467,39 +467,47 @@ static void _test_cert_methods()
     printf("=== passed %s()\n", __FUNCTION__);
 }
 
-void TestRSA(void)
+void TestRSA(char* path)
 {
-    OE_TEST(read_cert("../data/self_signed.cert.der", _DER_CERT) == OE_OK);
-    OE_TEST(read_cert("../data/leaf.cert.pem", _CERT1) == OE_OK);
+    OE_TEST(
+        read_cert(path, "../data/self_signed.cert.der", _DER_CERT) == OE_OK);
+    OE_TEST(read_cert(path, "../data/leaf.cert.pem", _CERT1) == OE_OK);
     OE_TEST(
         read_chain(
+            path,
             "../data/intermediate.cert.pem",
             "../data/root.cert.pem",
             CHAIN1,
             OE_COUNTOF(CHAIN1)) == OE_OK);
     OE_TEST(
         read_chain(
+            path,
             "../data/intermediate2.cert.pem",
             "../data/root2.cert.pem",
             CHAIN2,
             OE_COUNTOF(CHAIN2)) == OE_OK);
     OE_TEST(
         read_mod(
+            path,
             "../data/leaf_modulus.hex",
             _CERT1_RSA_MODULUS,
             &rsa_modulus_size) == OE_OK);
     OE_TEST(
         read_pem_key(
-            "../data/leaf.key.pem", _PRIVATE_KEY, sizeof(_PRIVATE_KEY), NULL) ==
-        OE_OK);
+            path,
+            "../data/leaf.key.pem",
+            _PRIVATE_KEY,
+            sizeof(_PRIVATE_KEY),
+            NULL) == OE_OK);
     OE_TEST(
         read_pem_key(
+            path,
             "../data/leaf.public.key.pem",
             _PUBLIC_KEY,
             sizeof(_PUBLIC_KEY),
             NULL) == OE_OK);
     OE_TEST(
-        read_sign("../data/test_rsa_signature", _SIGNATURE, &sign_size) ==
+        read_sign(path, "../data/test_rsa_signature", _SIGNATURE, &sign_size) ==
         OE_OK);
     OE_TEST(
         read_mixed_chain(

--- a/tests/crypto/tests.c
+++ b/tests/crypto/tests.c
@@ -3,17 +3,17 @@
 
 #include "tests.h"
 
-void TestAll()
+void TestAll(char* path)
 {
 #if !defined(_WIN32)
-    TestASN1();
+    TestASN1(path);
 #endif
-    TestCRL();
+    TestCRL(path);
 #if defined(OE_BUILD_ENCLAVE)
     TestCert();
 #endif
-    TestEC();
-    TestRSA();
+    TestEC(path);
+    TestRSA(path);
     TestRandom();
 #if defined(__x86_64__) || defined(__i386__)
     // Test the RDRAND/RDSEED instructions, which are x86/64-specific.

--- a/tests/crypto/tests.h
+++ b/tests/crypto/tests.h
@@ -4,18 +4,18 @@
 #ifndef _TESTS_CRYPTO_TESTS_H
 #define _TESTS_CRYPTO_TESTS_H
 
-void TestASN1(void);
-void TestCRL(void);
+void TestASN1(char* path);
+void TestCRL(char* path);
 #if defined(OE_BUILD_ENCLAVE)
 void TestCert(void);
 #endif
-void TestEC(void);
+void TestEC(char* path);
 void TestKDF(void);
 void TestRandom(void);
 void TestCpuEntropy(void);
-void TestRSA(void);
+void TestRSA(char* path);
 void TestSHA(void);
 void TestHMAC(void);
-void TestAll(void);
+void TestAll(char* path);
 
 #endif /* _TESTS_CRYPTO_TESTS_H */


### PR DESCRIPTION
`SYSCALL_NO_INLINE` is removed in musl version 1.2.2, causing code coverage to fail for tests under `tests/crypto`. This PR fixes this issue.