### PR TITLE
Add TDX Service-TD extension quote support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is upgraded (out-of-date to up-to-date, out-of-date-configuration-needed to
   configuration-needed) when the platform's TCB level date is at or after the
   caller-supplied baseline date. The policy value is a Unix epoch timestamp
-  (seconds since 1970-01-01T00:00:00Z) stored as an `int64_t`.
+  (seconds since 1970-01-01T00:00:00Z) stored as an `int64_t`. TDX verification
+  emits the effective aggregate TCB date as `OE_CLAIM_TCB_DATE` and, when this
+  policy is supplied, the enforced date as
+  `OE_CLAIM_TCB_BASELINE_DATE`.
 
 - Added a new API `oe_get_tdx_fmspc_from_quote` to extract the FMSPC
   (Family-Model-Stepping-Platform-CustomSKU) from a TDX quote. Available in both
   host and enclave builds. The `oeutil get-fmspc` subcommand and the `oeverify
   -g` option print the FMSPC of a TDX quote.
+
+- Added support for the TDX report body type 4 (v1.5 with the Service-TD
+  extension). For a type-4 quote, `oe_verify_evidence` emits the following
+  additional claims carrying the raw report-body fields describing the bound
+  Service-TD at build time (`init_*`) and currently (`curr_*`), along with the
+  platform TCB context recorded when the Service-TD was first bound (these
+  values are only semantically meaningful when the TD `ATTRIBUTES.SERVTD_EXT`
+  bit is set):
+  - `tdx_vmid`
+  - `tdx_td_id`
+  - `tdx_devinfo`
+  - `tdx_init_server_td_hash`
+  - `tdx_init_server_td_attr`
+  - `tdx_init_cpu_svn`
+  - `tdx_init_tee_tcb_svn`
+  - `tdx_init_tee_fmspc`
+  - `tdx_curr_server_td_hash`
+  - `tdx_curr_server_td_attr`
+
+- Added OE-side evaluation of the TDX Service-TD's initial platform TCB,
+  controlled by the `TDX_ENABLE_SERVTD_INIT_TCB_EVAL` build option (default
+  `ON`). When enabled, `init_cpu_svn`/`init_tee_tcb_svn` are evaluated against
+  the already-fetched platform TCB info. The evaluation runs only when the TD
+  `ATTRIBUTES.SERVTD_EXT` bit is set (the type-4 body type alone is not treated
+  as sufficient). As a single-platform stopgap, it additionally requires
+  `init_tee_fmspc` to match the platform FMSPC and authenticates the TCB info
+  and its signing chain against Intel's root of trust. When the bit is not set,
+  evaluation is skipped. When the bit is set but evaluation is indeterminate,
+  including an FMSPC mismatch or unavailable component TCB-level match, the
+  aggregate `tcb_status` is invalid and the per-component claims below are
+  omitted. The
+  current-platform and initial-platform TCB status/date components are exposed
+  as claims:
+  - `tdx_curr_platform_tcb_status`
+  - `tdx_curr_platform_tcb_date`
+  - `tdx_init_platform_tcb_status`
+  - `tdx_init_platform_tcb_date`
+  The `OE_POLICY_TCB_BASELINE_DATE` policy is applied to each component
+  independently using its own TCB date. With DCAP supplemental data version
+  3.5, the current-platform claims use `tcb_status_current` and
+  `tcb_date_current`; earlier versions fall back to the QVL result. Because the
+  Service-TD extension does not record an initial PCE SVN, its TCB
+  info level is matched using the recorded SGX and TDX component SVNs. Its TCB
+  info and signing chain rely on QVL's validation of the same endorsements at
+  `OE_POLICY_ENDORSEMENTS_TIME`, when supplied, rather than being revalidated
+  against the current wall clock. The
+  aggregate `tcb_status` preserves terminal QVL results (`OUT_OF_DATE`,
+  `OUT_OF_DATE_CONFIGURATION_NEEDED`, `REVOKED`, and `INVALID`). Otherwise, a
+  terminal initial-platform status overrides the QVL result. When the QVL
+  result is `UP_TO_DATE`, an
+  initial-platform advisory status is also surfaced; competing non-terminal
+  advisories preserve the QVL result.
+  The initial-TCB evaluation can be disabled once Intel's verification library
+  performs it natively.
 
 [v0.19.0][v0.19.0_log]
 --------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,23 @@ option(BUILD_TESTS "Build OE tests" ON)
 option(ENABLE_FUZZING "Build OE with fuzzing flags enabled" OFF)
 option(BUILD_OEUTIL_TOOL "Build oeutil tool" ON)
 
+# OE-side evaluation of the TDX Service-TD initial platform TCB
+# (init_cpu_svn/init_tee_tcb_svn evaluated against the platform TCB info, which
+# is keyed by the platform FMSPC; the evaluation runs only when init_tee_fmspc
+# matches the platform FMSPC, which holds for the single-platform production
+# target). This is a temporary capability: once Intel's verification library
+# evaluates the Service-TD initial TCB natively, this can be turned off.
+# When disabled, the Service-TD extension report fields are still exposed as
+# claims, but the tdx_curr_platform_tcb_status/date and
+# tdx_init_platform_tcb_status/date claims and the init-TCB baseline-date gating
+# are omitted, and the aggregate tcb_status reflects only the current platform
+# TCB.
+option(TDX_ENABLE_SERVTD_INIT_TCB_EVAL
+       "Enable OE-side evaluation of the TDX Service-TD initial platform TCB" ON)
+if (NOT TDX_ENABLE_SERVTD_INIT_TCB_EVAL)
+  add_compile_definitions(OE_TDX_ENABLE_SERVTD_INIT_TCB_EVAL=0)
+endif ()
+
 # For EEID see https://github.com/openenclave/openenclave/pull/2647
 option(
   WITH_EEID

--- a/common/datetime.c
+++ b/common/datetime.c
@@ -302,3 +302,37 @@ oe_result_t oe_datetime_to_time_t(const oe_datetime_t* datetime, time_t* value)
 done:
     return result;
 }
+
+oe_result_t oe_datetime_from_time_t(time_t value, oe_datetime_t* datetime)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    struct tm timeinfo = {0};
+
+    if (datetime == NULL)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    memset(datetime, 0, sizeof(*datetime));
+
+#ifdef _WIN32
+    if (gmtime_r(&value, &timeinfo) != 0)
+#else
+    if (gmtime_r(&value, &timeinfo) == NULL)
+#endif
+        OE_RAISE(OE_INVALID_UTC_DATE_TIME);
+
+    datetime->year = (uint32_t)timeinfo.tm_year + 1900;
+    datetime->month = (uint32_t)timeinfo.tm_mon + 1;
+    datetime->day = (uint32_t)timeinfo.tm_mday;
+    datetime->hours = (uint32_t)timeinfo.tm_hour;
+    datetime->minutes = (uint32_t)timeinfo.tm_min;
+    datetime->seconds = (uint32_t)timeinfo.tm_sec;
+
+    OE_CHECK(oe_datetime_is_valid(datetime));
+
+    result = OE_OK;
+done:
+    if (datetime && result != OE_OK)
+        memset(datetime, 0, sizeof(*datetime));
+
+    return result;
+}

