### PR TITLE
Adding openssl_symcrypt_fips as build option for file-encryptor sample

### DIFF
--- a/samples/file-encryptor/CMakeLists.txt
+++ b/samples/file-encryptor/CMakeLists.txt
@@ -25,6 +25,31 @@ set(OE_CRYPTO_LIB
     mbedtls
     CACHE STRING "Crypto library used by enclaves.")
 
+if (OE_CRYPTO_LIB STREQUAL "openssl_symcrypt_fips")
+  # Download the SymCrypt release package at config-time
+  include(FetchContent)
+  FetchContent_Declare(
+    symcrypt_pkg
+    SOURCE_DIR ${CMAKE_BINARY_DIR}/SymCrypt
+    URL https://github.com/microsoft/SymCrypt/releases/download/v103.0.1/symcrypt-linux-oe_full-AMD64-103.0.1-69dbff3.tar.gz
+    URL_HASH
+      SHA256=27C8C1C309B217E74D6055734D305AA86D8CE9E05D6D75AFD12C885F13CEA710)
+
+  # Make the downloaded package globally available
+  FetchContent_GetProperties(symcrypt_pkg)
+  if (NOT symcrypt_pkg_POPULATED)
+    FetchContent_Populate(symcrypt_pkg)
+  endif ()
+
+  # The linker can only resolve up to single number after .so
+  configure_file(${CMAKE_BINARY_DIR}/SymCrypt/lib/libsymcrypt.so.103.0.1
+                 ${CMAKE_BINARY_DIR}/libsymcrypt.so.103 COPYONLY)
+
+  # Option passed in oeedger8r to include entropy.edl (required by
+  # SymCrypt FIPS module)
+  set(EDL_USE_HOST_ENTROPY "-DEDL_USE_HOST_ENTROPY")
+endif ()
+
 add_subdirectory(enclave)
 add_subdirectory(host)
 

--- a/samples/file-encryptor/Makefile
+++ b/samples/file-encryptor/Makefile
@@ -6,15 +6,42 @@
 OE_CRYPTO_LIB := mbedtls
 export OE_CRYPTO_LIB
 
-all: build
+TARGETS =
+
+SYMCRYPT_TAR = symcrypt-linux-oe_full-AMD64-103.0.1-69dbff3.tar.gz
+SYMCRYPT_URL = https://github.com/microsoft/SymCrypt/releases/download/v103.0.1/${SYMCRYPT_TAR}
+SYMCRYPT_SHA256 = 27C8C1C309B217E74D6055734D305AA86D8CE9E05D6D75AFD12C885F13CEA710
+SYMCRYPT_DIR = SymCrypt
+SYMCRYPT_SO = libsymcrypt.so.103.0.1
+# The linker can only resolve up to single number after .so
+SYMCRYPT_LINK_SO = libsymcrypt.so.103
+
+ifeq (${OE_CRYPTO_LIB}, openssl_symcrypt_fips)
+	TARGETS += symcrypt
+endif
+
+TARGETS += build
+
+all: ${TARGETS}
+
+symcrypt:
+	wget ${SYMCRYPT_URL}
+	echo "${SYMCRYPT_SHA256} ${SYMCRYPT_TAR}" | sha256sum --check
+	mkdir -p ${SYMCRYPT_DIR}
+	tar zxvf ${SYMCRYPT_TAR} -C ${SYMCRYPT_DIR}
+	rm ${SYMCRYPT_TAR}
+	cp ${SYMCRYPT_DIR}/lib/${SYMCRYPT_SO} enclave/${SYMCRYPT_LINK_SO}
 
 build:
+	make symcrypt
 	$(MAKE) -C enclave
 	$(MAKE) -C host
 
 clean:
 	$(MAKE) -C enclave clean
 	$(MAKE) -C host clean
+	rm -rf ${SYMCRYPT_DIR}
+	rm -f enclave/${SYMCRYPT_LINK_SO}
 
 run:
 	host/file-encryptorhost testfile ./enclave/file-encryptorenc.signed

