### PR TITLE
Hardcode codeql-action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
         submodules: recursive
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v3.27.9
       with:
         languages: ${{ matrix.language }}
         config-file: .github/codeql/codeql-config.yml
@@ -50,4 +50,4 @@ jobs:
        make -j8
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v3.27.9


### PR DESCRIPTION
As of CodeQL Action v3.28.0, a minimum version of 2.15.5 is required for CodeQL bundle. In #4862 we pinned CodeQL bundle to v2.15.1 due to breaking changes and it is still broken in v2.20 as seen in https://github.com/openenclave/openenclave/actions/runs/12602583321/job/35125957011

We will address the codeql issues in a separate PR.