### PR TITLE
Add user-agent header

### DIFF
--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -229,6 +229,7 @@ function Start-FileDownload {
     Start-ExecuteWithRetry -ScriptBlock {
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         $wc = New-Object System.Net.WebClient
+        $wc.Headers.Add("user-agent", "curl");
         $wc.DownloadFile($URL, $Destination)
     } -MaxRetryCount $RetryCount -RetryInterval 3 -RetryMessage "Failed to download $URL. Retrying"
 }


### PR DESCRIPTION
Their website checks for valid user-agent in request header. Add that so we can download successfully.

```
This would throw HTTP 403
curl -H 'User-Agent:' https://downloadmirror.intel.com/

This would work
curl -H 'User-Agent:curl' https://downloadmirror.intel.com/
```