### PR TITLE
Remove CodeQL hardcoded version

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,4 +4,4 @@
 name: "CodeQL config"
 disable-default-queries: true
 queries:
-  - uses: "openenclave/openenclave-security/src/static/codeql/queries/cpp/suites/oe-codeql-security-queries.qls@main"
+  - uses: "asvrada/openenclave-security/src/static/codeql/queries/cpp/suites/oe-codeql-security-queries.qls@main"

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,4 +4,4 @@
 name: "CodeQL config"
 disable-default-queries: true
 queries:
-  - uses: "asvrada/openenclave-security/src/static/codeql/queries/cpp/suites/oe-codeql-security-queries.qls@main"
+  - uses: "openenclave/openenclave-security/src/static/codeql/queries/cpp/suites/oe-codeql-security-queries.qls@main"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,12 +35,10 @@ jobs:
         submodules: recursive
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3.27.9
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config-file: .github/codeql/codeql-config.yml
-        # Hardcode the CodeQL bundle version to 2.15.0, as 2.15.1 contains a breaking change that will need to be addressed before updating.
-        tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.15.0/codeql-bundle-linux64.tar.gz
 
     - name: Build
       run: |
@@ -50,4 +48,4 @@ jobs:
        make -j8
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3.27.9
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Work in progress for #4864 

Upgrade CodeQL versions by not hardcoding to old versions

The CodeQL queries are defined in a separate repo: https://github.com/asvrada/openenclave-security

This PR (https://github.com/openenclave/openenclave-security/pull/20) needs to be merged before this one