### PR TITLE
Fix clang-11 detection in config.mk for samples

### DIFF
--- a/samples/config.mk
+++ b/samples/config.mk
@@ -10,7 +10,7 @@ else ifneq ($(shell $(CC) --version | grep clang),)
         # CC is default (cc), and aliases to clang.
 else
         # CC is default (cc), and does not alias to clang.
-        CLANG_VERSION = $(shell for v in "10" "9" "8"; do \
+        CLANG_VERSION = $(shell for v in "11" "10" "9" "8"; do \
                                         if [ -n "$$(command -v clang-$$v)" ]; then \
                                                 echo $$v; \
                                                 break; \


### PR DESCRIPTION
There was an issue where running "samples -R ctest" would not pick up clang-11 installation. It would use gc++ instead, which would cause a compilation error for attested_tls sample with openssl_symcrypt_fips option.