### PR TITLE
Fix compiler warnings of clang-14

### DIFF
--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -470,6 +470,8 @@ oe_result_t oe_sgx_create_enclave(
         else
             secs->base = (uint64_t)image_base;
     }
+#else
+    OE_UNUSED(ex_features);
 #endif // !defined(OEHOSTMR)
     *enclave_addr = image_base ? (uint64_t)image_base : secs->base;
     context->state = OE_SGX_LOAD_STATE_ENCLAVE_CREATED;

--- a/tests/invalid_image/CMakeLists.txt
+++ b/tests/invalid_image/CMakeLists.txt
@@ -4,4 +4,5 @@
 add_executable(invalid_image main.cpp)
 target_link_libraries(invalid_image oehost)
 set_property(TARGET invalid_image PROPERTY POSITION_INDEPENDENT_CODE OFF)
+target_link_options(invalid_image PRIVATE -no-pie)
 add_test(tests/invalid_image invalid_image)

--- a/tests/sgx_zerobase/enc/enc.cpp
+++ b/tests/sgx_zerobase/enc/enc.cpp
@@ -36,6 +36,7 @@ void _initialize_exception_handler(void)
 {
     oe_result_t result;
     result = oe_add_vectored_exception_handler(false, test_pfgp_handler);
+    OE_UNUSED(result);
 }
 
 int test_enclave_memory_access(uint64_t address, bool* exception)

--- a/tests/stdcxx/enc/enc.cpp
+++ b/tests/stdcxx/enc/enc.cpp
@@ -89,7 +89,7 @@ int enc_test(bool* caught, bool* dynamic_cast_works, size_t* n_constructions)
     /* Try strings */
     {
         string s = "hello world";
-        s.find("world");
+        OE_TEST(s.find("world") == 6);
     }
 
     /* Try vectors */

--- a/tests/tools/oesign/test-enclave/enclave/enc.c
+++ b/tests/tools/oesign/test-enclave/enclave/enc.c
@@ -13,11 +13,10 @@
 #include "oesign_test_t.h"
 
 /* Null-terminated hex string buffer size with 2 char per byte */
-const size_t OE_KSS_ID_HEX_BUFFER_SIZE = sizeof(oe_uuid_t) * 2 + 1;
+#define OE_KSS_ID_HEX_BUFFER_SIZE (sizeof(oe_uuid_t) * 2 + 1)
 /* Null-terminated hex string buffer size with 2 char per byte and 4 formatting
  * chars */
-const size_t FORMATTED_OE_KSS_ID_HEX_BUFFER_SIZE =
-    OE_KSS_ID_HEX_BUFFER_SIZE + 4;
+#define FORMATTED_OE_KSS_ID_HEX_BUFFER_SIZE (OE_KSS_ID_HEX_BUFFER_SIZE + 4)
 
 static const oe_uuid_t _ecdsa_uuid = {OE_FORMAT_UUID_SGX_ECDSA};
 


### PR DESCRIPTION
This fixes some warnings I got when compiling with clang-14. I know it's not supported, but I think the changes improve the code irrespective of that.