### PR TITLE
Do not rely on undefined behavior where size is not a multiple of alignment.

### DIFF
--- a/enclave/core/debugmalloc.c
+++ b/enclave/core/debugmalloc.c
@@ -450,7 +450,9 @@ int oe_debug_posix_memalign(void** memptr, size_t alignment, size_t size)
 void* oe_debug_aligned_alloc(size_t alignment, size_t size)
 {
     const size_t padding_size = _get_padding_size(alignment);
-    const size_t block_size = _calculate_block_size(alignment, size);
+    const size_t block_size = oe_round_up_to_multiple(
+        _calculate_block_size(alignment, size), alignment);
+
     void* block = NULL;
     header_t* header = NULL;
 


### PR DESCRIPTION
Avoid enclave abort when snmalloc's aligned_alloc is called with size not being a multiple of alignment.
Round request size up to mulitple of alignment.