### PR TITLE
Minor fixes

### DIFF
--- a/.jenkins/library/vars/helpers.groovy
+++ b/.jenkins/library/vars/helpers.groovy
@@ -345,7 +345,7 @@ def testSamplesWindows(boolean lvi_mitigation, String oe_package) {
             """
         )
         dir("C:\\oe\\${oe_package}\\openenclave\\share\\openenclave\\samples\\${sample}\\build") {
-            buildCommand(cmakeArgs, "C:\\oe\\${oe_package}\\openenclave\\share\\openenclave\\samples\\${sample}")
+            buildCommand(cmakeArgs, 'Ninja', "C:\\oe\\${oe_package}\\openenclave\\share\\openenclave\\samples\\${sample}")
             bat(
                 script: """
                     call vcvars64.bat x64

--- a/.jenkins/library/vars/helpers.groovy
+++ b/.jenkins/library/vars/helpers.groovy
@@ -345,7 +345,7 @@ def testSamplesWindows(boolean lvi_mitigation, String oe_package) {
             """
         )
         dir("C:\\oe\\${oe_package}\\openenclave\\share\\openenclave\\samples\\${sample}\\build") {
-            ninjaBuildCommand(cmakeArgs, "C:\\oe\\${oe_package}\\openenclave\\share\\openenclave\\samples\\${sample}")
+            buildCommand(cmakeArgs, "C:\\oe\\${oe_package}\\openenclave\\share\\openenclave\\samples\\${sample}")
             bat(
                 script: """
                     call vcvars64.bat x64

--- a/.jenkins/pipelines/Azure/Nightly/libcxx_tests.Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Nightly/libcxx_tests.Jenkinsfile
@@ -51,7 +51,7 @@ def ACCLibcxxTest(String label, String compiler, String build_type) {
 pipeline {
     agent any
     options {
-        timeout(time: 240, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         buildDiscarder(logRotator(artifactDaysToKeepStr: '90', artifactNumToKeepStr: '180', daysToKeepStr: '90', numToKeepStr: '180'))
     }
     parameters {

--- a/.jenkins/pipelines/OpenEnclave/releases/tests/Jenkinsfile
+++ b/.jenkins/pipelines/OpenEnclave/releases/tests/Jenkinsfile
@@ -5,4 +5,7 @@ library "OpenEnclaveJenkinsLibrary@${params.OECI_LIB_VERSION}"
 
 parallel "Ubuntu 20.04":        { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, params.STORAGE_CREDENTIALS_ID, params.STORAGE_BLOB, false) },
          "Ubuntu 20.04 w/ LVI": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, params.STORAGE_CREDENTIALS_ID, params.STORAGE_BLOB, true)  },
+         "Ubuntu 22.04":        { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-22.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, params.STORAGE_CREDENTIALS_ID, params.STORAGE_BLOB, false) },
+         "Ubuntu 22.04 w/ LVI": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-ubuntu-22.04"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, params.STORAGE_CREDENTIALS_ID, params.STORAGE_BLOB, true)  },
+
          "Windows Server 2022": { tests.OEReleaseTest(globalvars.AGENTS_LABELS["acc-win2022-dcap"], params.OE_RELEASE_VERSION, params.OE_PACKAGE, params.RELEASE_SOURCE, params.STORAGE_CREDENTIALS_ID, params.STORAGE_BLOB, false) }


### PR DESCRIPTION
* Use new helpers.buildCommand for Windows sample tests for OE release tests
* Increase libcxx timeout to 6 hours since we have added more tests added over the years