### PR TITLE
Various fixes

### DIFF
--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -8,7 +8,6 @@ GLOBAL_TIMEOUT_MINUTES = 480
 JENKINS_USER_CREDS_ID = 'oeadmin-credentials'
 OETOOLS_REPO = 'oejenkinscidockerregistry.azurecr.io'
 OETOOLS_REPO_CREDENTIALS_ID = 'oejenkinscidockerregistry'
-SERVICE_PRINCIPAL_CREDENTIALS_ID = 'SERVICE_PRINCIPAL_OSTCLAB'
 AZURE_IMAGES_MAP = [
     "WS22": [
         "image": "MicrosoftWindowsServer:WindowsServer:2022-datacenter-azure-edition:latest",
@@ -52,13 +51,10 @@ def buildLinuxManagedImage(String os_type, String version, String managed_image_
                             usernamePassword(credentialsId: OETOOLS_REPO_CREDENTIALS_ID,
                                              usernameVariable: "DOCKER_USER_NAME",
                                              passwordVariable: "DOCKER_USER_PASSWORD"),
-                            usernamePassword(credentialsId: SERVICE_PRINCIPAL_CREDENTIALS_ID,
-                                             passwordVariable: 'SERVICE_PRINCIPAL_PASSWORD',
-                                             usernameVariable: 'SERVICE_PRINCIPAL_ID'),
-                            string(credentialsId: 'openenclaveci-subscription-id', variable: 'SUBSCRIPTION_ID'),
-                            string(credentialsId: 'TenantID', variable: 'TENANT_ID')]) {
+                            string(credentialsId: 'Jenkins-CI-Subscription-Id', variable: 'SUBSCRIPTION_ID'),
+                            string(credentialsId: 'Jenkins-CI-Tenant-Id', variable: 'TENANT_ID')]) {
                         sh '''#!/bin/bash
-                            az login --service-principal -u ${SERVICE_PRINCIPAL_ID} -p ${SERVICE_PRINCIPAL_PASSWORD} --tenant ${TENANT_ID}
+                            az login --identity
                             az account set -s ${SUBSCRIPTION_ID}
                         '''
                         retry(5) {
@@ -350,14 +346,11 @@ node(params.AGENTS_LABEL) {
         }
         stage("Azure CLI Login") {
             withCredentials([
-                    usernamePassword(credentialsId: SERVICE_PRINCIPAL_CREDENTIALS_ID,
-                                     passwordVariable: 'SERVICE_PRINCIPAL_PASSWORD',
-                                     usernameVariable: 'SERVICE_PRINCIPAL_ID'),
-                    string(credentialsId: 'openenclaveci-subscription-id', variable: 'SUBSCRIPTION_ID'),
-                    string(credentialsId: 'TenantID', variable: 'TENANT_ID')]) {
+                    string(credentialsId: 'Jenkins-CI-Subscription-Id', variable: 'SUBSCRIPTION_ID'),
+                    string(credentialsId: 'Jenkins-CI-Tenant-Id', variable: 'TENANT_ID')]) {
                 retry(5) {
                     sh '''#!/bin/bash
-                        az login --service-principal -u ${SERVICE_PRINCIPAL_ID} -p ${SERVICE_PRINCIPAL_PASSWORD} --tenant ${TENANT_ID}
+                        az login --identity
                         az account set -s ${SUBSCRIPTION_ID}
                     '''
                 }

--- a/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
+++ b/.jenkins/infrastructure/build_azure_managed_images.Jenkinsfile
@@ -342,11 +342,9 @@ node(params.AGENTS_LABEL) {
                         sudo tee /etc/apt/sources.list.d/azure-cli.list
                     ${helpers.WaitForAptLock()}
                     sudo apt-get update
-                    # temporarily pinning to 2.56.0-1~focal to avoid breaking changes in 2.57.0
-                    # can be removed after 2.58 is released (eta 3-5-2024)
                     # see https://github.com/Azure/azure-cli/issues/28397
                     apt-cache show azure-cli | grep Version
-                    sudo apt-get -y install azure-cli=2.56.0-1~focal jq
+                    sudo apt-get -y install azure-cli jq
                 """
             }
         }

--- a/.jenkins/infrastructure/build_base_azure_gallery_image.Jenkinsfile
+++ b/.jenkins/infrastructure/build_base_azure_gallery_image.Jenkinsfile
@@ -30,11 +30,7 @@ def buildLinuxVMBaseImage(String os_type, String os_version) {
                 """
             }
             sh '''
-                az login \
-                    --service-principal \
-                    -u ${SERVICE_PRINCIPAL_ID} \
-                    -p ${SERVICE_PRINCIPAL_PASSWORD} \
-                    --tenant ${TENANT_ID}
+                az login --identity
                 az account set -s ${SUBSCRIPTION_ID}
             '''
         }

--- a/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
+++ b/.jenkins/infrastructure/update_production_infrastructure.Jenkinsfile
@@ -25,7 +25,7 @@ def update_production_azure_gallery_images(String image_name) {
                     string(credentialsId: 'openenclaveci-subscription-id', variable: 'SUBSCRIPTION_ID'),
                     string(credentialsId: 'TenantID', variable: 'TENANT_ID')]) {
                 sh '''#!/bin/bash
-                    az login --service-principal -u ${SERVICE_PRINCIPAL_ID} -p ${SERVICE_PRINCIPAL_PASSWORD} --tenant ${TENANT_ID}
+                    az login --identity
                     az account set -s ${SUBSCRIPTION_ID}
                 '''
             }

--- a/.jenkins/library/vars/tests.groovy
+++ b/.jenkins/library/vars/tests.groovy
@@ -940,6 +940,7 @@ def buildCrossPlatform(String version, String compiler, String pr_id = '') {
                            export PACK_PATH=\${sdk_path}/path
                            export OS_CODENAME=${os}
 
+                           sudo scripts/ansible/install-ansible.sh
                            sudo ansible-playbook scripts/ansible/oe-contributors-setup-cross-arm.yml
                            sudo apt install python python3-pyelftools p7zip-full -y
 

--- a/scripts/ansible/roles/linux/openenclave/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/ubuntu/main.yml
@@ -49,7 +49,6 @@ apt_arm_packages:
 validation_distribution_binaries:
   - "/usr/bin/shellcheck"
   - "/usr/bin/clang-11"
-  - "/usr/bin/clang-10"
 
 validation_distribution_files:
   - "/usr/lib/x86_64-linux-gnu/libssl.so"

--- a/scripts/ansible/roles/windows/openenclave/tasks/main.yml
+++ b/scripts/ansible/roles/windows/openenclave/tasks/main.yml
@@ -3,12 +3,6 @@
 
 ---
 
-  - name: OE setup | Set clang 10 version url and hash
-    set_fact:
-      clang_url:  "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe"
-      clang_hash: "893F8A12506F8AD29CA464D868FB432FDADD782786A10655B86575FC7FC1A562"
-    when: clang_target_version == "10"
-
   - name: OE setup | Set clang 11 version url and hash
     set_fact:
       clang_url:  "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/LLVM-11.1.0-win64.exe"

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -158,11 +158,11 @@ check_version()
 ##==============================================================================
 check_clang-format()
 {
-    # First check explicitly for the clang-format-10 executable.
-    cf=$(command -v clang-format-10 2> /dev/null)
+    # First check explicitly for the clang-format-11 executable.
+    cf=$(command -v clang-format-11 2> /dev/null)
 
     if [[ -x ${cf} ]]; then
-        cf="clang-format-10"
+        cf="clang-format-11"
         return
     else
         cf=$(command -v clang-format 2> /dev/null)


### PR DESCRIPTION
* Unpin Azure CLI version, to revert a change made in https://github.com/openenclave/openenclave/pull/4921
* Use managed identity to login
* Switch to clang-format-11, and remove requirement for clang-10 as it is deprecated.
* Fixes case where a test expected Ansible to be installed, but recently was (correctly) removed in Docker images due to a change made in https://github.com/openenclave/openenclave/pull/4921