--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -527,6 +527,10 @@ static oe_result_t _read_tcb_info_tcb_level_tcb_v3(
     tcb_level->pce_svn = (uint16_t)value;
 
     // Optionally, read array of tcbcomponents for TDX
+    memset(
+        tcb_level->tdx_tcb_comp_svn,
+        0,
+        sizeof(tcb_level->tdx_tcb_comp_svn));
     if (OE_OK == _read(',', itr, end))
     {
         OE_TRACE_VERBOSE("Reading tdxtcbcomponents");
@@ -568,7 +572,8 @@ done:
 // 4. If no tcb level was chosen, then the status of the platform is unknown.
 static void _determine_platform_tcb_info_tcb_level(
     oe_tcb_info_tcb_level_t* platform_tcb_level,
-    oe_tcb_info_tcb_level_t* tcb_level)
+    oe_tcb_info_tcb_level_t* tcb_level,
+    bool use_pce_svn)
 {
     // If the platform's status has already been determined, return.
     if (platform_tcb_level->status.AsUINT32 != OE_TCB_LEVEL_STATUS_UNKNOWN)
@@ -583,7 +588,18 @@ static void _determine_platform_tcb_info_tcb_level(
             tcb_level->sgx_tcb_comp_svn[i])
             return;
     }
-    if (platform_tcb_level->pce_svn < tcb_level->pce_svn)
+    // Compare all of the platform's TDX comp svn values (populated only for TDX
+    // TCB info; zero for the SGX path, in which case the comparison is a no-op)
+    // with the corresponding values in the current tcb level.
+    for (uint32_t i = 0; i < OE_COUNTOF(platform_tcb_level->tdx_tcb_comp_svn);
+         ++i)
+    {
+        if (platform_tcb_level->tdx_tcb_comp_svn[i] <
+            tcb_level->tdx_tcb_comp_svn[i])
+            return;
+    }
+    if (use_pce_svn &&
+        platform_tcb_level->pce_svn < tcb_level->pce_svn)
         return;
 
     // If all the values of the tcb level are less than corresponding values of
@@ -621,7 +637,8 @@ static oe_result_t _read_tcb_info_tcb_level_v1(
     const uint8_t** itr,
     const uint8_t* end,
     oe_tcb_info_tcb_level_t* platform_tcb_level,
-    oe_tcb_info_tcb_level_t* tcb_level)
+    oe_tcb_info_tcb_level_t* tcb_level,
+    bool use_pce_svn)
 {
     oe_result_t result = OE_JSON_INFO_PARSE_ERROR;
     const uint8_t* status = NULL;
@@ -651,7 +668,7 @@ static oe_result_t _read_tcb_info_tcb_level_v1(
         if (tcb_level->status.AsUINT32 != OE_TCB_LEVEL_STATUS_UNKNOWN)
         {
             _determine_platform_tcb_info_tcb_level(
-                platform_tcb_level, tcb_level);
+                platform_tcb_level, tcb_level, use_pce_svn);
         }
         // Read end of array or comma separator.
         if (*itr < end && **itr == ']')
@@ -705,7 +722,8 @@ static oe_result_t _read_tcb_info_tcb_level_v2_or_v3(
     const uint8_t** itr,
     const uint8_t* end,
     oe_tcb_info_tcb_level_t* platform_tcb_level,
-    oe_tcb_info_tcb_level_t* tcb_level)
+    oe_tcb_info_tcb_level_t* tcb_level,
+    bool use_pce_svn)
 {
     oe_result_t result = OE_JSON_INFO_PARSE_ERROR;
     const uint8_t* status = NULL;
@@ -770,7 +788,7 @@ static oe_result_t _read_tcb_info_tcb_level_v2_or_v3(
         if (tcb_level->status.AsUINT32 != OE_TCB_LEVEL_STATUS_UNKNOWN)
         {
             _determine_platform_tcb_info_tcb_level(
-                platform_tcb_level, tcb_level);
+                platform_tcb_level, tcb_level, use_pce_svn);
         }
 
         // Optimization
@@ -958,7 +976,8 @@ static oe_result_t _read_tcb_info_v1_or_v2(
     const uint8_t** itr,
     const uint8_t* end,
     oe_tcb_info_tcb_level_t* platform_tcb_level,
-    oe_parsed_tcb_info_t* parsed_info)
+    oe_parsed_tcb_info_t* parsed_info,
+    bool use_pce_svn)
 {
     oe_result_t result = OE_JSON_INFO_PARSE_ERROR;
 
@@ -971,7 +990,11 @@ static oe_result_t _read_tcb_info_v1_or_v2(
     OE_TRACE_VERBOSE("Reading tcbLevels");
     if (parsed_info->version == 1)
         OE_CHECK(_read_tcb_info_tcb_level_v1(
-            itr, end, platform_tcb_level, &parsed_info->tcb_info_v2.tcb_level));
+            itr,
+            end,
+            platform_tcb_level,
+            &parsed_info->tcb_info_v2.tcb_level,
+            use_pce_svn));
     else if (parsed_info->version == 2)
         OE_CHECK(_read_tcb_info_tcb_level_v2_or_v3(
             parsed_info->version,
@@ -979,7 +1002,8 @@ static oe_result_t _read_tcb_info_v1_or_v2(
             itr,
             end,
             platform_tcb_level,
-            &parsed_info->tcb_info_v2.tcb_level));
+            &parsed_info->tcb_info_v2.tcb_level,
+            use_pce_svn));
     else
     {
         OE_RAISE_MSG(
@@ -1005,7 +1029,8 @@ static oe_result_t _read_tcb_info_v3(
     const uint8_t** itr,
     const uint8_t* end,
     oe_tcb_info_tcb_level_t* platform_tcb_level,
-    oe_parsed_tcb_info_t* parsed_info)
+    oe_parsed_tcb_info_t* parsed_info,
+    bool use_pce_svn)
 {
     oe_result_t result = OE_JSON_INFO_PARSE_ERROR;
     const uint8_t* str = NULL;
@@ -1043,7 +1068,8 @@ static oe_result_t _read_tcb_info_v3(
             itr,
             end,
             platform_tcb_level,
-            &parsed_info->tcb_info_v3.tcb_level));
+            &parsed_info->tcb_info_v3.tcb_level,
+            use_pce_svn));
     else
     {
         OE_RAISE_MSG(
@@ -1110,7 +1136,8 @@ static oe_result_t _read_tcb_info(
     const uint8_t** itr,
     const uint8_t* end,
     oe_tcb_info_tcb_level_t* platform_tcb_level,
-    oe_parsed_tcb_info_t* parsed_info)
+    oe_parsed_tcb_info_t* parsed_info,
+    bool use_pce_svn)
 {
     oe_result_t result = OE_JSON_INFO_PARSE_ERROR;
     uint64_t version = 0;
@@ -1139,10 +1166,20 @@ static oe_result_t _read_tcb_info(
 
     if (parsed_info->version == 1 || parsed_info->version == 2)
         OE_CHECK(_read_tcb_info_v1_or_v2(
-            tcb_info_json, itr, end, platform_tcb_level, parsed_info));
+            tcb_info_json,
+            itr,
+            end,
+            platform_tcb_level,
+            parsed_info,
+            use_pce_svn));
     else if (parsed_info->version == 3)
         OE_CHECK(_read_tcb_info_v3(
-            tcb_info_json, itr, end, platform_tcb_level, parsed_info));
+            tcb_info_json,
+            itr,
+            end,
+            platform_tcb_level,
+            parsed_info,
+            use_pce_svn));
 
     result = OE_OK;
 done:
@@ -1156,11 +1193,12 @@ done:
  *    "signature" : "hex string"
  * }
  */
-oe_result_t oe_parse_tcb_info_json(
+static oe_result_t _parse_tcb_info_json(
     const uint8_t* tcb_info_json,
     size_t tcb_info_json_size,
     oe_tcb_info_tcb_level_t* platform_tcb_level,
-    oe_parsed_tcb_info_t* parsed_info)
+    oe_parsed_tcb_info_t* parsed_info,
+    bool use_pce_svn)
 {
     oe_result_t result = OE_JSON_INFO_PARSE_ERROR;
     const uint8_t* itr = tcb_info_json;
@@ -1183,7 +1221,12 @@ oe_result_t oe_parse_tcb_info_json(
     OE_TRACE_VERBOSE("Reading tcbInfo");
     OE_CHECK(_read_property_name_and_colon("tcbInfo", &itr, end));
     OE_CHECK(_read_tcb_info(
-        tcb_info_json, &itr, end, platform_tcb_level, parsed_info));
+        tcb_info_json,
+        &itr,
+        end,
+        platform_tcb_level,
+        parsed_info,
+        use_pce_svn));
     OE_CHECK(_read(',', &itr, end));
 
     OE_TRACE_VERBOSE("Reading signature");
@@ -1231,6 +1274,34 @@ oe_result_t oe_parse_tcb_info_json(
     }
 done:
     return result;
+}
+
+oe_result_t oe_parse_tcb_info_json(
+    const uint8_t* tcb_info_json,
+    size_t tcb_info_json_size,
+    oe_tcb_info_tcb_level_t* platform_tcb_level,
+    oe_parsed_tcb_info_t* parsed_info)
+{
+    return _parse_tcb_info_json(
+        tcb_info_json,
+        tcb_info_json_size,
+        platform_tcb_level,
+        parsed_info,
+        true);
+}
+
+oe_result_t oe_parse_tcb_info_json_without_pce_svn(
+    const uint8_t* tcb_info_json,
+    size_t tcb_info_json_size,
+    oe_tcb_info_tcb_level_t* platform_tcb_level,
+    oe_parsed_tcb_info_t* parsed_info)
+{
+    return _parse_tcb_info_json(
+        tcb_info_json,
+        tcb_info_json_size,
+        platform_tcb_level,
+        parsed_info,
+        false);
 }
 
 OE_INLINE uint32_t read_uint32(const uint8_t* p)

--- a/common/sgx/tcbinfo.h
+++ b/common/sgx/tcbinfo.h
@@ -198,6 +198,16 @@ oe_result_t oe_parse_tcb_info_json(
     oe_tcb_info_tcb_level_t* platform_tcb_level,
     oe_parsed_tcb_info_t* parsed_info);
 
+/**
+ * Parse TCB info while matching only SGX and TDX component SVNs. This is for
+ * platform state records that do not carry a PCE SVN.
+ */
+oe_result_t oe_parse_tcb_info_json_without_pce_svn(
+    const uint8_t* tcb_info_json,
+    size_t tcb_info_json_size,
+    oe_tcb_info_tcb_level_t* platform_tcb_level,
+    oe_parsed_tcb_info_t* parsed_info);
+
 oe_result_t oe_verify_ecdsa256_signature(
     const uint8_t* tcb_info_start,
     size_t tcb_info_size,

--- a/common/tdx/verifier.c
+++ b/common/tdx/verifier.c
@@ -5,14 +5,18 @@
 #include <openenclave/attestation/tdx/evidence.h>
 #include <openenclave/bits/evidence.h>
 #include <openenclave/bits/tdx/tdxquote.h>
+#include <openenclave/internal/crypto/cert.h>
 #include <openenclave/internal/plugin.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/safemath.h>
 
 #include "../common.h"
 #include "../sgx/quote.h"
+#include "../sgx/tcbinfo.h"
 #include "collateral.h"
 #include "quote.h"
+
+#include <openenclave/internal/datetime.h>
 
 // Copied from common/sgx/verifier.c:25
 #ifdef OE_BUILD_ENCLAVE
@@ -59,46 +63,468 @@ static oe_sgx_tcb_status_t _verification_result_to_tcb_status(
     }
 }
 