--- a/samples/file-encryptor/enclave/CMakeLists.txt
+++ b/samples/file-encryptor/enclave/CMakeLists.txt
@@ -8,10 +8,10 @@ add_custom_command(
   COMMAND
     openenclave::oeedger8r --trusted ${CMAKE_SOURCE_DIR}/fileencryptor.edl
     --search-path ${OE_INCLUDEDIR} --search-path
-    ${OE_INCLUDEDIR}/openenclave/edl/sgx)
+    ${OE_INCLUDEDIR}/openenclave/edl/sgx ${EDL_USE_HOST_ENTROPY})
 
 set(CRYPTO_SRC ${OE_CRYPTO_LIB}_src)
-if (OE_CRYPTO_LIB STREQUAL "openssl_3")
+if (OE_CRYPTO_LIB STREQUAL "openssl_3" OR OE_CRYPTO_LIB STREQUAL "openssl_symcrypt_fips")
   set(CRYPTO_SRC openssl_src)
 endif ()
 
@@ -29,6 +29,23 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} # Needed for #include "../shared.h"
           ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR})
 
-target_link_libraries(
-  enclave openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB}
-  openenclave::oelibcxx)
+if (${OE_CRYPTO_LIB} STREQUAL "openssl_symcrypt_fips")
+  add_custom_command(
+    TARGET enclave
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/libsymcrypt.so.103
+            ${CMAKE_CURRENT_BINARY_DIR}/libsymcrypt.so.103)
+
+  target_link_libraries(
+    enclave
+    openenclave::oeenclave
+    openenclave::oesymcryptengine
+    openenclave::oecryptoopenssl
+    # Workaround: refer to the root of the build location so that we don't rely on the
+    # order of copy
+    ${CMAKE_BINARY_DIR}/libsymcrypt.so.103
+    openenclave::oelibcxx)
+else()
+  target_link_libraries(
+    enclave openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB}
+    openenclave::oelibcxx)
+endif()

--- a/samples/file-encryptor/enclave/Makefile
+++ b/samples/file-encryptor/enclave/Makefile
@@ -15,14 +15,22 @@ INCDIR=$(shell pkg-config oeenclave-$(C_COMPILER) --variable=includedir)
 CRYPTO_LDFLAGS=$(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libs)
 
 CRYPTO_SRC = $(OE_CRYPTO_LIB)_src
+# Cover openssl, openssl_symcrypt_fips, and openssl_3
+ifneq (,$(findstring openssl,$(OE_CRYPTO_LIB)))
+	CRYPTO_SRC = openssl_src
+endif
+
 CXXINCDIR = -I. -I../ -I../..
 CXXSRCS = common/ecalls.cpp \
 		$(CRYPTO_SRC)/encryptor.cpp \
 		$(CRYPTO_SRC)/keys.cpp
 
-# Cover openssl, openssl_symcrypt_fips, and openssl_3
-ifneq (,$(findstring openssl,$(OE_CRYPTO_LIB)))
-	CRYPTO_SRC = openssl_src
+EDL_USE_HOST_ENTROPY =
+SYMCRYPT_OBJ_FILES =
+
+ifeq (${OE_CRYPTO_LIB}, openssl_symcrypt_fips)
+	SYMCRYPT_OBJ_FILES = libsymcrypt.so.103
+	EDL_USE_HOST_ENTROPY = -DEDL_USE_HOST_ENTROPY
 endif
 
 all:
@@ -34,11 +42,12 @@ build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../fileencryptor.edl --trusted \
 		--search-path $(INCDIR) \
-		--search-path $(INCDIR)/openenclave/edl/sgx
+		--search-path $(INCDIR)/openenclave/edl/sgx \
+		$(EDL_USE_HOST_ENTROPY)
 	$(CXX) -g -c $(CXXFLAGS) -DOE_API_VERSION=2 -std=c++11 $(CXXINCDIR) \
 		$(CXXSRCS)
 	$(CC) -g -c $(CFLAGS) -DOE_API_VERSION=2 fileencryptor_t.c -o fileencryptor_t.o
