### PR TITLE
Ansible: Specify SGX PSW/DCAP version for Ubuntu

### DIFF
--- a/scripts/ansible/roles/linux/intel/tasks/ubuntu/sgx-packages-install.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/ubuntu/sgx-packages-install.yml
@@ -20,6 +20,19 @@
     update_cache: yes
     install_recommends: no
 
+- name: Download SGX custom version configuration files
+  ansible.builtin.get_url:
+    url: "https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/99sgx_{{ intel_sgx_psw_version | replace('.', '_') }}_{{ ansible_distribution_release | lower }}_custom_version.cfg"
+    dest: "/etc/apt/preferences.d/intel-sgx.pref"
+    force: yes
+  register: download_result
+  until: download_result is succeeded
+  retries: 3
+  delay: 3
+  when:
+    - intel_sgx_psw_version is defined
+    - intel_sgx_psw_version | default('') | length > 0
+
 - name: Install the Intel libsgx packages
   ansible.builtin.apt:
     name: "{{ intel_sgx_packages }}"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/bionic.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/bionic.yml
@@ -1,8 +1,0 @@
-# Copyright (c) Open Enclave SDK contributors.
-# Licensed under the MIT License.
-
----
-intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.7/linux/distro/ubuntu18.04-server/sgx_linux_x64_driver_1.35.bin"
-intel_sgx1_driver_url: "https://download.01.org/intel-sgx/sgx-linux/2.18/distro/ubuntu18.04-server/sgx_linux_x64_driver_2.11.054c9c4c.bin"
-intel_sgx_package_dependencies:
-  - "libprotobuf10"

--- a/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/intel/vars/ubuntu/main.yml
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 
 ---
+# PSW 2.23.100 and DCAP 1.20.100
+intel_sgx_psw_version: "2.23.100"
+
 intel_dcap_driver_files:
   - "/dev/sgx_provision"
   - "/dev/sgx_enclave"


### PR DESCRIPTION
* Add an Ansible task to specify and hold SGX PSW/DCAP packages at a specific version on Ubuntu, defined by `intel_sgx_psw_version`
* Cleanup bionic variables, as those are deprecated.