-/* Apply an optional TCB-date baseline policy to the verification result.
+static bool _is_terminal_tcb_status(oe_sgx_tcb_status_t status)
+{
+    return status == OE_SGX_TCB_STATUS_OUT_OF_DATE ||
+           status == OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED ||
+           status == OE_SGX_TCB_STATUS_REVOKED ||
+           status == OE_SGX_TCB_STATUS_INVALID;
+}
+
+oe_sgx_tcb_status_t oe_tdx_get_effective_tcb_status(
+    oe_sgx_tcb_status_t current_status,
+    oe_sgx_tcb_status_t init_status,
+    bool* uses_init_status)
+{
+    if (uses_init_status)
+        *uses_init_status = false;
+
+    if (_is_terminal_tcb_status(current_status))
+        return current_status;
+
+    if (_is_terminal_tcb_status(init_status) ||
+        (current_status == OE_SGX_TCB_STATUS_UP_TO_DATE &&
+         init_status != OE_SGX_TCB_STATUS_UP_TO_DATE))
+    {
+        if (uses_init_status)
+            *uses_init_status = true;
+        return init_status;
+    }
+
+    return current_status;
+}
+
+/* Enable OE's own evaluation of the Service-TD's initial platform TCB.
  *
- * When the platform TCB is reported out-of-date but the platform's TCB level
- * date (tcb_level_date_tag from the verification supplemental data) is at or
- * after the caller-supplied baseline date, the result is upgraded:
- *   - OUT_OF_DATE                -> OK
- *   - OUT_OF_DATE_CONFIG_NEEDED  -> CONFIG_NEEDED
- * All other results, or cases where the supplemental data or baseline date is
- * unavailable, are returned unchanged.
+ * This is a temporary capability. Once Intel's verification library evaluates
+ * the Service-TD initial TCB natively, this OE-side evaluation can be disabled
+ * (or removed) by building with -DOE_TDX_ENABLE_SERVTD_INIT_TCB_EVAL=0. When
+ * disabled, the Service-TD extension report fields are still emitted as claims,
+ * but the tdx_curr_platform_tcb_status/date and tdx_init_platform_tcb_status/
+ * date claims are omitted, the init-TCB baseline-date gating is not applied,
+ * and the aggregate tcb_status reflects only the current platform TCB. Enabled
+ * by default. */
+#ifndef OE_TDX_ENABLE_SERVTD_INIT_TCB_EVAL
+#define OE_TDX_ENABLE_SERVTD_INIT_TCB_EVAL 1
+#endif
+
+/* Result of evaluating the Service-TD's initial platform TCB (from the type-4
+ * report body's init_cpu_svn/init_tee_tcb_svn against the platform TCB info).
+ * Only meaningful when 'valid' is true. */
+typedef struct _tdx_servtd_init_tcb
+{
+    bool required;
+    bool valid;
+    oe_sgx_tcb_status_t tcb_status;
+    oe_datetime_t tcb_date;
+    time_t tcb_date_time;
+} tdx_servtd_init_tcb_t;
+
+#if OE_TDX_ENABLE_SERVTD_INIT_TCB_EVAL
+typedef struct _tdx_collateral_header
+{
+    uint32_t version;
+    uint32_t tee_type;
+    char* pck_crl_issuer_chain;
+    uint32_t pck_crl_issuer_chain_size;
+    char* root_ca_crl;
+    uint32_t root_ca_crl_size;
+    char* pck_crl;
+    uint32_t pck_crl_size;
+    char* tcb_info_issuer_chain;
+    uint32_t tcb_info_issuer_chain_size;
+    char* tcb_info;
+    uint32_t tcb_info_size;
+    char* qe_identity_issuer_chain;
+    uint32_t qe_identity_issuer_chain_size;
+    char* qe_identity;
+    uint32_t qe_identity_size;
+} tdx_collateral_header_t;
+
+static oe_result_t _advance_collateral_cursor(
+    const uint8_t** cursor,
+    const uint8_t* end,
+    uint32_t size)
+{
+    if ((size_t)(end - *cursor) < size)
+        return OE_OUT_OF_BOUNDS;
+
+    *cursor += size;
+    return OE_OK;
+}
+
+/* Extract TCB info from the flattened tdx_ql_qve_collateral_t representation
+ * produced by host/sgx/sgxquote.c. */
+static oe_result_t _get_tdx_tcb_info(
+    const uint8_t* endorsements,
+    size_t endorsements_size,
+    const uint8_t** tcb_info,
+    size_t* tcb_info_size,
+    const uint8_t** tcb_issuer_chain,
+    size_t* tcb_issuer_chain_size)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    tdx_collateral_header_t header = {0};
+    const uint8_t* cursor = NULL;
+    const uint8_t* end = NULL;
+
+    if (!endorsements || !tcb_info || !tcb_info_size || !tcb_issuer_chain ||
+        !tcb_issuer_chain_size ||
+        endorsements_size < sizeof(header))
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    memcpy(&header, endorsements, sizeof(header));
+    if ((header.version != 0x00000003 &&
+         header.version != 0x00010003 &&
+         header.version != 0x00000004) ||
+        header.tee_type != TDX_QUOTE_TYPE)
+        OE_RAISE(OE_INVALID_ENDORSEMENT);
+
+    cursor = endorsements + sizeof(header);
+    end = endorsements + endorsements_size;
+
+    OE_CHECK(_advance_collateral_cursor(
+        &cursor, end, header.pck_crl_issuer_chain_size));
+    OE_CHECK(
+        _advance_collateral_cursor(&cursor, end, header.root_ca_crl_size));
+    OE_CHECK(_advance_collateral_cursor(&cursor, end, header.pck_crl_size));
+    if ((size_t)(end - cursor) < header.tcb_info_issuer_chain_size)
+        OE_RAISE(OE_OUT_OF_BOUNDS);
+    *tcb_issuer_chain = cursor;
+    *tcb_issuer_chain_size = header.tcb_info_issuer_chain_size;
+    OE_CHECK(_advance_collateral_cursor(
+        &cursor, end, header.tcb_info_issuer_chain_size));
+
+    if ((size_t)(end - cursor) < header.tcb_info_size)
+        OE_RAISE(OE_OUT_OF_BOUNDS);
+    *tcb_info = cursor;
+    *tcb_info_size = header.tcb_info_size;
+
+    OE_CHECK(
+        _advance_collateral_cursor(&cursor, end, header.tcb_info_size));
+    OE_CHECK(_advance_collateral_cursor(
+        &cursor, end, header.qe_identity_issuer_chain_size));
+    OE_CHECK(
+        _advance_collateral_cursor(&cursor, end, header.qe_identity_size));
+    if (cursor != end)
+        OE_RAISE(OE_OUT_OF_BOUNDS);
+
+    result = OE_OK;
+
+done:
+    return result;
+}
+
+/* Evaluate the Service-TD's initial platform TCB.
+ *
+ * When the evidence is a TDX v5 type-4 (v1.5_ex) quote whose SERVTD_EXT bit is
+ * set, the report body records the platform TCB (init_cpu_svn, init_tee_tcb_svn,
+ * init_tee_fmspc) captured when the Service-TD was first bound. Intel QVL only
+ * evaluates the current platform TCB, so this routine performs an additional,
+ * OE-side TCB-info evaluation of that initial TCB and reports its status and
+ * date. The evaluation is gated on the ATTRIBUTES.SERVTD_EXT bit (not the body
+ * type alone); when the bit is not set the routine skips (out->valid = false).
+ *
+ * The TCB info is taken from the already-fetched endorsements, authenticated
+ * by the successful QVL verification of those exact endorsements, and required
+ * to match the platform FMSPC. Cross-platform initial TCB evaluation is not
+ * supported by this stopgap.
+ * PCESVN is not carried by the Service-TD extension, so the evaluation matches
+ * only the recorded SGX and TDX component SVNs. The caller treats a required
+ * but indeterminate evaluation as an invalid aggregate TCB status. */
+static oe_result_t _evaluate_servtd_init_tcb(
+    const uint8_t* quote,
+    size_t quote_size,
+    const uint8_t* endorsements,
+    size_t endorsements_size,
+    tdx_servtd_init_tcb_t* out)
+{
+    oe_result_t result = OE_UNEXPECTED;
+    const tdx_quote_t* tdx_quote = (const tdx_quote_t*)quote;
+    const tdx_quote_v5_t* tdx_quote_v5 = NULL;
+    const tdx_report_body_v1_5_ex_t* body = NULL;
+    oe_tcb_info_tcb_level_t platform_tcb_level = {0};
+    oe_parsed_tcb_info_t parsed_info = {0};
+    oe_cert_chain_t tcb_issuer_chain = {0};
+    const uint8_t* tcb_info = NULL;
+    size_t tcb_info_size = 0;
+    const uint8_t* tcb_issuer_chain_data = NULL;
+    size_t tcb_issuer_chain_size = 0;
+    uint8_t platform_fmspc[OE_TDX_FMSPC_SIZE] = {0};
+
+    if (!out)
+        OE_RAISE(OE_INVALID_PARAMETER);
+
+    out->required = false;
+    out->valid = false;
+
+    /* Only TDX v5 type-4 (v1.5_ex) bodies carry the Service-TD init TCB. */
+    if (tdx_quote->version != 5)
+    {
+        result = OE_OK;
+        goto done;
+    }
+    tdx_quote_v5 = (const tdx_quote_v5_t*)quote;
+    if (tdx_quote_v5->type != 4)
+    {
+        result = OE_OK;
+        goto done;
+    }
+    body = (const tdx_report_body_v1_5_ex_t*)tdx_quote_v5->body;
+
+    /* The Service-TD extension fields are only meaningful when the TD
+     * ATTRIBUTES.SERVTD_EXT bit is set. The report body type alone is not
+     * treated as sufficient (a type-4 body carries other fields too), so the
+     * init TCB is evaluated only when the bit confirms the extension is active.
+     * When it is not set, the evaluation is skipped (out->valid = false): the
+     * raw type-4 field claims are still emitted, but the current/initial
+     * platform TCB status/date pair (the evaluation results) is not. */
+    if (!body->td_attributes.sec.d.servtd_ext)
+    {
+        OE_TRACE_WARNING(
+            "Service-TD init TCB not evaluated: ATTRIBUTES.SERVTD_EXT not set");
+        result = OE_OK;
+        goto done;
+    }
+    out->required = true;
+
+    /* The init TCB can only be evaluated when endorsements (which carry the TCB
+     * info JSON) are available. If not, skip without failing verification. */
+    if (!endorsements || !endorsements_size)
+    {
+        OE_TRACE_WARNING(
+            "Service-TD init TCB not evaluated: endorsements unavailable");
+        result = OE_OK;
+        goto done;
+    }
+
+    result = _get_tdx_tcb_info(
+        endorsements,
+        endorsements_size,
+        &tcb_info,
+        &tcb_info_size,
+        &tcb_issuer_chain_data,
+        &tcb_issuer_chain_size);
+    if (result != OE_OK)
+    {
+        OE_TRACE_WARNING(
+            "Service-TD init TCB not evaluated: invalid TDX collateral (%s)",
+            oe_result_str(result));
+        result = OE_OK;
+        goto done;
+    }
+
+    result = oe_cert_chain_read_pem(
+        &tcb_issuer_chain, tcb_issuer_chain_data, tcb_issuer_chain_size);
+    if (result != OE_OK)
+    {
+        OE_TRACE_WARNING(
+            "Service-TD init TCB not evaluated: invalid TCB issuer chain (%s)",
+            oe_result_str(result));
+        result = OE_OK;
+        goto done;
+    }
+    /* QVL has already authenticated this exact collateral, including its TCB
+     * signing chain, using OE_POLICY_ENDORSEMENTS_TIME when supplied. Do not
+     * revalidate the certificate against the current wall clock here. The
+     * signature check below still binds the parsed TCB info to that chain. */
+
+    /* Reuse the already-fetched (platform) TCB info only when the Service-TD's
+     * recorded FMSPC matches the platform FMSPC. Production targets a single
+     * platform, so this always holds; a mismatch (e.g. a cross-platform
+     * migration this stopgap does not support) skips the init-TCB evaluation
+     * rather than reporting a status/date matched against the wrong platform's
+     * TCB-level table. */
+    OE_CHECK(oe_get_tdx_fmspc_from_quote(
+        quote, (uint32_t)quote_size, platform_fmspc, sizeof(platform_fmspc)));
+    if (memcmp(body->init_tee_fmspc, platform_fmspc, OE_TDX_FMSPC_SIZE) != 0)
+    {
+        OE_TRACE_WARNING(
+            "Service-TD init TCB not evaluated: init_tee_fmspc differs from "
+            "platform FMSPC");
+        result = OE_OK;
+        goto done;
+    }
+
+    /* Build the platform TCB level from the Service-TD's initial TCB. The 16
+     * init_cpu_svn bytes map to the SGX TCB components and the TEE TCB SVN bytes
+     * map to the TDX TCB components. PCESVN is unavailable for the initial TCB,
+     * so it is excluded from this component-level match. */
+    OE_STATIC_ASSERT(
+        sizeof(platform_tcb_level.sgx_tcb_comp_svn) ==
+        sizeof(body->init_cpu_svn));
+    OE_STATIC_ASSERT(
+        sizeof(platform_tcb_level.tdx_tcb_comp_svn) ==
+        sizeof(body->init_tee_tcb_svn));
+    memcpy(
+        platform_tcb_level.sgx_tcb_comp_svn,
+        body->init_cpu_svn,
+        sizeof(platform_tcb_level.sgx_tcb_comp_svn));
+    memcpy(
+        platform_tcb_level.tdx_tcb_comp_svn,
+        &body->init_tee_tcb_svn,
+        sizeof(platform_tcb_level.tdx_tcb_comp_svn));
+    /* oe_parse_tcb_info_json returns OE_TCB_LEVEL_INVALID (with status and
+     * tcb_date still populated) when the matched TCB level is not up-to-date.
+     * That is a valid evaluation outcome for the Service-TD init TCB, not a
+     * verification failure, so it is accepted here. Any other error means the
+     * init TCB could not be evaluated and is treated as skipped (best-effort)
+     * without affecting the primary verification result. */
+    result = oe_parse_tcb_info_json_without_pce_svn(
+        tcb_info, tcb_info_size, &platform_tcb_level, &parsed_info);
+    if (result != OE_OK && result != OE_TCB_LEVEL_INVALID)
+    {
+        OE_TRACE_WARNING(
+            "Service-TD init TCB not evaluated: failed to parse TCB info (%s)",
+            oe_result_str(result));
+        result = OE_OK;
+        goto done;
+    }
+
+    if (memcmp(
+            OE_TCB_INFO_GET(&parsed_info, fmspc),
+            platform_fmspc,
+            sizeof(platform_fmspc)) != 0)
+    {
+        OE_TRACE_WARNING(
+            "Service-TD init TCB not evaluated: TCB info FMSPC mismatch");
+        result = OE_OK;
+        goto done;
+    }
+
+    if (platform_tcb_level.status.AsUINT32 == OE_TCB_LEVEL_STATUS_UNKNOWN)
+    {
+        OE_TRACE_WARNING(
+            "Service-TD init TCB not evaluated: no component TCB level "
+            "matched");
+        result = OE_OK;
+        goto done;
+    }
+
+    result = oe_verify_ecdsa256_signature(
+        parsed_info.tcb_info_start,
+        parsed_info.tcb_info_size,
+        (sgx_ecdsa256_signature_t*)parsed_info.signature,
+        &tcb_issuer_chain);
+    if (result != OE_OK)
+    {
+        OE_TRACE_WARNING(
+            "Service-TD init TCB not evaluated: TCB info signature invalid "
+            "(%s)",
+            oe_result_str(result));
+        result = OE_OK;
+        goto done;
+    }
+
+    out->tcb_status =
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status);
+    out->tcb_date = platform_tcb_level.tcb_date;
+    OE_CHECK(
+        oe_datetime_to_time_t(&platform_tcb_level.tcb_date, &out->tcb_date_time));
+    out->valid = true;
+
+    result = OE_OK;
+
+done:
+    oe_cert_chain_free(&tcb_issuer_chain);
+    return result;
+}
+#endif /* OE_TDX_ENABLE_SERVTD_INIT_TCB_EVAL */
+
+/* Apply an optional TCB-date baseline policy to a single TCB status.
+ *
+ * When the status is out-of-date but the corresponding TCB level date is at or
+ * after the caller-supplied baseline date, the status is upgraded:
+ *   - OUT_OF_DATE                       -> UP_TO_DATE
+ *   - OUT_OF_DATE_CONFIGURATION_NEEDED  -> CONFIGURATION_NEEDED
+ * All other statuses, or cases where no baseline date is supplied or the TCB
+ * date is unavailable (0) or older than the baseline, are returned unchanged.
+ *
+ * The policy is applied independently to the QVL aggregate, current platform
+ * TCB, and (for a Service-TD extension quote) Service-TD initial platform TCB,
+ * using each one's own TCB date.
  *
  * Note: this runs in the trusted component (inside the enclave for enclave
  * attestation) after the QvE report and result have already been validated, so
- * adjusting the result here does not weaken the QvE attestation guarantee. */
-static sgx_ql_qv_result_t _apply_tcb_baseline_date_policy(
-    sgx_ql_qv_result_t verification_result,
-    const uint8_t* supplemental_data,
-    size_t supplemental_data_size,
+ * adjusting the status here does not weaken the QvE attestation guarantee. */
+static oe_sgx_tcb_status_t _apply_tcb_baseline_date_policy(
+    oe_sgx_tcb_status_t tcb_status,
+    time_t tcb_date,
     const time_t* tcb_baseline_date)
 {
-    const sgx_ql_qv_supplemental_t* supplemental = NULL;
+    if (tcb_status != OE_SGX_TCB_STATUS_OUT_OF_DATE &&
+        tcb_status != OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED)
+        return tcb_status;
 
-    if (verification_result != SGX_QL_QV_RESULT_OUT_OF_DATE &&
-        verification_result != SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED)
-        return verification_result;
+    if (!tcb_baseline_date || tcb_date == 0 ||
+        tcb_date < *tcb_baseline_date)
+        return tcb_status;
 
-    if (!tcb_baseline_date || !supplemental_data ||
-        supplemental_data_size < sizeof(sgx_ql_qv_supplemental_t))
-        return verification_result;
+    return (tcb_status == OE_SGX_TCB_STATUS_OUT_OF_DATE)
+               ? OE_SGX_TCB_STATUS_UP_TO_DATE
+               : OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED;
+}
 
-    supplemental = (const sgx_ql_qv_supplemental_t*)supplemental_data;
+static bool _supplemental_field_available(
+    size_t supplemental_data_size,
+    size_t field_offset,
+    size_t field_size)
+{
+    return field_offset <= supplemental_data_size &&
+           field_size <= supplemental_data_size - field_offset;
+}
 
-    /* Only upgrade when the platform's TCB level date is at or after the
-     * baseline date required by the policy. */
-    if (supplemental->tcb_level_date_tag < *tcb_baseline_date)
-        return verification_result;
+static void _get_platform_tcb_data(
+    uint32_t verification_result,
+    const uint8_t* supplemental_data,
+    size_t supplemental_data_size,
+    oe_sgx_tcb_status_t* qvl_tcb_status,
+    time_t* qvl_tcb_date,
+    oe_sgx_tcb_status_t* current_tcb_status,
+    time_t* current_tcb_date)
+{
+    const sgx_ql_qv_supplemental_t* supplemental =
+        (const sgx_ql_qv_supplemental_t*)supplemental_data;
 
-    if (verification_result == SGX_QL_QV_RESULT_OUT_OF_DATE)
-        return SGX_QL_QV_RESULT_OK;
+    *qvl_tcb_status = _verification_result_to_tcb_status(
+        (sgx_ql_qv_result_t)verification_result);
+    *qvl_tcb_date = 0;
+    *current_tcb_status = *qvl_tcb_status;
+    *current_tcb_date = 0;
 
-    return SGX_QL_QV_RESULT_CONFIG_NEEDED;
+    if (!supplemental_data ||
+        !_supplemental_field_available(
+            supplemental_data_size,
+            OE_OFFSETOF(sgx_ql_qv_supplemental_t, tcb_level_date_tag),
+            sizeof(supplemental->tcb_level_date_tag)))
+        return;
+
+    *qvl_tcb_date = supplemental->tcb_level_date_tag;
+    *current_tcb_date = *qvl_tcb_date;
+
+    /* Supplemental data version 3.5 separates the current TCB from the launch
+     * TCB represented by the legacy status/date. A revoked aggregate may be a
+     * launch-TCB result, so still expose the independently reported current
+     * TCB while preserving the revoked aggregate status. */
+    if (supplemental->major_version == 3 &&
+        supplemental->minor_version >= 5 &&
+        verification_result != SGX_QL_QV_RESULT_INVALID_SIGNATURE &&
+        verification_result != SGX_QL_QV_RESULT_UNSPECIFIED &&
+        _supplemental_field_available(
+            supplemental_data_size,
+            OE_OFFSETOF(sgx_ql_qv_supplemental_t, tcb_status_current),
+            sizeof(supplemental->tcb_status_current)))
+    {
+        oe_sgx_tcb_status_t status = _verification_result_to_tcb_status(
+            supplemental->tcb_status_current);
+
+        if (status != OE_SGX_TCB_STATUS_INVALID &&
+            supplemental->tcb_date_current != 0)
+        {
+            *current_tcb_status = status;
+            *current_tcb_date = supplemental->tcb_date_current;
+        }
+    }
 }
 
 static oe_result_t _on_register(
@@ -177,13 +603,24 @@ static oe_result_t _fill_with_known_tdx_claims(
     const uint8_t* supplemental_data,
     size_t supplemental_data_size,
     const time_t* tcb_baseline_date,
+    const tdx_servtd_init_tcb_t* init_tcb,
     oe_claim_t* claims,
     size_t claims_length,
     size_t* claims_added)
 {
     oe_sgx_tcb_status_t tcb_status = OE_SGX_TCB_STATUS_INVALID;
+    oe_sgx_tcb_status_t qvl_tcb_status = OE_SGX_TCB_STATUS_INVALID;
+    oe_sgx_tcb_status_t curr_platform_tcb_status = OE_SGX_TCB_STATUS_INVALID;
+    oe_sgx_tcb_status_t init_platform_tcb_status = OE_SGX_TCB_STATUS_INVALID;
+    time_t platform_tcb_date = 0;
+    time_t curr_platform_tcb_date = 0;
+    bool init_tcb_evaluated = (init_tcb && init_tcb->valid);
+    bool init_tcb_required = (init_tcb && init_tcb->required);
+    bool aggregate_uses_init_tcb = false;
+    bool aggregate_tcb_date_available = true;
     const tdx_report_body_t* tdx_report = NULL;
     const tdx_report_body_v5_t* tdx_report_v5 = NULL;
+    const tdx_report_body_v1_5_ex_t* tdx_report_v5_ex = NULL;
     const tdx_attributes_t* attributes = NULL;
     oe_result_t result = OE_UNEXPECTED;
     tdx_quote_t* tdx_quote = NULL;
@@ -196,8 +633,46 @@ static oe_result_t _fill_with_known_tdx_claims(
 
     if (claims_length < OE_REQUIRED_CLAIMS_COUNT +
                             OE_TDX_REQUIRED_CLAIMS_COUNT +
+                            OE_TDX_SERVTD_EXT_CLAIMS_COUNT +
                             OE_TDX_ADDITIONAL_CLAIMS_COUNT)
         OE_RAISE(OE_INVALID_PARAMETER);
+
+    /* Apply the baseline separately to the QVL aggregate (which includes any
+     * launch-TCB implications), the current platform TCB, and the Service-TD
+     * initial platform TCB. */
+    _get_platform_tcb_data(
+        verification_result,
+        supplemental_data,
+        supplemental_data_size,
+        &qvl_tcb_status,
+        &platform_tcb_date,
+        &curr_platform_tcb_status,
+        &curr_platform_tcb_date);
+
+    qvl_tcb_status = _apply_tcb_baseline_date_policy(
+        qvl_tcb_status,
+        platform_tcb_date,
+        tcb_baseline_date);
+    curr_platform_tcb_status = _apply_tcb_baseline_date_policy(
+        curr_platform_tcb_status,
+        curr_platform_tcb_date,
+        tcb_baseline_date);
+
+    tcb_status = qvl_tcb_status;
+    if (init_tcb_required && !init_tcb_evaluated)
+    {
+        tcb_status = OE_SGX_TCB_STATUS_INVALID;
+        aggregate_tcb_date_available = false;
+    }
+    else if (init_tcb_evaluated)
+    {
+        init_platform_tcb_status = _apply_tcb_baseline_date_policy(
+            init_tcb->tcb_status, init_tcb->tcb_date_time, tcb_baseline_date);
+        tcb_status = oe_tdx_get_effective_tcb_status(
+            tcb_status,
+            init_platform_tcb_status,
+            &aggregate_uses_init_tcb);
+    }
 
     /* TDX quote versions 4 and 5 have the same header, which contains version
      * number */
@@ -215,9 +690,15 @@ static oe_result_t _fill_with_known_tdx_claims(
             OE_RAISE(OE_UNEXPECTED);
         /* Type 2 is TDX V4 report body */
         tdx_report = (tdx_report_body_t*)tdx_quote_v5->body;
-        /* Type 3 is TDX V5 report body */
-        if (tdx_quote_v5->type == 3)
+        /* Type 3 is TDX V5 report body; type 4 is the V5 report body extended
+         * with the Service-TD extension fields (v1.5_ex). Both share the same
+         * first 648 bytes, so the V5 claims apply to type 4 as well. */
+        if (tdx_quote_v5->type == 3 || tdx_quote_v5->type == 4)
             tdx_report_v5 = (tdx_report_body_v5_t*)tdx_quote_v5->body;
+        /* Type 4 additionally carries the Service-TD extension fields */
+        if (tdx_quote_v5->type == 4)
+            tdx_report_v5_ex =
+                (tdx_report_body_v1_5_ex_t*)tdx_quote_v5->body;
     }
 
     /* OE-specific claims. Not applicable to TDX so just fill with zeros */
@@ -499,14 +980,135 @@ static oe_result_t _fill_with_known_tdx_claims(
             sizeof(tdx_report_v5->mrservicetd)));
     }
 
+    /* Service-TD extension claims introduced in TDX report body type 4
+     * (v1.5_ex). Present only when the TD ATTRIBUTES.SERVTD_EXT bit is set. */
+    if (tdx_report_v5_ex != NULL)
+    {
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TDX_VMID,
+            sizeof(OE_CLAIM_TDX_VMID),
+            &tdx_report_v5_ex->vmid,
+            sizeof(tdx_report_v5_ex->vmid)));
+
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TDX_TD_ID,
+            sizeof(OE_CLAIM_TDX_TD_ID),
+            tdx_report_v5_ex->td_id,
+            sizeof(tdx_report_v5_ex->td_id)));
+
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TDX_DEVINFO,
+            sizeof(OE_CLAIM_TDX_DEVINFO),
+            tdx_report_v5_ex->devinfo,
+            sizeof(tdx_report_v5_ex->devinfo)));
+
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TDX_INIT_SERVER_TD_HASH,
+            sizeof(OE_CLAIM_TDX_INIT_SERVER_TD_HASH),
+            tdx_report_v5_ex->init_server_td_hash,
+            sizeof(tdx_report_v5_ex->init_server_td_hash)));
+
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TDX_INIT_SERVER_TD_ATTR,
+            sizeof(OE_CLAIM_TDX_INIT_SERVER_TD_ATTR),
+            tdx_report_v5_ex->init_server_td_attr,
+            sizeof(tdx_report_v5_ex->init_server_td_attr)));
+
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TDX_INIT_CPU_SVN,
+            sizeof(OE_CLAIM_TDX_INIT_CPU_SVN),
+            tdx_report_v5_ex->init_cpu_svn,
+            sizeof(tdx_report_v5_ex->init_cpu_svn)));
+
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TDX_INIT_TEE_TCB_SVN,
+            sizeof(OE_CLAIM_TDX_INIT_TEE_TCB_SVN),
+            (uint8_t*)&tdx_report_v5_ex->init_tee_tcb_svn,
+            sizeof(tdx_report_v5_ex->init_tee_tcb_svn)));
+
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TDX_INIT_TEE_FMSPC,
+            sizeof(OE_CLAIM_TDX_INIT_TEE_FMSPC),
+            tdx_report_v5_ex->init_tee_fmspc,
+            sizeof(tdx_report_v5_ex->init_tee_fmspc)));
+
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TDX_CURR_SERVER_TD_HASH,
+            sizeof(OE_CLAIM_TDX_CURR_SERVER_TD_HASH),
+            tdx_report_v5_ex->curr_server_td_hash,
+            sizeof(tdx_report_v5_ex->curr_server_td_hash)));
+
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TDX_CURR_SERVER_TD_ATTR,
+            sizeof(OE_CLAIM_TDX_CURR_SERVER_TD_ATTR),
+            tdx_report_v5_ex->curr_server_td_attr,
+            sizeof(tdx_report_v5_ex->curr_server_td_attr)));
+
+        /* When the Service-TD's initial platform TCB could be evaluated, emit
+         * the current-platform and initial-platform TCB status/date components
+         * alongside the QVL aggregate. Each component status is the effective
+         * status after the TCB-date baseline policy. */
+        if (init_tcb_evaluated)
+        {
+            char tcb_date_str[OE_DATETIME_STRING_SIZE] = {0};
+            size_t tcb_date_str_size = sizeof(tcb_date_str);
+            oe_datetime_t curr_platform_date = {0};
+
+            OE_CHECK(_add_claim(
+                &claims[claims_index++],
+                OE_CLAIM_TDX_CURR_PLATFORM_TCB_STATUS,
+                sizeof(OE_CLAIM_TDX_CURR_PLATFORM_TCB_STATUS),
+                &curr_platform_tcb_status,
+                sizeof(curr_platform_tcb_status)));
+
+            if (curr_platform_tcb_date != 0)
+            {
+                OE_CHECK(oe_datetime_from_time_t(
+                    curr_platform_tcb_date, &curr_platform_date));
+                OE_CHECK(oe_datetime_to_string(
+                    &curr_platform_date, tcb_date_str, &tcb_date_str_size));
+                OE_CHECK(_add_claim(
+                    &claims[claims_index++],
+                    OE_CLAIM_TDX_CURR_PLATFORM_TCB_DATE,
+                    sizeof(OE_CLAIM_TDX_CURR_PLATFORM_TCB_DATE),
+                    tcb_date_str,
+                    tcb_date_str_size));
+            }
+
+            OE_CHECK(_add_claim(
+                &claims[claims_index++],
+                OE_CLAIM_TDX_INIT_PLATFORM_TCB_STATUS,
+                sizeof(OE_CLAIM_TDX_INIT_PLATFORM_TCB_STATUS),
+                &init_platform_tcb_status,
+                sizeof(init_platform_tcb_status)));
+
+            tcb_date_str_size = sizeof(tcb_date_str);
+            OE_CHECK(oe_datetime_to_string(
+                &init_tcb->tcb_date, tcb_date_str, &tcb_date_str_size));
+            OE_CHECK(_add_claim(
+                &claims[claims_index++],
+                OE_CLAIM_TDX_INIT_PLATFORM_TCB_DATE,
+                sizeof(OE_CLAIM_TDX_INIT_PLATFORM_TCB_DATE),
+                tcb_date_str,
+                tcb_date_str_size));
+        }
+    }
+
     /* Additional claims */
 
