### PR TITLE
Update to Ansible 2.16-2.17 for Ubuntu 22.04 

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -179,7 +179,8 @@ pipeline {
                                 string(name: 'REPOSITORY_NAME', value: params.REPOSITORY_NAME),
                                 string(name: 'BRANCH_NAME', value: params.BRANCH_NAME),
                                 string(name: 'DOCKER_TAG', value: params.DOCKER_TAG),
-                                string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx"]),
+                                string(name: 'UBUNTU_2004_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2004"]),
+                                string(name: 'UBUNTU_2204_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2204"]),
                                 string(name: 'OECI_LIB_VERSION', value: params.OECI_LIB_VERSION),
                                 booleanParam(name: 'FULL_TEST_SUITE', value: params.FULL_TEST_SUITE)
                             ]
@@ -194,7 +195,8 @@ pipeline {
                                 string(name: 'BRANCH_NAME', value: params.BRANCH_NAME),
                                 string(name: 'DOCKER_TAG', value: params.DOCKER_TAG),
                                 string(name: 'UBUNTU_2004_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["acc-ubuntu-20.04"]),
-                                string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx"]),
+                                string(name: 'UBUNTU_2004_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2004"]),
+                                string(name: 'UBUNTU_2204_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2204"]),
                                 string(name: 'WS2022_NONSGX_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["ws2022-nonsgx"]),
                                 string(name: 'OECI_LIB_VERSION', value: params.OECI_LIB_VERSION),
                                 booleanParam(name: 'FULL_TEST_SUITE', value: params.FULL_TEST_SUITE)
@@ -209,7 +211,8 @@ pipeline {
                                 string(name: 'REPOSITORY_NAME', value: params.REPOSITORY_NAME),
                                 string(name: 'BRANCH_NAME', value: params.BRANCH_NAME),
                                 string(name: 'DOCKER_TAG', value: params.DOCKER_TAG),
-                                string(name: 'UBUNTU_NONSGX_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx"]),
+                                string(name: 'UBUNTU_2004_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2004"]),
+                                string(name: 'UBUNTU_2204_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2204"]),
                                 string(name: 'WS2022_DCAP_CFL_LABEL', value: globalvars.AGENTS_LABELS["acc-win2022-dcap"]),
                                 string(name: 'WS2022_DCAP_ICX_LABEL', value: globalvars.AGENTS_LABELS["acc-v3-win2022-dcap"]),
                                 string(name: 'OECI_LIB_VERSION', value: params.OECI_LIB_VERSION),

--- a/.jenkins/infrastructure/e2e_testing.Jenkinsfile
+++ b/.jenkins/infrastructure/e2e_testing.Jenkinsfile
@@ -34,7 +34,10 @@ pipeline {
         string(name: 'REPLICATION_REGIONS', defaultValue: 'westeurope,eastus,uksouth,eastus2,westus,canadacentral', description: '[OPTIONAL] Replication regions for the shared gallery images definitions (comma-separated)', trim: true)
         string(name: 'UBUNTU_2004_CFL_LABEL', defaultValue: 'e2e-ACC-2004', description: 'Label to use for image testing and promotion', trim: true)
         string(name: 'UBUNTU_2004_ICX_LABEL', defaultValue: 'e2e-ACC-2004-v3', description: 'Label to use for image testing and promotion', trim: true)
-        string(name: 'UBUNTU_NONSGX_LABEL', defaultValue: 'e2e-nonSGX-ubuntu-2004', description: 'Label to use for image testing and promotion', trim: true)
+        string(name: 'UBUNTU_2004_NONSGX_LABEL', defaultValue: 'e2e-nonSGX-ubuntu-2004', description: 'Label to use for image testing and promotion', trim: true)
+        string(name: 'UBUNTU_2204_CFL_LABEL', defaultValue: 'e2e-ACC-2204', description: 'Label to use for image testing and promotion', trim: true)
+        string(name: 'UBUNTU_2204_ICX_LABEL', defaultValue: 'e2e-ACC-2204-v3', description: 'Label to use for image testing and promotion', trim: true)
+        string(name: 'UBUNTU_2204_NONSGX_LABEL', defaultValue: 'e2e-nonsgx-ubuntu-2204', description: 'Label to use for image testing and promotion', trim: true)
         string(name: 'WS2022_DCAP_CFL_LABEL', defaultValue: 'e2e-SGXFLC-Windows-2022-DCAP-v2', description: 'Label to use for image testing and promotion', trim: true)
         string(name: 'WS2022_DCAP_ICX_LABEL', defaultValue: 'e2e-SGXFLC-Windows-2022-DCAP-v3', description: 'Label to use for image testing and promotion', trim: true)
         string(name: 'WS2022_NONSGX_CUSTOM_LABEL', defaultValue: 'e2e-nonsgx-windows-2022', description: 'Label to use for image testing and promotion', trim: true)
@@ -98,7 +101,10 @@ pipeline {
                     string(name: 'OECI_LIB_VERSION', value: OECI_LIB_VERSION),
                     string(name: 'UBUNTU_2004_CFL_CUSTOM_LABEL', value: params.UBUNTU_2004_CFL_LABEL),
                     string(name: 'UBUNTU_2004_ICX_CUSTOM_LABEL', value: params.UBUNTU_2004_ICX_LABEL),
-                    string(name: 'UBUNTU_2004_NONSGX_LABEL', value: params.UBUNTU_NONSGX_LABEL),
+                    string(name: 'UBUNTU_2004_NONSGX_LABEL', value: params.UBUNTU_2004_NONSGX_LABEL),
+                    string(name: 'UBUNTU_2204_CFL_CUSTOM_LABEL', value: params.UBUNTU_2204_CFL_LABEL),
+                    string(name: 'UBUNTU_2204_ICX_CUSTOM_LABEL', value: params.UBUNTU_2204_ICX_LABEL),
+                    string(name: 'UBUNTU_2204_NONSGX_LABEL', value: params.UBUNTU_2204_NONSGX_LABEL),
                     string(name: 'WS2022_DCAP_CFL_LABEL', value: params.WS2022_DCAP_CFL_LABEL),
                     string(name: 'WS2022_DCAP_ICX_LABEL', value: params.WS2022_DCAP_ICX_LABEL),
                     string(name: 'WS2022_NONSGX_CUSTOM_LABEL', value: params.WS2022_NONSGX_CUSTOM_LABEL),

--- a/.jenkins/library/vars/globalvars.groovy
+++ b/.jenkins/library/vars/globalvars.groovy
@@ -13,17 +13,18 @@ import groovy.transform.Field
 @Field AGENTS_LABELS = [
     // ACC VMs
     "acc-ubuntu-20.04":            env.UBUNTU_2004_CUSTOM_LABEL ?: "ACC-2004",
-    "acc-ubuntu-22.04":            "ACC-2204",
+    "acc-ubuntu-22.04":            env.UBUNTU_2204_CUSTOM_LABEL ?: "ACC-2204",
     "acc-v2-ubuntu-20.04":         env.UBUNTU_2004_CUSTOM_LABEL ?: "ACC-v2-2004-DC4",
-    "acc-v2-ubuntu-22.04":         "ACC-v2-2204-DC4",
-    "acc-v3-ubuntu-20.04":         env.UBUNTU_2004_ICX_CUSTOM_LABEL ?: "ACC-v3-2004",
-    "acc-v3-ubuntu-22.04":         "ACC-v3-2204-DC4",
+    "acc-v2-ubuntu-22.04":         env.UBUNTU_2204_CUSTOM_LABEL ?: "ACC-v2-2204-DC4",
+    "acc-v3-ubuntu-20.04":         env.UBUNTU_2004_ICX_CUSTOM_LABEL ?: "ACC-v3-2004-DC4",
+    "acc-v3-ubuntu-22.04":         env.UBUNTU_2204_ICX_CUSTOM_LABEL ?: "ACC-v3-2204-DC4",
     "acc-win2022-dcap":            env.WS2022_DCAP_CUSTOM_LABEL ?: "SGXFLC-Windows-2022-DCAP-v2",
     "acc-v3-win2022-dcap":         env.WS2022_DCAP_ICX_CUSTOM_LABEL ?: "SGXFLC-Windows-2022-DCAP-v3",
     // Non SGX VMs
+    // ubuntu-nonsgx will be deprecated in favor of ubuntu-nonsgx-[version]
     "ubuntu-nonsgx":               env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004",
-    "ubuntu-nonsgx-20.04":         env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2004",
-    "ubuntu-nonsgx-22.04":         env.UBUNTU_NONSGX_CUSTOM_LABEL ?: "nonSGX-ubuntu-2204",
+    "ubuntu-nonsgx-20.04":         env.UBUNTU_2004_NONSGX_LABEL ?: "nonSGX-ubuntu-2004",
+    "ubuntu-nonsgx-22.04":         env.UBUNTU_2204_NONSGX_LABELL ?: "nonSGX-ubuntu-2204",
     "ws2022-nonsgx":               env.WS2022_NONSGX_CUSTOM_LABEL ?: "nonSGX-Windows-2022",
     // Plain VMs
     "acc-ubuntu-22.04-vanilla":    "ACC-marketplace-ubuntu-2204",

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -15,6 +15,7 @@ def testing_stages = [
 if(FULL_TEST_SUITE == "true") {
     testing_stages += [
         "ELF Win2022 Ubuntu2004 clang-11 Debug":                                 { tests.windowsLinuxElfBuild(params.WS2022_DCAP_CFL_LABEL, params.UBUNTU_2004_NONSGX_LABEL, 'clang-11', 'Debug', 'None', 'OFF', params.PULL_REQUEST_ID) },
+        "ELF Win2022 Ubuntu2204 clang-11 Debug":                                 { tests.windowsLinuxElfBuild(params.WS2022_DCAP_CFL_LABEL, params.UBUNTU_2204_NONSGX_LABEL, 'clang-11', 'Debug', 'None', 'OFF', params.PULL_REQUEST_ID) },
         "XC Win2022 v2 clang-11 RelWithDebInfo ControlFlow-Clang":               { tests.windowsCrossCompile(params.WS2022_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang', '0', 'OFF', 'OFF', params.PULL_REQUEST_ID) },
         "XC Win2022 v2 clang-11 Debug ControlFlow Sim snmalloc":                 { tests.windowsCrossCompile(params.WS2022_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow',       '1', 'OFF', 'ON', params.PULL_REQUEST_ID) },
         "Cross Platform Win2022":                                                { tests.windowsCrossPlatform(params.WS2022_DCAP_CFL_LABEL, params.PULL_REQUEST_ID) }

--- a/scripts/ansible/requirements-ubuntu2004.txt
+++ b/scripts/ansible/requirements-ubuntu2004.txt
@@ -1,9 +1,9 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
-cryptography==44.0.2
-pyOpenSSL==25.0.0
-ansible>=9.13.0,<11.0
-ansible-core>=2.16.14,<2.18
+cryptography==43.0.3
+pyOpenSSL==24.2.1
+ansible>=8.7,<9.0
+ansible-core>=2.15.13,<2.16
 cmake_format==0.6.13
 pywinrm==0.5.0
 requests==2.32.3

--- a/scripts/ansible/requirements-ubuntu2004.txt
+++ b/scripts/ansible/requirements-ubuntu2004.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Open Enclave SDK contributors.
 # Licensed under the MIT License.
-cryptography==43.0.3
-pyOpenSSL==24.2.1
+cryptography==44.0.2
+pyOpenSSL==25.0.0
 ansible>=8.7,<9.0
 ansible-core>=2.15.13,<2.16
 cmake_format==0.6.13


### PR DESCRIPTION
This PR will install the latest supported version of Python and Ansible on Ubuntu 22.04, which is Python 3.11, Ansible 8, Ansible core 2.17.

This PR also adds:
* Ubuntu 22.04 non-SGX agent labels and pipeline parameters to support ad-hoc E2E testing on Jenkins
* test `ELF Win2022 Ubuntu2204 clang-11 Debug`
* Update cryptography to 44.0.2 and pyOpenSSL to 25.0.0 on Ubuntu 22.04

Note: Ansible on Ubuntu 20.04 cannot be updated further through official Canonical Ubuntu repositories as it only supports Python 3.9 (or up to Ansible core 2.15). Ansible core 2.16 requires 3.10 minimum.