### PR TITLE
Bump size

### DIFF
--- a/common/sgx/quote.c
+++ b/common/sgx/quote.c
@@ -48,7 +48,7 @@ extern bool _should_skip_date_check;
 #endif
 
 // Max length of SGX DCAP QVL/QvE returned supplemental data
-#define MAX_SUPPLEMENTAL_DATA_SIZE 1000
+#define MAX_SUPPLEMENTAL_DATA_SIZE 2048
 
 OE_INLINE uint16_t ReadUint16(const uint8_t* p)
 {

--- a/common/tdx/quote.c
+++ b/common/tdx/quote.c
@@ -16,7 +16,7 @@
 #endif
 
 // Max length of SGX DCAP QVL/QvE returned supplemental data
-#define MAX_SUPPLEMENTAL_DATA_SIZE 1000
+#define MAX_SUPPLEMENTAL_DATA_SIZE 2048
 
 #ifndef OEUTIL_TCB_ALLOW_ANY_ROOT_KEY
 // UUID only needed for Intel QVL path


### PR DESCRIPTION
```
315: 2026-07-23T00:09:52+0000.725637Z [(H)INFO] tid(0x7fdf8d47f740) | Loading libsgx_dcap_quoteverify.so.1 for TDX
315:  [../host/sgx/sgxquote.c:_load_tdx_dcap_qvl_impl:563]
315: 2026-07-23T00:09:52+0000.726197Z [(H)INFO] tid(0x7fdf8d47f740) | tdx supplemental data size=1136, major version=3, minor version=5 [../host/sgx/sgxquote.c:oe_tdx_get_supplemental_data_size:1457]
315: 2026-07-23T00:09:52+0000.726200Z [(H)ERROR] tid(0x7fdf8d47f740) | :OE_BUFFER_TOO_SMALL [../host/tdx/quote.c:tdx_verify_quote:41]

```