### PR TITLE
Support claims for TDX Live Migration and update tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `SGX_QL_EPHEMERAL_QVE_MULTI_THREAD` - QvE is loaded per thread and be unloaded before function exit.
   - `SGX_QL_PERSISTENT_QVE_MULTI_THREAD` - QvE is loaded per thread and only be unloaded before thread exit.
 
+- Supported the following new claims for TDX Quote v1.5 verification
+  - `tdx_td_attributes_perf_prof`
+  - `tdx_td_attributes_pmt_prof`
+  - `tdx_td_attributes_icssd`
+  - `tdx_td_attributes_servtd_ext`
+  - `tdx_td_attributes_lass`
+  - `tdx_td_attributes_migratable`
+
 [v0.19.0][v0.19.0_log]
 --------------
 ### Added

--- a/common/sgx/quote.h
+++ b/common/sgx/quote.h
@@ -121,6 +121,20 @@ oe_result_t oe_get_sgx_quote_validity(
     oe_datetime_t* valid_from,
     oe_datetime_t* valid_until);
 
+#ifdef OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
+/*!
+ * Internal TDX quote verification bypassing Intel QVL.
+ * Uses OE's certificate validation with custom root certificate.
+ * Only available when OEUTIL_TCB_ALLOW_ANY_ROOT_KEY is defined.
+ *
+ * @param[in] quote Input TDX quote.
+ * @param[in] quote_size The size of the quote.
+ */
+oe_result_t oe_verify_tdx_quote_internal(
+    const uint8_t* quote,
+    size_t quote_size);
+#endif
+
 OE_EXTERNC_END
 
 #endif // _OE_COMMON_QUOTE_H

--- a/common/tdx/verifier.c
+++ b/common/tdx/verifier.c
@@ -271,11 +271,59 @@ static oe_result_t _fill_with_known_tdx_claims(
         attributes,
         sizeof(tdx_attributes_t)));
 
-    flag = !!attributes->tud.d.debug;
+    flag = !!attributes->tud_tup.d.debug;
     OE_CHECK(_add_claim(
         &claims[claims_index++],
         OE_CLAIM_TDX_TD_ATTRIBUTES_DEBUG,
         sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_DEBUG),
+        &flag,
+        sizeof(flag)));
+
+    flag = !!attributes->tud_tup.d.hgs_plus_prof;
+    OE_CHECK(_add_claim(
+        &claims[claims_index++],
+        OE_CLAIM_TDX_TD_ATTRIBUTES_HGS_PLUS_PROF,
+        sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_HGS_PLUS_PROF),
+        &flag,
+        sizeof(flag)));
+
+    flag = !!attributes->tud_tup.d.perf_prof;
+    OE_CHECK(_add_claim(
+        &claims[claims_index++],
+        OE_CLAIM_TDX_TD_ATTRIBUTES_PERF_PROF,
+        sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_PERF_PROF),
+        &flag,
+        sizeof(flag)));
+
+    flag = !!attributes->tud_tup.d.pmt_prof;
+    OE_CHECK(_add_claim(
+        &claims[claims_index++],
+        OE_CLAIM_TDX_TD_ATTRIBUTES_PMT_PROF,
+        sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_PMT_PROF),
+        &flag,
+        sizeof(flag)));
+
+    flag = !!attributes->sec.d.icssd;
+    OE_CHECK(_add_claim(
+        &claims[claims_index++],
+        OE_CLAIM_TDX_TD_ATTRIBUTES_ICSSD,
+        sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_ICSSD),
+        &flag,
+        sizeof(flag)));
+
+    flag = !!attributes->sec.d.servtd_ext;
+    OE_CHECK(_add_claim(
+        &claims[claims_index++],
+        OE_CLAIM_TDX_TD_ATTRIBUTES_SERVTD_EXT,
+        sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_SERVTD_EXT),
+        &flag,
+        sizeof(flag)));
+
+    flag = !!attributes->sec.d.lass;
+    OE_CHECK(_add_claim(
+        &claims[claims_index++],
+        OE_CLAIM_TDX_TD_ATTRIBUTES_LASS,
+        sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_LASS),
         &flag,
         sizeof(flag)));
 
