### PR TITLE
cmake: gate MSVC-specific flags with if(MSVC) on Windows

### DIFF
--- a/debugger/debugrt/host/CMakeLists.txt
+++ b/debugger/debugrt/host/CMakeLists.txt
@@ -18,12 +18,16 @@ else ()
   # must be installed alongside oedebugrt.dll.
   # Note: VS Debugger does not have this requirement. This WinDbg requirement
   # is temporary.
-  set_target_properties(
-    oedebugrt PROPERTIES COMPILE_FLAGS "/Zi" # Compile with debug information
-                         LINK_FLAGS "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF /Guard:CF"
-  )# Create pdb
-  install(FILES $<TARGET_PDB_FILE:oedebugrt>
-          DESTINATION ${CMAKE_INSTALL_BINDIR})
+  if (MSVC)
+    set_target_properties(
+      oedebugrt
+      PROPERTIES COMPILE_FLAGS "/Zi" # Compile with debug information
+                 LINK_FLAGS
+                 "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF /Guard:CF"
+    )# Create pdb
+    install(FILES $<TARGET_PDB_FILE:oedebugrt>
+            DESTINATION ${CMAKE_INSTALL_BINDIR})
+  endif ()
   install(
     TARGETS oedebugrt
     EXPORT openenclave-targets

--- a/tools/oesgx/CMakeLists.txt
+++ b/tools/oesgx/CMakeLists.txt
@@ -8,7 +8,7 @@ target_include_directories(oesgx PRIVATE ${PROJECT_SOURCE_DIR}/include)
 # assemble into proper collector dir
 set_property(TARGET oesgx PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
-if (WIN32)
+if (WIN32 AND MSVC)
   set_target_properties(oesgx PROPERTIES LINK_FLAGS "/Guard:CF")
 endif ()
 

--- a/tools/oesign/CMakeLists.txt
+++ b/tools/oesign/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(oesign oehostmr)
 # assemble into proper collector dir
 set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
-if (WIN32)
+if (WIN32 AND MSVC)
   set_target_properties(oesign PROPERTIES LINK_FLAGS "/Guard:CF")
 endif ()
 


### PR DESCRIPTION
Guard /Zi, /Guard:CF, TARGET_PDB_FILE and related link flags behind an if(MSVC) check so the build works with non-MSVC compilers (e.g. Clang) on Windows.

- debugger/debugrt/host: wrap PDB install and /Zi+/Guard:CF flags in if(MSVC)
- tools/oesgx: change if(WIN32) to if(WIN32 AND MSVC) for /Guard:CF
- tools/oesign: change if(WIN32) to if(WIN32 AND MSVC) for /Guard:CF