### PR TITLE
Install trace.h for oehostverify

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -28,6 +28,14 @@ install(FILES openenclave/trace.h
 install(FILES openenclave/tracee.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(
+  FILES openenclave/log.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/
+  COMPONENT OEHOSTVERIFY)
+install(
+  FILES openenclave/trace.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/
+  COMPONENT OEHOSTVERIFY)
+install(
   FILES openenclave/host_verify.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/
   COMPONENT OEHOSTVERIFY)

--- a/include/openenclave/trace.h
+++ b/include/openenclave/trace.h
@@ -23,8 +23,10 @@ oe_result_t oe_log_set_callback(void* context, oe_log_callback_t callback);
 /// Host API to set host logging level verbosity dynamically.
 oe_result_t oe_set_host_log_level(oe_log_level_t log_level);
 
+#ifndef OE_BUILD_HOST_VERIFY
 /// Host API to set enclave logging level verbosity dynamically.
 oe_result_t oe_set_enclave_log_level(oe_enclave_t* enclave, uint32_t log_level);
+#endif
 
 OE_EXTERNC_END
 


### PR DESCRIPTION
Previously `trace.h` is not installed for `oehostverify` component.

This PR adds installation of `trace.h` and it's dependency `log.h` when installing `oehostverify`.
Also we have `target_compile_definitions(oehostverify PUBLIC OE_BUILD_HOST_VERIFY)`
So we can toggle off the `oe_set_enclave_log_level` API declaration in `trace.h`, as it's shouldn't be available for host verify.