### PR TITLE
Workaround for openssl 3.0.2 genrsa issue

### DIFF
--- a/.jenkins/library/vars/helpers.groovy
+++ b/.jenkins/library/vars/helpers.groovy
@@ -18,7 +18,7 @@ import java.time.format.DateTimeFormatter
  * @param code_coverage             [boolean] Enable code coverage?
  *                                            Default: OFF
  * @param debug_malloc              [boolean] Enable debug malloc?
- *                                            Default: OFF
+ *                                            Default: ON
  * @param lvi_mitigation            [string]  The LVI mitigation to use.
  *                                            Choice of: None, ControlFlow, ControlFlow-Clang, ControlFlow-GNU
  *                                            Default: None
@@ -54,9 +54,9 @@ def CmakeArgs(Map args) {
         code_coverage = 'ON'
     }
     // set debug_malloc
-    def debug_malloc = 'OFF'
-    if (args.debug_malloc) {
-        debug_malloc = 'ON'
+    def debug_malloc = 'ON'
+    if (args.debug_malloc == false) {
+        debug_malloc = 'OFF'
     }
     // Check valid lvi_mitigation parameters
     def lvi_args = ""

--- a/.jenkins/library/vars/tests.groovy
+++ b/.jenkins/library/vars/tests.groovy
@@ -312,7 +312,7 @@ def ACCHostVerificationTest(String version, String build_type, String compiler, 
                 def runArgs = "--cap-add=SYS_PTRACE"
                 def task = """
                            ${helpers.ninjaBuildCommand(cmakeArgs)}
-                           ctest -R host_verify --output-on-failure --timeout ${globalvars.CTEST_TIMEOUT_SECONDS} || ctest --rerun-failed --output-on-failure --timeout ${globalvars.CTEST_TIMEOUT_SECONDS}
+                           ${helpers.TestCommand('host_verify')}
                            """
                 // Note: Include the commands to build and run the quote verification test above
                 common.ContainerRun("oetools-${version}:${params.DOCKER_TAG}", compiler, task, runArgs)
@@ -617,27 +617,25 @@ def windowsPrereqsVerify(String label, String pr_id = '') {
  * @param lvi_mitigation             [string]  build enclave libraries with LVI mitigation.
  *                                             Choice of: None, ControlFlow-GNU, ControlFlow-Clang, or ControlFlow
  * @param lvi_mitigation_skip_tests  [boolean] Whether to skip LVI mitigation tests
- * @param extra_cmake_args           [string]  Add custom cmake args
  * @param pr_id                      [string]  Optional - to checkout a specific oe pull request merge head
  */
-def windowsLinuxElfBuild(String windows_label, String ubuntu_label, String compiler, String build_type, String lvi_mitigation = 'None', String lvi_mitigation_skip_tests = 'OFF', List extra_cmake_args = [], String pr_id = '') {
+def windowsLinuxElfBuild(String windows_label, String ubuntu_label, String compiler, String build_type, String lvi_mitigation = 'None', String lvi_mitigation_skip_tests = 'OFF', String pr_id = '') {
     stage("${ubuntu_label} ${compiler} ${build_type} LVI_MITIGATION=${lvi_mitigation}") {
         node(ubuntu_label) {
             timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 helpers.oeCheckoutScm(pr_id)
                 def runArgs = "--cap-add=SYS_PTRACE"
-                def task = """
-                           cmake ${WORKSPACE}                                           \
-                               -G Ninja                                                 \
-                               -DCMAKE_BUILD_TYPE=${build_type}                         \
-                               -DLVI_MITIGATION=${lvi_mitigation}                       \
-                               -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
-                               -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} \
-                               -Wdev                                                    \
-                               ${extra_cmake_args.join(' ')}
-                           ninja -v
-                           """
+                def cmakeArgs = helpers.CmakeArgs(
+                               builder: 'Ninja',
+                               build_type: build_type,
+                               code_coverage: false,
+                               debug_malloc: false,
+                               lvi_mitigation: lvi_mitigation,
+                               lvi_mitigation_skip_tests: lvi_mitigation_skip_tests,
+                               use_snmalloc: false,
+                               use_eeid: false)
+                def task = "${helpers.ninjaBuildCommand(cmakeArgs)}"
                 def imageName
                 if (! ubuntu_label.contains("2004") && ! ubuntu_label.contains("2204")) {
                     println("Unable to determine version from Ubuntu agent label. Defaulting to Ubuntu 22.04")
@@ -678,7 +676,7 @@ def windowsLinuxElfBuild(String windows_label, String ubuntu_label, String compi
                                 call vcvars64.bat x64
                                 setlocal EnableDelayedExpansion
                                 cmake.exe ${WORKSPACE} -G Ninja -DADD_WINDOWS_ENCLAVE_TESTS=ON -DBUILD_ENCLAVES=OFF -DCMAKE_BUILD_TYPE=${build_type} -DLINUX_BIN_DIR=${WORKSPACE}\\linuxbin\\tests -DLVI_MITIGATION=${lvi_mitigation} -DLVI_MITIGATION_SKIP_TESTS=${lvi_mitigation_skip_tests} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -Wdev || exit !ERRORLEVEL!
-                                ninja -v || exit !ERRORLEVEL!
+                                ninja.exe -v || exit !ERRORLEVEL!
                                 ctest.exe -V -C ${build_type} --timeout ${ globalvars.CTEST_TIMEOUT_SECONDS * 2.2 } || exit !ERRORLEVEL!
                             """
                         )
@@ -898,28 +896,34 @@ def windowsCrossPlatform(String label, String pr_id = '') {
 
 /* Builds OE in Simulation mode inside a containar
  *
- * @param version           [string]  Version of Ubuntu to use
- * @param build_type        [string]  The build type to use.
- *                                    Choice of: Debug, Release, or RelWithDebInfo
- * @param compiler          [string]  Compiler to use
- * @param extra_cmake_args  [string]  Add custom cmake args
- * @param pr_id             [string]  Optional - to checkout a specific oe pull request merge head
+ * @param version                    [string]  Version of Ubuntu to use
+ * @param build_type                 [string]  The build type to use.
+ *                                             Choice of: Debug, Release, or RelWithDebInfo
+ * @param compiler                   [string]  Compiler to use
+ * @param extra_cmake_args           [string]  Add custom cmake args
+ * @param lvi_mitigation             [string]  build enclave libraries with LVI mitigation.
+ *                                             Choice of: None, ControlFlow, ControlFlow-Clang
+ * @param skip_lvi_mitigation_tests  [boolean] Whether to skip LVI mitigation tests
+ * @param use_snmalloc               [string]  Use snmalloc as the default malloc implementation
+ * @param pr_id                      [string]  Optional - to checkout a specific oe pull request merge head
  */
-def simulationContainerTest(String version, String build_type, String compiler, List extra_cmake_args = [], String pr_id = '') {
-    stage("Simulation Ubuntu ${version} clang-${compiler} ${build_type}, extra_cmake_args: ${extra_cmake_args}") {
+def simulationContainerTest(String version, String build_type, String compiler, String lvi_mitigation, boolean skip_lvi_mitigation_tests, boolean use_snmalloc, String pr_id = '') {
+    stage("Simulation Ubuntu ${version} clang-${compiler} ${build_type}") {
         node(globalvars.AGENTS_LABELS["ubuntu-nonsgx-${version}"]) {
             timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
                 cleanWs()
                 helpers.oeCheckoutScm(pr_id)
                 def runArgs = "--cap-add=SYS_PTRACE"
+                def cmakeArgs = helpers.CmakeArgs(
+                                 builder: 'Ninja',
+                                 build_type: build_type,
+                                 code_coverage: false,
+                                 debug_malloc: false,
+                                 lvi_mitigation: lvi_mitigation,
+                                 lvi_mitigation_skip_tests: skip_lvi_mitigation_tests,
+                                 use_snmalloc: use_snmalloc)
                 def task = """
-                           cmake ${WORKSPACE}                                           \
-                               -G Ninja                                                 \
-                               -DCMAKE_BUILD_TYPE=${build_type}                         \
-                               -DLVI_MITIGATION_BINDIR=/usr/local/lvi-mitigation/bin    \
-                               ${extra_cmake_args.join(' ')}                            \
-                               -Wdev
-                           ninja -v
+                           ${helpers.ninjaBuildCommand(cmakeArgs)}
                            ${helpers.TestCommand()}
                            """
                 withEnv(["OE_SIMULATION=1"]) {
@@ -968,36 +972,6 @@ def buildCrossPlatform(String version, String compiler, String pr_id = '') {
     }
 }
 
-/* Builds OE for ARM64 inside a containar
- *
- * @param version           [string]  Version of Ubuntu to use
- * @param build_type        [string]  The build type to use.
- *                                    Choice of: Debug, Release, or RelWithDebInfo
- * @param pr_id             [string]  Optional - to checkout a specific oe pull request merge head
- */
-def AArch64GNUTest(String version, String build_type, String pr_id = '') {
-    stage("AArch64 GNU gcc Ubuntu${version} ${build_type}") {
-        node(globalvars.AGENTS_LABELS["ubuntu-nonsgx-${version}"]) {
-            timeout(globalvars.GLOBAL_TIMEOUT_MINUTES) {
-                cleanWs()
-                helpers.oeCheckoutScm(pr_id)
-                def runArgs = "--cap-add=SYS_PTRACE"
-                def task = """
-                            cmake ${WORKSPACE}                                                     \
-                                -G Ninja                                                           \
-                                -DCMAKE_BUILD_TYPE=${build_type}                                   \
-                                -DCMAKE_TOOLCHAIN_FILE=${WORKSPACE}/cmake/arm-cross.cmake          \
-                                -DOE_TA_DEV_KIT_DIR=/devkits/vexpress-qemu_armv8a/export-ta_arm64  \
-                                -DHAS_QUOTE_PROVIDER=OFF                                           \
-                                -Wdev
-                            ninja -v
-                            """
-                common.ContainerRun("oetools-${version}:${DOCKER_TAG}", "cross", task, runArgs)
-            }
-        }
-    }
-}
-
 def checkDevFlows(String version, String compiler, String pr_id = '') {
     stage('Default compiler') {
         node(globalvars.AGENTS_LABELS["ubuntu-nonsgx-${version}"]) {
@@ -1005,10 +979,20 @@ def checkDevFlows(String version, String compiler, String pr_id = '') {
                 cleanWs()
                 helpers.oeCheckoutScm(pr_id)
                 def runArgs = "--cap-add=SYS_PTRACE"
-                def task = """
-                           cmake ${WORKSPACE} -G Ninja -DHAS_QUOTE_PROVIDER=OFF -Wdev --warn-uninitialized -Werror=dev
-                           ninja -v
-                           """
+                def cmakeArgs = helpers.CmakeArgs(
+                                  builder: 'Ninja',
+                                  build_type: 'Debug',
+                                  code_coverage: false,
+                                  debug_malloc: false,
+                                  lvi_mitigation: 'None',
+                                  lvi_mitigation_skip_tests: 'ON',
+                                  use_snmalloc: false)
+                // Add custom cmake args that are used only for this test
+                cmakeArgs += """
+                               --warn-uninitialized
+                               -Werror=dev
+                             """
+                def task = "${helpers.ninjaBuildCommand(cmakeArgs)}"
                 common.ContainerRun("oetools-${version}:${DOCKER_TAG}", compiler, task, runArgs)
             }
         }

--- a/.jenkins/library/vars/tests.groovy
+++ b/.jenkins/library/vars/tests.groovy
@@ -25,7 +25,7 @@ def ACCCodeCoverageTest(String version, String compiler, String build_type, Stri
                     builder: 'Ninja',
                     build_type: build_type,
                     code_coverage: true,
-                    debug_malloc: false,
+                    debug_malloc: true,
                     lvi_mitigation: 'None',
                     lvi_mitigation_skip_tests: true,
                     use_snmalloc: false,
@@ -94,7 +94,7 @@ def ACCTest(String label, String compiler, String build_type, String lvi_mitigat
                     builder: 'Ninja',
                     build_type: build_type,
                     code_coverage: false,
-                    debug_malloc: false,
+                    debug_malloc: true,
                     lvi_mitigation: lvi_mitigation,
                     lvi_mitigation_skip_tests: lvi_mitigation_skip_tests,
                     use_snmalloc: use_snmalloc,
@@ -130,7 +130,7 @@ def ACCUpgradeTest(String version, String compiler, String lvi_mitigation, boole
                     builder: 'Ninja',
                     build_type: 'RelWithDebInfo',
                     code_coverage: false,
-                    debug_malloc: false,
+                    debug_malloc: true,
                     lvi_mitigation: lvi_mitigation,
                     lvi_mitigation_skip_tests: lvi_mitigation_skip_tests,
                     use_snmalloc: false,
@@ -170,7 +170,7 @@ def ACCContainerTest(String version, String compiler, String lvi_mitigation, boo
                     builder: 'Ninja',
                     build_type: 'RelWithDebInfo',
                     code_coverage: false,
-                    debug_malloc: false,
+                    debug_malloc: true,
                     lvi_mitigation: lvi_mitigation,
                     lvi_mitigation_skip_tests: lvi_mitigation_skip_tests,
                     use_snmalloc: false,
@@ -209,7 +209,7 @@ def ACCPackageTest(String version, String build_type, String lvi_mitigation, boo
                     builder: 'CMake',
                     build_type: build_type,
                     code_coverage: false,
-                    debug_malloc: false,
+                    debug_malloc: true,
                     lvi_mitigation: lvi_mitigation,
                     lvi_mitigation_skip_tests: lvi_mitigation_skip_tests,
                     use_snmalloc: use_snmalloc,
@@ -630,7 +630,7 @@ def windowsLinuxElfBuild(String windows_label, String ubuntu_label, String compi
                                builder: 'Ninja',
                                build_type: build_type,
                                code_coverage: false,
-                               debug_malloc: false,
+                               debug_malloc: true,
                                lvi_mitigation: lvi_mitigation,
                                lvi_mitigation_skip_tests: lvi_mitigation_skip_tests,
                                use_snmalloc: false,
@@ -918,7 +918,7 @@ def simulationContainerTest(String version, String build_type, String compiler, 
                                  builder: 'Ninja',
                                  build_type: build_type,
                                  code_coverage: false,
-                                 debug_malloc: false,
+                                 debug_malloc: true,
                                  lvi_mitigation: lvi_mitigation,
                                  lvi_mitigation_skip_tests: skip_lvi_mitigation_tests,
                                  use_snmalloc: use_snmalloc)
@@ -983,15 +983,12 @@ def checkDevFlows(String version, String compiler, String pr_id = '') {
                                   builder: 'Ninja',
                                   build_type: 'Debug',
                                   code_coverage: false,
-                                  debug_malloc: false,
+                                  debug_malloc: true,
                                   lvi_mitigation: 'None',
                                   lvi_mitigation_skip_tests: 'ON',
                                   use_snmalloc: false)
                 // Add custom cmake args that are used only for this test
-                cmakeArgs += """
-                               --warn-uninitialized
-                               -Werror=dev
-                             """
+                cmakeArgs += " --warn-uninitialized -Werror=dev"
                 def task = "${helpers.ninjaBuildCommand(cmakeArgs)}"
                 common.ContainerRun("oetools-${version}:${DOCKER_TAG}", compiler, task, runArgs)
             }

--- a/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Agnostic/Linux/Jenkinsfile
@@ -3,11 +3,11 @@
 
 library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 GLOBAL_ERROR = globalvars.GLOBAL_ERROR
-SKIP_LVI_MITIGATION_TESTS="ON"
+SKIP_LVI_MITIGATION_TESTS=true
 
 try{
     if(FULL_TEST_SUITE == "true") {
-        SKIP_LVI_MITIGATION_TESTS="OFF"
+        SKIP_LVI_MITIGATION_TESTS=false
     }
     def testing_stages = [
         "Check CI":                                { tests.checkCI('clang-11', params.PULL_REQUEST_ID) },
@@ -15,16 +15,17 @@ try{
         "Ubuntu 2004 Cross Platform Build":        { tests.buildCrossPlatform("20.04", 'clang-11', params.PULL_REQUEST_ID) },
         // Disabled as OP-TEE build needs to be upgraded to use Python3
         // "Ubuntu 2204 Cross Platform Build":        { tests.buildCrossPlatform("22.04", 'clang-11', params.PULL_REQUEST_ID) },
-        "Sim 2004 clang-11 SGX1FLC RelWithDebInfo":          { tests.simulationContainerTest('20.04', 'RelWithDebInfo', 'clang-11', ['-DHAS_QUOTE_PROVIDER=ON', '-DLVI_MITIGATION=None', "-DLVI_MITIGATION_SKIP_TESTS=${SKIP_LVI_MITIGATION_TESTS}"], params.PULL_REQUEST_ID) },
-        "Sim 2204 clang-11 SGX1FLC RelWithDebInfo":          { tests.simulationContainerTest('22.04', 'RelWithDebInfo', 'clang-11', ['-DHAS_QUOTE_PROVIDER=ON', '-DLVI_MITIGATION=None', "-DLVI_MITIGATION_SKIP_TESTS=${SKIP_LVI_MITIGATION_TESTS}"], params.PULL_REQUEST_ID) },
-        "Sim 2004 clang-11 SGX1FLC RelWithDebInfo snmalloc": { tests.simulationContainerTest('20.04', 'RelWithDebInfo', 'clang-11', ['-DHAS_QUOTE_PROVIDER=ON', '-DLVI_MITIGATION=None', "-DLVI_MITIGATION_SKIP_TESTS=${SKIP_LVI_MITIGATION_TESTS}", '-DUSE_SNMALLOC=ON'], params.PULL_REQUEST_ID) },
-        "Sim 2204 clang-11 SGX1FLC RelWithDebInfo snmalloc": { tests.simulationContainerTest('22.04', 'RelWithDebInfo', 'clang-11', ['-DHAS_QUOTE_PROVIDER=ON', '-DLVI_MITIGATION=None', "-DLVI_MITIGATION_SKIP_TESTS=${SKIP_LVI_MITIGATION_TESTS}", '-DUSE_SNMALLOC=ON'], params.PULL_REQUEST_ID) }
+        //                                                                            Ubuntu Version, Build Type, Compiler, LVI Mitigation, Skip LVI Mitigation Tests, Use snmalloc, PR ID
+        "Sim 2004 clang-11 SGX1FLC RelWithDebInfo":          { tests.simulationContainerTest('20.04', 'RelWithDebInfo', 'clang-11', 'None', SKIP_LVI_MITIGATION_TESTS, false, params.PULL_REQUEST_ID) },
+        "Sim 2204 clang-11 SGX1FLC RelWithDebInfo":          { tests.simulationContainerTest('22.04', 'RelWithDebInfo', 'clang-11', 'None', SKIP_LVI_MITIGATION_TESTS, false, params.PULL_REQUEST_ID) },
+        "Sim 2004 clang-11 SGX1FLC RelWithDebInfo snmalloc": { tests.simulationContainerTest('20.04', 'RelWithDebInfo', 'clang-11', 'None', SKIP_LVI_MITIGATION_TESTS, true, params.PULL_REQUEST_ID) },
+        "Sim 2204 clang-11 SGX1FLC RelWithDebInfo snmalloc": { tests.simulationContainerTest('22.04', 'RelWithDebInfo', 'clang-11', 'None', SKIP_LVI_MITIGATION_TESTS, true, params.PULL_REQUEST_ID) }
     ]
     if(FULL_TEST_SUITE == "true") {
         stage("Full Test Suite") {
             testing_stages += [
-                "Sim 2004 clang-11 SGX1FLC Debug snmalloc":  { tests.simulationContainerTest('20.04', 'Debug',          'clang-11', ['-DHAS_QUOTE_PROVIDER=ON', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], params.PULL_REQUEST_ID) },
-                "Sim 2204 clang-11 SGX1FLC Debug snmalloc":  { tests.simulationContainerTest('22.04', 'Debug',          'clang-11', ['-DHAS_QUOTE_PROVIDER=ON', '-DLVI_MITIGATION=None', '-DLVI_MITIGATION_SKIP_TESTS=OFF', '-DUSE_SNMALLOC=ON'], params.PULL_REQUEST_ID) }
+                "Sim 2004 clang-11 SGX1FLC Debug snmalloc":  { tests.simulationContainerTest('20.04', 'Debug',          'clang-11', 'None', SKIP_LVI_MITIGATION_TESTS, true, params.PULL_REQUEST_ID) },
+                "Sim 2204 clang-11 SGX1FLC Debug snmalloc":  { tests.simulationContainerTest('22.04', 'Debug',          'clang-11', 'None', SKIP_LVI_MITIGATION_TESTS, true, params.PULL_REQUEST_ID) }
             ]
             parallel testing_stages
         }

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -16,8 +16,7 @@ try{
         // TODO: To do after 22.04 packages are available
         // "Upgrade ACC2004 RelWithDebInfo":                            { tests.ACCUpgradeTest('22.04', 'clang-11', 'None', true, params.PULL_REQUEST_ID) },
         "Container ACC2004 RelWithDebInfo ControlFlow":              { tests.ACCContainerTest('20.04', 'clang-11', 'ControlFlow', false, params.PULL_REQUEST_ID) },
-        // TODO: To add after a 22.04 Docker image is published
-        // "Container ACC2004 RelWithDebInfo ControlFlow":              { tests.ACCContainerTest('22.04', 'clang-11', 'ControlFlow', false, params.PULL_REQUEST_ID) },
+        "Container ACC2004 RelWithDebInfo ControlFlow":              { tests.ACCContainerTest('22.04', 'clang-11', 'ControlFlow', false, params.PULL_REQUEST_ID) },
         "Code Coverage ACC2204":                                     { tests.ACCCodeCoverageTest('22.04', 'clang-11', 'Debug', params.PULL_REQUEST_ID) },                                                                                                                       // ACCTEST BOOL OPTIONS: SKIP LVI TESTS, SNMALLOC, EEID,  E2E
                                                                                                                                                      // ACCTEST BOOL OPTIONS: SKIP LVI TESTS, SNMALLOC, EEID,  E2E
         // "ACC2004 v2 clang-11 RelWithDebInfo ControlFlow e2e":        { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04-vanilla"], 'clang-11', 'RelWithDebInfo', 'ControlFlow', true, false,    false, true,  params.PULL_REQUEST_ID) },

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -14,7 +14,7 @@ def testing_stages = [
 ]
 if(FULL_TEST_SUITE == "true") {
     testing_stages += [
-        "ELF Win2022 Ubuntu2004 clang-11 Debug":                                 { tests.windowsLinuxElfBuild(params.WS2022_DCAP_CFL_LABEL, params.UBUNTU_2004_NONSGX_LABEL, 'clang-11', 'Debug', 'None', 'OFF', [], params.PULL_REQUEST_ID) },
+        "ELF Win2022 Ubuntu2004 clang-11 Debug":                                 { tests.windowsLinuxElfBuild(params.WS2022_DCAP_CFL_LABEL, params.UBUNTU_2004_NONSGX_LABEL, 'clang-11', 'Debug', 'None', 'OFF', params.PULL_REQUEST_ID) },
         "XC Win2022 v2 clang-11 RelWithDebInfo ControlFlow-Clang":               { tests.windowsCrossCompile(params.WS2022_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang', '0', 'OFF', 'OFF', params.PULL_REQUEST_ID) },
         "XC Win2022 v2 clang-11 Debug ControlFlow Sim snmalloc":                 { tests.windowsCrossCompile(params.WS2022_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow',       '1', 'OFF', 'ON', params.PULL_REQUEST_ID) },
         "Cross Platform Win2022":                                                { tests.windowsCrossPlatform(params.WS2022_DCAP_CFL_LABEL, params.PULL_REQUEST_ID) }


### PR DESCRIPTION
When using openssl 3.0.2-3.1.7 there is a random chance of failure when generating RSA keys: 
[RSA keygen fixes · openssl/openssl@2b84a62](https://github.com/openssl/openssl/commit/2b84a620d299b9614ab59342eb2911617b1bb3c3)
 
Currently, Ubuntu 22.04 has OpenSSL 3.0.2 as the latest available through official channels. Rather than compiling from source or use non-official repository to get OpenSSL 3.1.8+, this PR proposes a workaround of simply retrying failed builds/tests that fail with this issue so that we stabilize our CI builds.

This PR also:
* Removes tests.AArch64GNUTest as we no longer run the test.
* Removes compiler option `HAS_QUOTE_PROVIDER` from test specifications as it is no longer used
* Restores default cmake option debug_malloc to ON