### PR TITLE
Add missing label

### DIFF
--- a/.jenkins/library/vars/globalvars.groovy
+++ b/.jenkins/library/vars/globalvars.groovy
@@ -23,6 +23,7 @@ import groovy.transform.Field
     // Non SGX VMs
     "ubuntu-nonsgx":               env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004",
     "ubuntu-nonsgx-20.04":         env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004",
+    "ubuntu-nonsgx-22.04":         env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2204",
     "ws2022-nonsgx":               env.WS2022_NONSGX_CUSTOM_LABEL ?: "nonSGX-Windows-2022",
     // Plain VMs
     "acc-ubuntu-22.04-vanilla":    "ACC-marketplace-ubuntu-2204",


### PR DESCRIPTION
This fixes an issue where no valid agent label was found for Ubuntu 22.04 non SGX agents, so the "Linux nonsgx verify quote" stage in Ubuntu 22.04 host verification tests defaulted to using a shared host and may fail.