@@ -284,6 +332,14 @@ static oe_result_t _fill_with_known_tdx_claims(
         &claims[claims_index++],
         OE_CLAIM_TDX_TD_ATTRIBUTES_SEPT_VE_DISABLE,
         sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_SEPT_VE_DISABLE),
+        &flag,
+        sizeof(flag)));
+
+    flag = !!attributes->sec.d.migratable;
+    OE_CHECK(_add_claim(
+        &claims[claims_index++],
+        OE_CLAIM_TDX_TD_ATTRIBUTES_MIGRATABLE,
+        sizeof(OE_CLAIM_TDX_TD_ATTRIBUTES_MIGRATABLE),
         &flag,
         sizeof(flag)));
 

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -409,6 +409,58 @@ if (CMAKE_C_COMPILER_ID MATCHES GNU)
   target_compile_options(oehostverify PRIVATE -Wjump-misses-init)
 endif ()
 
+# Build oehostverify_prerelease (with support for pre-production/ certificates)
+add_library(oehostverify_prerelease STATIC ${PLATFORM_HOST_ONLY_SRC})
+target_link_libraries(oehostverify_prerelease PUBLIC oe_includes)
+target_compile_definitions(oehostverify_prerelease PUBLIC OE_BUILD_HOST_VERIFY)
+# Enable internal TDX verification with custom root certificates
+target_compile_definitions(oehostverify_prerelease
+                           PUBLIC OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)
+target_compile_definitions(
+  oehostverify_prerelease
+  PUBLIC # NOTE: This definition is public to the rest of our project's
+         # targets, but should not be exposed to consumers of our
+         # package.
+         $<BUILD_INTERFACE:OE_API_VERSION=2>
+  PRIVATE OE_BUILD_UNTRUSTED OE_REPO_BRANCH_NAME="${GIT_BRANCH}"
+          OE_REPO_LAST_COMMIT="${GIT_COMMIT}")
+
+if (OE_SGX)
+  target_include_directories(
+    oehostverify_prerelease
+    PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/sgxsdk/include)
+endif ()
+
+if (UNIX)
+  target_link_libraries(
+    oehostverify_prerelease PRIVATE openenclave::crypto openenclave::dl
+                                    Threads::Threads)
+  target_compile_options(
+    oehostverify_prerelease
+    PRIVATE -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS}
+    PUBLIC -fstack-protector-strong)
+  target_compile_definitions(
+    oehostverify_prerelease
+    PRIVATE _GNU_SOURCE
+    PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
+  target_link_libraries(oehostverify_prerelease INTERFACE -Wl,-z,noexecstack
+                                                          -rdynamic)
+elseif (WIN32)
+  target_include_directories(
+    oehostverify_prerelease
+    PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/mbedtls/mbedtls/include)
+  target_link_libraries(oehostverify_prerelease PRIVATE bcrypt Crypt32)
+endif ()
+
+if (WITH_EEID)
+  target_compile_definitions(oehostverify_prerelease
+                             PRIVATE OE_WITH_EXPERIMENTAL_EEID)
+endif ()
+
+if (CMAKE_C_COMPILER_ID MATCHES GNU)
+  target_compile_options(oehostverify_prerelease PRIVATE -Wjump-misses-init)
+endif ()
+
 # Install oehostverify
 if (WIN32)
   # Install .pdb files to enable stepping into oehost srcs for Debug

--- a/host/sgx/sgxquote.c
+++ b/host/sgx/sgxquote.c
@@ -1729,6 +1729,36 @@ done:
     return result;
 }
 
