### PR TITLE
Check for quote-ex failure in oe_sgx_get_supported_attester_format_ids

### DIFF
--- a/enclave/sgx/attester.c
+++ b/enclave/sgx/attester.c
@@ -19,6 +19,7 @@
 #include "../common/attest_plugin.h"
 #include "../common/sgx/endorsements.h"
 #include "../core/sgx/report.h"
+#include "../core/sgx/tracee.h"
 #include "platform_t.h"
 
 /**
@@ -438,6 +439,10 @@ oe_result_t oe_attester_initialize(void)
 
 done:
     oe_mutex_unlock(&mutex);
+    if (result == OE_SERVICE_UNAVAILABLE && oe_sgx_is_in_simulation_mode())
+    {
+        result = OE_UNSUPPORTED;
+    }
     return result;
 }
 

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -1197,6 +1197,13 @@ oe_result_t oe_sgx_get_supported_attester_format_ids(
             index++;
         }
     }
+    else if (!_quote_ex_library.use_dcap_library_instead)
+    {
+        OE_RAISE_MSG(
+            _quote_ex_library.load_result,
+            "Failed to use SGX quote-ex library\n",
+            NULL);
+    }
     else
     {
         // Case when DCAP is used


### PR DESCRIPTION
We recently encountered a hiccup in Azure Kubernetes Service where the sgx-quote-helper-plugin pod was not scheduled by the time our service launched and run `oe_attester_initialize`. There were errors in the logs:
```
[init ../../../psw/ae/aesm_service/source/core/ipc/UnixCommunicationSocket.cpp:225] Failed to connect to socket /var/run/aesmd/aesm.socket
SGX AESM service unavailable (oe_result_t=OE_SERVICE_UNAVAILABLE) [/source/openenclave/host/sgx/sgxquote.c:_load_quote_ex_library_once:479]
```
but this was not an error in the app—`oe_attester_initialize` returned `OE_OK`, which we think is a bug. All future calls to `oe_get_evidence` did fail, even after the sgx-quote-helper-plugin pod came up—which we understand and do not consider a bug.

We traced the initialization to `oe_sgx_get_supported_attester_format_ids`, which does not have an `else if (!_quote_ex_library.use_dcap_library_instead)` block that is used by other methods with a similar structure.

## Tests

Unfortunately, I didn’t see a good place to add a unit test, and all existing tests pass with this change. I do have before and after logs from `oeutil` for this scenario, which demonstrates the fail-faster nature of the change.

```diff
--- master-no-ts.txt	2024-05-22 16:57:02
+++ branch-no-ts.txt	2024-05-22 16:56:58
@@ -1,18 +1,14 @@
 # ./cmake-build/output/bin/oeutil generate-evidence --format SGX_ECDSA --verbose -p out
 NOTICE: oeutil generate-evidence is purely a debugging utility and not suitable for production use.
 
 [init ../../../psw/ae/aesm_service/source/core/ipc/UnixCommunicationSocket.cpp:225] Failed to connect to socket /var/run/aesmd/aesm.socket
 [(H)ERROR] tid(0x7…) | SGX AESM service unavailable (oe_result_t=OE_SERVICE_UNAVAILABLE) [../host/sgx/sgxquote.c:_load_quote_ex_library_once:720]
-[(H)ERROR] tid(0x7…) | Failed to load SGX quote-ex library
- (oe_result_t=OE_SERVICE_UNAVAILABLE) [../host/sgx/sgxquote.c:oe_sgx_qe_get_target_info:929]
-[(H)ERROR] tid(0x7…) | :OE_SERVICE_UNAVAILABLE [../host/sgx/quote.c:sgx_get_qetarget_info:37]
-[(E)ERROR] tid(0x7…) | oeutil_enc.signed::OE_SERVICE_UNAVAILABLE [../enclave/core/sgx/report.c:oe_get_remote_report:283]
-[(E)ERROR] tid(0x7…) | oeutil_enc.signed::OE_SERVICE_UNAVAILABLE [../enclave/core/sgx/report.c:_oe_get_report_internal:388]
-[(E)ERROR] tid(0x7…) | oeutil_enc.signed::OE_SERVICE_UNAVAILABLE [../enclave/core/sgx/report.c:oe_get_report_v2_internal:443]
-[(E)ERROR] tid(0x7…) | oeutil_enc.signed:SGX Plugin: Failed to get OE report. OE_SERVICE_UNAVAILABLE (oe_result_t=OE_SERVICE_UNAVAILABLE) [../enclave/sgx/attester.c:_get_evidence:165]
-[(E)ERROR] tid(0x7…) | oeutil_enc.signed::OE_SERVICE_UNAVAILABLE [../enclave/attest_plugin.c:oe_get_evidence:116]
-[(E)ERROR] tid(0x7…) | oeutil_enc.signed::OE_SERVICE_UNAVAILABLE [../tools/oeutil/enc/generate_evidence_enc.cpp:get_plugin_evidence:130]
+[(H)ERROR] tid(0x7…) | Failed to use SGX quote-ex library
+ (oe_result_t=OE_SERVICE_UNAVAILABLE) [../host/sgx/sgxquote.c:oe_sgx_get_supported_attester_format_ids:1205]
+[(E)ERROR] tid(0x7…) | oeutil_enc.signed::OE_SERVICE_UNAVAILABLE [../enclave/sgx/attester.c:_get_attester_plugins:353]
+[(E)ERROR] tid(0x7…) | oeutil_enc.signed::OE_SERVICE_UNAVAILABLE [../enclave/sgx/attester.c:oe_attester_initialize:427]
+[(E)ERROR] tid(0x7…) | oeutil_enc.signed::OE_SERVICE_UNAVAILABLE [../tools/oeutil/enc/generate_evidence_enc.cpp:get_plugin_evidence:118]
 [(H)ERROR] tid(0x7…) | Failed to create OE evidence. Error: OE_SERVICE_UNAVAILABLE
  (oe_result_t=OE_SERVICE_UNAVAILABLE) [../tools/oeutil/host/generate_evidence.cpp:generate_oe_evidence:1260]
 [(H)ERROR] tid(0x7…) | :OE_SERVICE_UNAVAILABLE [../tools/oeutil/host/generate_evidence.cpp:_process_parameters:1770]
 Failed to process parameters. Error: OE_SERVICE_UNAVAILABLE
```
