### PR TITLE
Add required argument for SGX module to load

### DIFF
--- a/docs/GettingStartedDocs/HyperVLinuxVMSetup.md
+++ b/docs/GettingStartedDocs/HyperVLinuxVMSetup.md
@@ -22,7 +22,7 @@ To set up a Linux VM on your Windows machine, do the following:
    ```
    Set-ExecutionPolicy Bypass -Scope Process
    Import-Module Drive:\Path\to\VirtualMachineSgxSettings.psm1
-   Set-VMSgx -VmName MyVM -SgxEnabled $True -SgxSize 32
+   Set-VMSgx -VmName MyVM -SgxEnabled $True -SgxSize 32 -SgxLaunchControlMode 2
    ```
 1. Start the VM and connect to it (right click, Connect...), finish the initial setup, reboot, and login.
    - Enable OpenSSH server installation when given the choice during setup.


### PR DESCRIPTION
Without the argument '-SgxLaunchControlMode and its value 2, the SGX modules /dev/sgx_enclave and /dev/sgx_provision are not created. 
Reference issue: https://github.com/openenclave/openenclave/issues/4262