+static oe_result_t _free_tdx_quote_verification_collateral(
+    uint8_t* p_quote_collateral)
+{
+    quote3_error_t error = SGX_QL_ERROR_UNEXPECTED;
+    oe_result_t result = OE_FAILURE;
+
+    if (!p_quote_collateral)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    // Always use QvE/QVL for TDX verification
+    if (!_load_tdx_dcap_qvl())
+        OE_RAISE(OE_PLATFORM_ERROR);
+
+    error = _tee_qv_free_collateral(p_quote_collateral);
+
+    if (error != SGX_QL_SUCCESS)
+    {
+        OE_RAISE_MSG(
+            result,
+            "Fail to free TDX quote collateral "
+            "quote3_error_t=%s\n",
+            get_quote3_error_t_string(error));
+    }
+
+    result = OE_OK;
+
+done:
+    return result;
+}
+
 oe_result_t oe_get_tdx_quote_verification_collateral(
     const uint8_t* p_quote,
     uint32_t quote_size,
@@ -1772,36 +1802,14 @@ oe_result_t oe_get_tdx_quote_verification_collateral(
     result = OE_OK;
 
 done:
-    oe_free_tdx_quote_verification_collateral(p_collateral);
+    _free_tdx_quote_verification_collateral(p_collateral);
     return result;
 }
 
 oe_result_t oe_free_tdx_quote_verification_collateral(
     uint8_t* p_quote_collateral)
 {
-    quote3_error_t error = SGX_QL_ERROR_UNEXPECTED;
-    oe_result_t result = OE_FAILURE;
+    free(p_quote_collateral);
 
-    if (!p_quote_collateral)
-        OE_RAISE(OE_INVALID_PARAMETER);
-
-    // Always use QvE/QVL for TDX verification
-    if (!_load_tdx_dcap_qvl())
-        OE_RAISE(OE_PLATFORM_ERROR);
-
-    error = _tee_qv_free_collateral(p_quote_collateral);
-
-    if (error != SGX_QL_SUCCESS)
-    {
-        OE_RAISE_MSG(
-            result,
-            "Fail to free TDX quote collateral "
-            "quote3_error_t=%s\n",
-            get_quote3_error_t_string(error));
-    }
-
-    result = OE_OK;
-
-done:
-    return result;
+    return OE_OK;
 }

--- a/include/openenclave/attestation/tdx/evidence.h
+++ b/include/openenclave/attestation/tdx/evidence.h
@@ -24,8 +24,16 @@ OE_EXTERNC_BEGIN
 #define OE_CLAIM_TDX_SEAM_ATTRIBUTES "tdx_seam_attributes"
 #define OE_CLAIM_TDX_TD_ATTRIBUTES "tdx_td_attributes"
 #define OE_CLAIM_TDX_TD_ATTRIBUTES_DEBUG "tdx_td_attributes_debug"
+#define OE_CLAIM_TDX_TD_ATTRIBUTES_HGS_PLUS_PROF \
+    "tdx_td_attributes_hgs_plus_prof"
+#define OE_CLAIM_TDX_TD_ATTRIBUTES_PERF_PROF "tdx_td_attributes_perf_prof"
+#define OE_CLAIM_TDX_TD_ATTRIBUTES_PMT_PROF "tdx_td_attributes_pmt_prof"
+#define OE_CLAIM_TDX_TD_ATTRIBUTES_ICSSD "tdx_td_attributes_icssd"
+#define OE_CLAIM_TDX_TD_ATTRIBUTES_SERVTD_EXT "tdx_td_attributes_servtd_ext"
+#define OE_CLAIM_TDX_TD_ATTRIBUTES_LASS "tdx_td_attributes_lass"
 #define OE_CLAIM_TDX_TD_ATTRIBUTES_SEPT_VE_DISABLE \
     "tdx_td_attributes_septve_disable"
+#define OE_CLAIM_TDX_TD_ATTRIBUTES_MIGRATABLE "tdx_td_attributes_migratable"
 #define OE_CLAIM_TDX_TD_ATTRIBUTES_PROTECTION_KEYS \
     "tdx_td_attributes_protection_keys"
 #define OE_CLAIM_TDX_TD_ATTRIBUTES_KEY_LOCKER "tdx_td_attributes_key_locker"
@@ -42,7 +50,7 @@ OE_EXTERNC_BEGIN
 #define OE_CLAIM_TDX_REPORT_DATA "tdx_report_data"
 #define OE_CLAIM_TDX_TEE_TCB_SVN_2 "tdx_tee_tcb_svn_2"
 #define OE_CLAIM_TDX_MRSERVICETD "tdx_mrservicetd"
-#define OE_TDX_REQUIRED_CLAIMS_COUNT 22
+#define OE_TDX_REQUIRED_CLAIMS_COUNT 29
 
 /*
  * Additional claims from other sources (e.g., data returned by QvE/QVL)

--- a/include/openenclave/bits/tdx/tdxquote.h
+++ b/include/openenclave/bits/tdx/tdxquote.h
@@ -22,22 +22,30 @@ typedef struct _tdx_attributes_t
         struct
         {
             uint8_t debug : 1;
-            uint8_t reserved : 7;
+            uint8_t reserved0 : 3;
+            uint8_t hgs_plus_prof : 1;
+            uint8_t perf_prof : 1;
+            uint8_t pmt_prof : 1;
+            uint8_t reserved1 : 1;
+            uint8_t reserved2;
         } d;
-        uint8_t u;
-    } tud;
+        uint8_t u[2];
+    } tud_tup;
     union
     {
         struct
         {
-            uint8_t reserved0[2];
-            uint8_t reserved1 : 4;
+            uint8_t icssd : 1;
+            uint8_t servtd_ext : 1;
+            uint8_t reserved0 : 6;
+            uint8_t reserved1 : 3;
+            uint8_t lass : 1;
             uint8_t sept_ve_disable : 1;
-            uint8_t reserved2 : 1;
+            uint8_t migratable : 1;
             uint8_t pks : 1;
             uint8_t kl : 1;
         } d;
-        uint8_t u[3];
+        uint8_t u[2];
     } sec;
     union
     {
@@ -253,6 +261,23 @@ OE_PACK_END
 OE_STATIC_ASSERT(OE_OFFSETOF(tdx_quote_auth_data_t, signature) == 0);
 OE_STATIC_ASSERT(OE_OFFSETOF(tdx_quote_auth_data_t, attestation_key) == 64);
 OE_STATIC_ASSERT(sizeof(tdx_quote_auth_data_t) == 128);
+
+#define TDX_QE_CERTIFICATION_DATA_TYPE_PCK_CERT_CHAIN 5
+#define TDX_QE_CERTIFICATION_DATA_TYPE_QE_REPORT 6
+
+OE_PACK_BEGIN
+typedef struct _tdx_qe_certification_data_t
+{
+    /* (0) Certification Data Type */
+    uint16_t type;
+
+    /* (2) Certification Data Size */
+    uint32_t size;
+
+    /* Place holder for tdx_qe_report_certification_data_t */
+    uint8_t certification_data[];
+} tdx_qe_certification_data_t;
+OE_PACK_END
 
 OE_PACK_BEGIN
 typedef struct _tdx_qe_report_certification_data_t

