### PR TITLE
Modified docker images to enable use of custom source repos

### DIFF
--- a/.jenkins/infrastructure/docker/dockerfiles/linux/Dockerfile
+++ b/.jenkins/infrastructure/docker/dockerfiles/linux/Dockerfile
@@ -36,8 +36,9 @@
 # Note that while building Ubuntu 22.04 is possible, it is not currently supported by Open Enclave SDK.
 
 ARG ubuntu_version=20.04
+ARG ubuntu_source_repo=""
 
-FROM ubuntu:${ubuntu_version}
+FROM ${ubuntu_source_repo}ubuntu:${ubuntu_version}
 
 ARG UNAME=jenkins
 ARG GNAME=jenkins

--- a/.jenkins/infrastructure/docker/dockerfiles/linux/base/Dockerfile
+++ b/.jenkins/infrastructure/docker/dockerfiles/linux/base/Dockerfile
@@ -3,7 +3,8 @@
 #
 # Please use the associated build.sh to build this Dockerfile
 ARG UBUNTU_CODENAME
-FROM ubuntu:${UBUNTU_CODENAME}
+ARG UBUNTU_SOURCE_REPO=""
+FROM ${UBUNTU_SOURCE_REPO}ubuntu:${UBUNTU_CODENAME}
 ARG UBUNTU_VERSION
 ARG UBUNTU_CODENAME
 ENV DEBIAN_FRONTEND noninteractive

--- a/.jenkins/infrastructure/docker/dockerfiles/windows/Dockerfile
+++ b/.jenkins/infrastructure/docker/dockerfiles/windows/Dockerfile
@@ -6,7 +6,9 @@
 # a contributor's system, as well as the script used when creating CI images; it seemed
 # like a logical choice to use the same work flow for setting up Docker containers.
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2022
+ARG windows_source_repo="mcr.microsoft.com/windows/"
+
+FROM ${windows_source_repo}servercore:ltsc2022
 
 COPY . oe
 RUN powershell.exe -ExecutionPolicy Unrestricted -NoLogo -NonInteractive -NoProfile -WindowStyle Hidden -File oe\scripts\install-windows-prereqs.ps1 -InstallPath C:\oe_prereqs -LaunchConfiguration SGX1FLC-NoIntelDrivers -DCAPClientType None


### PR DESCRIPTION
## Description
This PR introduces a new argument to the dockerfiles used to build base ubuntu, full ubuntu, and windows images. This new argument allows users of the dockerfiles to configure a custom repository that the base images can come from, (ex: a private docker registry). This change is made such that if the argument is left empty then the original behavior will occur (using MCR for the windows image and the default docker registry for the ubuntu images).

## Verification
Built images all images using the argument to point to a non default registry and built the images without the argument and saw the intended original behavior.