### PR TITLE
Fix overflow check for iov.c

### DIFF
--- a/syscall/iov.c
+++ b/syscall/iov.c
@@ -162,7 +162,8 @@ int oe_iov_sync(
                 if (src_size != dest_size)
                     goto done;
 
-                if (src < (uint8_t*)buf || (size_t)src + src_size < src ||
+                if (src < (uint8_t*)buf ||
+                    (size_t)src + src_size < (size_t)src ||
                     src + src_size > (uint8_t*)buf + buf_size)
                     goto done;
 

--- a/syscall/iov.c
+++ b/syscall/iov.c
@@ -154,7 +154,7 @@ int oe_iov_sync(
             /* Sync the base data for this element. */
             {
                 /* Note: buf[i].iov_base is an offset here (not a pointer). */
-                uint8_t* src = (uint8_t*)buf[i].iov_base + (uint64_t)buf;
+                uint8_t* src = (uint8_t*)buf + (uint64_t)buf[i].iov_base;
                 size_t src_size = buf[i].iov_len;
                 uint8_t* dest = (uint8_t*)iov[i].iov_base;
                 size_t dest_size = iov[i].iov_len;
@@ -162,7 +162,7 @@ int oe_iov_sync(
                 if (src_size != dest_size)
                     goto done;
 
-                if (src < (uint8_t*)buf || src + src_size < src ||
+                if (src < (uint8_t*)buf || (size_t)src + src_size < src ||
                     src + src_size > (uint8_t*)buf + buf_size)
                     goto done;
 


### PR DESCRIPTION
The current way to check for pointer overflow (`src < (uint8_t*)buf || src + src_size < src`) triggers CodeQL complaints due to the undefined behavior of addition overflow. This PR introduces a check that does not rely on this behavior.

Fix applied as suggested by [this page](https://codeql.github.com/codeql-query-help/cpp/cpp-pointer-overflow-check/)