### PR TITLE
Updated attestation sample to use openssl 3

### DIFF
--- a/samples/apkman/CMakeLists.txt
+++ b/samples/apkman/CMakeLists.txt
@@ -13,7 +13,7 @@ project("OEAPKMAN Sample" LANGUAGES C)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 set(OE_CRYPTO_LIB
-    mbedtls
+    openssl_3
     CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(enclave)

--- a/samples/apkman/Makefile
+++ b/samples/apkman/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: all build clean run simulate
 
-OE_CRYPTO_LIB := mbedtls
+OE_CRYPTO_LIB := openssl_3
 export OE_CRYPTO_LIB
 
 all: build

--- a/samples/attestation/CMakeLists.txt
+++ b/samples/attestation/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
 set(OE_CRYPTO_LIB
-    mbedtls
+    openssl_3
     CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(common)

--- a/samples/attestation/Makefile
+++ b/samples/attestation/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: all build clean run
 
-OE_CRYPTO_LIB := mbedtls
+OE_CRYPTO_LIB := openssl_3
 export OE_CRYPTO_LIB
 
 all: build

--- a/samples/attestation/common/attestation.cpp
+++ b/samples/attestation/common/attestation.cpp
@@ -73,7 +73,7 @@ bool Attestation::generate_attestation_evidence(
          .value_size = sizeof(custom_claim1_value)},
         {.name = custom_claim2_name, .value = nullptr, .value_size = 0}};
 
-    if (m_crypto->Sha256(data, data_size, hash) != 0)
+    if (m_crypto->Sha256(data, data_size, hash) != true)
     {
         TRACE_ENCLAVE("data hashing failed");
         goto exit;
@@ -295,7 +295,7 @@ bool Attestation::attest_attestation_evidence(
         goto exit;
     }
 
-    if (m_crypto->Sha256(data, data_size, hash) != 0)
+    if (m_crypto->Sha256(data, data_size, hash) != true)
     {
         goto exit;
     }

--- a/samples/attestation/common/crypto.h
+++ b/samples/attestation/common/crypto.h
@@ -5,15 +5,10 @@
 #define OE_SAMPLES_ATTESTATION_ENC_CRYPTO_H
 
 #include <openenclave/enclave.h>
+#include <openssl/evp.h>
 // Includes for mbedtls shipped with oe.
 // Also add the following libraries to your linker command line:
 // -loeenclave -lmbedcrypto -lmbedtls -lmbedx509
-#include <mbedtls/config.h>
-#include <mbedtls/ctr_drbg.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/pk.h>
-#include <mbedtls/rsa.h>
-#include <mbedtls/sha256.h>
 #include "log.h"
 
 #define PUBLIC_KEY_SIZE 512
@@ -21,10 +16,8 @@
 class Crypto
 {
   private:
-    mbedtls_ctr_drbg_context m_ctr_drbg_contex;
-    mbedtls_entropy_context m_entropy_context;
-    mbedtls_pk_context m_pk_context;
     uint8_t m_public_key[512];
+    EVP_PKEY* rsa_pkey;
     bool m_initialized;
 
     // Public key of another enclave.
@@ -54,7 +47,7 @@ class Crypto
      * decrypt decrypts the given data using current enclave's private key.
      * Used to receive encrypted data from another enclave.
      */
-    bool decrypt(
+    bool Decrypt(
         const uint8_t* encrypted_data,
         size_t encrypted_data_size,
         uint8_t* data,
@@ -69,7 +62,7 @@ class Crypto
     /**
      * Compute the sha256 hash of given data.
      */
-    int Sha256(const uint8_t* data, size_t data_size, uint8_t sha256[32]);
+    bool Sha256(const uint8_t* data, size_t data_size, uint8_t sha256[32]);
 
   private:
     /**
@@ -82,9 +75,8 @@ class Crypto
 
     /** init_mbedtls initializes the crypto module.
      */
-    bool init_mbedtls(void);
-
-    void cleanup_mbedtls(void);
+    bool init_openssl3(void);
+    void cleanup_openssl3(void);
 };
 
 #endif // OE_SAMPLES_ATTESTATION_ENC_CRYPTO_H

--- a/samples/attestation/common/dispatcher.cpp
+++ b/samples/attestation/common/dispatcher.cpp
@@ -292,7 +292,7 @@ int ecall_dispatcher::process_encrypted_message(message_t* message)
     }
 
     data_size = sizeof(data);
-    if (m_crypto->decrypt(message->data, message->size, data, &data_size))
+    if (m_crypto->Decrypt(message->data, message->size, data, &data_size))
     {
         // This is where the business logic for verifying the data should be.
         // In this sample, both enclaves start with identical data in

--- a/samples/attested_tls/CMakeLists.txt
+++ b/samples/attested_tls/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_CXX_STANDARD 11)
 # set OE_CRYPTO_LIB to either "mbedtls" or "openssl" based on the crypto wrapper to be used.
 # OE_CRYPTO_LIB is case sensitive. Use all lowercase letters.
 set(OE_CRYPTO_LIB
-    mbedtls
+    openssl_3
     CACHE STRING "Crypto library used by enclaves.")
 
 find_package(OpenEnclave CONFIG REQUIRED)
@@ -31,8 +31,7 @@ if (OE_CRYPTO_LIB MATCHES ".*symcrypt.*")
   include(FetchContent)
   FetchContent_Declare(
     symcrypt_pkg
-    SOURCE_DIR
-    ${CMAKE_BINARY_DIR}/SymCrypt
+    SOURCE_DIR ${CMAKE_BINARY_DIR}/SymCrypt
     URL https://github.com/microsoft/SymCrypt/releases/download/v103.4.2/symcrypt-linux-oe_full-amd64-release-103.4.2-171f697.tar.gz
     URL_HASH
       SHA256=AA562EC53CFBA400A2A27027F480BC81DD9C530A5DCA32CC5C6834ED191D03FD)

--- a/samples/attested_tls/README.md
+++ b/samples/attested_tls/README.md
@@ -9,11 +9,9 @@ It has the following properties:
 - Demonstrates attested TLS feature
   - between two enclaves
   - between an enclave application and a non enclave application
-- Use of MbedTLS/OpenSSL crypto libraries within enclaves for TLS
-- Select between MbedTLS and OpenSSL crypto libraries by setting an environment variable `OE_CRYPTO_LIB` to `mbedtls` or `openssl` at build time (Note that `OE_CRYPTO_LIB` is case sensitive).
-- If the `OE_CRYPTO_LIB` not set, Mbed TLS will be used by default (see [Makefile](Makefile#L8) and [CMakeLists.txt](CMakeLists.txt#L10)).
+- Use of OpenSSL crypto libraries within enclaves for TLS
+- If the `OE_CRYPTO_LIB` not set, OpenSSL 3 will be used by default (see [Makefile](Makefile#L8) and [CMakeLists.txt](CMakeLists.txt#L10)).
 - To use FIPS-enabled OpenSSL based on SymCrypt engine, set the `OE_CRYPTO_LIB` to `openssl_symcrypt_fips`
-- To use OpenSSL 3.0, set the `OE_CRYPTO_LIB` to `openssl_3`
 - To use FIPS-enabled OpenSSL 3 based on SymCrypt provider, set the `OE_CRYPTO_LIB` to `openssl_3_symcrypt_prov_fips`
 - Configure both the server and the client with recommended cipher suites and elliptic curves (refer to the [section](#recommended-tls-configurations-when-using-openssl) for more details).
 - Use of following Enclave APIs
@@ -41,7 +39,7 @@ Note: Both of them can run on the same machine or separate machines.
     - Instantiate an enclave before transitioning the control into the enclave via an ecall.
   - Enclave (tls_server_enclave.signed)
     - Call oe_get_attestation_certificate_with_evidence to generate an certificate
-    - Use the MbedTLS/OpenSSL API to configure a TLS server using the generated certificate
+    - Use the OpenSSL API to configure a TLS server using the generated certificate
     - Launch a TLS server and wait for client connection request
     - Read client payload and reply with server payload
   - How to launch a server instance
@@ -53,7 +51,7 @@ Note: Both of them can run on the same machine or separate machines.
     - Instantiate an enclave before transitioning the control into the enclave via an ecall.
   - Enclave (tls_client_enclave.signed)
     - Call oe_get_attestation_certificate_with_evidence to generate an certificate
-    - Use MbedTLS/OpenSSL API to configure an TLS client after configuring above certificate as the client's certificate
+    - Use OpenSSL API to configure an TLS client after configuring above certificate as the client's certificate
     - Launch a TLS client and connect to the server
     - Send client payload and wait for server's payload
   - How to launch a client instance
@@ -77,14 +75,6 @@ Note: Both of them can run on the same machine or separate machines.
 ### Linux
 
 #### CMake
-- Use Mbed TLS
-  ```bash
-  mkdir build
-  cd build
-  cmake -DOE_CRYPTO_LIB=mbedtls ..
-  make
-  make run
-  ```
 - Use OpenSSL
   ```bash
   mkdir build
@@ -122,11 +112,6 @@ Note: Both of them can run on the same machine or separate machines.
   ```
 
 #### GNU Make
-- Use Mbed TLS
-  ```bash
-  make OE_CRYPTO_LIB=mbedtls build
-  make run
-  ```
 - Use OpenSSL
   ```bash
   make OE_CRYPTO_LIB=openssl build
@@ -154,14 +139,6 @@ Note: Both of them can run on the same machine or separate machines.
 ### Windows
 
 #### CMake
-- Use Mbed TLS
-  ```bash
-  mkdir build
-  cd build
-  cmake -G Ninja -DOE_CRYPTO_LIB=mbedtls ..
-  ninja
-  ninja run
-  ```
 - Use OpenSSL
   ```bash
   mkdir build

--- a/samples/file-encryptor/CMakeLists.txt
+++ b/samples/file-encryptor/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
 set(OE_CRYPTO_LIB
-    mbedtls
+    openssl_3
     CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(enclave)

--- a/samples/file-encryptor/Makefile
+++ b/samples/file-encryptor/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: all build clean run simulate
 
-OE_CRYPTO_LIB := mbedtls
+OE_CRYPTO_LIB := openssl_3
 export OE_CRYPTO_LIB
 
 all: build

--- a/samples/log_callback/CMakeLists.txt
+++ b/samples/log_callback/CMakeLists.txt
@@ -29,7 +29,7 @@ find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
 set(OE_CRYPTO_LIB
-    mbedtls
+    openssl_3
     CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(enclave)

--- a/samples/pluggable_allocator/CMakeLists.txt
+++ b/samples/pluggable_allocator/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(OpenEnclave CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
 set(OE_CRYPTO_LIB
-    mbedtls
+    openssl_3
     CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(enclave)

--- a/samples/test-samples.cmake
+++ b/samples/test-samples.cmake
@@ -42,17 +42,17 @@ endif ()
 if (BUILD_ENCLAVES)
   set(SAMPLES_LIST debugmalloc file-encryptor helloworld log_callback
                    switchless)
-  set(CRYPTO_LIB_LIST mbedtls mbedtls mbedtls mbedtls mbedtls)
+  set(CRYPTO_LIB_LIST openssl_3 openssl_3 openssl_3 openssl_3 openssl_3)
   # Debug malloc will set allocated memory to a fixed pattern.
   # Hence do not enable pluggable_allocator test under USE_DEBUG_MALLOC.
   if (COMPILER_SUPPORTS_SNMALLOC AND NOT USE_DEBUG_MALLOC)
     list(APPEND SAMPLES_LIST pluggable_allocator)
-    list(APPEND CRYPTO_LIB_LIST mbedtls)
+    list(APPEND CRYPTO_LIB_LIST openssl_3)
   endif ()
 
   if (UNIX)
     list(APPEND SAMPLES_LIST apkman)
-    list(APPEND CRYPTO_LIB_LIST mbedtls)
+    list(APPEND CRYPTO_LIB_LIST openssl_3)
   endif ()
 endif ()
 
@@ -71,7 +71,7 @@ else ()
   # that cause they directly interface with the AESM service.
   if (BUILD_ENCLAVES)
     list(APPEND SAMPLES_LIST data-sealing)
-    list(APPEND CRYPTO_LIB_LIST mbedtls)
+    list(APPEND CRYPTO_LIB_LIST openssl_3)
 
     # These tests can only run with SGX-FLC, meaning they were built
     # against SGX.
@@ -83,21 +83,17 @@ else ()
         attested_tls
         attested_tls
         attested_tls
-        attested_tls
         attestation
-        file-encryptor
         file-encryptor
         file-encryptor)
       list(
         APPEND
         CRYPTO_LIB_LIST
-        mbedtls
         openssl
         openssl_symcrypt_fips
         openssl_3
         openssl_3_symcrypt_prov_fips
-        mbedtls
-        mbedtls
+        openssl_3
         openssl
         openssl_3)
     endif ()


### PR DESCRIPTION
Updated attestation sample to use openssl 3, as well as updating all samples test to deprecate mbedtls usage