-	$(CXX) -o file-encryptorenc ecalls.o encryptor.o keys.o fileencryptor_t.o $(LDFLAGS) $(CRYPTO_LDFLAGS)
+	$(CXX) -o file-encryptorenc ecalls.o encryptor.o keys.o fileencryptor_t.o $(SYMCRYPT_OBJ_FILES) $(LDFLAGS) $(CRYPTO_LDFLAGS)
 
 sign:
 	oesign sign -e file-encryptorenc -c common/file-encryptor.conf -k private.pem

--- a/samples/file-encryptor/fileencryptor.edl
+++ b/samples/file-encryptor/fileencryptor.edl
@@ -4,18 +4,21 @@
 enclave {
     from "openenclave/edl/syscall.edl" import *;
     from "platform.edl" import *;
+#ifdef EDL_USE_HOST_ENTROPY
+    from "openenclave/edl/sgx/entropy.edl" import *;
+#endif
 
     include "../shared.h"
 
     trusted {
-        public int initialize_encryptor( bool encrypt, 
-                                        [in, count=password_len] const char* password, 
-                                        size_t password_len, 
-                                        [in, out] encryption_header_t *header); 
-        
-        public int encrypt_block(bool encrypt, 
-                                        [in, count=size] unsigned char* input_buf, 
-                                        [out, count=size] unsigned char* output_buf, 
+        public int initialize_encryptor( bool encrypt,
+                                        [in, count=password_len] const char* password,
+                                        size_t password_len,
+                                        [in, out] encryption_header_t *header);
+
+        public int encrypt_block(bool encrypt,
+                                        [in, count=size] unsigned char* input_buf,
+                                        [out, count=size] unsigned char* output_buf,
                                         size_t size);
 
         public void close_encryptor();

--- a/samples/file-encryptor/host/CMakeLists.txt
+++ b/samples/file-encryptor/host/CMakeLists.txt
@@ -7,7 +7,7 @@ add_custom_command(
   COMMAND
     openenclave::oeedger8r --untrusted ${CMAKE_SOURCE_DIR}/fileencryptor.edl
     --search-path ${OE_INCLUDEDIR} --search-path
-    ${OE_INCLUDEDIR}/openenclave/edl/sgx)
+    ${OE_INCLUDEDIR}/openenclave/edl/sgx ${EDL_USE_HOST_ENTROPY})
 
 add_executable(file-encryptor_host
                host.cpp ${CMAKE_CURRENT_BINARY_DIR}/fileencryptor_u.c)

--- a/samples/file-encryptor/host/Makefile
+++ b/samples/file-encryptor/host/Makefile
@@ -8,13 +8,20 @@ CXXFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --cflags)
 LDFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --libs)
 INCDIR=$(shell pkg-config oehost-$(C_COMPILER) --variable=includedir)
 
+EDL_USE_HOST_ENTROPY =
+
+ifeq (${OE_CRYPTO_LIB}, openssl_symcrypt_fips)
+	EDL_USE_HOST_ENTROPY = -DEDL_USE_HOST_ENTROPY
+endif
+
 all: build
 
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../fileencryptor.edl --untrusted \
 		--search-path $(INCDIR) \
-		--search-path $(INCDIR)/openenclave/edl/sgx
+		--search-path $(INCDIR)/openenclave/edl/sgx \
+		$(EDL_USE_HOST_ENTROPY)
 	$(CXX) -g -c $(CXXFLAGS) host.cpp
 	$(CC) -g -c $(CFLAGS) fileencryptor_u.c
 	$(CXX) -o file-encryptorhost host.o fileencryptor_u.o $(LDFLAGS)

--- a/samples/file-encryptor/host/host.cpp
+++ b/samples/file-encryptor/host/host.cpp
@@ -405,7 +405,7 @@ int main(int argc, const char* argv[])
         argv[2], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);
     if (result != OE_OK)
     {
-        cerr << "oe_create_fileencryptor_enclave() failed with " << argv[0]
+        cerr << "oe_create_fileencryptor_enclave() failed with " << argv[2]
              << " " << result << endl;
         ret = 1;
         goto exit;


### PR DESCRIPTION
The attested_tls sample was often used as an example of how to build with openssl_symcrypt_fips option. However, the attested_tls sample is complex, with two enclaves and two host processes.

This change updates file-encryptor to work with openssl_symcrypt_fips, to serve as a more straightforward example.