### PR TITLE
Fix Redundant null check due to previous dereference

### DIFF
--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -961,10 +961,10 @@ oe_result_t oe_sgx_qe_get_quote_size(
     size_t* quote_size)
 {
     oe_result_t result = OE_UNEXPECTED;
+    if (!quote_size)
+        OE_RAISE(OE_INVALID_PARAMETER);
     uint32_t local_quote_size = (uint32_t)*quote_size;
-    quote3_error_t error = SGX_QL_ERROR_UNEXPECTED;
-
-    if (!format_id || !quote_size)
+    if (!format_id)
         OE_RAISE(OE_INVALID_PARAMETER);
 
     if (_use_quote_ex_library())


### PR DESCRIPTION
https://github.com/openenclave/openenclave/blob/7f69e87cf21a1e6929a739f731396a0ad6c7c622/host/sgx/sgxquote.c#L965-L967

Fix the issue, the null check for `quote_size` should be moved before the dereference on line 964. This ensures that the pointer is validated before any operations are performed on it. Additionally, the null check for `format_id` (also on line 967) should remain in place, as it is unrelated to the issue and ensures the validity of `format_id`.


This rule finds comparisons of a pointer to null that occur after a reference of that pointer. It's likely either the check is not required and can be removed, or it should be moved to before the dereference so that a null pointer dereference does not occur.

#### Recommendation
The check should be moved to before the dereference, in a way that prevents a null pointer value from being dereferenced. If it's clear that the pointer cannot be null, consider removing the check instead.

```c
int f(MyList *list) {
	list->append(1);

	// ...

	if (list != NULL)
	{
		list->append(2);
	}
}
```
[Null Dereference](https://www.owasp.org/index.php/Null_Dereference)