### PR TITLE
[Docker] Add Step to enable exec permissions for scripts in dockerfile

### DIFF
--- a/.jenkins/infrastructure/docker/dockerfiles/linux/Dockerfile
+++ b/.jenkins/infrastructure/docker/dockerfiles/linux/Dockerfile
@@ -65,7 +65,8 @@ RUN echo ${devkits_uri##*/} > /devkits/TARBALL
 # Run Ansible
 COPY ./scripts/ansible /ansible
 COPY ./scripts/lvi-mitigation /lvi-mitigation
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC /ansible/install-ansible.sh && \
+RUN chmod +x /ansible/install-ansible.sh /ansible/remove-ansible.sh && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC /ansible/install-ansible.sh && \
     ansible localhost --playbook-dir=/ansible -m import_role -a "name=linux/docker tasks_from=ci-setup.yml" -vvv && \
     /ansible/remove-ansible.sh && \
     apt-get remove -y python3-pip && \


### PR DESCRIPTION
### Description

Introduces a step in the linux docker images to enable execute permissions for ansible related shell scripts. This is added in case permissions are removed for any reason, and ensures the docker image can be built successfully.

### Verification
Verified through jenkins pipelines that Docker image is successfully built.