### PR TITLE
Expand openssl workaround

### DIFF
--- a/.jenkins/library/vars/tests.groovy
+++ b/.jenkins/library/vars/tests.groovy
@@ -25,7 +25,9 @@ def ACCCodeCoverageTest(String version, String compiler, String build_type, Stri
                     builder: 'Ninja',
                     build_type: build_type,
                     code_coverage: true,
-                    debug_malloc: true,
+                    //  The CODE_COVERAGE option currently is not supported when the
+                    //  USE_DEBUG_MALLOC option is ON
+                    debug_malloc: false,
                     lvi_mitigation: 'None',
                     lvi_mitigation_skip_tests: true,
                     use_snmalloc: false,

--- a/.jenkins/pipelines/Azure/Nightly/libcxx_tests.Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Nightly/libcxx_tests.Jenkinsfile
@@ -28,10 +28,19 @@ def ACCLibcxxTest(String label, String compiler, String build_type) {
                         credentialsId: 'github-oeciteam-user-pat'
                     ]]
                 ])
+                def cmakeArgs = helpers.CmakeArgs(
+                    builder: 'Make',
+                    build_type: build_type,
+                    code_coverage: false,
+                    debug_malloc: true,
+                    lvi_mitigation: 'None',
+                    lvi_mitigation_skip_tests: true,
+                    use_snmalloc: false,
+                    use_eeid: false)
+                cmakeArgs += " -DENABLE_FULL_LIBCXX_TESTS=ON"
                 def task = """
-                           cmake .. -DCMAKE_BUILD_TYPE=${build_type} -DHAS_QUOTE_PROVIDER=ON -DENABLE_FULL_LIBCXX_TESTS=ON
-                           make
-                           ctest -VV -debug --timeout ${CTEST_TIMEOUT_SECONDS}
+                           ${helpers.buildCommand(cmakeArgs, 'Make')}
+                           ${helpers.TestCommand()}
                            """
                 common.Run(compiler, task)
             }


### PR DESCRIPTION
Expands the openssl workaround to libcxx tests:
* Add debug option to `helpers.TestCommand`
* Create a unified `helpers.buildCommand` to apply to both ninja and make. `helpers.ninjaBuildCommand` and `helpers.makeBuildCommand` are removed.

Fix code coverage by turning off debug_malloc as it's not supported