### PR TITLE
Avoid leap year date

### DIFF
--- a/common/datetime.c
+++ b/common/datetime.c
@@ -261,8 +261,17 @@ void oe_datetime_log(const char* msg, const oe_datetime_t* date)
     {
         char str[OE_DATETIME_STR_SIZE];
         size_t size = sizeof(str);
-        oe_datetime_to_string(date, str, &size);
-        OE_TRACE_VERBOSE("%s %s\n", msg, str);
+        oe_result_t ret = oe_datetime_to_string(date, str, &size);
+        if (OE_OK != ret)
+        {
+            OE_TRACE_ERROR(
+                "Failed to convert oe_datetime_t to string. Error=%s\n",
+                oe_result_str(ret));
+        }
+        else
+        {
+            OE_TRACE_VERBOSE("%s %s\n", msg, str);
+        }
     }
 }
 

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -714,6 +714,11 @@ static void _test_time(
 
     tmp = *from;
     tmp.year--;
+    // Avoid leap year 2/29
+    if (tmp.month == 2 && tmp.day == 29)
+    {
+        tmp.day = 28;
+    }
     OE_TEST_CODE(
         oe_verify_sgx_quote(
             report_body,
@@ -726,6 +731,11 @@ static void _test_time(
 
     tmp = *until;
     tmp.year++;
+    // Avoid leap year 2/29
+    if (tmp.month == 2 && tmp.day == 29)
+    {
+        tmp.day = 28;
+    }
     OE_TEST_CODE(
         oe_verify_sgx_quote(
             report_body,

--- a/tests/attestation_plugin/plugin/tests.c
+++ b/tests/attestation_plugin/plugin/tests.c
@@ -714,7 +714,7 @@ static void _test_time(
 
     tmp = *from;
     tmp.year--;
-    // Avoid leap year 2/29
+    // Avoid 2/29 in a leap year
     if (tmp.month == 2 && tmp.day == 29)
     {
         tmp.day = 28;
@@ -731,7 +731,7 @@ static void _test_time(
 
     tmp = *until;
     tmp.year++;
-    // Avoid leap year 2/29
+    // Avoid 2/29 in a leap year
     if (tmp.month == 2 && tmp.day == 29)
     {
         tmp.day = 28;
@@ -797,6 +797,11 @@ static void _test_time_policy(
 
     dt = *from;
     dt.year--;
+    // Avoid 2/29 in a leap year
+    if (dt.month == 2 && dt.day == 29)
+    {
+        dt.day = 28;
+    }
     OE_TEST_CODE(
         oe_verify_evidence(
             wrapped_with_header ? NULL : format_id,
@@ -812,6 +817,11 @@ static void _test_time_policy(
 
     dt = *until;
     dt.year++;
+    // Avoid 2/29 in a leap year
+    if (dt.month == 2 && dt.day == 29)
+    {
+        dt.day = 28;
+    }
     OE_TEST_CODE(
         oe_verify_evidence(
             wrapped_with_header ? NULL : format_id,

--- a/tests/report/common/tests.cpp
+++ b/tests/report/common/tests.cpp
@@ -1477,6 +1477,11 @@ void test_verify_report_with_collaterals()
         memset(&parsed_report, 0, sizeof(parsed_report));
 
         valid_from.year -= 1;
+        // Avoid leap year 2/29
+        if (valid_from.month == 2 && valid_from.day == 29)
+        {
+            valid_from.day = 28;
+        }
         OE_TEST(
             VerifyReportWithCollaterals(
                 report_buffer_ptr,
@@ -1487,6 +1492,11 @@ void test_verify_report_with_collaterals()
                 NULL) == OE_VERIFY_FAILED_TO_FIND_VALIDITY_PERIOD);
 
         valid_until.year += 1;
+        // Avoid leap year 2/29
+        if (valid_until.month == 2 && valid_until.day == 29)
+        {
+            valid_until.day = 28;
+        }
         OE_TEST(
             VerifyReportWithCollaterals(
                 report_buffer_ptr,

--- a/tests/report/common/tests.cpp
+++ b/tests/report/common/tests.cpp
@@ -1403,9 +1403,9 @@ void test_verify_report_with_collaterals()
 
         // convert tm to oe_datetime_t
         oe_datetime_t past = {
-            (uint32_t)timeinfo.tm_year + 1890,
+            (uint32_t)timeinfo.tm_year + 1890, // 10 years ago
             (uint32_t)timeinfo.tm_mon + 1,
-            (uint32_t)timeinfo.tm_mday,
+            (uint32_t)10, // using arbitrary day to avoid leap year problem
             (uint32_t)timeinfo.tm_hour,
             (uint32_t)timeinfo.tm_min,
             (uint32_t)timeinfo.tm_sec};
@@ -1420,9 +1420,9 @@ void test_verify_report_with_collaterals()
 
         /* Test with time in the future */
         oe_datetime_t future = {
-            (uint32_t)timeinfo.tm_year + 1910,
+            (uint32_t)timeinfo.tm_year + 1910, // 10 years in the future
             (uint32_t)timeinfo.tm_mon + 1,
-            (uint32_t)timeinfo.tm_mday,
+            (uint32_t)10, // using arbitrary day to avoid leap year problem
             (uint32_t)timeinfo.tm_hour,
             (uint32_t)timeinfo.tm_min,
             (uint32_t)timeinfo.tm_sec};

--- a/tests/report/common/tests.cpp
+++ b/tests/report/common/tests.cpp
@@ -1477,7 +1477,7 @@ void test_verify_report_with_collaterals()
         memset(&parsed_report, 0, sizeof(parsed_report));
 
         valid_from.year -= 1;
-        // Avoid leap year 2/29
+        // Avoid 2/29 in a leap year
         if (valid_from.month == 2 && valid_from.day == 29)
         {
             valid_from.day = 28;
@@ -1492,7 +1492,7 @@ void test_verify_report_with_collaterals()
                 NULL) == OE_VERIFY_FAILED_TO_FIND_VALIDITY_PERIOD);
 
         valid_until.year += 1;
-        // Avoid leap year 2/29
+        // Avoid 2/29 in a leap year
         if (valid_until.month == 2 && valid_until.day == 29)
         {
             valid_until.day = 28;


### PR DESCRIPTION
Avoid generating leap year date in test.
Previously this test is generating a date exactly 10 years in the past. For 2024/2/29, the generated date is 2014/2/29 which is invalid because 2014 is not leap year. This problem only occurs on Feb 29th.