--- a/tools/oeutil/host/CMakeLists.txt
+++ b/tools/oeutil/host/CMakeLists.txt
@@ -15,7 +15,7 @@ add_custom_command(
   COMMAND edger8r --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../oeutil.edl
           --search-path ${PROJECT_SOURCE_DIR}/include -DOE_SGX)
 
-add_executable(oeutil host.cpp generate_evidence.cpp
+add_executable(oeutil host.cpp generate_evidence.cpp get_endorsements.cpp
                       ${CMAKE_CURRENT_BINARY_DIR}/ oeutil_u.c)
 
 add_dependencies(oeutil enclave_key_pair)

--- a/tools/oeutil/host/get_endorsements.cpp
+++ b/tools/oeutil/host/get_endorsements.cpp
@@ -1,0 +1,285 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "get_endorsements.h"
+#include <openenclave/attestation/tdx/evidence.h>
+#include <openenclave/host.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "parse_args_helper.h"
+
+#define INPUT_PARAM_OPTION_INPUT_FILE "--input"
+#define INPUT_PARAM_OPTION_OUT_FILE "--out"
+#define INPUT_PARAM_OPTION_HELP "--help"
+#define SHORT_INPUT_PARAM_OPTION_INPUT_FILE "-i"
+#define SHORT_INPUT_PARAM_OPTION_OUT_FILE "-o"
+#define SHORT_INPUT_PARAM_OPTION_HELP "-h"
+
+typedef struct _get_endorsements_parameters
+{
+    const char* input_filename;
+    const char* output_filename;
+} get_endorsements_parameters_t;
+
+static get_endorsements_parameters_t _parameters;
+
+static void _display_help(const char* command)
+{
+    printf("Get-endorsements Usage: %s get-endorsements <options>\n", command);
+    printf("options:\n");
+    printf(
+        "\t%s, %s <filename>: input TDX evidence file.\n",
+        SHORT_INPUT_PARAM_OPTION_INPUT_FILE,
+        INPUT_PARAM_OPTION_INPUT_FILE);
+    printf(
+        "\t%s, %s <filename>: output endorsements file.\n",
+        SHORT_INPUT_PARAM_OPTION_OUT_FILE,
+        INPUT_PARAM_OPTION_OUT_FILE);
+    printf(
+        "\t%s, %s: show this help message.\n",
+        SHORT_INPUT_PARAM_OPTION_HELP,
+        INPUT_PARAM_OPTION_HELP);
+    printf("Example:\n");
+    printf("\toeutil get-endorsements --input evidence.bin --out "
+           "endorsements.bin\n");
+}
+
+static int _parse_args(int argc, const char* argv[])
+{
+    // Clear parameters memory
+    memset(&_parameters, 0, sizeof(_parameters));
+
+    _parameters.input_filename = nullptr;
+    _parameters.output_filename = nullptr;
+
+    int i = 2; // Start from the third argument (after command name)
+
+    if (argc == 3 && (strcasecmp(INPUT_PARAM_OPTION_HELP, argv[i]) == 0 ||
+                      strcasecmp(SHORT_INPUT_PARAM_OPTION_HELP, argv[i]) == 0))
+    {
+        _display_help(argv[0]);
+        return 2; // Special return value for help
+    }
+
+    if (argc < 4)
+    {
+        _display_help(argv[0]);
+        return 1;
+    }
+
+    while (i < argc)
+    {
+        if (strcasecmp(INPUT_PARAM_OPTION_INPUT_FILE, argv[i]) == 0 ||
+            strcasecmp(SHORT_INPUT_PARAM_OPTION_INPUT_FILE, argv[i]) == 0)
+        {
+            if (argc < i + 2)
+                break;
+
+            _parameters.input_filename = argv[i + 1];
+            i += 2;
+        }
+        else if (
+            strcasecmp(INPUT_PARAM_OPTION_OUT_FILE, argv[i]) == 0 ||
+            strcasecmp(SHORT_INPUT_PARAM_OPTION_OUT_FILE, argv[i]) == 0)
+        {
+            if (argc < i + 2)
+                break;
+
+            _parameters.output_filename = argv[i + 1];
+            i += 2;
+        }
+        else
+        {
+            printf("Invalid option: %s\n\n", argv[i]);
+            _display_help(argv[0]);
+            return 1;
+        }
+    }
+
+    if (i < argc)
+    {
+        printf("%s has invalid number of parameters.\n\n", argv[i]);
+        _display_help(argv[0]);
+        return 1;
+    }
+
+    if (!_parameters.input_filename)
+    {
+        printf("Input file is required.\n\n");
+        _display_help(argv[0]);
+        return 1;
+    }
+
+    if (!_parameters.output_filename)
+    {
+        printf("Output file is required.\n\n");
+        _display_help(argv[0]);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int _read_evidence_file(
+    const char* filename,
+    uint8_t** data,
+    uint32_t* size)
+{
+    FILE* fp = nullptr;
+    long file_size = 0;
+    uint8_t* buffer = nullptr;
+    size_t bytes_read = 0;
+
+#ifdef _WIN32
+    if (fopen_s(&fp, filename, "rb") != 0 || fp == nullptr)
+#else
+    fp = fopen(filename, "rb");
+    if (fp == nullptr)
+#endif
+    {
+        printf("Failed to open input file: %s\n", filename);
+        return 1;
+    }
+
+    // Get file size
+    if (fseek(fp, 0, SEEK_END) != 0)
+    {
+        printf("Failed to seek to end of file: %s\n", filename);
+        fclose(fp);
+        return 1;
+    }
+
+    file_size = ftell(fp);
+    if (file_size <= 0)
+    {
+        printf("Invalid file size for: %s\n", filename);
+        fclose(fp);
+        return 1;
+    }
+
+    if (fseek(fp, 0, SEEK_SET) != 0)
+    {
+        printf("Failed to seek to beginning of file: %s\n", filename);
+        fclose(fp);
+        return 1;
+    }
+
+    // Allocate buffer
+    buffer = (uint8_t*)malloc((size_t)file_size);
+    if (buffer == nullptr)
+    {
+        printf("Failed to allocate memory for file: %s\n", filename);
+        fclose(fp);
+        return 1;
+    }
+
+    // Read file
+    bytes_read = fread(buffer, 1, (size_t)file_size, fp);
+    fclose(fp);
+
+    if (bytes_read != (size_t)file_size)
+    {
+        printf("Failed to read complete file: %s\n", filename);
+        free(buffer);
+        return 1;
+    }
+
+    *data = buffer;
+    *size = (uint32_t)file_size;
+    return 0;
+}
+
+static int _write_endorsements_file(
+    const char* filename,
+    const uint8_t* data,
+    uint32_t size)
+{
+    FILE* fp = nullptr;
+    size_t bytes_written = 0;
+
+#ifdef _WIN32
+    if (fopen_s(&fp, filename, "wb") != 0 || fp == nullptr)
+#else
+    fp = fopen(filename, "wb");
+    if (fp == nullptr)
+#endif
+    {
+        printf("Failed to open output file: %s\n", filename);
+        return 1;
+    }
+
+    bytes_written = fwrite(data, 1, size, fp);
+    fclose(fp);
+
+    if (bytes_written != size)
+    {
+        printf("Failed to write complete endorsements to file: %s\n", filename);
+        return 1;
+    }
+
+    printf(
+        "Successfully wrote endorsements to: %s (%u bytes)\n", filename, size);
+
+    return 0;
+}
+
+int oeutil_get_endorsements(int argc, const char* argv[])
+{
+    int ret = 0;
+    uint8_t* evidence_data = nullptr;
+    uint32_t evidence_size = 0;
+    uint8_t* endorsements_data = nullptr;
+    uint32_t endorsements_size = 0;
+    oe_result_t result = OE_OK;
+    bool endorsements_allocated = false;
+
+    // Parse command line arguments first to handle help
+    ret = _parse_args(argc, argv);
+    if (ret == 2) // Help was displayed
+        return 0;
+    if (ret != 0)
+        return ret;
+
+    printf("Getting TDX endorsements for input evidence file.\n\n");
+
+    // Read evidence file
+    ret = _read_evidence_file(
+        _parameters.input_filename, &evidence_data, &evidence_size);
+    if (ret != 0)
+        goto done;
+
+    printf(
+        "Read evidence file: %s (%u bytes)\n",
+        _parameters.input_filename,
+        evidence_size);
+
+    // Get TDX endorsements
+    result = oe_get_tdx_endorsements(
+        evidence_data, evidence_size, &endorsements_data, &endorsements_size);
+
+    if (result != OE_OK)
+    {
+        printf(
+            "Failed to get TDX endorsements. Error: %u (%s)\n",
+            result,
+            oe_result_str(result));
+        ret = 1;
+        goto done;
+    }
+
+    endorsements_allocated = true;
+    printf("Retrieved TDX endorsements (%u bytes)\n", endorsements_size);
+
+    // Write endorsements to output file
+    ret = _write_endorsements_file(
+        _parameters.output_filename, endorsements_data, endorsements_size);
+
+done:
+    if (evidence_data)
+        free(evidence_data);
+    if (endorsements_allocated && endorsements_data)
+        oe_free_tdx_endorsements(endorsements_data);
+
+    return ret;
+}

--- a/tools/oeutil/host/get_endorsements.h
+++ b/tools/oeutil/host/get_endorsements.h
@@ -1,0 +1,9 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_UTIL_GET_ENDORSEMENTS_H
+#define _OE_UTIL_GET_ENDORSEMENTS_H
+
+int oeutil_get_endorsements(int argc, const char* argv[]);
+
+#endif // _OE_UTIL_GET_ENDORSEMENTS_H

--- a/tools/oeutil/host/host.cpp
+++ b/tools/oeutil/host/host.cpp
@@ -7,11 +7,13 @@
 #include "oeutil_u.h"
 
 #include "generate_evidence.h"
+#include "get_endorsements.h"
 #include "parse_args_helper.h"
 
 FILE* log_file = nullptr;
 
 #define COMMAND_GENERATE_EVIDENCE "generate-evidence"
+#define COMMAND_GET_ENDORSEMENTS "get-endorsements"
 
 typedef enum _oeutil_command
 {
@@ -20,6 +22,10 @@ typedef enum _oeutil_command
      * Generate evidence, a report, or a certificate.
      */
     OEUTIL_GENERATE_EVIDENCE = 1,
+    /**
+     * Get endorsements for TDX evidence.
+     */
+    OEUTIL_GET_ENDORSEMENTS = 2,
 
 } oeutil_command_t;
 
@@ -30,6 +36,9 @@ static void _display_help(const char* command)
     printf(
         "\t1. %s: generate evidence, a report, or a certificate.\n",
         COMMAND_GENERATE_EVIDENCE);
+    printf(
+        "\t2. %s: get endorsements for input TDX evidence.\n",
+        COMMAND_GET_ENDORSEMENTS);
     printf("Options:\n\tType oeutil <command> --help for more information\n");
 }
 
@@ -46,6 +55,11 @@ static oeutil_command_t _get_oeutil_command(int argc, const char* argv[])
     if (strncasecmp(COMMAND_GENERATE_EVIDENCE, argv[1], strlen(argv[1])) == 0)
     {
         command_type = OEUTIL_GENERATE_EVIDENCE;
+    }
+    else if (
+        strncasecmp(COMMAND_GET_ENDORSEMENTS, argv[1], strlen(argv[1])) == 0)
+    {
+        command_type = OEUTIL_GET_ENDORSEMENTS;
     }
     else
     {
@@ -66,6 +80,9 @@ int main(int argc, const char* argv[])
     {
         case OEUTIL_GENERATE_EVIDENCE:
             ret = oeutil_generate_evidence(argc, argv);
+            break;
+        case OEUTIL_GET_ENDORSEMENTS:
+            ret = oeutil_get_endorsements(argc, argv);
             break;
         default:
             _display_help(argv[0]);

--- a/tools/oeverify/CMakeLists.txt
+++ b/tools/oeverify/CMakeLists.txt
@@ -5,13 +5,25 @@ add_executable(oeverify oeverify.c)
 
 target_include_directories(oeverify PRIVATE ${PROJECT_SOURCE_DIR}/include)
 
-target_link_libraries(oeverify oehostverify)
+# By default, link against standard oehostverify (production certificates only)
+# To enable pre-production certificate support, set OE_VERIFY_USE_PRERELEASE=ON
+option(OE_VERIFY_USE_PRERELEASE
+       "Build oeverify with pre-production certificate support" OFF)
+
+if (OE_VERIFY_USE_PRERELEASE)
+  message(STATUS "Building oeverify with pre-production certificate support")
+  target_compile_definitions(oeverify PRIVATE OEUTIL_TCB_ALLOW_ANY_ROOT_KEY)
+  target_link_libraries(oeverify oehostverify_prerelease)
+else ()
+  message(STATUS "Building oeverify with production certificates only")
+  target_link_libraries(oeverify oehostverify)
+endif ()
 
 # assemble into proper collector dir
 set_property(TARGET oeverify PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
 # install rule
 install(
-    TARGETS oeverify
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT OEHOSTVERIFY)
+  TARGETS oeverify
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT OEHOSTVERIFY)


### PR DESCRIPTION
This PR implements claims for TDX live migration. In addition, the PR makes the updates tools as follows:
- oeutil: support get endorsement command
- oeverifiy: support build with pre-production support and output claims in the result

The PR also fixes a bug in `oe_get_tdx_quote_verification_collateral`/`oe_free_tdx_quote_verification_collateral`