### PR TITLE
Update to JDK 17

### DIFF
--- a/scripts/ansible/roles/linux/jenkins/vars/ubuntu/main.yml
+++ b/scripts/ansible/roles/linux/jenkins/vars/ubuntu/main.yml
@@ -3,7 +3,7 @@
 
 ---
 java_packages:
-  - "openjdk-11-jre-headless"
+  - "openjdk-17-jre-headless"
 
 apt_packages_code_coverage:
   - "lcov"

--- a/scripts/ansible/roles/windows/jenkins/tasks/packer.yml
+++ b/scripts/ansible/roles/windows/jenkins/tasks/packer.yml
@@ -11,19 +11,20 @@
     path: "{{ jenkins_agent_root_dir }}"
     state: directory
 
-- name: Oracle JDK - Download
+- name: JDK - Download
   ansible.windows.win_get_url:
     url: "{{ jdk_url }}"
-    headers:
-      Cookie: "oraclelicense=accept-securebackup-cookie"
     dest: "{{ tmp_dir }}\\jdk-windows-x64.exe"
+    checksum_algorithm: "sha256"
+    checksum: "{{ jdk_checksum }}"
   register: jdk_download
 
-- name: Oracle JDK - Install
+- name: JDK - Install
   ansible.windows.win_package:
     path: "{{ jdk_download.dest }}"
     state: present
-  when: jdk_download is changed
+    creates_path: "{{ jdk_path }}"
+    product_id: "{{ jdk_productcode }}"
 
 - name: Configure Git in target image to enable merge/rebase actions - email
   ansible.windows.win_shell: |

--- a/scripts/ansible/roles/windows/jenkins/vars/windows.yml
+++ b/scripts/ansible/roles/windows/jenkins/vars/windows.yml
@@ -6,8 +6,15 @@ tmp_dir: "C:\\Windows\\Temp"
 shellcheck_dest: "C:\\Program Files\\shellcheck"
 jenkins_agent_root_dir: "C:/Jenkins"
 servicewrapper_url: "https://github.com/cloudbase/OpenStackService/releases/download/v0.1/service-wrapper-sdk10-x64.zip"
-jdk_url: "https://jenkinsprivatestorage.blob.core.windows.net/oraclejdk/jdk-11.0.16.1_windows-x64_bin.exe"
+# From https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-17
+jdk_url: "https://aka.ms/download-jdk/microsoft-jdk-17.0.13-windows-x64.msi"
+# From https://aka.ms/download-jdk/microsoft-jdk-17.0.13-windows-x64.msi.sha256sum.txt
+jdk_checksum: "186ef846423e498ef401aad1ffd92992546aa7e14702ffb90a2389ea51ae1b7a"
+jdk_path: "C:\\Program Files\\Microsoft\\jdk-17.0.13.11-hotspot\\bin\\java.exe"
+# This GUID is determined by installing jdk and then running the Powershell command:
+# `Get-WmiObject Win32_Product | Format-Table IdentifyingNumber, Name`
+jdk_productcode: "879C3E29-AA5D-4009-B30D-7F4C8EC13044"
 
 validation_binaries:
-  - "C:\\Program Files\\Java\\jdk-11.0.16.1\\bin\\java.exe"
+  - "{{ jdk_path }}"
   - "C:\\Windows\\System32\\docker.exe"


### PR DESCRIPTION
* This updates Ansible roles to install JDK 17 for Linux and Windows. 
* On Windows we switch from Oracle JDK to Microsoft's Open JDK build.