### PR TITLE
Update to Ansible 8

### DIFF
--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -342,7 +342,11 @@ node(params.AGENTS_LABEL) {
                         sudo tee /etc/apt/sources.list.d/azure-cli.list
                     ${helpers.WaitForAptLock()}
                     sudo apt-get update
-                    sudo apt-get -y install azure-cli jq
+                    # temporarily pinning to 2.56.0-1~focal to avoid breaking changes in 2.57.0
+                    # can be removed after 2.58 is released (eta 3-5-2024)
+                    # see https://github.com/Azure/azure-cli/issues/28397
+                    apt-cache show azure-cli | grep Version
+                    sudo apt-get -y install azure-cli=2.56.0-1~focal jq
                 """
             }
         }

--- a/.jenkins/library/vars/globalvars.groovy
+++ b/.jenkins/library/vars/globalvars.groovy
@@ -14,8 +14,8 @@ import groovy.transform.Field
     // ACC VMs
     "acc-ubuntu-20.04":            env.UBUNTU_2004_CUSTOM_LABEL ?: "ACC-2004",
     "acc-v3-ubuntu-20.04":         env.UBUNTU_2004_ICX_CUSTOM_LABEL ?: "ACC-v3-2004",
-    "acc-win2022-dcap":            env.WS2022_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2022-DCAP",
-    "acc-v3-win2022-dcap":         env.WS2022_DCAP_ICX_CUSTOM_LABEL ?: "ACC-v3-SGXFLC-Windows-2022-DCAP",
+    "acc-win2022-dcap":            env.WS2022_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2022-DCAP-v2",
+    "acc-v3-win2022-dcap":         env.WS2022_DCAP_ICX_CUSTOM_LABEL ?: "SGXFLC-Windows-2022-DCAP-v3",
     // Non SGX VMs
     "ubuntu-nonsgx":               env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004",
     "ubuntu-nonsgx-20.04":         env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004",

--- a/scripts/ansible/ansible.cfg
+++ b/scripts/ansible/ansible.cfg
@@ -6,5 +6,5 @@ inventory = inventory
 # "Authentication or permission failure. In some cases, you may have been able
 # to authenticate and did not have permissions on the target directory. Consider
 # changing the remote tmp path in ansible.cfg to a path rooted in \"/tmp\" ." 
-remote_tmp = /tmp/.ansible
-local_tmp  = /tmp/.ansible
+remote_tmp = ~/.ansible/tmp
+local_tmp  = ~/.ansible/tmp

--- a/scripts/ansible/remove-ansible.sh
+++ b/scripts/ansible/remove-ansible.sh
@@ -7,14 +7,28 @@ set -o errexit
 
 DIR=$(dirname "$0")
 
-if command -v yum > /dev/null; then
-    yum install python3-pip -y
-elif command -v apt-get > /dev/null; then
-    apt-get update
-    apt-get install python3-pip -y
-else
-    echo "ERROR: Only these package managers are supported: yum, apt-get"
-    exit 1
+if [[ -d ~/.ansible/collections/ansible_collections/community/general ]]; then
+    echo "Removing community.general from Ansible collections..."
+    rm -rf ~/.ansible/collections/ansible_collections/community/general
+fi
+if [[ -d ~/.ansible/collections/ansible_collections/ansible/windows ]]; then
+    echo "Removing ansiblle.windows from Ansible collections..."
+    rm -rf ~/.ansible/collections/ansible_collections/ansible/windows
+fi
+if [[ -d ~/.ansible/collections/ansible_collections/community/windows ]]; then
+    echo "Removing community.windows from Ansible collections..."
+    rm -rf ~/.ansible/collections/ansible_collections/community/windows
+fi
+if ! command -v ansible; then
+    echo "No Ansible installation found!"
 fi
 
-pip3 uninstall -r "$DIR/requirements.txt" -y
+# Get Python version from Ansible in PATH
+PYTHON_VERSION=$(ansible --version | grep "python version" | awk '{print $4}' | cut -d "." -f 1,2)
+PYTHON_EXECUTABLE=python${PYTHON_VERSION}
+
+if [[ -z ${PYTHON_VERSION+x} ]]; then
+    echo "ERROR: The Python version from Ansible could not be found! Found version: ${PYTHON_VERSION}"
+fi
+
+${PYTHON_EXECUTABLE} -m pip uninstall -r "$DIR/requirements.txt" -y

--- a/scripts/ansible/requirements.txt
+++ b/scripts/ansible/requirements.txt
@@ -1,8 +1,8 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
-cryptography==41.0.6
-pyOpenSSL==23.2.0
+cryptography==42.0.5
+pyOpenSSL==24.0.0
 ansible>=8.7,<9.0
-ansible-core>=2.15.5
+ansible-core>=2.15.5,<2.16
 cmake_format==0.6.9
-pywinrm>=0.3.0
+pywinrm==0.4.3

--- a/scripts/ansible/requirements.txt
+++ b/scripts/ansible/requirements.txt
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 cryptography==41.0.6
 pyOpenSSL==23.2.0
-ansible>=4.10,<=5.2.0
+ansible>=8.7,<9.0
+ansible-core>=2.15.5
 cmake_format==0.6.9
 pywinrm>=0.3.0

--- a/scripts/ansible/roles/linux/openenclave/vars/ubuntu/focal.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/ubuntu/focal.yml
@@ -5,9 +5,8 @@
 gcc_target_version: "9.4.0"
 # For specifying distribution-specific packages
 apt_distribution_packages:
-  - "python"
-  - "clang-10"
-  - "clang-format-10"
+  - "python3"
+  - "python-is-python3"
   - "clang-11"
   - "clang-format-11"
 apt_arm_distribution_packages:


### PR DESCRIPTION
* Also updates dependencies that Ansible needs
* Also pins azure-cli to 2.56 to create standard security type VMs
* Removed requirement to run install scripts with sudo entirely so the install script can be used as local user. Sudo is still required for the privileged apt-get commands.
* Explicitly use python3 and python-is-python3 (which is to symlink python to python3)
* Fix Windows label