### PR TITLE
Deprecate Intel Coffee Lake tests

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -213,7 +213,6 @@ pipeline {
                                 string(name: 'DOCKER_TAG', value: params.DOCKER_TAG),
                                 string(name: 'UBUNTU_2004_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2004"]),
                                 string(name: 'UBUNTU_2204_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2204"]),
-                                string(name: 'WS2022_DCAP_CFL_LABEL', value: globalvars.AGENTS_LABELS["acc-win2022-dcap"]),
                                 string(name: 'WS2022_DCAP_ICX_LABEL', value: globalvars.AGENTS_LABELS["acc-v3-win2022-dcap"]),
                                 string(name: 'OECI_LIB_VERSION', value: params.OECI_LIB_VERSION),
                                 booleanParam(name: 'FULL_TEST_SUITE', value: params.FULL_TEST_SUITE)

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -179,8 +179,8 @@ pipeline {
                                 string(name: 'REPOSITORY_NAME', value: params.REPOSITORY_NAME),
                                 string(name: 'BRANCH_NAME', value: params.BRANCH_NAME),
                                 string(name: 'DOCKER_TAG', value: params.DOCKER_TAG),
-                                string(name: 'UBUNTU_2004_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2004"]),
-                                string(name: 'UBUNTU_2204_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2204"]),
+                                string(name: 'UBUNTU_2004_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-20.04"]),
+                                string(name: 'UBUNTU_2204_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-22.04"]),
                                 string(name: 'OECI_LIB_VERSION', value: params.OECI_LIB_VERSION),
                                 booleanParam(name: 'FULL_TEST_SUITE', value: params.FULL_TEST_SUITE)
                             ]
@@ -195,8 +195,8 @@ pipeline {
                                 string(name: 'BRANCH_NAME', value: params.BRANCH_NAME),
                                 string(name: 'DOCKER_TAG', value: params.DOCKER_TAG),
                                 string(name: 'UBUNTU_2004_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["acc-ubuntu-20.04"]),
-                                string(name: 'UBUNTU_2004_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2004"]),
-                                string(name: 'UBUNTU_2204_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2204"]),
+                                string(name: 'UBUNTU_2004_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-20.04"]),
+                                string(name: 'UBUNTU_2204_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-22.04"]),
                                 string(name: 'WS2022_NONSGX_CUSTOM_LABEL', value: globalvars.AGENTS_LABELS["ws2022-nonsgx"]),
                                 string(name: 'OECI_LIB_VERSION', value: params.OECI_LIB_VERSION),
                                 booleanParam(name: 'FULL_TEST_SUITE', value: params.FULL_TEST_SUITE)
@@ -211,8 +211,8 @@ pipeline {
                                 string(name: 'REPOSITORY_NAME', value: params.REPOSITORY_NAME),
                                 string(name: 'BRANCH_NAME', value: params.BRANCH_NAME),
                                 string(name: 'DOCKER_TAG', value: params.DOCKER_TAG),
-                                string(name: 'UBUNTU_2004_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2004"]),
-                                string(name: 'UBUNTU_2204_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-2204"]),
+                                string(name: 'UBUNTU_2004_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-20.04"]),
+                                string(name: 'UBUNTU_2204_NONSGX_LABEL', value: globalvars.AGENTS_LABELS["ubuntu-nonsgx-22.04"]),
                                 string(name: 'WS2022_DCAP_ICX_LABEL', value: globalvars.AGENTS_LABELS["acc-v3-win2022-dcap"]),
                                 string(name: 'OECI_LIB_VERSION', value: params.OECI_LIB_VERSION),
                                 booleanParam(name: 'FULL_TEST_SUITE', value: params.FULL_TEST_SUITE)

--- a/.jenkins/pipelines/Azure/Linux/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Linux/Jenkinsfile
@@ -21,12 +21,11 @@ try{
                                                                                                                                                      // ACCTEST BOOL OPTIONS: SKIP LVI TESTS, SNMALLOC, EEID,  E2E
         // "ACC2004 v2 clang-11 RelWithDebInfo ControlFlow e2e":        { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-20.04-vanilla"], 'clang-11', 'RelWithDebInfo', 'ControlFlow', true, false,    false, true,  params.PULL_REQUEST_ID) },
         "ACC2204 v3 clang-11 RelWithDebInfo ControlFlow e2e":        { tests.ACCTest(globalvars.AGENTS_LABELS["acc-ubuntu-22.04-vanilla"], 'clang-11', 'RelWithDebInfo', 'ControlFlow', true, false,    false, true,  params.PULL_REQUEST_ID) },
-        "ACC2004 v2 clang-11 RelWithDebInfo ControlFlow snmalloc":   { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-20.04"],      'clang-11', 'RelWithDebInfo', 'ControlFlow', true, true,     false, false, params.PULL_REQUEST_ID) },
-        "ACC2204 v2 clang-11 RelWithDebInfo ControlFlow snmalloc":   { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-22.04"],      'clang-11', 'RelWithDebInfo', 'ControlFlow', true, true,     false, false, params.PULL_REQUEST_ID) },
-        "ACC2004 v2 clang-11 Debug":                                 { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-20.04"],      'clang-11', 'Debug',          'None',        true, false,    false, false, params.PULL_REQUEST_ID) },
-        "ACC2204 v2 clang-11 Debug":                                 { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-22.04"],      'clang-11', 'Debug',          'None',        true, false,    false, false, params.PULL_REQUEST_ID) },
+        "ACC2004 v3 clang-11 RelWithDebInfo ControlFlow snmalloc":   { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-20.04"],      'clang-11', 'RelWithDebInfo', 'ControlFlow', true, true,     false, false, params.PULL_REQUEST_ID) },
+        "ACC2204 v3 clang-11 RelWithDebInfo ControlFlow snmalloc":   { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-22.04"],      'clang-11', 'RelWithDebInfo', 'ControlFlow', true, true,     false, false, params.PULL_REQUEST_ID) },
+        "ACC2004 v3 clang-11 Debug":                                 { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-20.04"],      'clang-11', 'Debug',          'None',        true, false,    false, false, params.PULL_REQUEST_ID) },
+        "ACC2204 v3 clang-11 Debug":                                 { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-22.04"],      'clang-11', 'Debug',          'None',        true, false,    false, false, params.PULL_REQUEST_ID) },
         "ACC2004 v3 clang-11 RelWithDebInfo ControlFlow":            { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-20.04"],      'clang-11', 'RelWithDebInfo', 'ControlFlow', true, false,    false, false, params.PULL_REQUEST_ID) },
-        "ACC2204 v2 clang-11 RelWithDebInfo ControlFlow":            { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-22.04"],      'clang-11', 'RelWithDebInfo', 'ControlFlow', true, false,    false, false, params.PULL_REQUEST_ID) },
         "ACC2204 v3 clang-11 RelWithDebInfo ControlFlow":            { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-22.04"],      'clang-11', 'RelWithDebInfo', 'ControlFlow', true, false,    false, false, params.PULL_REQUEST_ID) }
     ]
     if(FULL_TEST_SUITE == "true") {
@@ -35,12 +34,12 @@ try{
             "Host verification 2204 Debug":                          { tests.ACCHostVerificationTest('22.04', 'Debug', 'clang-11', params.PULL_REQUEST_ID) },
             "Package ACC2004 Debug ControlFlow":                     { tests.ACCPackageTest('20.04', 'Debug', 'ControlFlow', false, false, params.PULL_REQUEST_ID) },
             "Package ACC2004 Debug ControlFlow":                     { tests.ACCPackageTest('22.04', 'Debug', 'ControlFlow', false, false, params.PULL_REQUEST_ID) },
-            "ACC2004 v2 clang-11 RelWithDebInfo ControlFlow":        { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-20.04"], 'clang-11', 'RelWithDebInfo', 'ControlFlow',       false, false, false, false, params.PULL_REQUEST_ID) },
-            "ACC2204 v2 clang-11 RelWithDebInfo ControlFlow":        { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-22.04"], 'clang-11', 'RelWithDebInfo', 'ControlFlow',       false, false, false, false, params.PULL_REQUEST_ID) },
-            "ACC2004 v2 clang-11 RelWithDebInfo ControlFlow-Clang":  { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-20.04"], 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang', false, false, false, false, params.PULL_REQUEST_ID) },
-            "ACC2204 v2 clang-11 RelWithDebInfo ControlFlow-Clang":  { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-22.04"], 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang', false, false, false, false, params.PULL_REQUEST_ID) },
-            "ACC2004 v2 clang-11 Debug ControlFlow":                 { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-20.04"], 'clang-11', 'Debug',          'ControlFlow',       false, false, false, false, params.PULL_REQUEST_ID) },
-            "ACC2204 v2 clang-11 Debug ControlFlow":                 { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v2-ubuntu-22.04"], 'clang-11', 'Debug',          'ControlFlow',       false, false, false, false, params.PULL_REQUEST_ID) }
+            "ACC2004 v3 clang-11 RelWithDebInfo ControlFlow":        { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-20.04"], 'clang-11', 'RelWithDebInfo', 'ControlFlow',       false, false, false, false, params.PULL_REQUEST_ID) },
+            "ACC2204 v3 clang-11 RelWithDebInfo ControlFlow":        { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-22.04"], 'clang-11', 'RelWithDebInfo', 'ControlFlow',       false, false, false, false, params.PULL_REQUEST_ID) },
+            "ACC2004 v3 clang-11 RelWithDebInfo ControlFlow-Clang":  { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-20.04"], 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang', false, false, false, false, params.PULL_REQUEST_ID) },
+            "ACC2204 v3 clang-11 RelWithDebInfo ControlFlow-Clang":  { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-22.04"], 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang', false, false, false, false, params.PULL_REQUEST_ID) },
+            "ACC2004 v3 clang-11 Debug ControlFlow":                 { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-20.04"], 'clang-11', 'Debug',          'ControlFlow',       false, false, false, false, params.PULL_REQUEST_ID) },
+            "ACC2204 v3 clang-11 Debug ControlFlow":                 { tests.ACCTest(globalvars.AGENTS_LABELS["acc-v3-ubuntu-22.04"], 'clang-11', 'Debug',          'ControlFlow',       false, false, false, false, params.PULL_REQUEST_ID) }
 
         ]
     }

--- a/.jenkins/pipelines/Azure/Windows/Jenkinsfile
+++ b/.jenkins/pipelines/Azure/Windows/Jenkinsfile
@@ -6,19 +6,18 @@ GLOBAL_ERROR = globalvars.GLOBAL_ERROR
 
 def testing_stages = [
     "Windows 2022 Install Prerequisites Verification" :                      { tests.windowsPrereqsVerify("acc-win2022-dcap", params.PULL_REQUEST_ID) },
-    "XC Win2022 v2 clang-11 RelWithDebInfo ControlFlow":                     { tests.windowsCrossCompile(params.WS2022_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '0', 'ON', 'OFF', params.PULL_REQUEST_ID) },
-    "XC Win2022 v2 clang-11 RelWithDebInfo ControlFlow Sim":                 { tests.windowsCrossCompile(params.WS2022_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '1', 'ON', 'OFF', params.PULL_REQUEST_ID) },
-    "XC Win2022 v2 clang-11 RelWithDebInfo ControlFlow snmalloc":            { tests.windowsCrossCompile(params.WS2022_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '0', 'ON', 'ON',  params.PULL_REQUEST_ID) },
     "XC Win2022 v3 clang-11 RelWithDebInfo ControlFlow":                     { tests.windowsCrossCompile(params.WS2022_DCAP_ICX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '0', 'ON', 'OFF', params.PULL_REQUEST_ID) },
-    "XC Win2022 v2 clang-11 Debug ControlFlow":                              { tests.windowsCrossCompile(params.WS2022_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow', '0', 'ON', 'OFF', params.PULL_REQUEST_ID) },
+    "XC Win2022 v3 clang-11 RelWithDebInfo ControlFlow Sim":                 { tests.windowsCrossCompile(params.WS2022_DCAP_ICX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '1', 'ON', 'OFF', params.PULL_REQUEST_ID) },
+    "XC Win2022 v3 clang-11 RelWithDebInfo ControlFlow snmalloc":            { tests.windowsCrossCompile(params.WS2022_DCAP_ICX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow', '0', 'ON', 'ON',  params.PULL_REQUEST_ID) },
+    "XC Win2022 v3 clang-11 Debug ControlFlow":                              { tests.windowsCrossCompile(params.WS2022_DCAP_ICX_LABEL, 'clang-11', 'Debug',          'ControlFlow', '0', 'ON', 'OFF', params.PULL_REQUEST_ID) },
 ]
 if(FULL_TEST_SUITE == "true") {
     testing_stages += [
-        "ELF Win2022 Ubuntu2004 clang-11 Debug":                                 { tests.windowsLinuxElfBuild(params.WS2022_DCAP_CFL_LABEL, params.UBUNTU_2004_NONSGX_LABEL, 'clang-11', 'Debug', 'None', 'OFF', params.PULL_REQUEST_ID) },
-        "ELF Win2022 Ubuntu2204 clang-11 Debug":                                 { tests.windowsLinuxElfBuild(params.WS2022_DCAP_CFL_LABEL, params.UBUNTU_2204_NONSGX_LABEL, 'clang-11', 'Debug', 'None', 'OFF', params.PULL_REQUEST_ID) },
-        "XC Win2022 v2 clang-11 RelWithDebInfo ControlFlow-Clang":               { tests.windowsCrossCompile(params.WS2022_DCAP_CFL_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang', '0', 'OFF', 'OFF', params.PULL_REQUEST_ID) },
-        "XC Win2022 v2 clang-11 Debug ControlFlow Sim snmalloc":                 { tests.windowsCrossCompile(params.WS2022_DCAP_CFL_LABEL, 'clang-11', 'Debug',          'ControlFlow',       '1', 'OFF', 'ON', params.PULL_REQUEST_ID) },
-        "Cross Platform Win2022":                                                { tests.windowsCrossPlatform(params.WS2022_DCAP_CFL_LABEL, params.PULL_REQUEST_ID) }
+        "ELF Win2022 Ubuntu2004 clang-11 Debug":                                 { tests.windowsLinuxElfBuild(params.WS2022_DCAP_ICX_LABEL, params.UBUNTU_2004_NONSGX_LABEL, 'clang-11', 'Debug', 'None', 'OFF', params.PULL_REQUEST_ID) },
+        "ELF Win2022 Ubuntu2204 clang-11 Debug":                                 { tests.windowsLinuxElfBuild(params.WS2022_DCAP_ICX_LABEL, params.UBUNTU_2204_NONSGX_LABEL, 'clang-11', 'Debug', 'None', 'OFF', params.PULL_REQUEST_ID) },
+        "XC Win2022 v3 clang-11 RelWithDebInfo ControlFlow-Clang":               { tests.windowsCrossCompile(params.WS2022_DCAP_ICX_LABEL, 'clang-11', 'RelWithDebInfo', 'ControlFlow-Clang', '0', 'OFF', 'OFF', params.PULL_REQUEST_ID) },
+        "XC Win2022 v3 clang-11 Debug ControlFlow Sim snmalloc":                 { tests.windowsCrossCompile(params.WS2022_DCAP_ICX_LABEL, 'clang-11', 'Debug',          'ControlFlow',       '1', 'OFF', 'ON', params.PULL_REQUEST_ID) },
+        "Cross Platform Win2022":                                                { tests.windowsCrossPlatform(params.WS2022_DCAP_ICX_LABEL, params.PULL_REQUEST_ID) }
     ]
 }
 stage("Run tests") {

--- a/tests/config_id/host/host.c
+++ b/tests/config_id/host/host.c
@@ -44,7 +44,7 @@ int main(int argc, const char* argv[])
     optional_settings.setting_type = OE_SGX_ENCLAVE_CONFIG_DATA;
     optional_settings.u.config_data = &optional_config_data_setting;
 
-    if (oe_sgx_is_kss_supported())
+    if (oe_sgx_is_kss_supported() && !(flags & OE_ENCLAVE_FLAG_SIMULATE))
     {
         result = oe_create_config_id_enclave(
             argv[1],

--- a/tests/config_id/host/host.c
+++ b/tests/config_id/host/host.c
@@ -44,7 +44,8 @@ int main(int argc, const char* argv[])
     optional_settings.setting_type = OE_SGX_ENCLAVE_CONFIG_DATA;
     optional_settings.u.config_data = &optional_config_data_setting;
 
-    if (oe_sgx_is_kss_supported() && !(flags & OE_ENCLAVE_FLAG_SIMULATE))
+    if (oe_sgx_is_kss_supported() &&
+        (flags & OE_ENCLAVE_FLAG_SIMULATE) == 0)
     {
         result = oe_create_config_id_enclave(
             argv[1],
@@ -59,6 +60,23 @@ int main(int argc, const char* argv[])
             enclave_test_config_id(enclave, &result);
             OE_TEST(result == OE_OK);
         }
+    }
+    else if (oe_sgx_is_kss_supported() &&
+             (flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
+    {
+        // KSS supported but in simulation mode enclave creation with KSS
+        // succeeds. Attestation is skipped because EREPORT is unsupported
+        // in simulation mode. 
+        result = oe_create_config_id_enclave(
+            argv[1],
+            OE_ENCLAVE_TYPE_SGX,
+            flags,
+            &mandatory_settings,
+            1,
+            &enclave);
+        OE_TEST(result == OE_OK);
+        printf("Skipping config_id attestation test in simulation mode on "
+               "KSS-capable hardware...\n");
     }
     else
     {

--- a/tests/config_id/host/host.c
+++ b/tests/config_id/host/host.c
@@ -44,8 +44,7 @@ int main(int argc, const char* argv[])
     optional_settings.setting_type = OE_SGX_ENCLAVE_CONFIG_DATA;
     optional_settings.u.config_data = &optional_config_data_setting;
 
-    if (oe_sgx_is_kss_supported() &&
-        (flags & OE_ENCLAVE_FLAG_SIMULATE) == 0)
+    if (oe_sgx_is_kss_supported() && (flags & OE_ENCLAVE_FLAG_SIMULATE) == 0)
     {
         result = oe_create_config_id_enclave(
             argv[1],
@@ -61,12 +60,12 @@ int main(int argc, const char* argv[])
             OE_TEST(result == OE_OK);
         }
     }
-    else if (oe_sgx_is_kss_supported() &&
-             (flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
+    else if (
+        oe_sgx_is_kss_supported() && (flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
     {
         // KSS supported but in simulation mode enclave creation with KSS
         // succeeds. Attestation is skipped because EREPORT is unsupported
-        // in simulation mode. 
+        // in simulation mode.
         result = oe_create_config_id_enclave(
             argv[1],
             OE_ENCLAVE_TYPE_SGX,

--- a/tests/tools/oesign/test-enclave/host/host.c
+++ b/tests/tools/oesign/test-enclave/host/host.c
@@ -87,9 +87,12 @@ int main(int argc, const char* argv[])
     }
 
     /* check_kss_extended_ids currently assumes the quote provider is available.
-     * Skip if there is no quote provider for now.
+     * Skip if there is no quote provider for now, or if in simulation mode.
+     * Skip in simulation mode because oe_sgx_is_kss_supported() queries real
+     * CPUID but sgx_create_report returns OE_UNSUPPORTED in simulation mode
      */
-    if (is_kss_supported && oe_sgx_has_quote_provider())
+    if (is_kss_supported && !(flags & OE_ENCLAVE_FLAG_SIMULATE) &&
+        oe_sgx_has_quote_provider())
     {
         result = check_kss_extended_ids(
             enclave,

--- a/tests/tools/oesign/test-enclave/host/host.c
+++ b/tests/tools/oesign/test-enclave/host/host.c
@@ -91,7 +91,8 @@ int main(int argc, const char* argv[])
      * Skip in simulation mode because oe_sgx_is_kss_supported() queries real
      * CPUID but sgx_create_report returns OE_UNSUPPORTED in simulation mode
      */
-    if (is_kss_supported && !(flags & OE_ENCLAVE_FLAG_SIMULATE) &&
+    if (is_kss_supported &&
+        (flags & OE_ENCLAVE_FLAG_SIMULATE) == 0 &&
         oe_sgx_has_quote_provider())
     {
         result = check_kss_extended_ids(

--- a/tests/tools/oesign/test-enclave/host/host.c
+++ b/tests/tools/oesign/test-enclave/host/host.c
@@ -91,8 +91,7 @@ int main(int argc, const char* argv[])
      * Skip in simulation mode because oe_sgx_is_kss_supported() queries real
      * CPUID but sgx_create_report returns OE_UNSUPPORTED in simulation mode
      */
-    if (is_kss_supported &&
-        (flags & OE_ENCLAVE_FLAG_SIMULATE) == 0 &&
+    if (is_kss_supported && (flags & OE_ENCLAVE_FLAG_SIMULATE) == 0 &&
         oe_sgx_has_quote_provider())
     {
         result = check_kss_extended_ids(


### PR DESCRIPTION
On 30 June 2026, DCsv2-series Azure Virtual Machines will be retired. Starting 1 July 2026, all remaining DCsv2-series VMs will be stopped.

This also changes tests for oesign and config_id to skip attestation when both simulation mode and KSS (#3054) are enabled. This change is needed since these KSS tests will call sgx_create_report and will return OE_UNSUPPORTED when simulation mode is enabled. This aligns with how other simulation tests will skip attestation flows.