-    tcb_status =
-        _verification_result_to_tcb_status(_apply_tcb_baseline_date_policy(
-            (sgx_ql_qv_result_t)verification_result,
-            supplemental_data,
-            supplemental_data_size,
-            tcb_baseline_date));
+    /* The aggregate starts with the QVL status, which retains launch-TCB
+     * implications, and includes the Service-TD initial platform TCB when that
+     * is required to avoid a false UP_TO_DATE result. */
 
     // TCB status.
     OE_CHECK(_add_claim(
@@ -515,6 +1117,34 @@ static oe_result_t _fill_with_known_tdx_claims(
         sizeof(OE_CLAIM_TCB_STATUS),
         &tcb_status,
         sizeof(tcb_status)));
+
+    if (platform_tcb_date && aggregate_tcb_date_available)
+    {
+        oe_datetime_t aggregate_tcb_date = {0};
+
+        if (aggregate_uses_init_tcb)
+            aggregate_tcb_date = init_tcb->tcb_date;
+        else
+            OE_CHECK(oe_datetime_from_time_t(
+                platform_tcb_date, &aggregate_tcb_date));
+
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TCB_DATE,
+            sizeof(OE_CLAIM_TCB_DATE),
+            &aggregate_tcb_date,
+            sizeof(aggregate_tcb_date)));
+    }
+
+    if (tcb_baseline_date)
+    {
+        OE_CHECK(_add_claim(
+            &claims[claims_index++],
+            OE_CLAIM_TCB_BASELINE_DATE,
+            sizeof(OE_CLAIM_TCB_BASELINE_DATE),
+            tcb_baseline_date,
+            sizeof(*tcb_baseline_date)));
+    }
 
     if (supplemental_data && supplemental_data_size)
     {
@@ -559,6 +1189,7 @@ static oe_result_t _extract_claims(
     const uint8_t* supplemental_data,
     size_t supplemental_data_size,
     const time_t* tcb_baseline_date,
+    const tdx_servtd_init_tcb_t* init_tcb,
     oe_claim_t** claims_out,
     size_t* claims_length_out)
 {
@@ -577,6 +1208,7 @@ static oe_result_t _extract_claims(
     // Get the number of claims we need and allocate the claims.
     // Include OE_REQUIRED_CLAIM_COUNT for compability with SGX plugins
     claims_length = OE_REQUIRED_CLAIMS_COUNT + OE_TDX_REQUIRED_CLAIMS_COUNT +
+                    OE_TDX_SERVTD_EXT_CLAIMS_COUNT +
                     OE_TDX_ADDITIONAL_CLAIMS_COUNT;
 
     OE_CHECK(oe_safe_mul_u64(claims_length, sizeof(oe_claim_t), &claims_size));
@@ -593,6 +1225,7 @@ static oe_result_t _extract_claims(
         supplemental_data,
         supplemental_data_size,
         tcb_baseline_date,
+        init_tcb,
         claims,
         claims_length,
         &claims_added));
@@ -776,6 +1409,20 @@ static oe_result_t _verify_evidence(
     // Last step is to return claims.
     if (claims)
     {
+        tdx_servtd_init_tcb_t init_tcb = {0};
+
+#if OE_TDX_ENABLE_SERVTD_INIT_TCB_EVAL
+        /* Evaluate the Service-TD's initial platform TCB (type-4 quotes only).
+         * This is best-effort: on any failure the init TCB is treated as not
+         * evaluated and the primary verification result is unaffected. */
+        OE_CHECK(_evaluate_servtd_init_tcb(
+            evidence_buffer,
+            evidence_buffer_size,
+            endorsements_buffer,
+            endorsements_buffer_size,
+            &init_tcb));
+#endif /* OE_TDX_ENABLE_SERVTD_INIT_TCB_EVAL */
+
         OE_CHECK(_extract_claims(
             format_id,
             evidence_buffer,
@@ -784,6 +1431,7 @@ static oe_result_t _verify_evidence(
             supplemental_data,
             supplemental_data_size,
             has_tcb_baseline_date ? &tcb_baseline_date : NULL,
+            &init_tcb,
             claims,
             claims_length));
     }

--- a/common/tdx/verifier.h
+++ b/common/tdx/verifier.h
@@ -6,10 +6,16 @@
 
 #include <openenclave/bits/defs.h>
 #include <openenclave/bits/types.h>
+#include <openenclave/attestation/sgx/evidence.h>
 
 OE_EXTERNC_BEGIN
 
 typedef int64_t time_t;
+
+oe_sgx_tcb_status_t oe_tdx_get_effective_tcb_status(
+    oe_sgx_tcb_status_t current_status,
+    oe_sgx_tcb_status_t init_status,
+    bool* uses_init_status);
 
 /* This file needs to be synchronized with Intel SGX SDK */
 
@@ -26,8 +32,7 @@ typedef struct _sgx_cpu_svn_t
 } sgx_cpu_svn_t;
 
 /* The following definition is based on sgx_qve_header.h from Intel SGX SDK
- * Version 1.20
- * https://github.com/intel/SGXDataCenterAttestationPrimitives/releases/tag/DCAP_1.20
+ * Version 2.27 / DCAP 1.27.
  */
 
 #ifndef SGX_QL_QV_MK_ERROR
@@ -74,8 +79,7 @@ typedef enum _sgx_ql_qv_result_t
                  ///< launched and ran for some time with out-of-date TDX
                  ///< Module. Relaunching or re-provisioning your TD is advised
     SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED_CONFIG_NEEDED =
-        SGX_QL_QV_MK_ERROR(0x0010), /// Upcoming change in Intel DCAP 1.21,
-                                    /// manually added, error code could change
+        SGX_QL_QV_MK_ERROR(0x000A),
     SGX_QL_QV_RESULT_MAX = SGX_QL_QV_MK_ERROR(
         0x00FF), ///< Indicate max result to allow better translation
 
@@ -93,7 +97,7 @@ typedef enum _pck_cert_flag_enum_t
 
 // Each Intel Advisory size is ~16 bytes
 // Assume each TCB level has 20 advisoryIDs at the very most
-#define MAX_SA_LIST_SIZE 320
+#define MAX_SA_LIST_SIZE 450
 
 // Nameless struct generates C4201 warning in MS compiler, but it is allowed in
 // c++ 11 standard Should remove the pragma after Microsoft fixes this issue
@@ -184,7 +188,22 @@ typedef struct _sgx_ql_qv_supplemental_t
                                     ///< generated the quote is not vulnerable
     uint32_t qe_iden_tcb_eval_ref_num; ///< Lower number of the QEIdentity
     sgx_ql_qv_result_t qe_iden_status; /// QEIdentity status
+    time_t platform_tcb_level_date_tag; ///< Date of the matched platform TCB
+                                        ///< level
+
+    /* Appended in supplemental data version 3.5. For a TDX
+     * TD-preserving update, the fields above describe the launch TCB and the
+     * fields below describe the current TCB. */
+    time_t tcb_date_current;
+    sgx_ql_qv_result_t tcb_status_current;
+    char sa_list_current[MAX_SA_LIST_SIZE];
 } sgx_ql_qv_supplemental_t;
+
+OE_STATIC_ASSERT(
+    OE_OFFSETOF(sgx_ql_qv_supplemental_t, tcb_date_current) == 672);
+OE_STATIC_ASSERT(
+    OE_OFFSETOF(sgx_ql_qv_supplemental_t, sa_list_current) == 684);
+OE_STATIC_ASSERT(sizeof(sgx_ql_qv_supplemental_t) == 1136);
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/include/openenclave/attestation/tdx/evidence.h
+++ b/include/openenclave/attestation/tdx/evidence.h
@@ -53,11 +53,53 @@ OE_EXTERNC_BEGIN
 #define OE_TDX_REQUIRED_CLAIMS_COUNT 29
 
 /*
+ * Service-TD extension claims from the TDX report body type 4 (v1.5_ex).
+ * Emitted for a type-4 report body (which carries these raw fields). They
+ * describe the Service-TD bound to the TD both at build time (init_*) and
+ * currently (curr_*), plus the platform TCB context recorded when the
+ * Service-TD was first bound. The values are only semantically meaningful when
+ * the TD ATTRIBUTES.SERVTD_EXT bit is set.
+ */
+#define OE_CLAIM_TDX_VMID "tdx_vmid"
+#define OE_CLAIM_TDX_TD_ID "tdx_td_id"
+#define OE_CLAIM_TDX_DEVINFO "tdx_devinfo"
+#define OE_CLAIM_TDX_INIT_SERVER_TD_HASH "tdx_init_server_td_hash"
+#define OE_CLAIM_TDX_INIT_SERVER_TD_ATTR "tdx_init_server_td_attr"
+#define OE_CLAIM_TDX_INIT_CPU_SVN "tdx_init_cpu_svn"
+#define OE_CLAIM_TDX_INIT_TEE_TCB_SVN "tdx_init_tee_tcb_svn"
+#define OE_CLAIM_TDX_INIT_TEE_FMSPC "tdx_init_tee_fmspc"
+#define OE_CLAIM_TDX_CURR_SERVER_TD_HASH "tdx_curr_server_td_hash"
+#define OE_CLAIM_TDX_CURR_SERVER_TD_ATTR "tdx_curr_server_td_attr"
+/*
+ * Per-component TCB status and TCB date that feed the aggregate OE_CLAIM_TCB_STATUS
+ * claim, emitted only for a Service-TD extension quote (type-4 body with the
+ * ATTRIBUTES.SERVTD_EXT bit set) whose initial platform TCB could be evaluated
+ * (see OE_TDX_ENABLE_SERVTD_INIT_TCB_EVAL; also requires init_tee_fmspc to match
+ * the platform FMSPC). Each status is the
+ * effective SGX TCB status after the OE_POLICY_TCB_BASELINE_DATE policy is
+ * applied to that component's own TCB date. OE_CLAIM_TCB_STATUS preserves the
+ * QVL result, including launch-TCB implications from a TD-preserving update,
+ * unless it is UP_TO_DATE and the evaluated initial-platform status is not.
+ * Consumers should use these component claims for the complete status details.
+ *   - curr: the current platform TCB (from supplemental data version 3.5 when
+ *     available; otherwise from the QVL result)
+ *   - init: the Service-TD's initial platform TCB (from init_cpu_svn /
+ *     init_tee_tcb_svn recorded when the Service-TD was first bound)
+ */
+#define OE_CLAIM_TDX_CURR_PLATFORM_TCB_STATUS "tdx_curr_platform_tcb_status"
+#define OE_CLAIM_TDX_CURR_PLATFORM_TCB_DATE "tdx_curr_platform_tcb_date"
+#define OE_CLAIM_TDX_INIT_PLATFORM_TCB_STATUS "tdx_init_platform_tcb_status"
+#define OE_CLAIM_TDX_INIT_PLATFORM_TCB_DATE "tdx_init_platform_tcb_date"
+#define OE_TDX_SERVTD_EXT_CLAIMS_COUNT 14
+
+/*
  * Additional claims from other sources (e.g., data returned by QvE/QVL)
  */
 #define OE_CLAIM_TDX_SA_LIST "tdx_sa_list"
 #define OE_CLAIM_TDX_PCE_SVN "tdx_pce_svn"
-#define OE_TDX_ADDITIONAL_CLAIMS_COUNT 3 // 2 (above) + 1 (TCB_STATUS)
+
+// 2 above + TCB_STATUS + TCB_DATE + TCB_BASELINE_DATE
+#define OE_TDX_ADDITIONAL_CLAIMS_COUNT 5
 
 /**
  * oe_tdx_verifier_initialize

--- a/include/openenclave/bits/evidence.h
+++ b/include/openenclave/bits/evidence.h
@@ -138,6 +138,13 @@ extern const char* OE_REQUIRED_CLAIMS[OE_REQUIRED_CLAIMS_COUNT];
 #define OE_CLAIM_TCB_DATE "tcb_date"
 
 /**
+ * The minimum TCB date enforced during verification, represented as an int64_t
+ * Unix epoch timestamp. This claim is present only when a TCB baseline policy
+ * is supplied.
+ */
+#define OE_CLAIM_TCB_BASELINE_DATE "tcb_baseline_date"
+
+/**
  * Overall datetime from which the evidence and endorsements are valid.
  */
 #define OE_CLAIM_VALIDITY_FROM "validity_from"

--- a/include/openenclave/bits/tdx/tdxquote.h
+++ b/include/openenclave/bits/tdx/tdxquote.h
@@ -165,6 +165,118 @@ typedef struct _tdx_report_body_v5_t
 } tdx_report_body_v5_t;
 OE_PACK_END
 
+/*
+** TDX report body type 4 (TD Quote body v1.5_ex). Present when the TD
+** ATTRIBUTES.SERVTD_EXT (bit 17) is set. Extends the v1.5 (type 3) body with
+** the Service-TD extension fields, allowing a verifier to observe both the
+** initial and current bound Service-TD measurement and attributes, plus the
+** platform TCB context (CPU SVN, TEE TCB SVN, FMSPC) recorded when the
+** Service-TD was first bound. The first 648 bytes are identical to
+** tdx_report_body_v5_t.
+*/
+OE_PACK_BEGIN
+typedef struct _tdx_report_body_v1_5_ex_t
+{
+    /* (0) */
+    tee_tcb_svn_t tee_tcb_svn;
+
+    /* (16) */
+    uint8_t mrseam[48];
+
+    /* (64) */
+    uint8_t mrseamsigner[48];
+
+    /* (112) */
+    uint8_t seam_attributes[8];
+
+    /* (120) */
+    tdx_attributes_t td_attributes;
+
+    /* (128) */
+    uint8_t xfam[8];
+
+    /* (136) */
+    uint8_t mrtd[48];
+
+    /* (184) */
+    uint8_t mrconfigid[48];
+
+    /* (232) */
+    uint8_t mrowner[48];
+
+    /* (280) */
+    uint8_t mrownerconfig[48];
+
+    /* (328) */
+    uint8_t rtmr0[48];
+
+    /* (376) */
+    uint8_t rtmr1[48];
+
+    /* (424) */
+    uint8_t rtmr2[48];
+
+    /* (472) */
+    uint8_t rtmr3[48];
+
+    /* (520) */
+    uint8_t report_data[64];
+
+    /* (584) */
+    tee_tcb_svn_t tee_tcb_svn2;
+
+    /* (600) */
+    uint8_t mrservicetd[48];
+
+    /* (648) Service-TD extension fields (v1.5_ex) */
+    uint8_t vmid;
+
+    /* (649) */
+    uint8_t td_id[32];
+
+    /* (681) */
+    uint8_t devinfo[48];
+
+    /* (729) SHA384 of the Service-TD bound at TD build time. */
+    uint8_t init_server_td_hash[48];
+
+    /* (777) Service-TD ATTRIBUTES recorded at TD build time. */
+    uint8_t init_server_td_attr[8];
+
+    /* (785) Platform CPU SVN recorded when the Service-TD was first bound. */
+    uint8_t init_cpu_svn[16];
+
+    /* (801) Platform TEE TCB SVN recorded when the Service-TD was first bound.
+     */
+    tee_tcb_svn_t init_tee_tcb_svn;
+
+    /* (817) Platform FMSPC recorded when the Service-TD was first bound. */
+    uint8_t init_tee_fmspc[12];
+
+    /* (829) SHA384 of the currently bound Service-TD. */
+    uint8_t curr_server_td_hash[48];
+
+    /* (877) ATTRIBUTES of the currently bound Service-TD. */
+    uint8_t curr_server_td_attr[8];
+} tdx_report_body_v1_5_ex_t;
+OE_PACK_END
+
+OE_STATIC_ASSERT(OE_OFFSETOF(tdx_report_body_v1_5_ex_t, mrservicetd) == 600);
+OE_STATIC_ASSERT(OE_OFFSETOF(tdx_report_body_v1_5_ex_t, vmid) == 648);
+OE_STATIC_ASSERT(
+    OE_OFFSETOF(tdx_report_body_v1_5_ex_t, init_server_td_hash) == 729);
+OE_STATIC_ASSERT(
+    OE_OFFSETOF(tdx_report_body_v1_5_ex_t, init_server_td_attr) == 777);
+OE_STATIC_ASSERT(OE_OFFSETOF(tdx_report_body_v1_5_ex_t, init_cpu_svn) == 785);
+OE_STATIC_ASSERT(
+    OE_OFFSETOF(tdx_report_body_v1_5_ex_t, init_tee_tcb_svn) == 801);
+OE_STATIC_ASSERT(OE_OFFSETOF(tdx_report_body_v1_5_ex_t, init_tee_fmspc) == 817);
+OE_STATIC_ASSERT(
+    OE_OFFSETOF(tdx_report_body_v1_5_ex_t, curr_server_td_hash) == 829);
+OE_STATIC_ASSERT(
+    OE_OFFSETOF(tdx_report_body_v1_5_ex_t, curr_server_td_attr) == 877);
+OE_STATIC_ASSERT(sizeof(tdx_report_body_v1_5_ex_t) == 885);
+
 OE_PACK_BEGIN
 typedef struct _tdx_quote_t
 {

--- a/include/openenclave/internal/datetime.h
+++ b/include/openenclave/internal/datetime.h
@@ -64,6 +64,11 @@ void oe_datetime_log(const char* msg, const oe_datetime_t* date);
  */
 oe_result_t oe_datetime_to_time_t(const oe_datetime_t* datetime, time_t* value);
 
+/**
+ * Convert time_t to oe datetime (in GMT time).
+ */
+oe_result_t oe_datetime_from_time_t(time_t value, oe_datetime_t* datetime);
+
 OE_EXTERNC_END
 
 #endif /* _OE_INTERNAL_DATETIME_H */

--- a/tests/report/enc/datetime.cpp
+++ b/tests/report/enc/datetime.cpp
@@ -32,6 +32,12 @@ void TestNegative(oe_datetime_t date_time, oe_result_t result)
 
 void test_iso8601_time()
 {
+    oe_datetime_t epoch = {0};
+    const oe_datetime_t expected_epoch = {1970, 1, 1, 0, 0, 0};
+
+    OE_TEST(oe_datetime_from_time_t(0, &epoch) == OE_OK);
+    OE_TEST(memcmp(&epoch, &expected_epoch, sizeof(epoch)) == 0);
+
     // Single digit fields
     TestPositive(oe_datetime_t{2018, 8, 8, 0, 0, 0}, "2018-08-08T00:00:00Z");
 

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -11,6 +11,7 @@
 #include <openenclave/internal/tests.h>
 #include <openenclave/internal/utils.h>
 #include <ctime>
+#include <limits>
 #include <vector>
 #include "../../../common/sgx/tcbinfo.h"
 #include "../../../host/sgx/quote.h"
@@ -50,6 +51,9 @@ extern void TestVerifyTCBInfoV2(
 extern void TestVerifyTCBInfoV3(
     oe_enclave_t* enclave,
     const char* test_filename);
+extern void TestVerifyTdxTcbInfoWithMissingComponents();
+extern void TestVerifyTdxTcbInfoWithoutPceSvn();
+extern void TestTdxEffectiveTcbStatus();
 extern void TestVerifyTCBInfo_AdvisoryIDs(
     oe_enclave_t* enclave,
     const char* test_filename,
@@ -103,6 +107,21 @@ int load_and_verify_report()
 
 int main(int argc, const char* argv[])
 {
+    oe_datetime_t invalid_time = {1, 1, 1, 1, 1, 1};
+    const oe_datetime_t empty_time = {0};
+
+    OE_TEST(
+        oe_datetime_from_time_t(
+            (std::numeric_limits<time_t>::max)(), &invalid_time) ==
+        OE_INVALID_UTC_DATE_TIME);
+    OE_TEST(memcmp(&invalid_time, &empty_time, sizeof(invalid_time)) == 0);
+
+    invalid_time = {1, 1, 1, 1, 1, 1};
+    OE_TEST(
+        oe_datetime_from_time_t((time_t)-1, &invalid_time) ==
+        OE_INVALID_UTC_DATE_TIME);
+    OE_TEST(memcmp(&invalid_time, &empty_time, sizeof(invalid_time)) == 0);
+
     oe_result_t result;
     oe_enclave_t* enclave = NULL;
 
@@ -345,6 +364,9 @@ int main(int argc, const char* argv[])
 
         TestVerifyTCBInfoV3(enclave, "./data_v3/tcbinfo_sgx.json");
         TestVerifyTCBInfoV3(enclave, "./data_v3/tcbinfo_tdx.json");
+        TestVerifyTdxTcbInfoWithMissingComponents();
+        TestVerifyTdxTcbInfoWithoutPceSvn();
+        TestTdxEffectiveTcbStatus();
 
         generate_and_save_report(enclave);
     }

--- a/tests/report/host/tcbinfo.cpp
+++ b/tests/report/host/tcbinfo.cpp
@@ -9,9 +9,11 @@
 #include <openenclave/internal/utils.h>
 
 #include <fstream>
+#include <string>
 #include <streambuf>
 #include <vector>
 #include "../../../common/sgx/tcbinfo.h"
+#include "../../../common/tdx/verifier.h"
 #include "../../../host/sgx/quote.h"
 #include "tests_u.h"
 
@@ -402,6 +404,12 @@ void TestVerifyTCBInfoV3(oe_enclave_t* enclave, const char* test_filename)
         {7, 9, 3, 3, 255, 255, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 8};
     oe_parsed_tcb_info_t parsed_info = {0};
 
+    if (std::string(test_filename).find("tdx") != std::string::npos)
+    {
+        platform_tcb_level.tdx_tcb_comp_svn[0] = 3;
+        platform_tcb_level.tdx_tcb_comp_svn[2] = 5;
+    }
+
     printf("TCB Info Version 3 tests with %s\n", test_filename);
     // ./data_v3/tcbInfo_sgx.json contains 5 tcb levels.
     // The first level with pce svn = 8 is UpToDate.
@@ -514,6 +522,206 @@ void TestVerifyTCBInfoV3(oe_enclave_t* enclave, const char* test_filename)
     printf("Unknown TCB Level determination test passed.\n");
 
     printf("TestVerifyTCBInfo V3: Positive Tests passed\n");
+}
+
+void TestVerifyTdxTcbInfoWithMissingComponents()
+{
+    oe_parsed_tcb_info_t parsed_info = {0};
+    oe_tcb_info_tcb_level_t platform_tcb_level = {
+        {7, 9, 3, 3, 255, 255, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 7};
+    const char sgx_components[] =
+        "[{\"svn\":7},{\"svn\":9},{\"svn\":3},{\"svn\":3},"
+        "{\"svn\":255},{\"svn\":255},{\"svn\":1},{\"svn\":0},"
+        "{\"svn\":0},{\"svn\":0},{\"svn\":0},{\"svn\":0},"
+        "{\"svn\":0},{\"svn\":0},{\"svn\":0},{\"svn\":0}]";
+    const char tdx_components[] =
+        "[{\"svn\":3},{\"svn\":0},{\"svn\":5},{\"svn\":0},"
+        "{\"svn\":0},{\"svn\":0},{\"svn\":0},{\"svn\":0},"
+        "{\"svn\":0},{\"svn\":0},{\"svn\":0},{\"svn\":0},"
+        "{\"svn\":0},{\"svn\":0},{\"svn\":0},{\"svn\":0}]";
+    const std::string json =
+        "{\"tcbInfo\":{\"id\":\"TDX\",\"version\":3,"
+        "\"issueDate\":\"2018-06-06T10:12:17Z\","
+        "\"nextUpdate\":\"2019-06-06T10:12:17Z\","
+        "\"fmspc\":\"00906EA10000\",\"pceId\":\"0000\","
+        "\"tcbType\":0,\"tcbEvaluationDataNumber\":14,"
+        "\"tdxModule\":{\"mrsigner\":\""
+        "000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000\","
+        "\"attributes\":\"0000000000000000\","
+        "\"attributesMask\":\"FFFFFFFFFFFFFFFF\"},\"tcbLevels\":["
+        "{\"tcb\":{\"sgxtcbcomponents\":" +
+        std::string(sgx_components) +
+        ",\"pcesvn\":8,\"tdxtcbcomponents\":" +
+        std::string(tdx_components) +
+        "},\"tcbDate\":\"2018-01-04T01:02:03Z\","
+        "\"tcbStatus\":\"UpToDate\"},"
+        "{\"tcb\":{\"sgxtcbcomponents\":" +
+        std::string(sgx_components) +
+        ",\"pcesvn\":7},\"tcbDate\":\"2018-01-03T01:02:03Z\","
+        "\"tcbStatus\":\"SWHardeningNeeded\"}]},"
+        "\"signature\":\""
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        "\"}";
+
+    platform_tcb_level.status.AsUINT32 = OE_TCB_LEVEL_STATUS_UNKNOWN;
+    OE_TEST(
+        oe_parse_tcb_info_json(
+            (const uint8_t*)json.c_str(),
+            json.size() + 1,
+            &platform_tcb_level,
+            &parsed_info) == OE_OK);
+    OE_TEST(
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status) ==
+        OE_SGX_TCB_STATUS_SW_HARDENING_NEEDED);
+}
+
+void TestVerifyTdxTcbInfoWithoutPceSvn()
+{
+    oe_parsed_tcb_info_t parsed_info = {0};
+    oe_tcb_info_tcb_level_t platform_tcb_level = {
+        {7, 9, 3, 3, 255, 255, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0};
+    const char sgx_components[] =
+        "[{\"svn\":7},{\"svn\":9},{\"svn\":3},{\"svn\":3},"
+        "{\"svn\":255},{\"svn\":255},{\"svn\":1},{\"svn\":0},"
+        "{\"svn\":0},{\"svn\":0},{\"svn\":0},{\"svn\":0},"
+        "{\"svn\":0},{\"svn\":0},{\"svn\":0},{\"svn\":0}]";
+    const char tdx_components[] =
+        "[{\"svn\":3},{\"svn\":0},{\"svn\":5},{\"svn\":0},"
+        "{\"svn\":0},{\"svn\":0},{\"svn\":0},{\"svn\":0},"
+        "{\"svn\":0},{\"svn\":0},{\"svn\":0},{\"svn\":0},"
+        "{\"svn\":0},{\"svn\":0},{\"svn\":0},{\"svn\":0}]";
+    const std::string json =
+        "{\"tcbInfo\":{\"id\":\"TDX\",\"version\":3,"
+        "\"issueDate\":\"2018-06-06T10:12:17Z\","
+        "\"nextUpdate\":\"2019-06-06T10:12:17Z\","
+        "\"fmspc\":\"00906EA10000\",\"pceId\":\"0000\","
+        "\"tcbType\":0,\"tcbEvaluationDataNumber\":14,"
+        "\"tdxModule\":{\"mrsigner\":\""
+        "000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000\","
+        "\"attributes\":\"0000000000000000\","
+        "\"attributesMask\":\"FFFFFFFFFFFFFFFF\"},\"tcbLevels\":["
+        "{\"tcb\":{\"sgxtcbcomponents\":" +
+        std::string(sgx_components) +
+        ",\"pcesvn\":8,\"tdxtcbcomponents\":" +
+        std::string(tdx_components) +
+        "},\"tcbDate\":\"2018-01-04T01:02:03Z\","
+        "\"tcbStatus\":\"UpToDate\"}]},"
+        "\"signature\":\""
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        "\"}";
+
+    platform_tcb_level.tdx_tcb_comp_svn[0] = 3;
+    platform_tcb_level.tdx_tcb_comp_svn[2] = 5;
+
+    OE_TEST(
+        oe_parse_tcb_info_json(
+            (const uint8_t*)json.c_str(),
+            json.size() + 1,
+            &platform_tcb_level,
+            &parsed_info) == OE_TCB_LEVEL_INVALID);
+
+    memset(&parsed_info, 0, sizeof(parsed_info));
+    OE_TEST(
+        oe_parse_tcb_info_json_without_pce_svn(
+            (const uint8_t*)json.c_str(),
+            json.size() + 1,
+            &platform_tcb_level,
+            &parsed_info) == OE_OK);
+    OE_TEST(
+        oe_tcb_level_status_to_sgx_tcb_status(platform_tcb_level.status) ==
+        OE_SGX_TCB_STATUS_UP_TO_DATE);
+
+    memset(&parsed_info, 0, sizeof(parsed_info));
+    platform_tcb_level.tdx_tcb_comp_svn[2] = 4;
+    OE_TEST(
+        oe_parse_tcb_info_json_without_pce_svn(
+            (const uint8_t*)json.c_str(),
+            json.size() + 1,
+            &platform_tcb_level,
+            &parsed_info) == OE_TCB_LEVEL_INVALID);
+}
+
+void TestTdxEffectiveTcbStatus()
+{
+    bool uses_init = false;
+
+#define TEST_EFFECTIVE_STATUS(current, init, expected, expected_uses_init) \
+    do                                                                  \
+    {                                                                   \
+        uses_init = !(expected_uses_init);                               \
+        OE_TEST(oe_tdx_get_effective_tcb_status(                         \
+                    (current), (init), &uses_init) == (expected));       \
+        OE_TEST(uses_init == (expected_uses_init));                      \
+    } while (0)
+
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_OUT_OF_DATE,
+        OE_SGX_TCB_STATUS_REVOKED,
+        OE_SGX_TCB_STATUS_OUT_OF_DATE,
+        false);
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_REVOKED,
+        OE_SGX_TCB_STATUS_OUT_OF_DATE,
+        OE_SGX_TCB_STATUS_REVOKED,
+        false);
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_INVALID,
+        OE_SGX_TCB_STATUS_REVOKED,
+        OE_SGX_TCB_STATUS_INVALID,
+        false);
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED,
+        OE_SGX_TCB_STATUS_REVOKED,
+        OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED,
+        false);
+
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED,
+        OE_SGX_TCB_STATUS_REVOKED,
+        OE_SGX_TCB_STATUS_REVOKED,
+        true);
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_SW_HARDENING_NEEDED,
+        OE_SGX_TCB_STATUS_OUT_OF_DATE,
+        OE_SGX_TCB_STATUS_OUT_OF_DATE,
+        true);
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_TD_RELAUNCH_ADVISED,
+        OE_SGX_TCB_STATUS_INVALID,
+        OE_SGX_TCB_STATUS_INVALID,
+        true);
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED,
+        OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED,
+        OE_SGX_TCB_STATUS_OUT_OF_DATE_CONFIGURATION_NEEDED,
+        true);
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_UP_TO_DATE,
+        OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED,
+        OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED,
+        true);
+
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED,
+        OE_SGX_TCB_STATUS_SW_HARDENING_NEEDED,
+        OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED,
+        false);
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED,
+        OE_SGX_TCB_STATUS_UP_TO_DATE,
+        OE_SGX_TCB_STATUS_CONFIGURATION_NEEDED,
+        false);
+    TEST_EFFECTIVE_STATUS(
+        OE_SGX_TCB_STATUS_UP_TO_DATE,
+        OE_SGX_TCB_STATUS_UP_TO_DATE,
+        OE_SGX_TCB_STATUS_UP_TO_DATE,
+        false);
+
+#undef TEST_EFFECTIVE_STATUS
 }
 
 void TestVerifyTCBInfo_AdvisoryIDs(

--- a/tests/secure_verify/enc/enc.cpp
+++ b/tests/secure_verify/enc/enc.cpp
@@ -15,6 +15,8 @@
 #include <string.h>
 #include "secure_verify_t.h"
 
+static const oe_uuid_t _tdx_quote_uuid = {OE_FORMAT_UUID_TDX_QUOTE_ECDSA};
+
 static void _dump_hex(char* key, uint8_t* data, size_t size)
 {
     printf("%s: ", key);
@@ -41,6 +43,20 @@ static void _dump_claims(oe_claim_t* claims, size_t claims_length)
             _dump_str(
                 claims[i].name, (char*)claims[i].value, claims[i].value_size);
     }
+}
+
+static const oe_claim_t* _find_claim(
+    const oe_claim_t* claims,
+    size_t claims_length,
+    const char* name)
+{
+    for (size_t i = 0; i < claims_length; i++)
+    {
+        if (strcmp(claims[i].name, name) == 0)
+            return &claims[i];
+    }
+
+    return NULL;
 }
 
 oe_result_t verify_plugin_evidence(
@@ -91,6 +107,36 @@ oe_result_t verify_plugin_evidence(
         oe_result_str(result));
 
     _dump_claims(claims, claims_length);
+
+    if (memcmp(format_id, &_tdx_quote_uuid, sizeof(*format_id)) == 0)
+    {
+        const oe_claim_t* tcb_date =
+            _find_claim(claims, claims_length, OE_CLAIM_TCB_DATE);
+        const oe_claim_t* baseline = _find_claim(
+            claims, claims_length, OE_CLAIM_TCB_BASELINE_DATE);
+
+        if (!tcb_date || tcb_date->value_size != sizeof(oe_datetime_t))
+            OE_RAISE_MSG(
+                OE_VERIFY_FAILED, "Missing or invalid TCB date claim");
+
+        if (has_tcb_baseline_date)
+        {
+            if (!baseline ||
+                baseline->value_size != sizeof(tcb_baseline_date) ||
+                memcmp(
+                    baseline->value,
+                    &tcb_baseline_date,
+                    sizeof(tcb_baseline_date)) != 0)
+                OE_RAISE_MSG(
+                    OE_VERIFY_FAILED, "Missing or invalid TCB baseline claim");
+        }
+        else if (baseline)
+        {
+            OE_RAISE_MSG(
+                OE_VERIFY_FAILED,
+                "Unexpected TCB baseline claim without baseline policy");
+        }
+    }
 
     result = OE_OK;
 


### PR DESCRIPTION
Support TDX v5 type-4 (v1.5_ex) report bodies and expose the Service-TD extension fields as evidence claims.

Evaluate the initial platform TCB when ATTRIBUTES.SERVTD_EXT is set and its FMSPC matches the current platform. Prevent aggregate tcb_status from reporting UP_TO_DATE when the evaluated initial-platform status is not, while preserving the exact component statuses in dedicated claims.

Apply the baseline-date policy independently to both platform TCB states and document the new claims and single-platform evaluation behavior.