### PR TITLE
Bugfix: Update Windows Prereqs script to use Openssl 1 by default

### DIFF
--- a/scripts/install-windows-prereqs.ps1
+++ b/scripts/install-windows-prereqs.ps1
@@ -384,6 +384,12 @@ function Install-Git {
 function Install-OpenSSL {
     $installDir = Join-Path $InstallPath "OpenSSL"
     nuget.exe install openssl -Source $PACKAGES_DIRECTORY -OutputDirectory $InstallPath -ExcludeVersion
+    # Add OpenSSL x86 to beginning of the path so OpenSSL 1 is used by default (x64 bin is currently broken)
+    [Environment]::SetEnvironmentVariable(
+    "Path",
+    "$installDir\x86\release\bin;" + [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine),
+    [EnvironmentVariableTarget]::Machine
+    )
     Add-ToSystemPath -Path @("$installDir\bin")
 }
 


### PR DESCRIPTION
### Description  
Currently, due to the order that we install our prereqs, programs will by default use the version of openssl provided by github (openssl 3) in the windows environment, instead of the openssl package we specifically install. This PR fixes this bug by adding the path to the openssl 1 bin to the beginning of the PATH environment variable. We use the x86 version because currently the x64 version of the package is broken and does not work with the `-out` option.

### Verification
Verified via using script to build a docker image, then build open enclave successfully within the docker container.